### PR TITLE
docs: update contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,17 +385,19 @@ Track decisions, action items, and organizational growth.
 
 ---
 
-# Contributors
+# 💖 Contributors
 
-### Shiv Raj Singh
+Thanks to all the amazing contributors who have helped improve MeetOnMemory!
 
-B.Tech – Artificial Intelligence & Machine Learning
-
-GitHub:
-https://github.com/imuniqueshiv
-
-LinkedIn:
-https://www.linkedin.com/in/shiv-raj-singh-387973299/
+<div align="center">
+  <a href="https://github.com/imuniqueshiv/MeetOnMemory/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=imuniqueshiv/MeetOnMemory&max=100" alt="MeetOnMemory contributors" />
+  </a>
+  <br />
+  <a href="https://github.com/imuniqueshiv/MeetOnMemory/graphs/contributors">
+    View all contributors
+  </a>
+</div>
 
 ---
 
@@ -432,16 +434,6 @@ If you find **MeetOnMemory** useful, please consider:
 <p align="center">
   <b>Proud participant of Elite Coders Summer of Code (ECSoC) 2026.</b>
 </p>
-
----
-
-# 💖 Contributors
-
-Thanks to all the amazing contributors who have helped improve MeetOnMemory!
-
-<a href="https://github.com/imuniqueshiv/MeetOnMemory/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=imuniqueshiv/MeetOnMemory" />
-</a>
 
 ---
 


### PR DESCRIPTION
## Description

Closes #19

This PR updates the README Contributors section to automatically display repository contributors.

## Changes Made

- Replaced the manual single-contributor section with an automatic contributors display
- Added contributor avatars using contrib.rocks
- Linked the contributor section to the GitHub contributors graph
- Kept the change focused only on README.md

## Testing

- Verified the README renders correctly in Markdown preview
- Confirmed the contributor image loads through contrib.rocks
- Confirmed the contributor image links to the GitHub contributors graph
- Confirmed only one Contributors section remains in the README

## ECSoC26

This PR is part of ECSoC26. Please add the ECSoC26 label before merging if I do not have permission to add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributors section to highlight the community with a live contributors display and a link to view all contributors.
  * Removed an outdated standalone contributors image block from the lower section of the page.
  * Kept the closing community message intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->