### PR TITLE
Feat: Add pagination and date filtering to getMeetings endpoint

### DIFF
--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -11,7 +11,7 @@ export const meetingApi = {
 
   summarizeMeeting: (data) => apiClient.post("/api/meetings/summarize", data),
 
-  getAllMeetings: () => apiClient.get("/api/meetings/all"),
+  getAllMeetings: (params = {}) => apiClient.get("/api/meetings/all", { params }),
 
   getMeetingById: (id) => apiClient.get(`/api/meetings/${id}`),
 

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -719,19 +719,44 @@ export const getAllMeetings = async (req, res) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
+    const { page = 1, limit = 10, startDate, endDate } = req.query;
+
     const queryOptions = [{ uploadedBy: userId }];
     if (req.user?.organization) {
       queryOptions.push({ organization: req.user.organization });
     }
 
-    const meetings = await Meeting.find({ $or: queryOptions })
+    const query = { $or: queryOptions };
+
+    if (startDate || endDate) {
+      query.date = {};
+      if (startDate) query.date.$gte = new Date(startDate);
+      if (endDate) query.date.$lte = new Date(endDate);
+    }
+
+    const skip = (parseInt(page) - 1) * parseInt(limit);
+
+    const meetings = await Meeting.find(query)
       .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(parseInt(limit))
       .select(
         "title summary structuredMoM createdAt date meetingType status time duration recordingType organization",
       )
       .populate("organization", "name");
 
-    return res.status(200).json({ success: true, meetings });
+    const totalMeetings = await Meeting.countDocuments(query);
+
+    return res.status(200).json({ 
+      success: true, 
+      meetings,
+      pagination: {
+        total: totalMeetings,
+        page: parseInt(page),
+        limit: parseInt(limit),
+        totalPages: Math.ceil(totalMeetings / parseInt(limit))
+      }
+    });
   } catch (error) {
     console.error("❌ getAllMeetings Error:", error.message);
     return res

--- a/server/controllers/organizationController.js
+++ b/server/controllers/organizationController.js
@@ -411,6 +411,14 @@ export const getPublicOrganizationBySlug = async (req, res) => {
     });
   } catch (error) {
     console.error("❌ Error fetching public organization:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error while fetching organization profile.",
+    });
+  }
+};
+
+/**
  * ✅ Browse public organizations with pagination and filters
  * Query params: page, limit, search, sortBy, filter
  * Returns: { success: true, organizations: [...], pagination: {...} }


### PR DESCRIPTION
- closes #179

### Description

This PR introduces server-side pagination and date filtering capabilities for the `getAllMeetings` endpoint, preventing performance bottlenecks and high memory consumption as the number of meetings generated by organizations scales up.

In addition, it resolves a syntax error in the `organizationController.js` file and updates the frontend API service to properly pass the new query parameters.

### Changes Made
- **Backend:** 
  - Updated `getAllMeetings` in `meetingController.js` to accept `page`, `limit`, `startDate`, and `endDate` query parameters.
  - Implemented `.skip()` and `.limit()` on the Mongoose query for pagination.
  - Implemented `$gte` and `$lte` operators for date filtering.
  - Formatted the response payload to include an enriched `pagination` metadata object (`total`, `page`, `limit`, `totalPages`).
  - **Fix:** Restored a missing block of code and JSDoc comment in `organizationController.js` that was causing the server to crash with a `SyntaxError` on boot.
- **Frontend:**
  - Updated the `getAllMeetings` method in `meetingApi.js` to accept and pass an optional `params` object, paving the way for infinite scrolling or paginated tables.

### Screenshots

<img width="2868" height="1472" alt="Screenshot 2026-07-12 160311" src="https://github.com/user-attachments/assets/bb9c80e3-1e96-4cce-9d18-2d8fbb77ed1a" />

### Acceptance Criteria Met
- [x] The `GET /api/meetings/all` route accepts `page`, `limit`, `startDate`, and `endDate` as query parameters.
- [x] The response payload is wrapped in a structured object containing the data and pagination metadata.
- [x] The Mongoose query correctly uses `.skip()` and `.limit()` for pagination.
- [x] The Mongoose query correctly uses `$gte` and `$lte` for date filtering.
- [x] Default fallback values are implemented if `page` or `limit` are not provided (page 1, limit 10).

### Testing Instructions
1. Authenticate and obtain a JWT token.
2. Hit the `getAllMeetings` endpoint to verify the fallback functionality:
   ```bash
   curl.exe -X GET "http://localhost:5000/api/meetings/all" -H "Authorization: Bearer <TOKEN>"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to meeting listings, including total counts and page information.
  * Added optional date-range filtering for meetings.
  * Enhanced meeting retrieval to support passing query parameters from the client.
* **Bug Fixes**
  * Improved the error message shown when a public organization profile fails to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->