### PR TITLE
Fix: correct favicon path to public directory (Closes #31)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/client/src/assets/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MeetOnMemory</title>
   </head>


### PR DESCRIPTION
Fixes #31 

## Changes
- Corrected favicon href path in client/index.html
- Changed from `/client/src/assets/favicon.svg` to `/favicon.svg` (correct public path for Vite)
- Favicon file already exists at client/public/favicon.svg with MeetOnMemory logo

## Verification
- No new files added
- No dependencies changed
- Minimal diff (1 line)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the site favicon path so the browser icon loads correctly from the new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->