### PR TITLE
feat: automate README contributors gallery

### DIFF
--- a/.github/workflows/contribution-gallery.yml
+++ b/.github/workflows/contribution-gallery.yml
@@ -34,11 +34,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
       - name: Commit and push if README changed
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          git add README.md
           if git diff --cached --quiet; then
             echo "No changes to README."
           else
-            git add README.md
             git commit -m "docs: update contributors gallery"
-            git push origin HEAD:${{ github.event.pull_request.base.ref }}
+            git push origin HEAD:$BASE_REF
           fi

--- a/.github/workflows/contribution-gallery.yml
+++ b/.github/workflows/contribution-gallery.yml
@@ -1,0 +1,44 @@
+name: Update Contributors
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  update-contributors:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: update contributors gallery
+        run: node scripts/update-contributors.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+      - name: Commit and push if README changed
+        run: |
+          if git diff --cached --quiet; then
+            echo "No changes to README."
+          else
+            git add README.md
+            git commit -m "docs: update contributors gallery"
+            git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          fi

--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ Thanks to all the amazing contributors who have helped improve MeetOnMemory!
             <img src="https://avatars.githubusercontent.com/u/278401462?v=4" width="75" alt="aadhish-saini"/>
         </a><a href="https://github.com/Payal29037">
             <img src="https://avatars.githubusercontent.com/u/185815252?v=4" width="75" alt="Payal29037"/>
+        </a><a href="https://github.com/mrunmayeekokitkar">
+            <img src="https://avatars.githubusercontent.com/u/184808271?v=4" width="75" alt="mrunmayeekokitkar"/>
         </a><a href="https://github.com/Aaryanvyas">
             <img src="https://avatars.githubusercontent.com/u/188873438?v=4" width="75" alt="Aaryanvyas"/>
         </a><a href="https://github.com/BhaveshGadling77">

--- a/README.md
+++ b/README.md
@@ -390,13 +390,27 @@ Track decisions, action items, and organizational growth.
 Thanks to all the amazing contributors who have helped improve MeetOnMemory!
 
 <div align="center">
-  <a href="https://github.com/imuniqueshiv/MeetOnMemory/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=imuniqueshiv/MeetOnMemory&max=100" alt="MeetOnMemory contributors" />
-  </a>
-  <br />
-  <a href="https://github.com/imuniqueshiv/MeetOnMemory/graphs/contributors">
-    View all contributors
-  </a>
+<!-- CONTRIBUTORS:START -->
+
+<a href="https://github.com/imuniqueshiv">
+            <img src="https://avatars.githubusercontent.com/u/144125626?v=4" width="75" alt="imuniqueshiv"/>
+        </a><a href="https://github.com/aadhish-saini">
+            <img src="https://avatars.githubusercontent.com/u/278401462?v=4" width="75" alt="aadhish-saini"/>
+        </a><a href="https://github.com/Payal29037">
+            <img src="https://avatars.githubusercontent.com/u/185815252?v=4" width="75" alt="Payal29037"/>
+        </a><a href="https://github.com/Aaryanvyas">
+            <img src="https://avatars.githubusercontent.com/u/188873438?v=4" width="75" alt="Aaryanvyas"/>
+        </a><a href="https://github.com/BhaveshGadling77">
+            <img src="https://avatars.githubusercontent.com/u/188820144?v=4" width="75" alt="BhaveshGadling77"/>
+        </a><a href="https://github.com/itxhadi27-cmd">
+            <img src="https://avatars.githubusercontent.com/u/222145496?v=4" width="75" alt="itxhadi27-cmd"/>
+        </a><a href="https://github.com/CodeWithShrey-collab">
+            <img src="https://avatars.githubusercontent.com/u/179368106?v=4" width="75" alt="CodeWithShrey-collab"/>
+        </a><a href="https://github.com/Khushi1310-nayak">
+            <img src="https://avatars.githubusercontent.com/u/221927504?v=4" width="75" alt="Khushi1310-nayak"/>
+        </a>
+
+<!-- CONTRIBUTORS:END -->
 </div>
 
 ---

--- a/scripts/update-contributors.js
+++ b/scripts/update-contributors.js
@@ -6,6 +6,7 @@ if (!repository) {
 const [owner, repo] = repository.split("/");
 
 async function fetchContributors() {
+  const PER_PAGE =100;
   const headers = {
     Accept: "application/vnd.github+json",
   };
@@ -13,20 +14,25 @@ async function fetchContributors() {
   if (process.env.GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
   }
-  const response = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/contributors`,
-    { headers },
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch contributors: ${response.status} ${response.statusText}`,
-    );
+  let page=1;
+  const contributors = [];
+  while(true){
+    const url=`https://api.github.com/repos/${owner}/${repo}/contributors?per_page=${PER_PAGE}&page=${page}`
+    const response = await fetch(url,{ headers });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch contributors: ${response.status} ${response.statusText}`,
+      );
+    }
+    const data=await response.json();
+    contributors.push(...data)
+    if(data.length<PER_PAGE) break
+    page++;
   }
-  const data = await response.json();
-  return data;
+  return contributors.filter((contributor)=>contributor.type==="User");
 }
 
-function generateContributorHTML(contributors) {
+function generateContributorHtml(contributors) {
   let html = "";
   for (const contributor of contributors) {
     html += `<a href="${contributor.html_url}">
@@ -60,7 +66,7 @@ async function updateReadme(html) {
 
 async function main() {
   const contributors = await fetchContributors();
-  const html = generateContributorHTML(contributors);
+  const html = generateContributorHtml(contributors);
   await updateReadme(html);
   console.log("README.md updated successfully.");
 }

--- a/scripts/update-contributors.js
+++ b/scripts/update-contributors.js
@@ -1,0 +1,68 @@
+import { readFile, writeFile } from "fs/promises";
+const repository = process.env.GITHUB_REPOSITORY;
+if (!repository) {
+  throw new Error("GITHUB_REPOSITORY environment variable is missing.");
+}
+const [owner, repo] = repository.split("/");
+
+async function fetchContributors() {
+  const headers = {
+    Accept: "application/vnd.github+json",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contributors`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch contributors: ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = await response.json();
+  return data;
+}
+
+function generateContributorHTML(contributors) {
+  let html = "";
+  for (const contributor of contributors) {
+    html += `<a href="${contributor.html_url}">
+            <img src="${contributor.avatar_url}" width="75" alt="${contributor.login}"/>
+        </a>`;
+  }
+  return html;
+}
+
+async function updateReadme(html) {
+  const readme = await readFile("README.md", "utf8");
+  const START = "<!-- CONTRIBUTORS:START -->";
+  const END = "<!-- CONTRIBUTORS:END -->";
+
+  const startIndex = readme.indexOf(START);
+  const endIndex = readme.indexOf(END);
+
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error("Contributor markers not found in README.");
+  }
+
+  const updatedReadme =
+    readme.slice(0, startIndex + START.length) +
+    "\n\n" +
+    html +
+    "\n\n" +
+    readme.slice(endIndex);
+
+  await writeFile("README.md", updatedReadme, "utf8");
+}
+
+async function main() {
+  const contributors = await fetchContributors();
+  const html = generateContributorHTML(contributors);
+  await updateReadme(html);
+  console.log("README.md updated successfully.");
+}
+
+await main();


### PR DESCRIPTION

## Summary
Closes #26 
This PR replaces the existing static **Contributors** section in `README.md` with an automated contributor gallery that updates whenever a pull request is merged.

## What Changed

- Added a GitHub Actions workflow (`.github/workflows/contribution-gallery.yml`) to automatically update the Contributors section after a merged pull request.
- Added `scripts/update-contributors.js` to:
  - Fetch all repository contributors using the GitHub REST API.
  - Generate a contributor avatar gallery.
  - Update only the Contributors section in `README.md` using dedicated marker comments.
- Added marker comments (`<!-- CONTRIBUTORS:START -->` and `<!-- CONTRIBUTORS:END -->`) to safely identify the auto-generated section without affecting the rest of the README.

## Why This Approach?

I initially evaluated **contrib.rocks**, as suggested in the issue. However, it displayed only one contributor for this repository, while GitHub's Contributors page showed multiple contributors.

After discussing this with the maintainer, I implemented a GitHub Actions–based solution that:

- Fetches contributors directly from GitHub's Contributors API.
- Automatically updates the README after merged pull requests.
- Requires little to no manual maintenance.
- Updates only the Contributors section while leaving the rest of the README unchanged.

## Verification

- ✅ All current contributors are displayed.
- ✅ Each contributor avatar links to the correct GitHub profile.
- ✅ Only the Contributors section is modified.
- ✅ The README renders correctly on GitHub.
- ✅ The contributor gallery updates automatically after merged pull requests.

## Files Changed

- `README.md`
- `.github/workflows/contribution-gallery.yml`
- `scripts/update-contributors.js`

## Screenshots

### Before
<img width="1097" height="325" alt="image" src="https://github.com/user-attachments/assets/bf4ac906-2c10-4871-8276-19b29de2dcb6" />

### After
<img width="1098" height="307" alt="image" src="https://github.com/user-attachments/assets/7f21789f-ebdc-46ba-9b84-baafda8a71dc" />


## Notes

- This PR is focused solely on automating the Contributors section in the README.
- No application source code or project functionality has been modified.
- The solution avoids manual maintenance by generating the contributor gallery automatically after pull requests are merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the README “💖 Contributors” section to display a linked contributor avatar gallery directly on the page (between dedicated start/end markers).
  * Added an automated contributor gallery update that runs after merged pull requests and refreshes the README contributor section.

* **Documentation**
  * Replaced the previous external contributors display with embedded contributor avatars for a more consistent, self-contained view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->