### PR TITLE
fix: support dynamic SMTP host and local mock mail fallback

### DIFF
--- a/server/config/nodeMailer.js
+++ b/server/config/nodeMailer.js
@@ -2,12 +2,23 @@ import nodemailer from "nodemailer";
 import dotenv from "dotenv";
 dotenv.config();
 
-const isMock = !process.env.SMTP_USER || process.env.SMTP_USER === "your_email" || process.env.SMTP_USER.trim() === "";
+const isMock =
+  !process.env.SMTP_USER ||
+  process.env.SMTP_USER === "your_email" ||
+  process.env.SMTP_USER.trim() === "" ||
+  !process.env.SMTP_PASS ||
+  process.env.SMTP_PASS === "your_password" ||
+  process.env.SMTP_PASS.trim() === "";
 
 let transporter;
 
 if (isMock) {
-  console.log("ℹ️ SMTP is in mock mode (console logging for emails)");
+  if (process.env.NODE_ENV === "production") {
+    console.warn("⚠️ CRITICAL WARNING: SMTP is running in mock mode in PRODUCTION! Real emails will NOT be sent.");
+  } else {
+    console.log("ℹ️ SMTP is in mock mode (console logging for emails)");
+  }
+
   transporter = {
     verify: (callback) => {
       if (typeof callback === "function") callback(null, true);
@@ -32,7 +43,11 @@ if (isMock) {
       host = "smtp-relay.brevo.com";
     }
   }
-  const port = parseInt(process.env.SMTP_PORT || "587", 10);
+  let port = parseInt(process.env.SMTP_PORT || "587", 10);
+  if (isNaN(port)) {
+    console.warn(`⚠️ Invalid SMTP_PORT specified: "${process.env.SMTP_PORT}". Defaulting to 587.`);
+    port = 587;
+  }
   const secure = process.env.SMTP_SECURE === "true" || port === 465;
 
   transporter = nodemailer.createTransport({

--- a/server/config/nodeMailer.js
+++ b/server/config/nodeMailer.js
@@ -2,22 +2,56 @@ import nodemailer from "nodemailer";
 import dotenv from "dotenv";
 dotenv.config();
 
-const transporter = nodemailer.createTransport({
-  host: "smtp-relay.brevo.com",
-  port: 587,
-  secure: false, // Must be false for port 587
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
+const isMock = !process.env.SMTP_USER || process.env.SMTP_USER === "your_email" || process.env.SMTP_USER.trim() === "";
 
-transporter.verify((error, success) => {
-  if (error) {
-    console.error("❌ SMTP Connection Error:", error);
-  } else {
-    console.log("✅ SMTP Server is ready to send emails!");
+let transporter;
+
+if (isMock) {
+  console.log("ℹ️ SMTP is in mock mode (console logging for emails)");
+  transporter = {
+    verify: (callback) => {
+      if (typeof callback === "function") callback(null, true);
+    },
+    sendMail: async (options) => {
+      console.log("=========================================");
+      console.log("✉️ MOCK EMAIL SENT");
+      console.log(`To: ${options.to}`);
+      console.log(`Subject: ${options.subject}`);
+      console.log("Content:");
+      console.log(options.text || options.html);
+      console.log("=========================================");
+      return { messageId: "mock-id-" + Date.now() };
+    }
+  };
+} else {
+  let host = process.env.SMTP_HOST;
+  if (!host) {
+    if (process.env.SMTP_USER && process.env.SMTP_USER.endsWith("@gmail.com")) {
+      host = "smtp.gmail.com";
+    } else {
+      host = "smtp-relay.brevo.com";
+    }
   }
-});
+  const port = parseInt(process.env.SMTP_PORT || "587", 10);
+  const secure = process.env.SMTP_SECURE === "true" || port === 465;
+
+  transporter = nodemailer.createTransport({
+    host,
+    port,
+    secure,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  transporter.verify((error, success) => {
+    if (error) {
+      console.error("❌ SMTP Connection Error:", error);
+    } else {
+      console.log("✅ SMTP Server is ready to send emails!");
+    }
+  });
+}
 
 export default transporter;


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves startup authentication failures when using Gmail/custom email providers and silences connection error spam when running the application offline/without configured mail credentials. 

Key changes:
1. **Dynamic SMTP Host:** Updated `server/config/nodeMailer.js` to dynamically determine the SMTP host. It automatically connects to `smtp.gmail.com` if a Gmail address is used, or respects optional `SMTP_HOST`, `SMTP_PORT`, and `SMTP_SECURE` variables in `.env`.
2. **Local Mock Transporter Fallback:** Added an `isMock` check. If credentials are left as placeholders (`"your_email"`) or empty, the transporter starts in mock mode—silently validating and logging email contents to the terminal console instead of crashing/spamming connection attempts.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #141 

## Testing

Describe the testing performed.

- [x] Tested locally (verified server starts cleanly with Gmail credentials and also falls back to mock mode if credentials are removed)
- [x] Existing functionality verified
- [x] No new warnings or errors


## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable email delivery using SMTP settings.
  * Added a mock email mode for environments without email credentials, allowing email flows to operate without sending real messages.
  * Added automatic SMTP host selection and secure connection handling based on configuration.

* **Bug Fixes**
  * Improved email service startup behavior when credentials are missing or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->