### PR TITLE
[FEATURE]: Role-Based Access Control (RBAC) for Organization Resources

### DIFF
--- a/server/controllers/analyticsController.js
+++ b/server/controllers/analyticsController.js
@@ -3,12 +3,25 @@ import Policy from "../models/policyModel.js";
 
 export const getAnalytics = async (req, res) => {
   try {
-    const totalMeetings = await Meeting.countDocuments();
-    const totalPolicies = await Policy.countDocuments();
+    const userId = req.user?.id || req.user?._id;
+    if (!userId) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const queryOptions = [{ uploadedBy: userId }];
+    if (req.user?.organization) {
+      queryOptions.push({ organization: req.user.organization });
+    }
+    const matchQuery = { $or: queryOptions };
+
+    const totalMeetings = await Meeting.countDocuments(matchQuery);
+    const totalPolicies = await Policy.countDocuments(matchQuery);
     const completedMeetings = await Meeting.countDocuments({
+      ...matchQuery,
       status: "completed",
     });
     const updatedPolicies = await Policy.countDocuments({
+      ...matchQuery,
       version: { $ne: "1.0" },
     });
 
@@ -16,7 +29,7 @@ export const getAnalytics = async (req, res) => {
     const lastSixMonths = new Date();
     lastSixMonths.setMonth(lastSixMonths.getMonth() - 5);
     const monthlyMeetings = await Meeting.aggregate([
-      { $match: { createdAt: { $gte: lastSixMonths } } },
+      { $match: { createdAt: { $gte: lastSixMonths }, ...matchQuery } },
       {
         $group: {
           _id: { $month: "$createdAt" },
@@ -27,7 +40,7 @@ export const getAnalytics = async (req, res) => {
     ]);
 
     const monthlyPolicies = await Policy.aggregate([
-      { $match: { createdAt: { $gte: lastSixMonths } } },
+      { $match: { createdAt: { $gte: lastSixMonths }, ...matchQuery } },
       {
         $group: {
           _id: { $month: "$createdAt" },

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -660,7 +660,12 @@ export const getAllMeetings = async (req, res) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const meetings = await Meeting.find({ uploadedBy: userId })
+    const queryOptions = [{ uploadedBy: userId }];
+    if (req.user?.organization) {
+      queryOptions.push({ organization: req.user.organization });
+    }
+
+    const meetings = await Meeting.find({ $or: queryOptions })
       .sort({ createdAt: -1 })
       .select(
         "title summary structuredMoM createdAt date meetingType status time duration recordingType organization",
@@ -678,11 +683,18 @@ export const getAllMeetings = async (req, res) => {
 
 export const deleteMeeting = async (req, res) => {
   try {
-    const meeting = await Meeting.findByIdAndDelete(req.params.id);
-    if (!meeting)
-      return res
-        .status(404)
-        .json({ success: false, message: "Meeting not found" });
+    const meeting = req.doc; // from requireOwnerOrAdmin middleware
+    if (!meeting) {
+      // Fallback if middleware isn't used
+      const deleted = await Meeting.findByIdAndDelete(req.params.id);
+      if (!deleted) {
+        return res
+          .status(404)
+          .json({ success: false, message: "Meeting not found" });
+      }
+    } else {
+      await meeting.deleteOne();
+    }
 
     res
       .status(200)
@@ -735,25 +747,13 @@ export const updateMeeting = async (req, res) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const meeting = await Meeting.findOne({
-      _id: req.params.id,
-      uploadedBy: userId,
-    });
+    // `req.doc` is provided by the `requireOwner` middleware
+    const meeting = req.doc || await Meeting.findOne({ _id: req.params.id, uploadedBy: userId });
 
     if (!meeting) {
       return res
         .status(404)
         .json({ success: false, message: "Meeting not found" });
-    }
-
-    // Check if user owns the meeting
-    if (meeting.uploadedBy.toString() !== userId.toString()) {
-      return res
-        .status(403)
-        .json({
-          success: false,
-          message: "You don't have permission to update this meeting",
-        });
     }
 
     // Update allowed fields

--- a/server/controllers/policyController.js
+++ b/server/controllers/policyController.js
@@ -186,6 +186,7 @@ export const uploadPolicy = async (req, res) => {
         key_changes: existing.key_changes,
         keywords: existing.keywords,
         uploadedBy: existing.uploadedBy,
+        organization: existing.organization,
         createdAt: existing.createdAt,
       });
 
@@ -223,6 +224,7 @@ export const uploadPolicy = async (req, res) => {
       commitMsg,
       uploadedBy: uploaderId,
       lastEditedBy: uploaderId,
+      organization: req.user.organization || null,
       status: "ready",
     });
 
@@ -327,7 +329,17 @@ export const analyzePolicy = async (req, res) => {
 // ─────────────────────────────────────────────────────────────
 export const getPolicies = async (req, res) => {
   try {
-    const policies = await Policy.find()
+    const userId = req.user?.id || req.user?._id;
+    if (!userId) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const queryOptions = [{ uploadedBy: userId }];
+    if (req.user?.organization) {
+      queryOptions.push({ organization: req.user.organization });
+    }
+
+    const policies = await Policy.find({ $or: queryOptions })
       .populate("uploadedBy", "name email")
       .populate("lastEditedBy", "name email")
       .sort({ updatedAt: -1 });
@@ -378,7 +390,7 @@ export const downloadPolicy = async (req, res) => {
 // ─────────────────────────────────────────────────────────────
 export const deletePolicy = async (req, res) => {
   try {
-    const policy = await Policy.findById(req.params.id);
+    const policy = req.doc || await Policy.findById(req.params.id);
     if (!policy) {
       return res
         .status(404)

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -1,4 +1,6 @@
 // server/middleware/rbac.js
+import mongoose from "mongoose";
+
 export const requireRole = (roles) => {
   return (req, res, next) => {
     if (!req.user) {
@@ -38,6 +40,9 @@ export const requireOwnerOrAdmin = (Model) => {
       if (!docId) {
         return res.status(400).json({ success: false, message: "Document ID required" });
       }
+      if (!mongoose.Types.ObjectId.isValid(docId)) {
+        return res.status(400).json({ success: false, message: "Invalid Document ID format" });
+      }
 
       const doc = await Model.findById(docId);
       if (!doc) {
@@ -75,6 +80,9 @@ export const requireOwner = (Model) => {
       if (!docId) {
         return res.status(400).json({ success: false, message: "Document ID required" });
       }
+      if (!mongoose.Types.ObjectId.isValid(docId)) {
+        return res.status(400).json({ success: false, message: "Invalid Document ID format" });
+      }
 
       const doc = await Model.findById(docId);
       if (!doc) {
@@ -91,6 +99,44 @@ export const requireOwner = (Model) => {
       next();
     } catch (error) {
       console.error("requireOwner error:", error);
+      res.status(500).json({ success: false, message: "Server error during authorization check" });
+    }
+  };
+};
+
+export const requireOrgAccess = (Model) => {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ success: false, message: "Unauthorized" });
+      }
+
+      const docId = req.params.id;
+      if (!docId) {
+        return res.status(400).json({ success: false, message: "Document ID required" });
+      }
+      if (!mongoose.Types.ObjectId.isValid(docId)) {
+        return res.status(400).json({ success: false, message: "Invalid Document ID format" });
+      }
+
+      const doc = await Model.findById(docId);
+      if (!doc) {
+        return res.status(404).json({ success: false, message: "Resource not found" });
+      }
+
+      const isOwner = doc.uploadedBy?.toString() === req.user._id.toString();
+      const isInSameOrg = 
+        doc.organization && req.user.organization &&
+        doc.organization.toString() === req.user.organization.toString();
+
+      if (!isOwner && !isInSameOrg) {
+        return res.status(403).json({ success: false, message: "Forbidden: You don't have access to this resource" });
+      }
+
+      req.doc = doc;
+      next();
+    } catch (error) {
+      console.error("requireOrgAccess error:", error);
       res.status(500).json({ success: false, message: "Server error during authorization check" });
     }
   };

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -1,0 +1,97 @@
+// server/middleware/rbac.js
+export const requireRole = (roles) => {
+  return (req, res, next) => {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    
+    const allowedRoles = Array.isArray(roles) ? roles : [roles];
+    
+    if (!allowedRoles.includes(req.user.role)) {
+      return res.status(403).json({ success: false, message: "Forbidden: Insufficient role" });
+    }
+    
+    next();
+  };
+};
+
+export const requireOrgMembership = (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ success: false, message: "Unauthorized" });
+  }
+
+  if (!req.user.organization) {
+    return res.status(403).json({ success: false, message: "Forbidden: Organization membership required" });
+  }
+
+  next();
+};
+
+export const requireOwnerOrAdmin = (Model) => {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ success: false, message: "Unauthorized" });
+      }
+
+      const docId = req.params.id;
+      if (!docId) {
+        return res.status(400).json({ success: false, message: "Document ID required" });
+      }
+
+      const doc = await Model.findById(docId);
+      if (!doc) {
+        return res.status(404).json({ success: false, message: "Resource not found" });
+      }
+
+      const isOwner = doc.uploadedBy?.toString() === req.user._id.toString();
+      const isAdminInSameOrg = 
+        req.user.role === "admin" && 
+        doc.organization && req.user.organization &&
+        doc.organization.toString() === req.user.organization.toString();
+
+      if (!isOwner && !isAdminInSameOrg) {
+        return res.status(403).json({ success: false, message: "Forbidden: You don't have permission to access or modify this resource" });
+      }
+
+      // Attach the fetched document to the request object so controllers don't need to fetch it again
+      req.doc = doc;
+      next();
+    } catch (error) {
+      console.error("requireOwnerOrAdmin error:", error);
+      res.status(500).json({ success: false, message: "Server error during authorization check" });
+    }
+  };
+};
+
+export const requireOwner = (Model) => {
+  return async (req, res, next) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ success: false, message: "Unauthorized" });
+      }
+
+      const docId = req.params.id;
+      if (!docId) {
+        return res.status(400).json({ success: false, message: "Document ID required" });
+      }
+
+      const doc = await Model.findById(docId);
+      if (!doc) {
+        return res.status(404).json({ success: false, message: "Resource not found" });
+      }
+
+      const isOwner = doc.uploadedBy?.toString() === req.user._id.toString();
+
+      if (!isOwner) {
+        return res.status(403).json({ success: false, message: "Forbidden: Only the owner can modify this resource" });
+      }
+
+      req.doc = doc;
+      next();
+    } catch (error) {
+      console.error("requireOwner error:", error);
+      res.status(500).json({ success: false, message: "Server error during authorization check" });
+    }
+  };
+};

--- a/server/models/policyModel.js
+++ b/server/models/policyModel.js
@@ -13,6 +13,7 @@ const versionSchema = new mongoose.Schema({
   key_changes: [String],
   keywords: [String],
   uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+  organization: { type: mongoose.Schema.Types.ObjectId, ref: "Organization", default: null },
   createdAt: { type: Date, default: Date.now },
 });
 
@@ -45,6 +46,7 @@ const policySchema = new mongoose.Schema(
     // Identity
     uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
     lastEditedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+    organization: { type: mongoose.Schema.Types.ObjectId, ref: "Organization", default: null },
 
     // Draft flag
     isDraft: { type: Boolean, default: false },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -887,25 +887,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -933,9 +932,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@socket.io/component-emitter": {
@@ -990,6 +989,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@xenova/transformers": {
@@ -1108,9 +1116,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1174,14 +1182,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -1367,23 +1401,40 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolean": {
@@ -1394,9 +1445,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2131,20 +2182,21 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
-      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
         "cors": "~2.8.5",
-        "debug": "~4.3.1",
+        "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1"
+        "ws": "~8.21.0"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -2170,23 +2222,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/engine.io/node_modules/mime-db": {
@@ -2217,27 +2252,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/es-define-property": {
@@ -2424,9 +2438,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -2499,9 +2513,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2552,16 +2566,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2713,9 +2727,10 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -2746,21 +2761,21 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2846,12 +2861,12 @@
       }
     },
     "node_modules/google-auth-library/node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -2930,12 +2945,12 @@
       }
     },
     "node_modules/gtoken/node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -3005,9 +3020,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3017,28 +3032,23 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3103,15 +3113,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3374,12 +3388,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -3562,9 +3576,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3602,18 +3616,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -3679,9 +3681,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.19.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.19.3.tgz",
-      "integrity": "sha512-fTAGaIohkk8wCggMuBuqTVD4YrM1/J8cBr1ekqzFqtz65qkLjtX2dcy3NH1e+2rk2365dyrrsPAnt4YTxBhEiQ==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -3728,21 +3730,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -3878,9 +3881,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
-      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -3992,9 +3995,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/onnx-proto/node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4128,9 +4131,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4184,9 +4187,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4287,24 +4290,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4324,10 +4326,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -4356,12 +4361,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -4389,34 +4395,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -4708,14 +4698,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -4727,13 +4717,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4883,81 +4873,26 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
-      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
       "dependencies": {
-        "debug": "~4.3.4",
-        "ws": "~8.17.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io/node_modules/accepts": {
@@ -5191,9 +5126,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -5330,17 +5265,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typedarray": {
@@ -5573,6 +5525,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -5611,15 +5584,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/server/routes/analyticsRoutes.js
+++ b/server/routes/analyticsRoutes.js
@@ -1,9 +1,10 @@
 import express from "express";
 import { getAnalytics } from "../controllers/analyticsController.js";
 import { apiLimiter } from "../middleware/rateLimiter.js";
+import userAuth from "../middleware/userAuth.js";
 
 const router = express.Router();
 
-router.get("/", apiLimiter, getAnalytics);
+router.get("/", apiLimiter, userAuth, getAnalytics);
 
 export default router;

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -1,7 +1,7 @@
 import express from "express";
 import multer from "multer";
 import Meeting from "../models/meetingModel.js";
-import { requireOwnerOrAdmin, requireOwner } from "../middleware/rbac.js";
+import { requireOwnerOrAdmin, requireOwner, requireOrgAccess } from "../middleware/rbac.js";
 import userAuth from "../middleware/userAuth.js";
 import {
   apiLimiter,
@@ -51,7 +51,7 @@ router.get("/:id", userAuth, getMeetingById);
 router.patch("/:id", userAuth, requireOwner(Meeting), updateMeeting);
 
 // ✅ Export Meeting
-router.get("/:id/export", userAuth, exportMeeting);
+router.get("/:id/export", userAuth, requireOrgAccess(Meeting), exportMeeting);
 
 // ✅ Delete Meeting
 router.delete("/delete/:id", userAuth, writeLimiter, requireOwnerOrAdmin(Meeting), deleteMeeting);

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -1,5 +1,7 @@
 import express from "express";
 import multer from "multer";
+import Meeting from "../models/meetingModel.js";
+import { requireOwnerOrAdmin, requireOwner } from "../middleware/rbac.js";
 import userAuth from "../middleware/userAuth.js";
 import {
   apiLimiter,
@@ -46,13 +48,13 @@ router.get("/all", userAuth, getAllMeetings);
 router.get("/:id", userAuth, getMeetingById);
 
 // ✅ Update Meeting (for Meeting Details Page - rename)
-router.patch("/:id", userAuth, updateMeeting);
+router.patch("/:id", userAuth, requireOwner(Meeting), updateMeeting);
 
 // ✅ Export Meeting
 router.get("/:id/export", userAuth, exportMeeting);
 
 // ✅ Delete Meeting
-router.delete("/delete/:id", userAuth, writeLimiter, deleteMeeting);
+router.delete("/delete/:id", userAuth, writeLimiter, requireOwnerOrAdmin(Meeting), deleteMeeting);
 
 // ========== NEW ROUTES (for CreateMeeting.jsx) ==========
 
@@ -72,6 +74,6 @@ router.post(
 router.post("/search", userAuth, searchMeetingsByText);
 
 // 🆕 ✅ Update Meeting Route (Frontend: Meeting Repository - rename, etc.)
-router.put("/:id", userAuth, writeLimiter, updateMeeting);
+router.put("/:id", userAuth, writeLimiter, requireOwner(Meeting), updateMeeting);
 
 export default router;

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -5,7 +5,7 @@ import crypto from "crypto";
 import rateLimit from "express-rate-limit";
 import userAuth from "../middleware/userAuth.js";
 import Policy from "../models/policyModel.js";
-import { requireOwnerOrAdmin } from "../middleware/rbac.js";
+import { requireOwnerOrAdmin, requireOrgMembership } from "../middleware/rbac.js";
 import {
   uploadPolicy,
   getPolicies,
@@ -137,11 +137,12 @@ router.post(
   "/upload",
   uploadLimiter,
   userAuth,
+  requireOrgMembership,
   handleMulterUpload,
   uploadPolicy,
 );
-router.post("/:id/analyze", analyzeLimiter, userAuth, analyzePolicy);
-router.get("/download/:id", downloadLimiter, userAuth, downloadPolicy);
+router.post("/:id/analyze", analyzeLimiter, userAuth, requireOwnerOrAdmin(Policy), analyzePolicy);
+router.get("/download/:id", downloadLimiter, userAuth, requireOwnerOrAdmin(Policy), downloadPolicy);
 router.delete("/:id", deleteLimiter, userAuth, requireOwnerOrAdmin(Policy), deletePolicy);
 
 export default router;

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -4,6 +4,8 @@ import path from "path";
 import crypto from "crypto";
 import rateLimit from "express-rate-limit";
 import userAuth from "../middleware/userAuth.js";
+import Policy from "../models/policyModel.js";
+import { requireOwnerOrAdmin } from "../middleware/rbac.js";
 import {
   uploadPolicy,
   getPolicies,
@@ -127,8 +129,8 @@ const handleMulterUpload = (req, res, next) => {
 // Routes
 // ──────────────────────────────────────────────
 
-// Public (read-only)
-router.get("/", getPolicies);
+// Protected (read-only)
+router.get("/", userAuth, getPolicies);
 
 // Protected — require authentication & rate limiting
 router.post(
@@ -140,6 +142,6 @@ router.post(
 );
 router.post("/:id/analyze", analyzeLimiter, userAuth, analyzePolicy);
 router.get("/download/:id", downloadLimiter, userAuth, downloadPolicy);
-router.delete("/:id", deleteLimiter, userAuth, deletePolicy);
+router.delete("/:id", deleteLimiter, userAuth, requireOwnerOrAdmin(Policy), deletePolicy);
 
 export default router;

--- a/server/test-rbac.js
+++ b/server/test-rbac.js
@@ -1,0 +1,181 @@
+import axios from 'axios';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import userModel from './models/userModel.js';
+import Organization from './models/organizationModel.js';
+import Meeting from './models/meetingModel.js';
+
+dotenv.config();
+
+const port = process.env.PORT || 4000;
+const API_URL = `http://localhost:${port}/api`;
+let userAToken = '';
+let userBToken = '';
+let meetingId = '';
+let orgId = '';
+let userA_id = '';
+let userB_id = '';
+
+const api = axios.create({
+  baseURL: API_URL,
+  validateStatus: () => true // Don't throw errors on 4xx/5xx responses
+});
+
+const delay = (ms) => new Promise(res => setTimeout(res, ms));
+
+async function runTests() {
+  try {
+    console.log("==========================================");
+    console.log("🚀 Starting RBAC & Org Scoping Integration Tests");
+    console.log("==========================================");
+
+    // 1. Connect to DB to manipulate records directly for setup
+    await mongoose.connect(process.env.MONGODB_URI);
+    console.log("✅ Connected to MongoDB");
+
+    // Clean up previous test runs
+    await userModel.deleteMany({ email: { $in: ['usera@test.com', 'userb@test.com'] } });
+    await Organization.deleteMany({ name: 'Test Org RBAC' });
+
+    // 2. Register Users
+    console.log("👤 Registering User A...");
+    let resA = await api.post('/auth/register', { name: 'User A', email: 'usera@test.com', password: 'password123' });
+    
+    console.log("👤 Registering User B...");
+    let resB = await api.post('/auth/register', { name: 'User B', email: 'userb@test.com', password: 'password123' });
+
+    // 3. Login and get Tokens
+    console.log("🔑 Logging in User A...");
+    const loginA = await api.post('/auth/login', { email: 'usera@test.com', password: 'password123' });
+    userAToken = loginA.headers['set-cookie'] ? loginA.headers['set-cookie'][0].split(';')[0].split('=')[1] : null;
+    
+    console.log("🔑 Logging in User B...");
+    const loginB = await api.post('/auth/login', { email: 'userb@test.com', password: 'password123' });
+    userBToken = loginB.headers['set-cookie'] ? loginB.headers['set-cookie'][0].split(';')[0].split('=')[1] : null;
+
+    if (!userAToken || !userBToken) {
+      // Fallback if cookies are not set, try to get from response if token is returned in body
+      // MeetOnMemory auth controller sets a cookie. We need to extract it, or mock it if cookie fails.
+      console.log("⚠️ Could not extract token from cookies. Make sure backend is running and returns set-cookie.");
+    }
+
+    // 4. Setup Organization in DB
+    const userA = await userModel.findOne({ email: 'usera@test.com' });
+    const userB = await userModel.findOne({ email: 'userb@test.com' });
+    userA_id = userA._id;
+    userB_id = userB._id;
+
+    const org = await Organization.create({
+      name: 'Test Org RBAC',
+      createdBy: userA._id,
+      members: [userA._id, userB._id]
+    });
+    orgId = org._id;
+
+    // Set roles and orgs
+    userA.organization = org._id;
+    userA.role = 'member';
+    await userA.save();
+
+    userB.organization = org._id;
+    userB.role = 'member';
+    await userB.save();
+    
+    console.log("✅ Created Test Organization and assigned roles (User A: member, User B: member)");
+
+    // 5. Create a Meeting as User A
+    const meeting = await Meeting.create({
+      title: "User A's Test Meeting",
+      uploadedBy: userA._id,
+      organization: org._id,
+      date: new Date(),
+      status: 'completed',
+      summary: 'Test summary'
+    });
+    meetingId = meeting._id;
+    console.log(`✅ Created Meeting ID: ${meetingId} (Owned by User A)`);
+
+    // --- TEST 1: Visibility (Organization Scoping) ---
+    console.log("\n--- TEST 1: Visibility (Organization Scoping) ---");
+    const getMeetingsRes = await api.get('/meetings/all', {
+      headers: { Cookie: `token=${userBToken}` }
+    });
+    
+    const found = getMeetingsRes.data.meetings?.find(m => m._id === meetingId.toString());
+    if (found) {
+      console.log("✅ PASS: User B can see User A's meeting (Same Org)");
+    } else {
+      console.error("❌ FAIL: User B cannot see User A's meeting");
+    }
+
+    // --- TEST 2: RBAC Enforcement (Deletion by Member) ---
+    console.log("\n--- TEST 2: RBAC Enforcement (Deletion by Member) ---");
+    const deleteRes1 = await api.delete(`/meetings/delete/${meetingId}`, {
+      headers: { Cookie: `token=${userBToken}` }
+    });
+
+    if (deleteRes1.status === 403) {
+      console.log("✅ PASS: User B (member) is FORBIDDEN (403) from deleting User A's meeting");
+    } else {
+      console.error(`❌ FAIL: User B deletion returned status ${deleteRes1.status} (Expected 403)`);
+    }
+
+    // --- TEST 3: RBAC Enforcement (Deletion by Admin) ---
+    console.log("\n--- TEST 3: RBAC Enforcement (Deletion by Admin) ---");
+    
+    // Promote User B to Admin
+    userB.role = 'admin';
+    await userB.save();
+    console.log("⬆️  Promoted User B to Admin in database");
+
+    const deleteRes2 = await api.delete(`/meetings/delete/${meetingId}`, {
+      headers: { Cookie: `token=${userBToken}` }
+    });
+
+    if (deleteRes2.status === 200) {
+      console.log("✅ PASS: User B (admin) SUCCESSFULLY deleted User A's meeting");
+    } else {
+      console.error(`❌ FAIL: User B deletion returned status ${deleteRes2.status} (Expected 200)`);
+    }
+
+    // --- TEST 4: Edit Restrictions (Ownership) ---
+    console.log("\n--- TEST 4: Edit Restrictions (Ownership) ---");
+    
+    // Create new meeting for User A
+    const meeting2 = await Meeting.create({
+      title: "User A's Second Meeting",
+      uploadedBy: userA._id,
+      organization: org._id,
+      date: new Date()
+    });
+    
+    const editRes = await api.put(`/meetings/${meeting2._id}`, 
+      { title: "Hacked Title" },
+      { headers: { Cookie: `token=${userBToken}` } }
+    );
+
+    if (editRes.status === 403) {
+      console.log("✅ PASS: User B (admin) is FORBIDDEN (403) from editing User A's meeting (Only Owner can edit)");
+    } else {
+      console.error(`❌ FAIL: User B edit returned status ${editRes.status} (Expected 403)`);
+    }
+
+    // Clean up
+    console.log("\n🧹 Cleaning up test data...");
+    await userModel.deleteMany({ email: { $in: ['usera@test.com', 'userb@test.com'] } });
+    await Organization.deleteOne({ _id: orgId });
+    await Meeting.deleteMany({ uploadedBy: userA_id });
+
+    console.log("\n🎉 All tests finished!");
+
+  } catch (error) {
+    console.error("❌ Test script failed:", error.message || error);
+    if (error.response) {
+      console.error("Response data:", error.response.data);
+    }
+  } finally {
+    mongoose.disconnect();
+  }
+}
+
+runTests();


### PR DESCRIPTION
- closes #103 

### **Description:**
This PR introduces comprehensive Role-Based Access Control (RBAC), Organization Scoping, and Security Patches across the backend API. These changes ensure that resources are properly secured, preventing unauthorized cross-organization data access, and safely isolating data based on the authenticated user's organization and assigned role.

### **Key Changes:**
**1. Role-Based Access Control (RBAC) Middleware**
* Added new middleware (`requireRole`, `requireOrgMembership`, `requireOrgAccess`, `requireOwnerOrAdmin`, and `requireOwner`) to `server/middleware/rbac.js`.
* **Meeting Routes:** Only the creator or an organization admin can now delete a meeting. Only the creator can update a meeting's details.
* **Policy Routes:** Only the uploader or an organization admin can delete, download, or analyze a policy.
* **Error Handling:** Added `mongoose.Types.ObjectId.isValid()` checks across all RBAC helpers to prevent unhandled `CastError` exceptions (500s) on malformed IDs, gracefully returning a `400 Bad Request` instead.

**2. Organization Scoping**
* Added the `organization` reference field to the `Policy` and `PolicyVersion` schemas. Enforced `requireOrgMembership` at the upload endpoint to prevent orphan policies.
* **Meetings:** `getAllMeetings` and `exportMeeting` now securely restrict access, returning/exporting only meetings uploaded personally OR meetings that belong to the user's organization.
* **Policies:** The `getPolicies` route is no longer public. It now strictly scopes returned policies to the authenticated user's organization.
* **Analytics:** Added missing authentication middleware. The `getAnalytics` dashboard data (counts and trends) is now accurately scoped to the user's organization rather than pulling global platform counts.

**3. Integration Testing**
* Created an automated integration script (`server/test-rbac.js`) to programmatically verify organization scoping and admin/member deletion flows.

### **How to Test:**
1. Log in as a standard `member` and verify you can see your organization's meetings/policies.
2. Attempt to delete, edit, or export a meeting/policy uploaded by another member in your organization (should fail with `403 Forbidden`).
3. Change your role to `admin` in the database, attempt the same deletion (should succeed with `200 OK`).
4. Verify that passing an invalid/malformed Document ID safely returns a `400 Bad Request` instead of crashing the server.
5. Verify the Analytics dashboard numbers now match only the resources visible to your organization.
