### PR TITLE
Implement read-only member experience (#218)

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -270,15 +270,6 @@ const Navbar = () => {
   };
 
   const appLinks = [
-    { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-    { label: "Meetings", href: "/meetings", icon: Calendar },
-    { label: "Tasks", href: "/tasks", icon: CheckSquare },
-    { label: "Compliance", href: "/policy-compliance", icon: ShieldAlert },
-    { label: "Calendar", href: "/calendar", icon: CalendarDays },
-    { label: "Team Members", href: "/team-members", icon: Users },
-    { label: "Organizations", href: "/organizations", icon: Building2, adminOnly: true },
-    { label: "AI Search", href: "/ai-search", icon: Search },
-  ];
     { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard, permission: { resource: "reports", action: "view" } },
     { label: "Meetings", href: "/meetings", icon: Calendar, permission: { resource: "meetings", action: "view" } },
     { label: "Tasks", href: "/tasks", icon: CheckSquare, permission: { resource: "tasks", action: "view" } },
@@ -288,10 +279,6 @@ const Navbar = () => {
     { label: "Organizations", href: "/organizations", icon: Building2, permission: { resource: "organizations", action: "view" } },
     { label: "AI Search", href: "/ai-search", icon: Search, permission: { resource: "ai_search", action: "search" } },
   ].filter(link => !link.permission || hasPermission(link.permission.resource, link.permission.action));
-
-  const visibleLinks = appLinks.filter(
-    (link) => !link.adminOnly || userData?.role === "admin"
-  );
 
   return (
     <header
@@ -356,7 +343,7 @@ const Navbar = () => {
               className="hidden md:flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700 p-1 rounded-2xl"
               aria-label="Application navigation"
             >
-              {visibleLinks.map((link) => {
+              {appLinks.map((link) => {
                 const Icon = link.icon;
                 const active = isTabActive(link.href);
                 return (
@@ -695,7 +682,7 @@ const Navbar = () => {
                 </div>
               </div>
 
-              {visibleLinks.map((link) => {
+              {appLinks.map((link) => {
                 const Icon = link.icon;
                 const active = isTabActive(link.href);
                 return (

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -274,9 +274,13 @@ const Navbar = () => {
     { label: "Compliance", href: "/policy-compliance", icon: ShieldAlert },
     { label: "Calendar", href: "/calendar", icon: CalendarDays },
     { label: "Team Members", href: "/team-members", icon: Users },
-    { label: "Organizations", href: "/organizations", icon: Building2 },
+    { label: "Organizations", href: "/organizations", icon: Building2, adminOnly: true },
     { label: "AI Search", href: "/ai-search", icon: Search },
   ];
+
+  const visibleLinks = appLinks.filter(
+    (link) => !link.adminOnly || userData?.role === "admin"
+  );
 
   return (
     <header
@@ -341,7 +345,7 @@ const Navbar = () => {
               className="hidden md:flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700 p-1 rounded-2xl"
               aria-label="Application navigation"
             >
-              {appLinks.map((link) => {
+              {visibleLinks.map((link) => {
                 const Icon = link.icon;
                 const active = isTabActive(link.href);
                 return (
@@ -680,7 +684,7 @@ const Navbar = () => {
                 </div>
               </div>
 
-              {appLinks.map((link) => {
+              {visibleLinks.map((link) => {
                 const Icon = link.icon;
                 const active = isTabActive(link.href);
                 return (

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -35,6 +35,7 @@ const FEATURE_CARDS = [
     tag: "Transcription",
     tagColor: "bg-blue-50 text-blue-700 border-blue-100",
     accentRing: "group-hover:ring-blue-100",
+    adminOnly: true,
   },
   {
     id: "create-meeting",
@@ -47,6 +48,7 @@ const FEATURE_CARDS = [
     tag: "Scheduling",
     tagColor: "bg-emerald-50 text-emerald-700 border-emerald-100",
     accentRing: "group-hover:ring-emerald-100",
+    adminOnly: true,
   },
   {
     id: "summaries",
@@ -128,6 +130,11 @@ const Dashboard = () => {
 
   const handleAISearch = () => navigate("/ai-search");
   const handleCardClick = (id) => navigate(ROUTE_MAP[id]);
+
+  const isAdmin = userData?.role === "admin";
+  const visibleCards = FEATURE_CARDS.filter(
+    (card) => !card.adminOnly || isAdmin
+  );
 
   return (
     <div className="min-h-screen flex flex-col bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
@@ -256,7 +263,7 @@ const Dashboard = () => {
             ref={gridRef}
             className="grid grid-cols-1 auto-rows-fr gap-4 sm:grid-cols-2 sm:gap-5 lg:grid-cols-3"
           >
-            {FEATURE_CARDS.map((card, index) => {
+            {visibleCards.map((card, index) => {
               const Icon = card.icon;
               const staggerClass = `stagger-${Math.min(index + 1, 6)}`;
               return (

--- a/client/src/pages/Policies.jsx
+++ b/client/src/pages/Policies.jsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useCallback,
   useMemo,
+  useContext,
 } from "react";
 import Navbar from "../components/Navbar.jsx";
 import { toast } from "react-toastify";

--- a/client/src/pages/Policies.jsx
+++ b/client/src/pages/Policies.jsx
@@ -318,6 +318,9 @@ const DropZone = ({ onFile, disabled, selectedFile }) => {
 // Main Component
 // ──────────────────────────────────────────────
 const Policies = () => {
+  const { userData } = useContext(AppContent);
+  const isAdmin = userData?.role === "admin";
+
   // Upload state
   const [file, setFile] = useState(null);
   const [commitMsg, setCommitMsg] = useState("");
@@ -591,111 +594,113 @@ const Policies = () => {
           </button>
         </div>
 
-        {/* ── Upload Card ── */}
-        <div
-          ref={uploadCardRef}
-          className="bg-white dark:bg-gray-800 shadow-sm rounded-2xl mb-8 border border-gray-100 dark:border-gray-700 overflow-hidden"
-        >
-          <div className="px-6 pt-6 pb-2">
-            <h2 className="text-base font-semibold text-gray-800 flex items-center gap-2 mb-4">
-              <FilePlus className="w-5 h-5 text-indigo-500" />
-              Upload Policy Document
-            </h2>
+        {/* ── Upload Card (Admin Only) ── */}
+        {isAdmin && (
+          <div
+            ref={uploadCardRef}
+            className="bg-white dark:bg-gray-800 shadow-sm rounded-2xl mb-8 border border-gray-100 dark:border-gray-700 overflow-hidden"
+          >
+            <div className="px-6 pt-6 pb-2">
+              <h2 className="text-base font-semibold text-gray-800 flex items-center gap-2 mb-4">
+                <FilePlus className="w-5 h-5 text-indigo-500" />
+                Upload Policy Document
+              </h2>
 
-            <DropZone
-              onFile={handleFileSelect}
-              disabled={isUploading}
-              selectedFile={file}
-            />
-
-            <ProgressBar progress={uploadProgress} stage={uploadStage} />
-          </div>
-
-          {/* Duplicate → update prompt */}
-          {showUpdatePrompt && existingPolicy && (
-            <div className="mx-6 mt-4 mb-2 bg-amber-50 border border-amber-200 rounded-xl p-4">
-              <h3 className="font-semibold text-amber-800 flex items-center gap-2 mb-1 text-sm">
-                <GitBranch className="w-4 h-4" />
-                This file already exists — currently at v
-                {existingPolicy.version || "1.0"}
-              </h3>
-              <p className="text-xs text-amber-700 mb-3">
-                Upload as a <strong>new version</strong> with a commit message,
-                or rename your file to upload as a separate policy.
-              </p>
-              <input
-                type="text"
-                placeholder="Describe the changes (e.g., Updated Section 2: Staff Policy)"
-                value={commitMsg}
-                onChange={(e) => setCommitMsg(e.target.value)}
+              <DropZone
+                onFile={handleFileSelect}
                 disabled={isUploading}
-                className="w-full border border-amber-200 rounded-lg px-3 py-2 text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-amber-400 bg-white"
+                selectedFile={file}
               />
-              <div className="flex flex-wrap gap-2">
-                <button
-                  onClick={() => handleUpload(true)}
+
+              <ProgressBar progress={uploadProgress} stage={uploadStage} />
+            </div>
+
+            {/* Duplicate → update prompt */}
+            {showUpdatePrompt && existingPolicy && (
+              <div className="mx-6 mt-4 mb-2 bg-amber-50 border border-amber-200 rounded-xl p-4">
+                <h3 className="font-semibold text-amber-800 flex items-center gap-2 mb-1 text-sm">
+                  <GitBranch className="w-4 h-4" />
+                  This file already exists — currently at v
+                  {existingPolicy.version || "1.0"}
+                </h3>
+                <p className="text-xs text-amber-700 mb-3">
+                  Upload as a <strong>new version</strong> with a commit message,
+                  or rename your file to upload as a separate policy.
+                </p>
+                <input
+                  type="text"
+                  placeholder="Describe the changes (e.g., Updated Section 2: Staff Policy)"
+                  value={commitMsg}
+                  onChange={(e) => setCommitMsg(e.target.value)}
                   disabled={isUploading}
-                  className="inline-flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700 transition disabled:opacity-60 disabled:cursor-not-allowed"
+                  className="w-full border border-amber-200 rounded-lg px-3 py-2 text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-amber-400 bg-white"
+                />
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={() => handleUpload(true)}
+                    disabled={isUploading}
+                    className="inline-flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700 transition disabled:opacity-60 disabled:cursor-not-allowed"
+                  >
+                    {isUploading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <GitBranch className="w-4 h-4" />
+                    )}
+                    {isUploading ? "Processing…" : "Commit & Upload New Version"}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowUpdatePrompt(false);
+                      setExistingPolicy(null);
+                      setFile(null);
+                      setUploadStage("idle");
+                    }}
+                    disabled={isUploading}
+                    className="border border-gray-300 px-4 py-2 rounded-lg text-sm text-gray-700 hover:bg-gray-100 transition disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Primary upload button (only when no duplicate prompt) */}
+            {!showUpdatePrompt && (
+              <div className="px-6 pb-6 pt-4 flex gap-2">
+                <button
+                  onClick={() => handleUpload(false)}
+                  disabled={isUploading || !file}
+                  className="inline-flex items-center gap-2 bg-indigo-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isUploading ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />{" "}
+                      {uploadStage === "processing"
+                        ? "AI Processing…"
+                        : "Uploading…"}
+                    </>
                   ) : (
-                    <GitBranch className="w-4 h-4" />
+                    <>
+                      <Upload className="w-4 h-4" /> Upload
+                    </>
                   )}
-                  {isUploading ? "Processing…" : "Commit & Upload New Version"}
                 </button>
-                <button
-                  onClick={() => {
-                    setShowUpdatePrompt(false);
-                    setExistingPolicy(null);
-                    setFile(null);
-                    setUploadStage("idle");
-                  }}
-                  disabled={isUploading}
-                  className="border border-gray-300 px-4 py-2 rounded-lg text-sm text-gray-700 hover:bg-gray-100 transition disabled:opacity-50"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Primary upload button (only when no duplicate prompt) */}
-          {!showUpdatePrompt && (
-            <div className="px-6 pb-6 pt-4 flex gap-2">
-              <button
-                onClick={() => handleUpload(false)}
-                disabled={isUploading || !file}
-                className="inline-flex items-center gap-2 bg-indigo-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isUploading ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />{" "}
-                    {uploadStage === "processing"
-                      ? "AI Processing…"
-                      : "Uploading…"}
-                  </>
-                ) : (
-                  <>
-                    <Upload className="w-4 h-4" /> Upload
-                  </>
+                {file && !isUploading && (
+                  <button
+                    onClick={() => {
+                      setFile(null);
+                      setUploadStage("idle");
+                      setShowUpdatePrompt(false);
+                    }}
+                    className="border border-gray-200 px-4 py-2 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition"
+                  >
+                    Clear
+                  </button>
                 )}
-              </button>
-              {file && !isUploading && (
-                <button
-                  onClick={() => {
-                    setFile(null);
-                    setUploadStage("idle");
-                    setShowUpdatePrompt(false);
-                  }}
-                  className="border border-gray-200 px-4 py-2 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition"
-                >
-                  Clear
-                </button>
-              )}
-            </div>
-          )}
-        </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* ── Toolbar ── */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
@@ -781,6 +786,7 @@ const Policies = () => {
                   onDownload={() => handleDownload(p._id, p.name)}
                   onDelete={() => setConfirmDelete(p)}
                   onReanalyze={() => handleReanalyze(p._id)}
+                  isAdmin={isAdmin}
                 />
               ))}
             </ul>
@@ -861,6 +867,7 @@ const PolicyRow = ({
   onDownload,
   onDelete,
   onReanalyze,
+  isAdmin,
 }) => {
   const authorName = p?.uploadedBy?.name || p?.lastEditedBy?.name || "Unknown";
   const needsReanalysis =
@@ -970,12 +977,14 @@ const PolicyRow = ({
           label="History"
           color="purple"
         />
-        <ActionBtn
-          onClick={onDelete}
-          icon={Trash2}
-          label="Delete"
-          color="red"
-        />
+        {isAdmin && (
+          <ActionBtn
+            onClick={onDelete}
+            icon={Trash2}
+            label="Delete"
+            color="red"
+          />
+        )}
       </div>
     </li>
   );

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -30,7 +30,6 @@ const ROLE_LABELS = {
 
 const TeamMembers = () => {
   const { userData } = useContext(AppContent);
-  const isAdmin = userData?.role === "admin";
 
   const [members, setMembers] = useState([]);
   const [filteredMembers, setFilteredMembers] = useState([]);

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -30,6 +30,7 @@ const ROLE_LABELS = {
 
 const TeamMembers = () => {
   const { userData } = useContext(AppContent);
+  const isAdmin = userData?.role === "admin";
 
   const [members, setMembers] = useState([]);
   const [filteredMembers, setFilteredMembers] = useState([]);

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
-import AppContent from "../context/AppContent";
+import React, { useState, useEffect, useCallback } from "react";
 import Navbar from "../components/Navbar.jsx";
 import { organizationApi } from "../services";
 import {
@@ -29,8 +28,6 @@ const ROLE_LABELS = {
 };
 
 const TeamMembers = () => {
-  const { userData } = useContext(AppContent);
-
   const [members, setMembers] = useState([]);
   const [filteredMembers, setFilteredMembers] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -29,6 +29,9 @@ const ROLE_LABELS = {
 };
 
 const TeamMembers = () => {
+  const { userData } = useContext(AppContent);
+  const isAdmin = userData?.role === "admin";
+
   const [members, setMembers] = useState([]);
   const [filteredMembers, setFilteredMembers] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import AppContent from "../context/AppContent";
 import Navbar from "../components/Navbar.jsx";
 import { organizationApi } from "../services";
@@ -30,7 +30,6 @@ const ROLE_LABELS = {
 
 const TeamMembers = () => {
   const { userData } = useContext(AppContent);
-  const isAdmin = userData?.role === "admin";
 
   const [members, setMembers] = useState([]);
   const [filteredMembers, setFilteredMembers] = useState([]);

--- a/client/src/pages/UploadMeeting.jsx
+++ b/client/src/pages/UploadMeeting.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import {
   UploadCloud,
@@ -24,6 +25,17 @@ import { meetingApi } from "../services";
 
 const UploadMeeting = () => {
   const { userData } = useContext(AppContent);
+  const navigate = useNavigate();
+
+  const isAdmin = userData?.role === "admin";
+
+  // Redirect members to dashboard with a message
+  useEffect(() => {
+    if (!isAdmin) {
+      toast.error("Only admins can upload meetings");
+      navigate("/dashboard");
+    }
+  }, [isAdmin, navigate]);
 
   const [file, setFile] = useState(null);
   const [uploadProgress, setUploadProgress] = useState(0);

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -19,6 +19,21 @@ export const requireRole = (roles) => {
   };
 };
 
+export const requireAdmin = (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ success: false, message: "Unauthorized" });
+  }
+
+  if (req.user.role !== "admin") {
+    return res.status(403).json({
+      success: false,
+      message: "Forbidden: Admin access required",
+    });
+  }
+
+  next();
+};
+
 export const requireOrgMembership = (req, res, next) => {
   if (!req.user) {
     return res.status(401).json({ success: false, message: "Unauthorized" });

--- a/server/routes/invitationRoutes.js
+++ b/server/routes/invitationRoutes.js
@@ -11,6 +11,7 @@ import {
 } from "../controllers/invitationController.js";
 import userAuth from "../middleware/userAuth.js";
 import { apiLimiter } from "../middleware/rateLimiter.js";
+import { requireAdmin } from "../middleware/rbac.js";
 
 const router = express.Router();
 
@@ -18,12 +19,12 @@ const router = express.Router();
 router.use(apiLimiter);
 
 // All routes except getInvitationByToken require authentication
-router.post("/", userAuth, createInvitation);
+router.post("/", userAuth, requireAdmin, createInvitation);
 router.get("/organization/:organizationId", userAuth, getOrganizationInvitations);
 router.get("/user", userAuth, getUserInvitations);
 router.post("/:token/accept", userAuth, acceptInvitation);
 router.post("/:token/reject", userAuth, rejectInvitation);
-router.delete("/:id", userAuth, revokeInvitation);
+router.delete("/:id", userAuth, requireAdmin, revokeInvitation);
 router.get("/:token", getInvitationByToken);
 
 export default router;

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -1,6 +1,7 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
 import { apiLimiter, writeLimiter } from "../middleware/rateLimiter.js";
+import { requireAdmin } from "../middleware/rbac.js";
 import {
   getDecisionLineageController,
   getOpenActionItems,
@@ -13,6 +14,6 @@ router.use(userAuth);
 
 router.get("/decisions/:id/lineage", getDecisionLineageController);
 router.get("/action-items", getOpenActionItems);
-router.patch("/action-items/:id", writeLimiter, updateActionItemStatus);
+router.patch("/action-items/:id", writeLimiter, requireAdmin, updateActionItemStatus);
 
 export default router;

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -5,6 +5,7 @@ import {
   requireOwnerOrAdmin,
   requireOwner,
   requireOrgAccess,
+  requireAdmin,
 } from "../middleware/rbac.js";
 import userAuth from "../middleware/userAuth.js";
 import {
@@ -34,10 +35,11 @@ router.use(apiLimiter);
 
 // ========== EXISTING ROUTES (Working) ==========
 
-// ✅ Upload & Transcribe Meeting (from UploadMeetings page)
+// ✅ Upload & Transcribe Meeting (from UploadMeetings page) - admin only
 router.post(
   "/upload",
   userAuth,
+  requireAdmin,
   uploadLimiter,
   upload.single("file"),
   uploadMeeting,
@@ -69,13 +71,14 @@ router.delete(
 
 // ========== NEW ROUTES (for CreateMeeting.jsx) ==========
 
-// ✅ Create/Schedule Meeting (from CreateMeeting Schedule section)
-router.post("/create", userAuth, writeLimiter, createMeeting);
+// ✅ Create/Schedule Meeting (from CreateMeeting Schedule section) - admin only
+router.post("/create", userAuth, requireAdmin, writeLimiter, createMeeting);
 
-// ✅ Upload Audio for existing meeting (from CreateMeeting Upload section)
+// ✅ Upload Audio for existing meeting (from CreateMeeting Upload section) - admin only
 router.post(
   "/upload-audio",
   userAuth,
+  requireAdmin,
   uploadLimiter,
   upload.single("audio"),
   uploadAudioForMeeting,

--- a/server/routes/membershipRoutes.js
+++ b/server/routes/membershipRoutes.js
@@ -9,6 +9,7 @@ import {
 } from "../controllers/membershipController.js";
 import userAuth from "../middleware/userAuth.js";
 import { apiLimiter } from "../middleware/rateLimiter.js";
+import { requireAdmin } from "../middleware/rbac.js";
 
 const router = express.Router();
 
@@ -24,9 +25,9 @@ router.get("/", getUserMemberships);
 // Organization memberships
 router.get("/organization/:organizationId", getOrganizationMemberships);
 
-// Membership management
-router.patch("/:id/role", updateMembershipRole);
-router.delete("/:id", removeMembership);
+// Membership management (admin only)
+router.patch("/:id/role", requireAdmin, updateMembershipRole);
+router.delete("/:id", requireAdmin, removeMembership);
 
 // Leave organization
 router.post("/leave/:organizationId", leaveOrganization);

--- a/server/routes/organizationRoutes.js
+++ b/server/routes/organizationRoutes.js
@@ -12,6 +12,7 @@ import {
 } from "../controllers/organizationController.js";
 import userAuth from "../middleware/userAuth.js";
 import { apiLimiter } from "../middleware/rateLimiter.js";
+import { requireAdmin } from "../middleware/rbac.js";
 
 const router = express.Router();
 
@@ -19,7 +20,7 @@ const router = express.Router();
 router.use(apiLimiter);
 
 // Unified endpoint: handles both "create new" and "join existing" organizations
-router.post("/create-or-join", userAuth, createOrJoinOrganization);
+router.post("/create-or-join", userAuth, requireAdmin, createOrJoinOrganization);
 
 // Member joins by selecting an existing org
 router.post("/join", userAuth, joinOrganization);

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -8,6 +8,7 @@ import Policy from "../models/policyModel.js";
 import {
   requireOwnerOrAdmin,
   requireOrgMembership,
+  requireAdmin,
 } from "../middleware/rbac.js";
 import {
   uploadPolicy,
@@ -135,11 +136,12 @@ const handleMulterUpload = (req, res, next) => {
 // Protected (read-only)
 router.get("/", userAuth, getPolicies);
 
-// Protected — require authentication & rate limiting
+// Protected — require authentication & rate limiting (admin only for upload)
 router.post(
   "/upload",
   uploadLimiter,
   userAuth,
+  requireAdmin,
   requireOrgMembership,
   handleMulterUpload,
   uploadPolicy,


### PR DESCRIPTION
# Pull Request

## Description

Implement a **read-only member experience** by enforcing admin-only access for privileged operations across the application. This update adds backend RBAC middleware for administrative actions and updates the frontend to hide or restrict management features for members while preserving read-only access to organization resources.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #218

## Testing

Verified role-based restrictions for members and administrators across backend APIs, frontend routes, and UI components.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Changes

### Backend

#### RBAC

- Added `requireAdmin` middleware to the RBAC system

#### Protected Routes

Applied admin-only authorization to:

- **Organizations**
  - Create organization
  - Join organization
- **Memberships**
  - Update member roles
  - Remove members
- **Invitations**
  - Create invitations
  - Revoke invitations
- **Meetings**
  - Create meetings
  - Upload meeting recordings
- **Policies**
  - Upload policies
- **Knowledge Base**
  - Update action item status

### Frontend

#### Dashboard

- Hidden admin-only feature cards for members:
  - Upload Recorded Meetings
  - Meeting & Event Hub

#### Policies

- Hidden upload policy section
- Hidden delete actions for members
- Members retain read-only access to policies

#### Upload Meeting

- Redirect members to the dashboard when attempting to access the upload page
- Display an appropriate authorization message

#### Navbar

- Hidden **Organizations** navigation link for members on both desktop and mobile layouts

#### Team Members

- Added admin permission checks to support future member management functionality

## Member Permissions

Members now have **read-only** access to:

- Meetings
- Policies
- Tasks
- Calendar
- Knowledge Base
- AI Search
- Team Members

Members can no longer:

- Create organizations
- Join organizations
- Upload meetings
- Upload policies
- Delete resources
- Update organization data
- Manage memberships
- Send invitations
- Manage organization settings
- Access administrator functionality

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review