### PR TITLE
feat: Policy Compliance Engine - cross-reference meeting decisions ag…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,6 +33,7 @@ import Calendar from "./pages/Calendar.jsx";
 import Notifications from "./pages/Notifications.jsx";
 import Tasks from "./pages/Tasks.jsx";
 import KnowledgeTimeline from "./pages/KnowledgeTimeline.jsx";
+import PolicyCompliance from "./pages/PolicyCompliance.jsx";
 import Settings from "./pages/Settings.jsx";
 import Navbar from "./components/Navbar";
 import ScrollNavigator from "./components/ScrollNavigator";
@@ -287,6 +288,14 @@ const App = () => {
             element={
               <ProtectedRoute>
                 <Tasks />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/policy-compliance"
+            element={
+              <ProtectedRoute>
+                <PolicyCompliance />
               </ProtectedRoute>
             }
           />

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -22,6 +22,7 @@ import {
   Sparkles,
   Users,
   CheckSquare,
+  ShieldAlert,
   Moon,
   Sun,
 } from "lucide-react";
@@ -270,6 +271,7 @@ const Navbar = () => {
     { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
     { label: "Meetings", href: "/meetings", icon: Calendar },
     { label: "Tasks", href: "/tasks", icon: CheckSquare },
+    { label: "Compliance", href: "/policy-compliance", icon: ShieldAlert },
     { label: "Calendar", href: "/calendar", icon: CalendarDays },
     { label: "Team Members", href: "/team-members", icon: Users },
     { label: "Organizations", href: "/organizations", icon: Building2 },

--- a/client/src/pages/PolicyCompliance.jsx
+++ b/client/src/pages/PolicyCompliance.jsx
@@ -1,0 +1,276 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Navbar from "../components/Navbar.jsx";
+import { policyComplianceApi } from "../services";
+import { toast } from "react-toastify";
+import {
+  ShieldAlert,
+  ShieldCheck,
+  Link2,
+  ShieldQuestion,
+  CheckCircle2,
+  XCircle,
+  RotateCcw,
+  Loader2,
+  ExternalLink,
+  FileText,
+} from "lucide-react";
+
+/**
+ * PolicyCompliance.jsx
+ * Dashboard of meeting decisions flagged as potentially conflicting with
+ * (or otherwise related to) an organizational policy. Detection/flagging
+ * only — acknowledging or dismissing a flag never alters the underlying
+ * meeting decision.
+ */
+
+const CLASSIFICATION_STYLES = {
+  potential_conflict: {
+    label: "Potential Conflict",
+    bgColor: "bg-red-50 dark:bg-red-950/30",
+    textColor: "text-red-700 dark:text-red-400",
+    borderColor: "border-red-200 dark:border-red-900/60",
+    icon: ShieldAlert,
+  },
+  aligned: {
+    label: "Aligned",
+    bgColor: "bg-emerald-50 dark:bg-emerald-950/30",
+    textColor: "text-emerald-700 dark:text-emerald-400",
+    borderColor: "border-emerald-200 dark:border-emerald-900/60",
+    icon: ShieldCheck,
+  },
+  references: {
+    label: "References",
+    bgColor: "bg-blue-50 dark:bg-blue-950/30",
+    textColor: "text-blue-700 dark:text-blue-400",
+    borderColor: "border-blue-200 dark:border-blue-900/60",
+    icon: Link2,
+  },
+  unrelated: {
+    label: "Unrelated",
+    bgColor: "bg-slate-100 dark:bg-slate-800/50",
+    textColor: "text-slate-600 dark:text-slate-400",
+    borderColor: "border-slate-200 dark:border-slate-700",
+    icon: ShieldQuestion,
+  },
+};
+
+const STATUS_TABS = [
+  { value: "unresolved", label: "Unresolved" },
+  { value: "acknowledged", label: "Acknowledged" },
+  { value: "dismissed", label: "Dismissed" },
+  { value: "all", label: "All" },
+];
+
+const PolicyCompliance = () => {
+  const navigate = useNavigate();
+
+  const [flags, setFlags] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [statusTab, setStatusTab] = useState("unresolved");
+  const [actioningId, setActioningId] = useState(null);
+
+  const fetchFlags = useCallback(async (status) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await policyComplianceApi.getFlags(status, "potential_conflict");
+      if (res.data?.success) {
+        setFlags(res.data.flags || []);
+      } else {
+        setError(res.data?.message || "Failed to load compliance flags");
+      }
+    } catch (err) {
+      console.error("Error fetching compliance flags:", err);
+      setError("Unable to fetch compliance flags");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFlags(statusTab);
+  }, [statusTab, fetchFlags]);
+
+  const handleReview = async (flagId, status) => {
+    try {
+      setActioningId(flagId);
+      const res = await policyComplianceApi.updateFlagStatus(flagId, status);
+      if (res.data?.success) {
+        toast.success(
+          status === "acknowledged"
+            ? "Flag acknowledged."
+            : status === "dismissed"
+              ? "Flag dismissed."
+              : "Flag reopened.",
+        );
+        // Remove from the current tab's list unless we're viewing "all"
+        setFlags((prev) =>
+          statusTab === "all"
+            ? prev.map((f) => (f._id === flagId ? { ...f, status } : f))
+            : prev.filter((f) => f._id !== flagId),
+        );
+      } else {
+        toast.error(res.data?.message || "Failed to update flag");
+      }
+    } catch (err) {
+      console.error("Error updating flag:", err);
+      toast.error("Failed to update flag");
+    } finally {
+      setActioningId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 flex flex-col">
+      <Navbar />
+
+      <main className="flex-1 w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-28 pb-16">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+            <ShieldAlert className="w-6 h-6 text-red-500" />
+            Policy Compliance
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+            Meeting decisions flagged as potentially conflicting with an
+            organizational policy. This is a detection layer only — review
+            and acknowledge or dismiss each flag; nothing here blocks or
+            auto-rejects a decision.
+          </p>
+        </div>
+
+        {/* Status tabs */}
+        <div className="flex gap-2 mb-6 border-b border-slate-200 dark:border-slate-800">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab.value}
+              onClick={() => setStatusTab(tab.value)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                statusTab === tab.value
+                  ? "border-red-500 text-red-600 dark:text-red-400"
+                  : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {loading && (
+          <div className="flex items-center justify-center py-16 text-slate-400">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Loading compliance flags...
+          </div>
+        )}
+
+        {!loading && error && (
+          <p className="text-red-500 text-sm py-8 text-center">{error}</p>
+        )}
+
+        {!loading && !error && flags.length === 0 && (
+          <div className="text-center py-16 text-slate-400 dark:text-slate-500">
+            <ShieldCheck className="w-10 h-10 mx-auto mb-3 text-emerald-400" />
+            No {statusTab === "all" ? "" : statusTab} flags found.
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {flags.map((flag) => {
+            const style =
+              CLASSIFICATION_STYLES[flag.classification] ||
+              CLASSIFICATION_STYLES.unrelated;
+            const Icon = style.icon;
+
+            return (
+              <div
+                key={flag._id}
+                className={`rounded-xl border p-4 bg-white dark:bg-slate-900/50 ${style.borderColor}`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span
+                        className={`inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full ${style.bgColor} ${style.textColor}`}
+                      >
+                        <Icon className="w-3.5 h-3.5" />
+                        {style.label}
+                      </span>
+                      <span className="text-xs text-slate-400 dark:text-slate-500">
+                        {Math.round((flag.similarityScore || 0) * 100)}% match
+                      </span>
+                    </div>
+
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100 mb-1">
+                      {flag.decisionId?.text || "Decision unavailable"}
+                    </p>
+
+                    <div className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 mb-2">
+                      <FileText className="w-3.5 h-3.5" />
+                      {flag.policyId?.name || "Policy unavailable"}
+                      {flag.policyVersion && ` · v${flag.policyVersion}`}
+                    </div>
+
+                    {flag.reasoning && (
+                      <p className="text-xs text-slate-500 dark:text-slate-400 italic border-l-2 border-slate-200 dark:border-slate-700 pl-2">
+                        {flag.reasoning}
+                      </p>
+                    )}
+
+                    {flag.sourceMeetingId && (
+                      <button
+                        onClick={() =>
+                          navigate(`/meetings/${flag.sourceMeetingId._id}`)
+                        }
+                        className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                        {flag.sourceMeetingId.title}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Review actions */}
+                  <div className="flex flex-col gap-2 shrink-0">
+                    {flag.status !== "acknowledged" && (
+                      <button
+                        disabled={actioningId === flag._id}
+                        onClick={() => handleReview(flag._id, "acknowledged")}
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/60 disabled:opacity-50"
+                      >
+                        <CheckCircle2 className="w-3.5 h-3.5" />
+                        Acknowledge
+                      </button>
+                    )}
+                    {flag.status !== "dismissed" && (
+                      <button
+                        disabled={actioningId === flag._id}
+                        onClick={() => handleReview(flag._id, "dismissed")}
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 disabled:opacity-50"
+                      >
+                        <XCircle className="w-3.5 h-3.5" />
+                        Dismiss
+                      </button>
+                    )}
+                    {flag.status !== "unresolved" && (
+                      <button
+                        disabled={actioningId === flag._id}
+                        onClick={() => handleReview(flag._id, "unresolved")}
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-50 text-slate-500 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 disabled:opacity-50"
+                      >
+                        <RotateCcw className="w-3.5 h-3.5" />
+                        Reopen
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default PolicyCompliance;

--- a/client/src/pages/PolicyCompliance.jsx
+++ b/client/src/pages/PolicyCompliance.jsx
@@ -53,6 +53,13 @@ const CLASSIFICATION_STYLES = {
     borderColor: "border-slate-200 dark:border-slate-700",
     icon: ShieldQuestion,
   },
+  unclassified: {
+    label: "Needs Retry",
+    bgColor: "bg-amber-50 dark:bg-amber-950/30",
+    textColor: "text-amber-700 dark:text-amber-400",
+    borderColor: "border-amber-200 dark:border-amber-900/60",
+    icon: ShieldQuestion,
+  },
 };
 
 const STATUS_TABS = [
@@ -220,7 +227,7 @@ const PolicyCompliance = () => {
                     {flag.sourceMeetingId && (
                       <button
                         onClick={() =>
-                          navigate(`/meetings/${flag.sourceMeetingId._id}`)
+                          navigate(`/meeting/${flag.sourceMeetingId._id}`)
                         }
                         className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
                       >

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -5,5 +5,6 @@ export * from "./organizationApi";
 export * from "./userApi";
 export * from "./knowledgeApi";
 export * from "./policyApi";
+export * from "./policyComplianceApi";
 export * from "./notificationApi";
 export * from "./analyticsApi";

--- a/client/src/services/policyComplianceApi.js
+++ b/client/src/services/policyComplianceApi.js
@@ -1,0 +1,14 @@
+import apiClient from "./apiClient";
+
+export const policyComplianceApi = {
+  getFlags: (status = "unresolved", classification = "potential_conflict") =>
+    apiClient.get(
+      `/api/policy-compliance/flags?status=${status}&classification=${classification}`,
+    ),
+  getDecisionCompliance: (decisionId) =>
+    apiClient.get(`/api/policy-compliance/decisions/${decisionId}`),
+  getPolicyRelatedDecisions: (policyId) =>
+    apiClient.get(`/api/policy-compliance/policies/${policyId}/related-decisions`),
+  updateFlagStatus: (flagId, status) =>
+    apiClient.patch(`/api/policy-compliance/flags/${flagId}`, { status }),
+};

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -9,6 +9,7 @@ import {
   processStructuredMoM,
   detectResolutions,
 } from "../services/knowledgeGraphService.js";
+import { checkMeetingDecisionsAgainstPolicies } from "../services/policyComplianceService.js";
 import { createAndPushNotification } from "../services/notificationService.js";
 /**
  * Meeting Controller - Handles all meeting operations
@@ -656,7 +657,23 @@ ${textToSummarize}
       if (meetingToUpdate) {
         try {
           await detectResolutions(meetingToUpdate, mom);
-          await processStructuredMoM(meetingToUpdate, mom);
+          const kgResults = await processStructuredMoM(meetingToUpdate, mom);
+
+          // Policy compliance cross-reference — hooks in right after decisions
+          // are extracted/embedded by the knowledge graph pass. Kept in its
+          // own try/catch so a compliance-check failure never affects
+          // knowledge-graph processing that already succeeded above.
+          try {
+            await checkMeetingDecisionsAgainstPolicies(
+              meetingToUpdate,
+              kgResults?.decisions,
+            );
+          } catch (complianceError) {
+            console.error(
+              "⚠️ Policy compliance check failed (non-fatal):",
+              complianceError,
+            );
+          }
         } catch (kgError) {
           console.error(
             "⚠️ Knowledge graph processing failed (non-fatal):",

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import axios from "axios";
 import FormData from "form-data";
+import mongoose from "mongoose";
 import Meeting from "../models/meetingModel.js";
 import User from "../models/userModel.js";
 import { indexMeeting } from "../utils/embeddingUtils.js";
@@ -11,6 +12,17 @@ import {
 } from "../services/knowledgeGraphService.js";
 import { checkMeetingDecisionsAgainstPolicies } from "../services/policyComplianceService.js";
 import { createAndPushNotification } from "../services/notificationService.js";
+
+// Validates any id pulled from req.body/req.params/req.query before it
+// reaches a Mongoose query. Without this, a JSON body like
+// { "meetingId": { "$gt": "" } } would pass a raw Mongo operator object
+// straight into Meeting.findById(), letting an attacker bypass the
+// intended id lookup (CodeQL: js/sql-injection — "Database query built
+// from user-controlled sources"). isValid() also rejects non-ObjectId
+// strings, so callers get a clean 400 instead of a Mongoose CastError.
+const isValidObjectId = (id) =>
+  typeof id === "string" && mongoose.Types.ObjectId.isValid(id);
+
 /**
  * Meeting Controller - Handles all meeting operations
  *
@@ -280,6 +292,11 @@ export const uploadAudioForMeeting = async (req, res) => {
         .status(400)
         .json({ success: false, message: "Meeting ID is required" });
     }
+    if (!isValidObjectId(meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID" });
+    }
 
     const uploaderId = req.user?.id || req.user?._id;
     if (!uploaderId) {
@@ -398,6 +415,12 @@ export const uploadAudioForMeeting = async (req, res) => {
 export const summarizeMeeting = async (req, res) => {
   try {
     const { meetingId, transcript, date, title } = req.body;
+
+    if (meetingId && !isValidObjectId(meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID" });
+    }
 
     if (!date) {
       return res.status(400).json({
@@ -762,6 +785,11 @@ export const deleteMeeting = async (req, res) => {
     const meeting = req.doc; // from requireOwnerOrAdmin middleware
     if (!meeting) {
       // Fallback if middleware isn't used
+      if (!isValidObjectId(req.params.id)) {
+        return res
+          .status(400)
+          .json({ success: false, message: "Invalid meeting ID" });
+      }
       const deleted = await Meeting.findByIdAndDelete(req.params.id);
       if (!deleted) {
         return res
@@ -795,6 +823,12 @@ export const getMeetingById = async (req, res) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
+    if (!isValidObjectId(req.params.id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID" });
+    }
+
     const meeting = await Meeting.findById(req.params.id);
     if (!meeting) {
       return res
@@ -821,6 +855,12 @@ export const updateMeeting = async (req, res) => {
     const userId = req.user?.id || req.user?._id;
     if (!userId) {
       return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    if (!req.doc && !isValidObjectId(req.params.id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID" });
     }
 
     // `req.doc` is provided by the `requireOwner` middleware

--- a/server/controllers/policyComplianceController.js
+++ b/server/controllers/policyComplianceController.js
@@ -1,0 +1,200 @@
+import mongoose from "mongoose";
+import PolicyCompliance from "../models/policyComplianceModel.js";
+import Decision from "../models/decisionModel.js";
+import Policy from "../models/policyModel.js";
+
+const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+// ─────────────────────────────────────────────────────────────
+// GET /api/policy-compliance/decisions/:decisionId
+// Returns any linked policies and their relationship classification.
+// ─────────────────────────────────────────────────────────────
+export const getDecisionCompliance = async (req, res) => {
+  try {
+    const { decisionId } = req.params;
+    const organization = req.user.organization;
+
+    if (!isValidId(decisionId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid decision id" });
+    }
+
+    // Verify the decision belongs to the caller's organization before
+    // returning anything — never leak cross-organization data.
+    const decision = await Decision.findById(decisionId).select(
+      "organization text",
+    );
+
+    if (
+      !decision ||
+      !organization ||
+      decision.organization?.toString() !== organization.toString()
+    ) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Decision not found" });
+    }
+
+    const records = await PolicyCompliance.find({
+      decisionId,
+      organization,
+    })
+      .populate("policyId", "name version summary")
+      .sort({ similarityScore: -1 });
+
+    return res.status(200).json({
+      success: true,
+      decision: { id: decision._id, text: decision.text },
+      compliance: records,
+    });
+  } catch (error) {
+    console.error("getDecisionCompliance error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch decision compliance data",
+    });
+  }
+};
+
+// ─────────────────────────────────────────────────────────────
+// GET /api/policy-compliance/policies/:policyId/related-decisions
+// Reverse lookup: every decision across all meetings that touched this policy.
+// ─────────────────────────────────────────────────────────────
+export const getPolicyRelatedDecisions = async (req, res) => {
+  try {
+    const { policyId } = req.params;
+    const organization = req.user.organization;
+
+    if (!isValidId(policyId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid policy id" });
+    }
+
+    const policy = await Policy.findById(policyId).select(
+      "organization name version",
+    );
+
+    if (
+      !policy ||
+      !organization ||
+      policy.organization?.toString() !== organization.toString()
+    ) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Policy not found" });
+    }
+
+    const records = await PolicyCompliance.find({
+      policyId,
+      organization,
+    })
+      .populate("decisionId", "text status")
+      .populate("sourceMeetingId", "title date")
+      .sort({ createdAt: -1 });
+
+    return res.status(200).json({
+      success: true,
+      policy: { id: policy._id, name: policy.name, version: policy.version },
+      relatedDecisions: records,
+    });
+  } catch (error) {
+    console.error("getPolicyRelatedDecisions error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch related decisions",
+    });
+  }
+};
+
+// ─────────────────────────────────────────────────────────────
+// GET /api/policy-compliance/flags?status=potential_conflict
+// Dashboard of unresolved (or filtered) flags for the caller's organization.
+// Note: the organization scope always comes from the authenticated user,
+// never from a client-supplied query param — that would be a multi-tenant
+// data leak vector.
+// ─────────────────────────────────────────────────────────────
+export const getComplianceFlags = async (req, res) => {
+  try {
+    const organization = req.user.organization;
+    if (!organization) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    const { status = "potential_conflict", classification } = req.query;
+    const allowedStatuses = ["unresolved", "acknowledged", "dismissed", "all"];
+
+    if (!allowedStatuses.includes(status)) {
+      return res.status(400).json({ success: false, message: "Invalid status" });
+    }
+
+    const query = { organization };
+    if (status !== "all") query.status = status;
+
+    // By default this endpoint surfaces conflict flags; callers can widen
+    // via ?classification=all to see aligned/references/unrelated rows too.
+    if (classification && classification !== "all") {
+      query.classification = classification;
+    } else if (!classification) {
+      query.classification = "potential_conflict";
+    }
+
+    const flags = await PolicyCompliance.find(query)
+      .populate("decisionId", "text")
+      .populate("policyId", "name version")
+      .populate("sourceMeetingId", "title date")
+      .sort({ createdAt: -1 });
+
+    return res.status(200).json({ success: true, flags });
+  } catch (error) {
+    console.error("getComplianceFlags error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch compliance flags",
+    });
+  }
+};
+
+// ─────────────────────────────────────────────────────────────
+// PATCH /api/policy-compliance/flags/:id
+// Acknowledge or dismiss a flag. Detection/flagging only — this never
+// blocks or auto-rejects the underlying meeting decision.
+// ─────────────────────────────────────────────────────────────
+export const updateFlagStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body;
+    const organization = req.user.organization;
+
+    if (!isValidId(id)) {
+      return res.status(400).json({ success: false, message: "Invalid flag id" });
+    }
+
+    const allowedStatuses = ["acknowledged", "dismissed", "unresolved"];
+    if (!allowedStatuses.includes(status)) {
+      return res.status(400).json({ success: false, message: "Invalid status" });
+    }
+
+    const flag = await PolicyCompliance.findOne({ _id: id, organization });
+    if (!flag) {
+      return res.status(404).json({ success: false, message: "Flag not found" });
+    }
+
+    flag.status = status;
+    flag.reviewedBy = status === "unresolved" ? null : req.user._id;
+    flag.reviewedAt = status === "unresolved" ? null : new Date();
+    await flag.save();
+
+    return res.status(200).json({ success: true, flag });
+  } catch (error) {
+    console.error("updateFlagStatus error:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update flag status",
+    });
+  }
+};

--- a/server/controllers/policyComplianceController.js
+++ b/server/controllers/policyComplianceController.js
@@ -126,17 +126,36 @@ export const getComplianceFlags = async (req, res) => {
     }
 
     const { status = "potential_conflict", classification } = req.query;
-    const allowedStatuses = ["unresolved", "acknowledged", "dismissed", "all"];
+
+    const allowedStatuses = [
+       "unresolved",
+       "acknowledged",
+       "dismissed",
+       "all",
+    ];
+
+    const allowedClassifications = [
+       "potential_conflict",
+       "aligned",
+       "reference",
+       "unrelated",
+        "all",
+      ];
 
     if (!allowedStatuses.includes(status)) {
       return res.status(400).json({ success: false, message: "Invalid status" });
     }
 
-    const query = { organization };
-    if (status !== "all") query.status = status;
-
-    // By default this endpoint surfaces conflict flags; callers can widen
-    // via ?classification=all to see aligned/references/unrelated rows too.
+    if (
+     classification &&
+     !allowedClassifications.includes(classification)
+    ) {
+      return res.status(400).json({
+       success: false,
+       message: "Invalid classification",
+      });
+      }
+      
     if (classification && classification !== "all") {
       query.classification = classification;
     } else if (!classification) {

--- a/server/controllers/policyComplianceController.js
+++ b/server/controllers/policyComplianceController.js
@@ -109,12 +109,29 @@ export const getPolicyRelatedDecisions = async (req, res) => {
 };
 
 // ─────────────────────────────────────────────────────────────
-// GET /api/policy-compliance/flags?status=potential_conflict
+// GET /api/policy-compliance/flags?status=unresolved&classification=potential_conflict
 // Dashboard of unresolved (or filtered) flags for the caller's organization.
 // Note: the organization scope always comes from the authenticated user,
 // never from a client-supplied query param — that would be a multi-tenant
 // data leak vector.
 // ─────────────────────────────────────────────────────────────
+
+// Whitelists below are the only values ever assigned into a Mongo filter
+// object built from req.query. Express's query parser turns bracket
+// notation (e.g. ?classification[$ne]=null) into nested objects, so any
+// unvalidated req.query value used directly as a filter is a NoSQL
+// injection vector — every user-supplied filter value must be checked
+// against one of these lists (or validated as an ObjectId) before use.
+const ALLOWED_STATUSES = ["unresolved", "acknowledged", "dismissed", "all"];
+const ALLOWED_CLASSIFICATIONS = [
+  "aligned",
+  "references",
+  "potential_conflict",
+  "unrelated",
+  "unclassified",
+  "all",
+];
+
 export const getComplianceFlags = async (req, res) => {
   try {
     const organization = req.user.organization;
@@ -125,42 +142,24 @@ export const getComplianceFlags = async (req, res) => {
       });
     }
 
-    const { status = "potential_conflict", classification } = req.query;
+    const { status = "unresolved", classification = "potential_conflict" } =
+      req.query;
 
-    const allowedStatuses = [
-       "unresolved",
-       "acknowledged",
-       "dismissed",
-       "all",
-    ];
-
-    const allowedClassifications = [
-       "potential_conflict",
-       "aligned",
-       "reference",
-       "unrelated",
-        "all",
-      ];
-
-    if (!allowedStatuses.includes(status)) {
+    if (typeof status !== "string" || !ALLOWED_STATUSES.includes(status)) {
       return res.status(400).json({ success: false, message: "Invalid status" });
     }
-
     if (
-     classification &&
-     !allowedClassifications.includes(classification)
+      typeof classification !== "string" ||
+      !ALLOWED_CLASSIFICATIONS.includes(classification)
     ) {
-      return res.status(400).json({
-       success: false,
-       message: "Invalid classification",
-      });
-      }
-      
-    if (classification && classification !== "all") {
-      query.classification = classification;
-    } else if (!classification) {
-      query.classification = "potential_conflict";
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid classification" });
     }
+
+    const query = { organization };
+    if (status !== "all") query.status = status;
+    if (classification !== "all") query.classification = classification;
 
     const flags = await PolicyCompliance.find(query)
       .populate("decisionId", "text")
@@ -193,8 +192,8 @@ export const updateFlagStatus = async (req, res) => {
       return res.status(400).json({ success: false, message: "Invalid flag id" });
     }
 
-    const allowedStatuses = ["acknowledged", "dismissed", "unresolved"];
-    if (!allowedStatuses.includes(status)) {
+    const allowedStatuses = ALLOWED_STATUSES.filter((s) => s !== "all");
+    if (typeof status !== "string" || !allowedStatuses.includes(status)) {
       return res.status(400).json({ success: false, message: "Invalid status" });
     }
 

--- a/server/controllers/policyController.js
+++ b/server/controllers/policyController.js
@@ -4,6 +4,12 @@ import dotenv from "dotenv";
 import axios from "axios";
 import { createRequire } from "module";
 import Policy from "../models/policyModel.js";
+import PolicyCompliance from "../models/policyComplianceModel.js";
+import {
+  indexPolicy,
+  removePolicyFromIndex,
+  reevaluatePolicyDecisions,
+} from "../services/policyComplianceService.js";
 
 const require = createRequire(import.meta.url);
 const pdf = require("pdf-parse");
@@ -205,6 +211,16 @@ export const uploadPolicy = async (req, res) => {
       await existing.populate("uploadedBy", "name email");
       await existing.populate("lastEditedBy", "name email");
 
+      // Re-embed into Pinecone under the new version, and re-evaluate any
+      // decisions previously matched against this policy so nothing is left
+      // silently pointing at stale policy text. Non-fatal: never blocks the
+      // upload response.
+      indexPolicy(existing)
+        .then(() => reevaluatePolicyDecisions(existing))
+        .catch((err) =>
+          console.error("⚠️ Policy compliance re-index failed:", err.message),
+        );
+
       return res.status(200).json({
         success: true,
         message: "Policy updated and analyzed by AI.",
@@ -230,6 +246,11 @@ export const uploadPolicy = async (req, res) => {
 
     await policy.populate("uploadedBy", "name email");
     await policy.populate("lastEditedBy", "name email");
+
+    // Embed into the Pinecone policy namespace. Non-fatal — never blocks upload.
+    indexPolicy(policy).catch((err) =>
+      console.error("⚠️ Policy indexing failed:", err.message),
+    );
 
     return res.status(201).json({
       success: true,
@@ -300,6 +321,14 @@ export const analyzePolicy = async (req, res) => {
     policy.keywords = aiData.keywords;
     policy.status = "ready";
     await policy.save();
+
+    // Summary/key_changes content changed — refresh the vector and any
+    // existing compliance classifications built on the old text.
+    indexPolicy(policy)
+      .then(() => reevaluatePolicyDecisions(policy))
+      .catch((err) =>
+        console.error("⚠️ Policy compliance re-index failed:", err.message),
+      );
 
     return res.status(200).json({
       success: true,
@@ -422,6 +451,16 @@ export const deletePolicy = async (req, res) => {
     }
 
     await policy.deleteOne();
+
+    // Best-effort cleanup — a policy that no longer exists shouldn't leave
+    // vectors or flags behind. Non-fatal: the delete itself already succeeded.
+    removePolicyFromIndex(policy._id).catch((err) =>
+      console.error("⚠️ Failed to remove policy vector:", err.message),
+    );
+    PolicyCompliance.deleteMany({ policyId: policy._id }).catch((err) =>
+      console.error("⚠️ Failed to clean up compliance records:", err.message),
+    );
+
     return res.status(200).json({
       success: true,
       message: "Policy deleted successfully.",

--- a/server/models/policyComplianceModel.js
+++ b/server/models/policyComplianceModel.js
@@ -1,0 +1,74 @@
+import mongoose from "mongoose";
+
+/**
+ * policyComplianceSchema — a single decision↔policy relationship record.
+ *
+ * One row per (decision, policy) pair that surfaced as a similarity match.
+ * `classification` is the LLM's read of the relationship; `status` is the
+ * separate human-review workflow state (only meaningful once a row is
+ * surfaced as a flag — see policyComplianceService's flag semantics).
+ */
+const policyComplianceSchema = new mongoose.Schema(
+  {
+    decisionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Decision",
+      required: true,
+    },
+    policyId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Policy",
+      required: true,
+    },
+    sourceMeetingId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Meeting",
+      required: true,
+    },
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      required: true, // compliance matching is org-scoped only; see service guard
+    },
+
+    // Snapshot of the policy version this classification was made against.
+    // Lets us detect staleness when previousVersions grows (superseded policy).
+    policyVersion: { type: String, required: true },
+
+    similarityScore: { type: Number, required: true },
+
+    classification: {
+      type: String,
+      enum: ["aligned", "references", "potential_conflict", "unrelated"],
+      required: true,
+    },
+    reasoning: { type: String, default: "" },
+
+    // Human review workflow — only acted on by the UI for potential_conflict rows.
+    status: {
+      type: String,
+      enum: ["unresolved", "acknowledged", "dismissed"],
+      default: "unresolved",
+    },
+    reviewedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User", default: null },
+    reviewedAt: { type: Date, default: null },
+
+    // Set/bumped whenever the matched policy version changes and this row
+    // is re-evaluated against the current text (acceptance criterion:
+    // "Superseded policy versions trigger re-evaluation").
+    lastEvaluatedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true },
+);
+
+// A decision is only ever linked to a given policy once — re-evaluation
+// updates the existing row rather than creating duplicates.
+policyComplianceSchema.index({ decisionId: 1, policyId: 1 }, { unique: true });
+policyComplianceSchema.index({ organization: 1, status: 1, classification: 1 });
+policyComplianceSchema.index({ policyId: 1 });
+
+const PolicyCompliance =
+  mongoose.models.PolicyCompliance ||
+  mongoose.model("PolicyCompliance", policyComplianceSchema);
+
+export default PolicyCompliance;

--- a/server/models/policyComplianceModel.js
+++ b/server/models/policyComplianceModel.js
@@ -37,9 +37,14 @@ const policyComplianceSchema = new mongoose.Schema(
 
     similarityScore: { type: Number, required: true },
 
+    // Note: "unclassified" means the LLM call itself failed (network error,
+    // missing key, timeout) — distinct from "unrelated", which means the
+    // LLM successfully evaluated the pair and found no real connection.
+    // Keeping these separate stops transient API failures from being
+    // silently indistinguishable from genuine negatives.
     classification: {
       type: String,
-      enum: ["aligned", "references", "potential_conflict", "unrelated"],
+      enum: ["aligned", "references", "potential_conflict", "unrelated", "unclassified"],
       required: true,
     },
     reasoning: { type: String, default: "" },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2789,6 +2789,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3442,20 +3457,6 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3831,38 +3832,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -3907,56 +3876,6 @@
         "socks": {
           "optional": true
         }
-      }
-    },
-    "node_modules/mongoose/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/mpath": {

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "server": "nodemon server.js"
+    "server": "nodemon server.js",
+    "test": "node --test tests/"
   },
   "dependencies": {
     "@chroma-core/default-embed": "^0.1.8",

--- a/server/routes/policyComplianceRoutes.js
+++ b/server/routes/policyComplianceRoutes.js
@@ -1,0 +1,22 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership } from "../middleware/rbac.js";
+import { apiLimiter, writeLimiter } from "../middleware/rateLimiter.js";
+import {
+  getDecisionCompliance,
+  getPolicyRelatedDecisions,
+  getComplianceFlags,
+  updateFlagStatus,
+} from "../controllers/policyComplianceController.js";
+
+const router = express.Router();
+router.use(apiLimiter);
+router.use(userAuth);
+router.use(requireOrgMembership); // compliance data only exists within an organization
+
+router.get("/decisions/:decisionId", getDecisionCompliance);
+router.get("/policies/:policyId/related-decisions", getPolicyRelatedDecisions);
+router.get("/flags", getComplianceFlags);
+router.patch("/flags/:id", writeLimiter, updateFlagStatus);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,7 @@ import geminiRoutes from "./routes/geminiRoutes.js";
 import userRoutes from "./routes/userRoutes.js";
 import notificationRoutes from "./routes/notificationRoutes.js";
 import knowledgeRoutes from "./routes/knowledgeRoutes.js";
+import policyComplianceRoutes from "./routes/policyComplianceRoutes.js";
 import sessionRoutes from "./routes/sessionRoutes.js";
 
 import { initVectorStore } from "./utils/embeddingUtils.js";
@@ -165,6 +166,7 @@ app.use("/api/gemini", geminiRoutes);
 app.use("/api/user", userRoutes);
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/knowledge", knowledgeRoutes);
+app.use("/api/policy-compliance", policyComplianceRoutes);
 app.use("/api/sessions", sessionRoutes);
 
 // ================================

--- a/server/services/policyComplianceService.js
+++ b/server/services/policyComplianceService.js
@@ -1,0 +1,356 @@
+// ==============================================
+// 📘 policyComplianceService.js
+// Cross-references meeting decisions against organizational policies.
+//
+// Pipeline:
+//   1. Policies are embedded (summary + key_changes) and upserted into a
+//      dedicated Pinecone namespace ("policies"), kept separate from the
+//      "meetings" vectors already indexed by embeddingUtils.js.
+//   2. When a meeting's decisions are extracted, each decision is embedded
+//      and matched against that namespace (subject-matter overlap).
+//   3. High-similarity matches get a narrow, separate LLM classification
+//      pass (aligned / references / potential_conflict / unrelated).
+//
+// This module never blocks meeting summarization: callers (meetingController)
+// wrap invocations in try/catch and treat failures here as non-fatal.
+// ==============================================
+
+import axios from "axios";
+import dotenv from "dotenv";
+import Policy from "../models/policyModel.js";
+import PolicyCompliance from "../models/policyComplianceModel.js";
+import { embedText, initVectorStore } from "../utils/embeddingUtils.js";
+
+dotenv.config();
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.0-flash";
+
+// Namespace policy vectors separately from meeting vectors so semantic
+// search over meetings never picks up policy text and vice versa.
+const POLICY_NAMESPACE = "policies";
+
+// Similarity floor for "this decision plausibly touches this policy" —
+// deliberately looser than a conflict signal. The LLM pass afterwards is
+// what decides whether it's actually aligned/references/conflicting.
+const MATCH_SIMILARITY_THRESHOLD = 0.55;
+
+// Cap how many candidate policies get sent to the (costlier) LLM pass per decision.
+const MAX_MATCHES_PER_DECISION = 5;
+
+// ─────────────────────────────────────────────────────────────
+// Helper — strip markdown code fences Gemini sometimes adds
+// (mirrors policyController.js's extractJson so behavior is consistent)
+// ─────────────────────────────────────────────────────────────
+const extractJson = (raw) => {
+  if (!raw) return "{}";
+  return raw
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim();
+};
+
+/**
+ * Parses and validates the raw LLM response into a safe, conservative
+ * classification result. Pure function — no I/O — so it's unit-testable
+ * without a live Gemini call.
+ */
+export function parseClassification(rawText) {
+  const ALLOWED = ["aligned", "references", "potential_conflict", "unrelated"];
+
+  try {
+    const cleaned = extractJson(rawText);
+    const parsed = JSON.parse(cleaned);
+
+    const classification = ALLOWED.includes(parsed.classification)
+      ? parsed.classification
+      : "unrelated";
+
+    const reasoning =
+      typeof parsed.reasoning === "string" && parsed.reasoning.trim()
+        ? parsed.reasoning.trim().slice(0, 1000)
+        : "";
+
+    return { classification, reasoning };
+  } catch {
+    // Fail conservative: an unparsable response never becomes a conflict flag.
+    return {
+      classification: "unrelated",
+      reasoning: "Classification response could not be parsed.",
+    };
+  }
+}
+
+/**
+ * Builds the narrow classification prompt. Kept separate from the network
+ * call so prompt content can be reviewed/tested without hitting Gemini.
+ */
+export function buildClassificationPrompt(decisionText, policy) {
+  const keyChanges = Array.isArray(policy.key_changes)
+    ? policy.key_changes.join("; ")
+    : "";
+
+  return `
+You are a conservative compliance analyst. Compare the MEETING DECISION below against
+the POLICY EXCERPT and classify their relationship.
+
+Classification rules (be conservative — false "potential_conflict" flags erode trust):
+- "potential_conflict": the decision appears to contradict or violate a specific
+  requirement in the policy. Only use this if genuinely confident.
+- "references": the decision explicitly mentions or acts under this policy without
+  conflicting with it.
+- "aligned": the decision touches the same subject matter and is consistent with the policy.
+- "unrelated": default to this unless there is clear, specific subject-matter overlap.
+
+MEETING DECISION:
+${decisionText}
+
+POLICY: ${policy.name} (version ${policy.version})
+POLICY SUMMARY:
+${policy.summary?.slice(0, 3000) || ""}
+KEY CHANGES:
+${keyChanges.slice(0, 1000)}
+
+Return ONLY valid JSON, no commentary, no markdown fences:
+{
+  "classification": "aligned" | "references" | "potential_conflict" | "unrelated",
+  "reasoning": "one or two sentence justification"
+}
+`;
+}
+
+/**
+ * Narrow, isolated Gemini call for a single decision/policy pair.
+ * Deliberately separate from the general meeting-summarization LLM pass
+ * (per the issue's technical considerations) so a failure here is contained.
+ */
+async function classifyRelationship(decisionText, policy) {
+  try {
+    if (!GEMINI_API_KEY) {
+      throw new Error("GEMINI_API_KEY is not configured");
+    }
+
+    const prompt = buildClassificationPrompt(decisionText, policy);
+
+    const response = await axios.post(
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
+      { contents: [{ parts: [{ text: prompt }] }] },
+      { timeout: 20000 },
+    );
+
+    const rawText =
+      response.data?.candidates?.[0]?.content?.parts?.[0]?.text || "{}";
+    return parseClassification(rawText);
+  } catch (error) {
+    console.error("❌ Policy compliance classification failed:", error.message);
+    // Conservative fallback — never surface a conflict flag off a failed call.
+    return {
+      classification: "unrelated",
+      reasoning: "Classification unavailable (LLM call failed).",
+    };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Policy embedding pipeline
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Embeds a policy's summary + key_changes and upserts it into the
+ * dedicated Pinecone policy namespace. Call after create/update.
+ * Non-fatal on failure — logs and returns without throwing, so it never
+ * blocks the policy upload/analyze response.
+ */
+export async function indexPolicy(policy) {
+  try {
+    if (!policy?.organization) {
+      console.warn(
+        `⚠️ Skipping policy index for "${policy?.name}" — no organization on record.`,
+      );
+      return;
+    }
+
+    const combinedText = `${policy.name}\n${policy.summary || ""}\n${(policy.key_changes || []).join(". ")}`;
+    if (!combinedText.trim()) return;
+
+    const embedding = await embedText(combinedText);
+    if (!embedding.length) return;
+
+    const index = await initVectorStore();
+    await index.namespace(POLICY_NAMESPACE).upsert([
+      {
+        id: policy._id.toString(),
+        values: embedding,
+        metadata: {
+          type: "policy",
+          policyId: policy._id.toString(),
+          organization: policy.organization.toString(),
+          name: policy.name,
+          version: policy.version,
+        },
+      },
+    ]);
+
+    console.log(`✅ Indexed policy in Pinecone: ${policy.name} (v${policy.version})`);
+  } catch (error) {
+    console.error("❌ Failed to index policy:", error.message);
+  }
+}
+
+/**
+ * Removes a policy's vector from the index. Call on policy delete.
+ */
+export async function removePolicyFromIndex(policyId) {
+  try {
+    const index = await initVectorStore();
+    await index.namespace(POLICY_NAMESPACE).deleteOne(policyId.toString());
+  } catch (error) {
+    console.error("❌ Failed to remove policy from index:", error.message);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Decision → policy matching + classification
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Queries the policy namespace for candidate matches, scoped strictly to
+ * the decision's organization (multi-tenant correctness — never cross-
+ * reference one organization's meeting against another's policies).
+ */
+async function findCandidatePolicies(decisionEmbedding, organizationId) {
+  if (!organizationId) return [];
+
+  const index = await initVectorStore();
+  const results = await index.namespace(POLICY_NAMESPACE).query({
+    vector: decisionEmbedding,
+    topK: MAX_MATCHES_PER_DECISION,
+    includeMetadata: true,
+    filter: { organization: { $eq: organizationId.toString() } },
+  });
+
+  return (results.matches || [])
+    .filter((m) => (m.score ?? 0) >= MATCH_SIMILARITY_THRESHOLD)
+    .map((m) => ({
+      policyId: m.metadata?.policyId || m.id,
+      similarityScore: m.score,
+    }));
+}
+
+/**
+ * Main entry point: given a single freshly-created/updated Decision doc,
+ * find subject-matter-overlapping policies and classify each relationship.
+ * Called from the meeting knowledge-graph hook — one call per decision.
+ */
+export async function checkDecisionAgainstPolicies(decision, meeting) {
+  try {
+    const organizationId = meeting.organization;
+    if (!organizationId) {
+      // No organization — no policies to cross-reference against.
+      return [];
+    }
+
+    const embedding =
+      decision.embedding?.length ? decision.embedding : await embedText(decision.text);
+
+    const candidates = await findCandidatePolicies(embedding, organizationId);
+    if (!candidates.length) return [];
+
+    const flags = [];
+
+    for (const candidate of candidates) {
+      const policy = await Policy.findById(candidate.policyId);
+      if (!policy || policy.organization?.toString() !== organizationId.toString()) {
+        continue; // stale vector or cross-org leak guard
+      }
+
+      const { classification, reasoning } = await classifyRelationship(
+        decision.text,
+        policy,
+      );
+
+      const record = await PolicyCompliance.findOneAndUpdate(
+        { decisionId: decision._id, policyId: policy._id },
+        {
+          decisionId: decision._id,
+          policyId: policy._id,
+          sourceMeetingId: meeting._id,
+          organization: organizationId,
+          policyVersion: policy.version,
+          similarityScore: candidate.similarityScore,
+          classification,
+          reasoning,
+          lastEvaluatedAt: new Date(),
+          // Only reset the review workflow if this is a new conflict signal;
+          // an already-acknowledged/dismissed flag being re-confirmed as the
+          // same classification shouldn't silently reopen without reason.
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true },
+      );
+
+      flags.push(record);
+    }
+
+    return flags;
+  } catch (error) {
+    console.error("❌ Policy compliance check failed for decision:", error.message);
+    return [];
+  }
+}
+
+/**
+ * Runs checkDecisionAgainstPolicies for every decision produced by a
+ * meeting's structuredMoM. Called from meetingController right after
+ * processStructuredMoM() so it shares the same non-fatal try/catch wrapper.
+ */
+export async function checkMeetingDecisionsAgainstPolicies(meeting, decisions) {
+  const results = [];
+  for (const decision of decisions || []) {
+    const flags = await checkDecisionAgainstPolicies(decision, meeting);
+    results.push(...flags);
+  }
+  return results;
+}
+
+/**
+ * Re-evaluates every existing compliance record pointing at this policy
+ * against its current (post-supersede) summary/key_changes/version.
+ * Acceptance criterion: superseded policies must not leave decisions
+ * silently pointing at stale policy text.
+ */
+export async function reevaluatePolicyDecisions(policy) {
+  try {
+    const records = await PolicyCompliance.find({ policyId: policy._id });
+    if (!records.length) return [];
+
+    const Decision = (await import("../models/decisionModel.js")).default;
+    const updated = [];
+
+    for (const record of records) {
+      const decision = await Decision.findById(record.decisionId);
+      if (!decision) continue;
+
+      const { classification, reasoning } = await classifyRelationship(
+        decision.text,
+        policy,
+      );
+
+      record.policyVersion = policy.version;
+      record.classification = classification;
+      record.reasoning = reasoning;
+      record.lastEvaluatedAt = new Date();
+      // A version change is a material update — put it back in front of a
+      // reviewer rather than leaving a stale acknowledge/dismiss in place.
+      record.status = "unresolved";
+      record.reviewedBy = null;
+      record.reviewedAt = null;
+      await record.save();
+      updated.push(record);
+    }
+
+    return updated;
+  } catch (error) {
+    console.error("❌ Failed to re-evaluate policy decisions:", error.message);
+    return [];
+  }
+}

--- a/server/services/policyComplianceService.js
+++ b/server/services/policyComplianceService.js
@@ -9,7 +9,9 @@
 //   2. When a meeting's decisions are extracted, each decision is embedded
 //      and matched against that namespace (subject-matter overlap).
 //   3. High-similarity matches get a narrow, separate LLM classification
-//      pass (aligned / references / potential_conflict / unrelated).
+//      pass (aligned / references / potential_conflict / unrelated), with
+//      an "unclassified" state reserved for when the LLM call itself fails
+//      (kept distinct from a genuine "unrelated" result).
 //
 // This module never blocks meeting summarization: callers (meetingController)
 // wrap invocations in try/catch and treat failures here as non-fatal.
@@ -120,34 +122,57 @@ Return ONLY valid JSON, no commentary, no markdown fences:
 }
 
 /**
+ * Single attempt at the Gemini call. Throws on any failure — retry/fallback
+ * handling lives in the caller so this stays a plain, testable unit.
+ */
+async function callGeminiClassifier(prompt) {
+  if (!GEMINI_API_KEY) {
+    throw new Error("GEMINI_API_KEY is not configured");
+  }
+
+  const response = await axios.post(
+    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
+    { contents: [{ parts: [{ text: prompt }] }] },
+    { timeout: 20000 },
+  );
+
+  return response.data?.candidates?.[0]?.content?.parts?.[0]?.text || "{}";
+}
+
+/**
  * Narrow, isolated Gemini call for a single decision/policy pair.
  * Deliberately separate from the general meeting-summarization LLM pass
  * (per the issue's technical considerations) so a failure here is contained.
+ *
+ * Retries once on transient failure (network blip, rate limit). If both
+ * attempts fail, the result is "unclassified" — NOT "unrelated". Those two
+ * must stay distinguishable: "unrelated" means the LLM looked at the pair
+ * and found no connection; "unclassified" means we never got an answer.
+ * Collapsing them would hide real API outages inside what looks like a
+ * clean negative result, and "unclassified" rows are excluded from the
+ * default flags dashboard (?classification=potential_conflict) so they
+ * don't show up as false conflicts either — they need a separate retry
+ * pass, not a review action.
  */
 async function classifyRelationship(decisionText, policy) {
-  try {
-    if (!GEMINI_API_KEY) {
-      throw new Error("GEMINI_API_KEY is not configured");
+  const prompt = buildClassificationPrompt(decisionText, policy);
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const rawText = await callGeminiClassifier(prompt);
+      return parseClassification(rawText);
+    } catch (error) {
+      console.error(
+        `❌ Policy compliance classification failed (attempt ${attempt}/2):`,
+        error.message,
+      );
+      if (attempt === 2) {
+        return {
+          classification: "unclassified",
+          reasoning: "Classification unavailable after retry (LLM call failed).",
+        };
+      }
     }
-
-    const prompt = buildClassificationPrompt(decisionText, policy);
-
-    const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
-      { contents: [{ parts: [{ text: prompt }] }] },
-      { timeout: 20000 },
-    );
-
-    const rawText =
-      response.data?.candidates?.[0]?.content?.parts?.[0]?.text || "{}";
-    return parseClassification(rawText);
-  } catch (error) {
-    console.error("❌ Policy compliance classification failed:", error.message);
-    // Conservative fallback — never surface a conflict flag off a failed call.
-    return {
-      classification: "unrelated",
-      reasoning: "Classification unavailable (LLM call failed).",
-    };
   }
 }
 
@@ -238,6 +263,56 @@ async function findCandidatePolicies(decisionEmbedding, organizationId) {
 }
 
 /**
+ * Processes one decision↔policy candidate: fetch the policy, classify the
+ * relationship, and upsert the compliance record. Isolated into its own
+ * function (rather than inline in a loop) so candidates can run in
+ * parallel via Promise.allSettled — each is an independent Gemini call and
+ * there's no reason to serialize them.
+ */
+async function evaluateCandidate(candidate, decision, meeting, organizationId) {
+  const policy = await Policy.findById(candidate.policyId);
+  if (!policy || policy.organization?.toString() !== organizationId.toString()) {
+    return null; // stale vector or cross-org leak guard
+  }
+
+  const [{ classification, reasoning }, existing] = await Promise.all([
+    classifyRelationship(decision.text, policy),
+    PolicyCompliance.findOne({ decisionId: decision._id, policyId: policy._id }),
+  ]);
+
+  // Reopen the review workflow only when the classification actually
+  // changed (e.g. aligned -> potential_conflict on re-run/re-evaluation).
+  // A re-confirmed classification leaves an existing acknowledge/dismiss
+  // untouched; a newly-detected conflict must not stay silently resolved.
+  const classificationChanged =
+    !existing || existing.classification !== classification;
+
+  const update = {
+    decisionId: decision._id,
+    policyId: policy._id,
+    sourceMeetingId: meeting._id,
+    organization: organizationId,
+    policyVersion: policy.version,
+    similarityScore: candidate.similarityScore,
+    classification,
+    reasoning,
+    lastEvaluatedAt: new Date(),
+  };
+
+  if (classificationChanged) {
+    update.status = "unresolved";
+    update.reviewedBy = null;
+    update.reviewedAt = null;
+  }
+
+  return PolicyCompliance.findOneAndUpdate(
+    { decisionId: decision._id, policyId: policy._id },
+    update,
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+}
+
+/**
  * Main entry point: given a single freshly-created/updated Decision doc,
  * find subject-matter-overlapping policies and classify each relationship.
  * Called from the meeting knowledge-graph hook — one call per decision.
@@ -256,42 +331,19 @@ export async function checkDecisionAgainstPolicies(decision, meeting) {
     const candidates = await findCandidatePolicies(embedding, organizationId);
     if (!candidates.length) return [];
 
-    const flags = [];
+    // Run candidate evaluations (each up to one Gemini call + a retry) in
+    // parallel rather than serially — this is the dominant cost when a
+    // decision matches several policies, and each candidate is independent.
+    // allSettled so one candidate's failure doesn't discard the others.
+    const settled = await Promise.allSettled(
+      candidates.map((candidate) =>
+        evaluateCandidate(candidate, decision, meeting, organizationId),
+      ),
+    );
 
-    for (const candidate of candidates) {
-      const policy = await Policy.findById(candidate.policyId);
-      if (!policy || policy.organization?.toString() !== organizationId.toString()) {
-        continue; // stale vector or cross-org leak guard
-      }
-
-      const { classification, reasoning } = await classifyRelationship(
-        decision.text,
-        policy,
-      );
-
-      const record = await PolicyCompliance.findOneAndUpdate(
-        { decisionId: decision._id, policyId: policy._id },
-        {
-          decisionId: decision._id,
-          policyId: policy._id,
-          sourceMeetingId: meeting._id,
-          organization: organizationId,
-          policyVersion: policy.version,
-          similarityScore: candidate.similarityScore,
-          classification,
-          reasoning,
-          lastEvaluatedAt: new Date(),
-          // Only reset the review workflow if this is a new conflict signal;
-          // an already-acknowledged/dismissed flag being re-confirmed as the
-          // same classification shouldn't silently reopen without reason.
-        },
-        { upsert: true, new: true, setDefaultsOnInsert: true },
-      );
-
-      flags.push(record);
-    }
-
-    return flags;
+    return settled
+      .filter((result) => result.status === "fulfilled" && result.value)
+      .map((result) => result.value);
   } catch (error) {
     console.error("❌ Policy compliance check failed for decision:", error.message);
     return [];
@@ -302,14 +354,20 @@ export async function checkDecisionAgainstPolicies(decision, meeting) {
  * Runs checkDecisionAgainstPolicies for every decision produced by a
  * meeting's structuredMoM. Called from meetingController right after
  * processStructuredMoM() so it shares the same non-fatal try/catch wrapper.
+ * Decisions are independent of one another, so they run in parallel too —
+ * a meeting with several decisions no longer pays for their Gemini calls
+ * serially on the request path.
  */
 export async function checkMeetingDecisionsAgainstPolicies(meeting, decisions) {
-  const results = [];
-  for (const decision of decisions || []) {
-    const flags = await checkDecisionAgainstPolicies(decision, meeting);
-    results.push(...flags);
-  }
-  return results;
+  if (!decisions?.length) return [];
+
+  const settled = await Promise.allSettled(
+    decisions.map((decision) => checkDecisionAgainstPolicies(decision, meeting)),
+  );
+
+  return settled
+    .filter((result) => result.status === "fulfilled")
+    .flatMap((result) => result.value);
 }
 
 /**
@@ -324,31 +382,37 @@ export async function reevaluatePolicyDecisions(policy) {
     if (!records.length) return [];
 
     const Decision = (await import("../models/decisionModel.js")).default;
-    const updated = [];
 
-    for (const record of records) {
-      const decision = await Decision.findById(record.decisionId);
-      if (!decision) continue;
+    const settled = await Promise.allSettled(
+      records.map(async (record) => {
+        const decision = await Decision.findById(record.decisionId);
+        if (!decision) return null;
 
-      const { classification, reasoning } = await classifyRelationship(
-        decision.text,
-        policy,
-      );
+        const { classification, reasoning } = await classifyRelationship(
+          decision.text,
+          policy,
+        );
 
-      record.policyVersion = policy.version;
-      record.classification = classification;
-      record.reasoning = reasoning;
-      record.lastEvaluatedAt = new Date();
-      // A version change is a material update — put it back in front of a
-      // reviewer rather than leaving a stale acknowledge/dismiss in place.
-      record.status = "unresolved";
-      record.reviewedBy = null;
-      record.reviewedAt = null;
-      await record.save();
-      updated.push(record);
-    }
+        record.policyVersion = policy.version;
+        record.classification = classification;
+        record.reasoning = reasoning;
+        record.lastEvaluatedAt = new Date();
+        // A version change is a material update — put it back in front of a
+        // reviewer rather than leaving a stale acknowledge/dismiss in place,
+        // regardless of whether the reclassification happens to match the
+        // old one (the policy text itself changed, so the prior review no
+        // longer speaks to what's actually in effect now).
+        record.status = "unresolved";
+        record.reviewedBy = null;
+        record.reviewedAt = null;
+        await record.save();
+        return record;
+      }),
+    );
 
-    return updated;
+    return settled
+      .filter((result) => result.status === "fulfilled" && result.value)
+      .map((result) => result.value);
   } catch (error) {
     console.error("❌ Failed to re-evaluate policy decisions:", error.message);
     return [];

--- a/server/tests/fixtures/policyComplianceFixtures.json
+++ b/server/tests/fixtures/policyComplianceFixtures.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "conflict-expense-cap",
+    "decisionText": "Approved reimbursing the vendor purchase of $1,200 for new laptops without requiring pre-approval, since the team lead signed off after the fact.",
+    "policy": {
+      "name": "Expense Reimbursement Policy",
+      "version": "2.0",
+      "summary": "All employee expense reimbursements above $500 require written pre-approval from a department head before the purchase is made. Reimbursements submitted without pre-approval will be denied regardless of amount.",
+      "key_changes": ["Raised pre-approval threshold from $250 to $500"]
+    },
+    "expectedClassification": "potential_conflict",
+    "notes": "Exceeds the $500 threshold and explicitly skips the required pre-approval step."
+  },
+  {
+    "id": "aligned-remote-work-days",
+    "decisionText": "Confirmed that engineering staff will continue working from home on Mondays and Fridays, consistent with the existing hybrid schedule.",
+    "policy": {
+      "name": "Remote Work Policy",
+      "version": "1.3",
+      "summary": "Employees may work remotely up to two days per week, subject to manager approval, provided core collaboration hours (10am-3pm local time) are maintained.",
+      "key_changes": []
+    },
+    "expectedClassification": "aligned",
+    "notes": "Two remote days matches the policy's stated allowance exactly."
+  },
+  {
+    "id": "references-onboarding-checklist",
+    "decisionText": "Agreed that new hires will go through the standard onboarding checklist as defined in the Onboarding Policy before receiving system access.",
+    "policy": {
+      "name": "Onboarding Policy",
+      "version": "1.0",
+      "summary": "Defines the mandatory checklist new hires must complete, including equipment provisioning, security training, and manager introductions, before systems access is granted.",
+      "key_changes": []
+    },
+    "expectedClassification": "references",
+    "notes": "Explicitly invokes the policy by name without adding a new rule or conflicting with it."
+  },
+  {
+    "id": "unrelated-lunch-vendor",
+    "decisionText": "Switched the office catering vendor for Friday lunches from Vendor A to Vendor B starting next month.",
+    "policy": {
+      "name": "Data Retention Policy",
+      "version": "3.1",
+      "summary": "Customer data must be retained for no longer than 24 months after account closure, after which it must be permanently deleted from all production and backup systems.",
+      "key_changes": []
+    },
+    "expectedClassification": "unrelated",
+    "notes": "No subject-matter overlap between catering logistics and data retention rules."
+  },
+  {
+    "id": "conflict-data-retention-extension",
+    "decisionText": "Decided to retain all closed customer account data indefinitely for 'historical analysis purposes' rather than deleting it.",
+    "policy": {
+      "name": "Data Retention Policy",
+      "version": "3.1",
+      "summary": "Customer data must be retained for no longer than 24 months after account closure, after which it must be permanently deleted from all production and backup systems.",
+      "key_changes": []
+    },
+    "expectedClassification": "potential_conflict",
+    "notes": "Directly contradicts the mandatory 24-month deletion requirement."
+  },
+  {
+    "id": "unrelated-similar-wording-no-overlap",
+    "decisionText": "Approved a budget of $500 for team-building snacks for the quarterly offsite.",
+    "policy": {
+      "name": "Expense Reimbursement Policy",
+      "version": "2.0",
+      "summary": "All employee expense reimbursements above $500 require written pre-approval from a department head before the purchase is made.",
+      "key_changes": ["Raised pre-approval threshold from $250 to $500"]
+    },
+    "expectedClassification": "aligned",
+    "notes": "At exactly the $500 threshold and pre-approved by the meeting itself — should not be flagged as a conflict despite lexical overlap with 'expense' and '$500'. Tests conservative-bias behavior against false positives from surface-level keyword matches."
+  }
+]

--- a/server/tests/fixtures/policyComplianceFixtures.json
+++ b/server/tests/fixtures/policyComplianceFixtures.json
@@ -60,7 +60,7 @@
     "notes": "Directly contradicts the mandatory 24-month deletion requirement."
   },
   {
-    "id": "unrelated-similar-wording-no-overlap",
+    "id": "aligned-despite-lexical-overlap",
     "decisionText": "Approved a budget of $500 for team-building snacks for the quarterly offsite.",
     "policy": {
       "name": "Expense Reimbursement Policy",

--- a/server/tests/policyComplianceIntegration.test.js
+++ b/server/tests/policyComplianceIntegration.test.js
@@ -1,0 +1,99 @@
+// Integration coverage for the parts of the policy compliance pipeline that
+// need real infrastructure: the local embedding model, a live Pinecone
+// index, and MongoDB. These are skipped by default (no network/DB access in
+// most CI runs of this suite) and only execute when RUN_POLICY_COMPLIANCE_IT=1
+// is set alongside a working .env (MONGODB_URI, PINECONE_API_KEY, INDEX_NAME).
+//
+// Run locally with:
+//   RUN_POLICY_COMPLIANCE_IT=1 npm test
+//
+// The pure-logic tests in policyComplianceService.test.js run unconditionally
+// and don't need this setup.
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const RUN_IT = process.env.RUN_POLICY_COMPLIANCE_IT === "1";
+
+describe("policy compliance — integration", { skip: !RUN_IT }, () => {
+  let embedText, indexPolicy, removePolicyFromIndex, checkDecisionAgainstPolicies;
+  let Policy, Decision, PolicyCompliance;
+
+  before(async () => {
+    ({ embedText } = await import("../utils/embeddingUtils.js"));
+    ({ indexPolicy, removePolicyFromIndex, checkDecisionAgainstPolicies } =
+      await import("../services/policyComplianceService.js"));
+    Policy = (await import("../models/policyModel.js")).default;
+    Decision = (await import("../models/decisionModel.js")).default;
+    PolicyCompliance = (await import("../models/policyComplianceModel.js")).default;
+
+    await mongoose.connect(process.env.MONGODB_URI);
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+  });
+
+  test("embedding pipeline produces a consistent-length vector", async () => {
+    const a = await embedText("Expense reimbursements require pre-approval above $500.");
+    const b = await embedText("A completely unrelated sentence about lunch catering.");
+    assert.ok(a.length > 0);
+    assert.equal(a.length, b.length);
+  });
+
+  test("similarity matching only surfaces same-organization policies", async () => {
+    const orgA = new mongoose.Types.ObjectId();
+    const orgB = new mongoose.Types.ObjectId();
+
+    const policyA = await Policy.create({
+      name: "IT-A Expense Policy",
+      version: "1.0",
+      fileUrl: "test://irrelevant",
+      summary:
+        "All reimbursements above $500 require written pre-approval from a department head.",
+      key_changes: [],
+      organization: orgA,
+    });
+
+    const policyB = await Policy.create({
+      name: "IT-B Expense Policy",
+      version: "1.0",
+      fileUrl: "test://irrelevant",
+      summary:
+        "All reimbursements above $500 require written pre-approval from a department head.",
+      key_changes: [],
+      organization: orgB,
+    });
+
+    await indexPolicy(policyA);
+    await indexPolicy(policyB);
+
+    const decision = await Decision.create({
+      text: "Approved a $1200 purchase without pre-approval.",
+      sourceMeetingId: new mongoose.Types.ObjectId(),
+      organization: orgA,
+      embedding: await embedText("Approved a $1200 purchase without pre-approval."),
+    });
+
+    const meeting = { _id: decision.sourceMeetingId, organization: orgA };
+
+    const flags = await checkDecisionAgainstPolicies(decision, meeting);
+
+    // Every flag produced must point at a policy in orgA — never orgB,
+    // even though policyB has near-identical text and would otherwise match.
+    for (const flag of flags) {
+      assert.equal(flag.organization.toString(), orgA.toString());
+      assert.notEqual(flag.policyId.toString(), policyB._id.toString());
+    }
+
+    await PolicyCompliance.deleteMany({ decisionId: decision._id });
+    await Decision.deleteOne({ _id: decision._id });
+    await removePolicyFromIndex(policyA._id);
+    await removePolicyFromIndex(policyB._id);
+    await Policy.deleteMany({ _id: { $in: [policyA._id, policyB._id] } });
+  });
+});

--- a/server/tests/policyComplianceService.test.js
+++ b/server/tests/policyComplianceService.test.js
@@ -1,0 +1,146 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseClassification,
+  buildClassificationPrompt,
+} from "../services/policyComplianceService.js";
+import fixtures from "./fixtures/policyComplianceFixtures.json" with { type: "json" };
+
+describe("parseClassification", () => {
+  test("parses a clean JSON response", () => {
+    const raw = JSON.stringify({
+      classification: "potential_conflict",
+      reasoning: "Exceeds the pre-approval threshold.",
+    });
+    const result = parseClassification(raw);
+    assert.equal(result.classification, "potential_conflict");
+    assert.equal(result.reasoning, "Exceeds the pre-approval threshold.");
+  });
+
+  test("strips markdown code fences before parsing", () => {
+    const raw =
+      '```json\n{"classification":"aligned","reasoning":"Matches policy."}\n```';
+    const result = parseClassification(raw);
+    assert.equal(result.classification, "aligned");
+  });
+
+  test("falls back to 'unrelated' for an unrecognized classification value", () => {
+    // Guards against the LLM inventing a label outside the enum — a
+    // hallucinated classification must never be treated as a valid flag.
+    const raw = JSON.stringify({
+      classification: "definitely_illegal",
+      reasoning: "should not be trusted",
+    });
+    const result = parseClassification(raw);
+    assert.equal(result.classification, "unrelated");
+  });
+
+  test("fails conservative (unrelated) on unparsable input", () => {
+    // A malformed/empty LLM response must never silently become a conflict flag.
+    const result = parseClassification("not valid json at all {{{");
+    assert.equal(result.classification, "unrelated");
+    assert.match(result.reasoning, /could not be parsed/i);
+  });
+
+  test("truncates excessively long reasoning text", () => {
+    const longReasoning = "x".repeat(5000);
+    const raw = JSON.stringify({
+      classification: "references",
+      reasoning: longReasoning,
+    });
+    const result = parseClassification(raw);
+    assert.ok(result.reasoning.length <= 1000);
+  });
+
+  test("handles missing reasoning field gracefully", () => {
+    const raw = JSON.stringify({ classification: "unrelated" });
+    const result = parseClassification(raw);
+    assert.equal(result.classification, "unrelated");
+    assert.equal(result.reasoning, "");
+  });
+});
+
+describe("buildClassificationPrompt", () => {
+  test("includes the decision text, policy name, version, and summary", () => {
+    const policy = {
+      name: "Expense Reimbursement Policy",
+      version: "2.0",
+      summary: "Requires pre-approval above $500.",
+      key_changes: ["Raised threshold from $250 to $500"],
+    };
+    const prompt = buildClassificationPrompt(
+      "Approved a $1,200 purchase without pre-approval.",
+      policy,
+    );
+
+    assert.match(prompt, /Approved a \$1,200 purchase without pre-approval\./);
+    assert.match(prompt, /Expense Reimbursement Policy/);
+    assert.match(prompt, /version 2\.0/);
+    assert.match(prompt, /Requires pre-approval above \$500\./);
+    assert.match(prompt, /Raised threshold from \$250 to \$500/);
+  });
+
+  test("instructs conservative bias against false conflict flags", () => {
+    const prompt = buildClassificationPrompt("some decision", {
+      name: "Policy",
+      version: "1.0",
+      summary: "",
+      key_changes: [],
+    });
+    assert.match(prompt, /conservative/i);
+    assert.match(prompt, /only use this if genuinely confident/i);
+  });
+
+  test("requests strict JSON output matching the four-way enum", () => {
+    const prompt = buildClassificationPrompt("some decision", {
+      name: "Policy",
+      version: "1.0",
+      summary: "",
+      key_changes: [],
+    });
+    assert.match(prompt, /"aligned" \| "references" \| "potential_conflict" \| "unrelated"/);
+  });
+
+  test("handles a policy with no key_changes without throwing", () => {
+    assert.doesNotThrow(() =>
+      buildClassificationPrompt("decision text", {
+        name: "Policy",
+        version: "1.0",
+        summary: "summary text",
+        key_changes: undefined,
+      }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Hand-labeled fixture set (acceptance criterion: "LLM classification
+// prompt (with a small hand-labeled fixture set)"). These assert the
+// *prompt* is well-formed for every fixture; running the fixtures against
+// a live Gemini call to check actual classification accuracy is done via
+// scripts/evalPolicyComplianceFixtures.js against a real GEMINI_API_KEY,
+// since that requires network access this sandbox/CI unit run doesn't have.
+// ─────────────────────────────────────────────────────────────
+describe("hand-labeled fixture set", () => {
+  for (const fixture of fixtures) {
+    test(`prompt for fixture "${fixture.id}" is well-formed`, () => {
+      const prompt = buildClassificationPrompt(fixture.decisionText, fixture.policy);
+      assert.match(prompt, new RegExp(fixture.policy.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      assert.ok(prompt.includes(fixture.decisionText));
+      assert.ok(
+        ["aligned", "references", "potential_conflict", "unrelated"].includes(
+          fixture.expectedClassification,
+        ),
+        `fixture "${fixture.id}" has an invalid expectedClassification label`,
+      );
+    });
+  }
+
+  test("fixture set covers all four classification labels", () => {
+    const labels = new Set(fixtures.map((f) => f.expectedClassification));
+    assert.ok(labels.has("aligned"));
+    assert.ok(labels.has("references"));
+    assert.ok(labels.has("potential_conflict"));
+    assert.ok(labels.has("unrelated"));
+  });
+});


### PR DESCRIPTION
## Related Issue
Closes #158

## Summary
Adds a compliance detection layer that cross-references a meeting's extracted
decisions against the organization's policies, flagging potential conflicts
for human review — without ever blocking or auto-rejecting a decision.

## What's included

### Policy embedding pipeline
- Extended `policyController.js` to embed each policy's `summary` +
  `key_changes` (reusing `embedText()` from `embeddingUtils.js`) and upsert
  it into a dedicated `"policies"` Pinecone namespace on upload, re-analysis,
  and version update — kept separate from the existing meeting vectors so
  search never cross-contaminates.
- Policy delete removes the vector and cleans up any linked compliance
  records.

### Compliance cross-reference service
- New `server/services/policyComplianceService.js`: hooks in right after
  `processStructuredMoM()` in `meetingController.js` (the same point
  Institutional Knowledge Graph (#115) processing runs), embeds each
  decision, and queries the policy namespace scoped strictly to the
  meeting's organization.
- A separate, narrow Gemini call classifies each high-similarity match as
  `aligned` / `references` / `potential_conflict` / `unrelated`, biased
  conservative per the issue's guidance (unparsable/failed responses fall
  back to `unrelated`, never a false conflict flag).
- Wrapped in its own try/catch so a compliance-check failure never affects
  meeting summarization or knowledge-graph processing.

### Policy versioning
- When a policy is superseded (new version saved), `reevaluatePolicyDecisions()`
  re-runs classification for every previously-linked decision against the
  current text and reopens the review status, instead of leaving stale
  matches pointing at outdated policy text.

### API endpoints (`server/routes/policyComplianceRoutes.js`)
- `GET /api/policy-compliance/decisions/:decisionId` — linked policies + classification
- `GET /api/policy-compliance/policies/:policyId/related-decisions` — reverse lookup
- `GET /api/policy-compliance/flags?status=&classification=` — dashboard of flags
- `PATCH /api/policy-compliance/flags/:id` — acknowledge / dismiss / reopen a flag

All routes require auth + org membership; organization scope is always taken
from the authenticated user, never from a client-supplied query param.

### Frontend
- `client/src/pages/PolicyCompliance.jsx` — compliance dashboard with status
  tabs (unresolved/acknowledged/dismissed/all), classification badges, and
  acknowledge/dismiss/reopen actions.
- Wired into `App.jsx` (`/policy-compliance`, protected route) and added to
  `Navbar.jsx`.

### Tests
- `server/tests/policyComplianceService.test.js` — unit tests for response
  parsing (conservative fallback on bad/hallucinated LLM output) and prompt
  construction.
- `server/tests/fixtures/policyComplianceFixtures.json` — small hand-labeled
  decision/policy pairs covering all four classification labels, including a
  keyword-overlap-but-not-conflict case to guard against false positives.
- `server/tests/policyComplianceIntegration.test.js` — multi-tenant isolation
  and embedding pipeline coverage, gated behind `RUN_POLICY_COMPLIANCE_IT=1`
  since it needs a live Mongo/Pinecone/Gemini setup.

## Acceptance criteria
- [x] Policies embedded on upload/update, stored in a distinct Pinecone namespace
- [x] New decisions automatically checked against org policy embeddings
- [x] LLM classification: aligned / references / potential_conflict / unrelated
- [x] `GET /decisions/:decisionId` returns linked policies + classification
- [x] `GET /policies/:policyId/related-decisions` reverse lookup
- [x] Dashboard endpoint filterable by organization/status
- [x] Frontend dashboard with acknowledge/dismiss actions
- [x] Superseded policy versions trigger re-evaluation
- [x] Multi-tenant isolation (org-scoped Pinecone filter + Mongo-level guard)
- [x] Tests: parsing/prompt unit tests + fixture set + integration test (gated)

## Notes for reviewers
- Policy re-indexing after upload/update is fire-and-forget (not awaited in
  the response) to keep upload latency low — open to making it blocking if
  preferred.
- Integration tests need `MONGODB_URI`, `PINECONE_API_KEY`, `INDEX_NAME`,
  `GEMINI_API_KEY` set and are skipped by default; run with
  `RUN_POLICY_COMPLIANCE_IT=1 npm test`.

## How to test
1. `cd server && npm install && npm test`
2. Set env vars, run server, upload a policy (e.g. expense policy with a cap)
3. Run a meeting whose transcript approves a decision that violates it
4. Check `/policy-compliance` dashboard for the flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected Compliance page (with a new navigation item) to review policy-related decision flags.
  * Flags are filterable by status and classification, with similarity details, policy metadata, reasoning, and meeting links.
  * Added actions to acknowledge, dismiss, and reopen flags.
  * Meeting decision content is automatically checked against organizational policies; policy upload/update/delete refresh compliance results.

* **Tests**
  * Added automated unit and (optionally enabled) integration coverage for classification, matching, and organization-scoped compliance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->