### PR TITLE
Fix logout redirect to landing page

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useContext, useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
+import { toast } from "react-toastify";
 import AppContent from "../context/AppContent";
 import {
   Menu,
@@ -28,7 +29,8 @@ const NAV_LINKS = [
 const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { backendUrl, userData, setUserData } = useContext(AppContent);
+  const { backendUrl, userData, setIsLoggedin, setUserData } =
+    useContext(AppContent);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -137,12 +139,18 @@ const Navbar = () => {
         {},
         { withCredentials: true },
       );
+      setIsLoggedin(false);
       setUserData(null);
       localStorage.removeItem("userData");
-      window.location.href = "/login";
+      setMenuOpen(false);
+      setMobileOpen(false);
+      setMobileNotifOpen(false);
+      setNotificationsOpen(false);
+      toast.success("Logged out successfully");
+      navigate("/");
     } catch (err) {
       console.error("Logout failed", err);
-      window.location.href = "/login";
+      toast.error("Failed to logout. Please try again.");
     }
   };
 


### PR DESCRIPTION
## Summary\n- Clear logged-in state after a successful logout\n- Redirect users to the landing page instead of forcing a hard navigation to /login\n- Keep users on the current page and show an error toast if logout fails\n\n## Validation\n- npm run lint --prefix client\n- npm run build --prefix client\n\nCloses #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout behavior so users are fully signed out, with login state and saved data cleared more reliably.
  * Added clearer success and error notifications during logout.
  * Updated post-logout navigation to return users to the home page instead of forcing a login redirect on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->