### PR TITLE
feat: implement bi-directional Slack Bot Integration for meeting management (#185)

### DIFF
--- a/server/controllers/slackController.js
+++ b/server/controllers/slackController.js
@@ -1,0 +1,299 @@
+// server/controllers/slackController.js
+/**
+ * Slack Controller — HTTP layer only.
+ *
+ * Handles the three Slack-facing endpoints:
+ *  GET  /api/slack/install          → Redirect user to Slack's OAuth consent page
+ *  GET  /api/slack/oauth_redirect   → Exchange one-time code for bot token; save to org
+ *  POST /api/slack/events           → Receive all Slack event/slash payloads
+ *
+ * Request signature verification (Slack Signing Secret) is applied as a
+ * middleware for the /events endpoint. OAuth endpoints are safe because
+ * they use the code parameter provided by Slack's own redirect.
+ */
+
+import Organization from "../models/organizationModel.js";
+import * as MeetingService from "../services/MeetingService.js";
+import {
+  verifySlackSignature,
+  exchangeSlackCodeForToken,
+  buildMeetingCreatedBlocks,
+} from "../services/slackService.js";
+
+// Helpers
+
+/**
+ * Parse the text portion of a Slack slash command.
+ 
+ * The convention we support:
+ *   /mom-create "Meeting Title" @optionalTag
+ 
+ * Returns { title, tags } where title is the quoted string (or the full
+ * trimmed text when no quotes are used) and tags is an array of @-mentions.
+ 
+ * @param {string} text - Raw command text from Slack payload
+ * @returns {{ title: string, tags: string[] }}
+ */
+const parseSlashCommandText = (text = "") => {
+  const trimmed = text.trim();
+
+  // Match a quoted string at the start: "Q3 Planning" or 'Q3 Planning'
+  const quotedMatch = trimmed.match(/^["'](.+?)["']/);
+  const title = quotedMatch ? quotedMatch[1].trim() : trimmed.replace(/@\S+/g, "").trim();
+
+  // Collect all @-mentions from the full text
+  const tags = [...trimmed.matchAll(/@(\S+)/g)].map((m) => m[1]);
+
+  return { title: title || "Untitled Meeting", tags };
+};
+
+// 1. GET /api/slack/install
+
+/**
+ * Redirects the authenticated user to Slack's OAuth consent page.
+ * The `organizationId` is embedded in the OAuth `state` parameter so we can
+ * associate the resulting bot token with the correct organization.
+ 
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+export const slackInstall = async (req, res, next) => {
+  try {
+    const clientId = process.env.SLACK_CLIENT_ID;
+    if (!clientId) {
+      return res
+        .status(500)
+        .json({ success: false, message: "Slack integration is not configured on this server." });
+    }
+
+    // organizationId can come from an authenticated request (query or user object)
+    const organizationId =
+      req.query.organizationId ||
+      req.user?.organization?.toString() ||
+      "";
+
+    if (!organizationId) {
+      return res.status(400).json({
+        success: false,
+        message: "organizationId is required to initiate Slack installation.",
+      });
+    }
+
+    const redirectUri = process.env.SLACK_REDIRECT_URI;
+    const scopes = "commands,chat:write,channels:read";
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      scope: scopes,
+      state: organizationId,
+      ...(redirectUri && { redirect_uri: redirectUri }),
+    });
+
+    return res.redirect(`https://slack.com/oauth/v2/authorize?${params.toString()}`);
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// 2. GET /api/slack/oauth_redirect
+
+/**
+ * Handles the redirect from Slack after the user approves the OAuth flow.
+ * Exchanges the temporary `code` for a permanent bot token and saves the
+ * Slack integration details to the matching Organization document.
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+export const slackOAuthRedirect = async (req, res, next) => {
+  try {
+    const { code, state: organizationId, error: slackError } = req.query;
+
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+
+    // Handle user-denied or Slack error cases
+    if (slackError) {
+      return res.redirect(
+        `${frontendUrl}/organizations/${organizationId}?slackInstall=error&reason=${slackError}`
+      );
+    }
+
+    if (!code) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Missing OAuth code from Slack." });
+    }
+
+    if (!organizationId) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Missing organizationId in OAuth state." });
+    }
+
+    // Verify the organization exists before persisting anything
+    const org = await Organization.findById(organizationId);
+    if (!org) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Organization not found." });
+    }
+
+    // Exchange the code for a bot token
+    const slackData = await exchangeSlackCodeForToken(code);
+
+    // Persist the integration details
+    // slackData.access_token  = the bot token (xoxb-...)
+    // slackData.incoming_webhook.channel_id = the channel the user selected
+    // slackData.team.id / slackData.team.name = the Slack workspace info
+    await Organization.findByIdAndUpdate(organizationId, {
+      $set: {
+        "slackIntegration.botToken": slackData.access_token,
+        "slackIntegration.channelId":
+          slackData.incoming_webhook?.channel_id || "",
+        "slackIntegration.teamId": slackData.team?.id || "",
+        "slackIntegration.teamName": slackData.team?.name || "",
+        "slackIntegration.installedAt": new Date(),
+      },
+    });
+
+    console.log(
+      `✅ [Slack] Workspace "${slackData.team?.name}" connected to org ${organizationId}`
+    );
+
+    // Redirect user back to the organization page in the frontend
+    return res.redirect(
+      `${frontendUrl}/organizations/${organizationId}?slackInstall=success`
+    );
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// 3. POST /api/slack/events
+
+/**
+ * Central handler for all incoming Slack payloads:
+ *   - URL verification challenge (for initial Slack Event API setup)
+ *   - Slash command: /mom-create
+ *   - Slack Event Subscriptions (future extension point)
+ * Signature verification is performed BEFORE reaching this handler via the
+ * `slackSignatureMiddleware` applied in slackRoutes.js.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+export const handleSlackEvents = async (req, res, next) => {
+  try {
+    const body = req.body;
+
+    // Case 1: Slack URL verification handshake 
+    // Slack sends this once when you first configure the Events API URL.
+    if (body?.type === "url_verification") {
+      return res.status(200).json({ challenge: body.challenge });
+    }
+
+    // Case 2: Slash command: /mom-create
+    // Slack sends slash commands as application/x-www-form-urlencoded POST.
+    // req.body will be parsed because express.urlencoded is active.
+    if (body?.command === "/mom-create") {
+      const { title, tags } = parseSlashCommandText(body.text);
+      const teamId = body.team_id;
+      const userName = body.user_name || "someone";
+
+      if (!teamId) {
+        return res.status(200).json({
+          response_type: "ephemeral",
+          text: "❌ Could not identify your Slack workspace. Please re-install the bot.",
+        });
+      }
+
+      // Find the organization linked to this Slack workspace
+      const org = await Organization.findOne({
+        "slackIntegration.teamId": teamId,
+      }).lean();
+
+      if (!org) {
+        return res.status(200).json({
+          response_type: "ephemeral",
+          text: `❌ Your Slack workspace is not connected to any MeetOnMemory organization.\nVisit your organization settings and click *Connect Slack* to get started.`,
+        });
+      }
+
+      if (!title) {
+        return res.status(200).json({
+          response_type: "ephemeral",
+          text: '❌ Please provide a meeting title. Usage: `/mom-create "Q3 Planning" @team`',
+        });
+      }
+
+      // Create the meeting using the MeetingService
+      // We pass null as userId (no authenticated user in slash commands);
+      // the meeting is attributed to the organization's owner.
+      const meeting = await MeetingService.createMeeting(
+        org.owner.toString(),  // userId — use org owner as the author
+        org._id.toString(),    // organizationId
+        {
+          title,
+          description: tags.length ? `Created via Slack by @${userName}. Participants: ${tags.join(", ")}` : `Created via Slack by @${userName}`,
+          meetingType: "conference",
+          date: new Date().toISOString(),
+          tags,
+        },
+        null  // io — socket not available in this context
+      );
+
+      // Respond immediately with a Block Kit message (Slack requires <3 s response)
+      const blocks = buildMeetingCreatedBlocks(meeting, `@${userName}`);
+      return res.status(200).json({
+        response_type: "in_channel",
+        text: `✅ Meeting "${title}" created by @${userName}`,
+        blocks,
+      });
+    }
+
+    // Case 3: Standard Slack Event Subscriptions
+    // Acknowledge all other events with a 200 OK immediately (Slack requires this)
+    // and process asynchronously if needed in the future.
+    if (body?.type === "event_callback") {
+      // Acknowledge first — Slack retries if no 200 within 3 seconds
+      res.status(200).send();
+
+      const event = body.event;
+      console.log(`ℹ️ [Slack] Received event: ${event?.type} from team ${body.team_id}`);
+      // Future: handle app_mention, message events, etc.
+      return;
+    }
+
+    // Default: acknowledge unknown payload types
+    return res.status(200).send();
+  } catch (err) {
+    return next(err);
+  }
+};
+
+// Middleware: Verify Slack Signing Secret
+
+/**
+ * Express middleware that verifies the Slack request signature.
+ * Applied only to the /events POST endpoint.
+ * Skipped in test environment (NODE_ENV === "test") to allow Jest to call freely.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+export const slackSignatureMiddleware = (req, res, next) => {
+  // In test environments, skip signature verification to allow integration tests
+  if (process.env.NODE_ENV === "test") {
+    return next();
+  }
+
+  const { valid, reason } = verifySlackSignature(req);
+  if (!valid) {
+    console.warn(`⚠️ [Slack] Invalid signature rejected: ${reason}`);
+    return res.status(401).json({ error: "Invalid Slack request signature." });
+  }
+  return next();
+};

--- a/server/models/organizationModel.js
+++ b/server/models/organizationModel.js
@@ -1,4 +1,3 @@
-// server/models/organizationModel.js
 import mongoose from "mongoose";
 
 const organizationSchema = new mongoose.Schema(
@@ -49,6 +48,31 @@ const organizationSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.Mixed,
       default: {},
     },
+
+    //Slack Integration
+    slackIntegration: {
+      botToken: {
+        type: String,
+        default: "",
+        select: false,
+      },
+      channelId: {
+        type: String,
+        default: "",
+      },
+      teamId: {
+        type: String,
+        default: "",
+      },
+      teamName: {
+        type: String,
+        default: "",
+      },
+      installedAt: {
+        type: Date,
+        default: null,
+      },
+    },
   },
   { timestamps: true },
 );
@@ -62,6 +86,8 @@ organizationSchema.index({ createdAt: -1 });
 organizationSchema.index({ name: "text", slug: "text", description: "text" });
 organizationSchema.index({ visibility: 1, createdAt: -1 });
 organizationSchema.index({ visibility: 1, name: 1 });
+// Sparse index: only indexes documents that actually have a Slack teamId
+organizationSchema.index({ "slackIntegration.teamId": 1 }, { sparse: true });
 
 const Organization =
   mongoose.models.Organization ||

--- a/server/routes/slackRoutes.js
+++ b/server/routes/slackRoutes.js
@@ -1,0 +1,38 @@
+/**
+ * Slack Integration Routes
+ *
+ * GET  /api/slack/install         → Initiate Slack OAuth 2.0 install flow
+ * GET  /api/slack/oauth_redirect  → Handle Slack OAuth callback, exchange code for token
+ * POST /api/slack/events          → Receive all Slack event payloads and slash commands
+ *
+ * All POST requests to /events are verified against Slack's Signing Secret
+ * via the slackSignatureMiddleware before reaching the controller.
+ */
+
+import { Router } from "express";
+import {
+  slackInstall,
+  slackOAuthRedirect,
+  handleSlackEvents,
+  slackSignatureMiddleware,
+} from "../controllers/slackController.js";
+import userAuth from "../middleware/userAuth.js";
+
+const router = Router();
+
+// GET /api/slack/install
+// Requires the user to be authenticated so we can derive their organizationId.
+// The organizationId is also accepted as a query param for direct deep-link flows.
+router.get("/install", userAuth, slackInstall);
+
+// GET /api/slack/oauth_redirect
+// Public route — Slack redirects here after the user approves the OAuth consent.
+// No userAuth needed; the organizationId is carried in the `state` query param.
+router.get("/oauth_redirect", slackOAuthRedirect);
+
+// POST /api/slack/events
+// Public route — Slack POSTs all events (slash commands, event callbacks, URL
+// verification) here. Signature verification middleware runs first.
+router.post("/events", slackSignatureMiddleware, handleSlackEvents);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -26,6 +26,11 @@ import knowledgeRoutes from "./routes/knowledgeRoutes.js";
 import policyComplianceRoutes from "./routes/policyComplianceRoutes.js";
 import sessionRoutes from "./routes/sessionRoutes.js";
 import webhookRoutes from "./routes/webhookRoutes.js";
+import slackRoutes from "./routes/slackRoutes.js";
+
+// Import slackService to register its eventBus 'mom.generated' listener.
+// The import itself is enough — the listener is set up at module load time.
+import "./services/slackService.js";
 
 import { initVectorStore } from "./utils/embeddingUtils.js";
 import meetingSocket from "./socket/meetingSocket.js";
@@ -73,8 +78,21 @@ app.use(
   }),
 );
 
-app.use(express.json({ limit: "50mb" }));
-app.use(express.urlencoded({ extended: true, limit: "50mb" }));
+// Capture the raw request body so Slack's signing-secret HMAC verification
+// can read it before the JSON/urlencoded parsers consume the stream.
+app.use(express.json({
+  limit: "50mb",
+  verify: (req, _res, buf) => {
+    req.rawBody = buf;
+  },
+}));
+app.use(express.urlencoded({
+  extended: true,
+  limit: "50mb",
+  verify: (req, _res, buf) => {
+    req.rawBody = buf;
+  },
+}));
 app.use(cookieParser());
 
 // Enforce CSRF protection on mutation routes
@@ -91,8 +109,10 @@ app.use((req, res, next) => {
   const isSafeMethod = ["GET", "HEAD", "OPTIONS"].includes(req.method);
   const isAuthRoute = req.path.startsWith("/api/auth");
   const isSyncPath = req.path.startsWith("/sync");
+  // Slack cannot send CSRF tokens — exclude all Slack endpoints
+  const isSlackRoute = req.path.startsWith("/api/slack");
 
-  if (isSafeMethod || isAuthRoute || isSyncPath || process.env.NODE_ENV === "test") {
+  if (isSafeMethod || isAuthRoute || isSyncPath || isSlackRoute || process.env.NODE_ENV === "test") {
     return next();
   }
   return csrfProtection(req, res, next);
@@ -131,6 +151,7 @@ app.use("/api/knowledge", knowledgeRoutes);
 app.use("/api/compliance", policyComplianceRoutes);
 app.use("/api/sessions", sessionRoutes);
 app.use("/api/webhooks", webhookRoutes);
+app.use("/api/slack", slackRoutes);
 
 // GLOBAL RATE LIMITER
 app.use(globalLimiter);

--- a/server/services/slackService.js
+++ b/server/services/slackService.js
@@ -1,0 +1,318 @@
+// server/services/slackService.js
+import crypto from "crypto";
+import axios from "axios";
+import Organization from "../models/organizationModel.js";
+import eventBus from "./eventBus.js";
+
+// Slack Request Signature Verification
+
+/**
+ * Verifies that an incoming HTTP request genuinely originated from Slack.
+ *
+ * Slack signs every request it sends using HMAC-SHA256:
+ *   basestring = "v0:{timestamp}:{rawBody}"
+ *   signature  = "v0=" + hex(HMAC_SHA256(SLACK_SIGNING_SECRET, basestring))
+ *
+ * We re-compute the same HMAC and compare using timingSafeEqual to prevent
+ * timing-attack vulnerabilities.
+ *
+ * @param {import('express').Request} req - Express request (must have req.rawBody set)
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+export const verifySlackSignature = (req) => {
+  const signingSecret = process.env.SLACK_SIGNING_SECRET;
+  if (!signingSecret) {
+    return { valid: false, reason: "SLACK_SIGNING_SECRET is not configured" };
+  }
+
+  const slackSignature = req.headers["x-slack-signature"];
+  const slackTimestamp = req.headers["x-slack-request-timestamp"];
+
+  if (!slackSignature || !slackTimestamp) {
+    return { valid: false, reason: "Missing Slack signature headers" };
+  }
+
+  // Reject requests older than 5 minutes to prevent replay attacks
+  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 5 * 60;
+  if (parseInt(slackTimestamp, 10) < fiveMinutesAgo) {
+    return { valid: false, reason: "Request timestamp is too old (possible replay attack)" };
+  }
+
+  const rawBody = req.rawBody
+    ? req.rawBody.toString("utf8")
+    : JSON.stringify(req.body);
+
+  const sigBasestring = `v0:${slackTimestamp}:${rawBody}`;
+  const computedSignature =
+    "v0=" +
+    crypto
+      .createHmac("sha256", signingSecret)
+      .update(sigBasestring, "utf8")
+      .digest("hex");
+
+  // Timing-safe comparison to prevent timing attacks
+  try {
+    const a = Buffer.from(computedSignature, "utf8");
+    const b = Buffer.from(slackSignature, "utf8");
+    if (a.length !== b.length) {
+      return { valid: false, reason: "Signature length mismatch" };
+    }
+    const isValid = crypto.timingSafeEqual(a, b);
+    return { valid: isValid, reason: isValid ? undefined : "Signature mismatch" };
+  } catch {
+    return { valid: false, reason: "Signature comparison failed" };
+  }
+};
+
+// Slack OAuth Token Exchange
+
+/**
+ * Exchanges a one-time OAuth code for a Slack Bot Token.
+ * Called during the OAuth redirect callback.
+ *
+ * @param {string} code - The authorization code from Slack
+ * @returns {Promise<object>} The Slack oauth.v2.access response data
+ */
+export const exchangeSlackCodeForToken = async (code) => {
+  const clientId = process.env.SLACK_CLIENT_ID;
+  const clientSecret = process.env.SLACK_CLIENT_SECRET;
+  const redirectUri = process.env.SLACK_REDIRECT_URI;
+
+  if (!clientId || !clientSecret) {
+    throw new Error("SLACK_CLIENT_ID or SLACK_CLIENT_SECRET is not configured");
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    ...(redirectUri && { redirect_uri: redirectUri }),
+  });
+
+  const response = await axios.post(
+    "https://slack.com/api/oauth.v2.access",
+    params.toString(),
+    {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      timeout: 10000,
+    }
+  );
+
+  if (!response.data.ok) {
+    throw new Error(`Slack OAuth exchange failed: ${response.data.error}`);
+  }
+
+  return response.data;
+};
+
+// Post Block Kit Message to Slack Channel
+
+/**
+ * Posts a Slack Block Kit message to a channel using the organization's bot token.
+ *
+ * @param {string} botToken - Slack bot OAuth token (xoxb-...)
+ * @param {string} channelId - Target Slack channel ID (e.g. "C0123ABCDEF")
+ * @param {Array}  blocks    - Array of Slack Block Kit block objects
+ * @param {string} [fallbackText] - Plain-text fallback for notifications
+ * @returns {Promise<object>} Slack API response
+ */
+export const postBlockMessage = async (botToken, channelId, blocks, fallbackText = "") => {
+  const response = await axios.post(
+    "https://slack.com/api/chat.postMessage",
+    {
+      channel: channelId,
+      text: fallbackText,
+      blocks,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        "Content-Type": "application/json",
+      },
+      timeout: 10000,
+    }
+  );
+
+  if (!response.data.ok) {
+    throw new Error(`Slack chat.postMessage failed: ${response.data.error}`);
+  }
+
+  return response.data;
+};
+
+// Block Kit Message Builders
+
+/**
+ * Builds a rich Slack Block Kit message to confirm a meeting was created
+ * via the /mom-create slash command.
+ *
+ * @param {object} meeting   - Meeting document from MongoDB
+ * @param {string} createdBy - Slack username who issued the command
+ * @returns {Array} Block Kit blocks array
+ */
+export const buildMeetingCreatedBlocks = (meeting, createdBy) => {
+  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+  const meetingUrl = `${frontendUrl}/meetings/${meeting._id}`;
+
+  return [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Meeting Created via MeetOnMemory",
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Title:*\n${meeting.title}` },
+        { type: "mrkdwn", text: `*Created by:*\n${createdBy}` },
+        {
+          type: "mrkdwn",
+          text: `*Date:*\n${meeting.date ? new Date(meeting.date).toDateString() : "TBD"}`,
+        },
+        { type: "mrkdwn", text: `*Type:*\n${meeting.meetingType || "General"}` },
+      ],
+    },
+    ...(meeting.description
+      ? [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: `*Description:*\n${meeting.description}` },
+        },
+      ]
+      : []),
+    { type: "divider" },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "View Meeting", emoji: true },
+          url: meetingUrl,
+          action_id: "view_meeting",
+          style: "primary",
+        },
+      ],
+    },
+  ];
+};
+
+/**
+ * Builds a rich Slack Block Kit message when Gemini finishes generating a MoM.
+ * Formats the AI summary, key decisions, and action items into a scannable card.
+ *
+ * @param {object} meeting - Meeting document (with populated summary & structuredMoM)
+ * @returns {Array} Block Kit blocks array
+ */
+export const buildMoMSummaryBlocks = (meeting) => {
+  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+  const meetingUrl = `${frontendUrl}/meetings/${meeting._id}`;
+  const mom = meeting.structuredMoM || {};
+
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "AI Meeting Summary Ready",
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*${meeting.title}*\n${meeting.summary ? meeting.summary.slice(0, 300) + (meeting.summary.length > 300 ? "…" : "") : "Summary generated."}`,
+      },
+    },
+    { type: "divider" },
+  ];
+
+  // Key Decisions section
+  const decisions = mom.decisions || mom.keyDecisions || [];
+  if (decisions.length > 0) {
+    const decisionList = decisions
+      .slice(0, 5)
+      .map((d) => `• ${typeof d === "string" ? d : d.description || d.decision || JSON.stringify(d)}`)
+      .join("\n");
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*📌 Key Decisions:*\n${decisionList}` },
+    });
+  }
+
+  // Action Items section
+  const actionItems = mom.actionItems || mom.action_items || [];
+  if (actionItems.length > 0) {
+    const actionList = actionItems
+      .slice(0, 5)
+      .map((a) => {
+        const task = typeof a === "string" ? a : a.task || a.description || JSON.stringify(a);
+        const assignee = a.assignee ? ` _(${a.assignee})_` : "";
+        return `• ${task}${assignee}`;
+      })
+      .join("\n");
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*Action Items:*\n${actionList}` },
+    });
+  }
+
+  blocks.push(
+    { type: "divider" },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "View Full Minutes", emoji: true },
+          url: meetingUrl,
+          action_id: "view_minutes",
+          style: "primary",
+        },
+      ],
+    }
+  );
+
+  return blocks;
+};
+
+// eventBus Listener: Post MoM to Slack on mom.generated
+
+/**
+ * Listens on the internal eventBus for 'mom.generated' events.
+ * When fired, checks if the meeting's organization has Slack integration
+ * configured. If yes, posts a formatted Block Kit summary to their channel.
+ */
+eventBus.on("mom.generated", async (meeting) => {
+  const orgId = meeting.organization;
+  if (!orgId) return;
+
+  try {
+    // Explicitly select slackIntegration.botToken since it's select:false by default
+    const org = await Organization.findById(orgId)
+      .select("+slackIntegration.botToken slackIntegration.channelId slackIntegration.teamId")
+      .lean();
+
+    const slack = org?.slackIntegration;
+    if (!slack?.botToken || !slack?.channelId) {
+      // Slack not integrated for this org — silently skip
+      return;
+    }
+
+    const blocks = buildMoMSummaryBlocks(meeting);
+    await postBlockMessage(
+      slack.botToken,
+      slack.channelId,
+      blocks,
+      `AI Meeting Summary ready for "${meeting.title}"`
+    );
+
+    console.log(`[Slack] MoM summary posted to channel ${slack.channelId} for org ${orgId}`);
+  } catch (err) {
+    // Non-fatal: Slack posting failure should never crash the main AI pipeline
+    console.error(`[Slack] Failed to post MoM summary to Slack for org ${orgId}:`, err.message);
+  }
+});

--- a/server/tests/slack.test.js
+++ b/server/tests/slack.test.js
@@ -1,0 +1,349 @@
+/**
+ * slack.test.js
+ *
+ * Integration tests for the Slack Bot Integration feature.
+ * Tests:
+ *  1. Slack Signature Verification utility (unit)
+ *  2. POST /api/slack/events - URL verification challenge
+ *  3. POST /api/slack/events - /mom-create slash command (org connected)
+ *  4. POST /api/slack/events - /mom-create slash command (org NOT connected)
+ *  5. POST /api/slack/events - generic event_callback acknowledgement
+ *  6. GET  /api/slack/install - missing organizationId
+ *  7. GET  /api/slack/oauth_redirect - missing code
+ */
+
+import request from "supertest";
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import axios from "axios";
+import { jest } from "@jest/globals";
+
+import { app } from "../server.js";
+import User from "../models/userModel.js";
+import Organization from "../models/organizationModel.js";
+import Membership from "../models/membershipModel.js";
+import { verifySlackSignature } from "../services/slackService.js";
+
+// Test helpers
+
+const SIGNING_SECRET = "test_signing_secret";
+
+/**
+ * Generates a valid Slack-style HMAC signature for a given body string.
+ * @param {string} body - Raw body string
+ * @param {number} [timestamp] - Unix timestamp (defaults to now)
+ * @returns {{ signature: string, timestamp: string }}
+ */
+const generateSlackSignature = (body, timestamp = Math.floor(Date.now() / 1000)) => {
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const signature =
+    "v0=" +
+    crypto
+      .createHmac("sha256", SIGNING_SECRET)
+      .update(sigBasestring, "utf8")
+      .digest("hex");
+  return { signature, timestamp: String(timestamp) };
+};
+
+// Mocks
+
+let axiosSpy;
+
+beforeAll(() => {
+  // Prevent real HTTP calls to Slack API
+  axiosSpy = jest.spyOn(axios, "post").mockResolvedValue({
+    status: 200,
+    data: {
+      ok: true,
+      access_token: "xoxb-test-token",
+      team: { id: "T12345TEST", name: "Test Workspace" },
+      incoming_webhook: { channel_id: "C12345TEST" },
+    },
+  });
+  process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+  process.env.SLACK_CLIENT_ID = "test_client_id";
+  process.env.SLACK_CLIENT_SECRET = "test_client_secret";
+  process.env.SLACK_REDIRECT_URI = "http://localhost:4000/api/slack/oauth_redirect";
+});
+
+afterAll(() => {
+  axiosSpy.mockRestore();
+  delete process.env.SLACK_SIGNING_SECRET;
+  delete process.env.SLACK_CLIENT_ID;
+  delete process.env.SLACK_CLIENT_SECRET;
+});
+
+// 1. Unit: verifySlackSignature
+
+describe("verifySlackSignature (unit)", () => {
+  it("returns valid=true for a correctly signed request", () => {
+    const body = "token=test&text=hello";
+    const { signature, timestamp } = generateSlackSignature(body);
+
+    const mockReq = {
+      headers: {
+        "x-slack-signature": signature,
+        "x-slack-request-timestamp": timestamp,
+      },
+      rawBody: Buffer.from(body),
+    };
+
+    const result = verifySlackSignature(mockReq);
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid=false for a tampered body", () => {
+    const body = "token=test&text=hello";
+    const { signature, timestamp } = generateSlackSignature(body);
+
+    const mockReq = {
+      headers: {
+        "x-slack-signature": signature,
+        "x-slack-request-timestamp": timestamp,
+      },
+      // Different body than what was signed
+      rawBody: Buffer.from("token=test&text=TAMPERED"),
+    };
+
+    const result = verifySlackSignature(mockReq);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid=false for a stale timestamp (replay attack)", () => {
+    const body = "token=test&text=hello";
+    const staleTimestamp = Math.floor(Date.now() / 1000) - 6 * 60; // 6 minutes ago
+    const { signature } = generateSlackSignature(body, staleTimestamp);
+
+    const mockReq = {
+      headers: {
+        "x-slack-signature": signature,
+        "x-slack-request-timestamp": String(staleTimestamp),
+      },
+      rawBody: Buffer.from(body),
+    };
+
+    const result = verifySlackSignature(mockReq);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/too old/i);
+  });
+
+  it("returns valid=false when signature headers are missing", () => {
+    const mockReq = {
+      headers: {},
+      rawBody: Buffer.from("token=test"),
+    };
+    const result = verifySlackSignature(mockReq);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/missing/i);
+  });
+});
+
+// Integration tests — /api/slack/events
+// NOTE: In NODE_ENV=test, slackSignatureMiddleware is bypassed.
+
+describe("POST /api/slack/events", () => {
+  // Case 1: URL verification challenge
+
+  it("responds to Slack URL verification challenge", async () => {
+    const res = await request(app)
+      .post("/api/slack/events")
+      .send({ type: "url_verification", challenge: "3eZbrw1aBm2rZgRNFdxV2595" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(200);
+    expect(res.body.challenge).toBe("3eZbrw1aBm2rZgRNFdxV2595");
+  });
+
+  // Case 2: Slash command — org connected
+
+  it("handles /mom-create slash command and creates a meeting when org is connected", async () => {
+    // Seed: org with Slack integration
+    const owner = await User.create({
+      name: "Slack Owner",
+      email: `slackowner-${Math.random()}@example.com`,
+      password: "password123",
+    });
+
+    const org = await Organization.create({
+      name: "Slack Org",
+      slug: "slack-org-" + Math.random().toString(36).substring(7),
+      owner: owner._id,
+      "slackIntegration.teamId": "TSLACKTEST",
+      "slackIntegration.botToken": "xoxb-fake",
+      "slackIntegration.channelId": "CTEST",
+    });
+
+    // Associate owner with org
+    await User.findByIdAndUpdate(owner._id, { organization: org._id });
+
+    // Create membership
+    await Membership.create({
+      user: owner._id,
+      organization: org._id,
+      role: "admin",
+      status: "active",
+    });
+
+    const slashPayload = new URLSearchParams({
+      command: "/mom-create",
+      text: '"Q3 Planning" @team',
+      team_id: "TSLACKTEST",
+      user_name: "chirag",
+      user_id: "UTEST",
+    }).toString();
+
+    const res = await request(app)
+      .post("/api/slack/events")
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .send(slashPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.response_type).toBe("in_channel");
+    expect(res.body.text).toMatch(/Q3 Planning/i);
+    expect(Array.isArray(res.body.blocks)).toBe(true);
+    // The first block should be our header block
+    expect(res.body.blocks[0].type).toBe("header");
+  });
+
+  // Case 3: Slash command — org NOT connected
+
+  it("returns ephemeral error when workspace is not connected to any org", async () => {
+    const slashPayload = new URLSearchParams({
+      command: "/mom-create",
+      text: '"Unknown Meeting"',
+      team_id: "TUNKNOWN",
+      user_name: "stranger",
+    }).toString();
+
+    const res = await request(app)
+      .post("/api/slack/events")
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .send(slashPayload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.response_type).toBe("ephemeral");
+    expect(res.body.text).toMatch(/not connected/i);
+  });
+
+  // Case 4: Generic event_callback
+
+  it("acknowledges generic event_callback with 200 OK", async () => {
+    const res = await request(app)
+      .post("/api/slack/events")
+      .send({
+        type: "event_callback",
+        team_id: "TTEST",
+        event: { type: "app_mention", text: "Hello bot" },
+      })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(200);
+  });
+
+  // Case 5: Unknown payload type
+
+  it("returns 200 for unknown payload types", async () => {
+    const res = await request(app)
+      .post("/api/slack/events")
+      .send({ type: "some_unknown_type" })
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// Integration tests — /api/slack/install
+
+describe("GET /api/slack/install", () => {
+  it("returns 401 when not authenticated", async () => {
+    const res = await request(app).get("/api/slack/install");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when organizationId is missing", async () => {
+    const user = await User.create({
+      name: "Install User",
+      email: `install-${Math.random()}@example.com`,
+      password: "password123",
+    });
+    const token = jwt.sign(
+      { id: user._id },
+      process.env.JWT_SECRET || "fallback_secret"
+    );
+
+    const res = await request(app)
+      .get("/api/slack/install")
+      .set("Authorization", `Bearer ${token}`);
+
+    // No organizationId in query or user.organization → 400
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/organizationId/i);
+  });
+});
+
+// Integration tests — /api/slack/oauth_redirect
+
+describe("GET /api/slack/oauth_redirect", () => {
+  it("returns 400 when no code is provided", async () => {
+    const res = await request(app)
+      .get("/api/slack/oauth_redirect")
+      .query({ state: new mongoose.Types.ObjectId().toString() });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/code/i);
+  });
+
+  it("returns 400 when no state (organizationId) is provided", async () => {
+    const res = await request(app)
+      .get("/api/slack/oauth_redirect")
+      .query({ code: "fake_code" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/organizationId/i);
+  });
+
+  it("returns 404 when organization does not exist", async () => {
+    const fakeOrgId = new mongoose.Types.ObjectId().toString();
+
+    const res = await request(app)
+      .get("/api/slack/oauth_redirect")
+      .query({ code: "fake_code", state: fakeOrgId });
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toMatch(/organization not found/i);
+  });
+
+  it("saves Slack integration to org on successful OAuth", async () => {
+    // Seed org
+    const owner = await User.create({
+      name: "OAuth Owner",
+      email: `oauthowner-${Math.random()}@example.com`,
+      password: "password123",
+    });
+    const org = await Organization.create({
+      name: "OAuth Org",
+      slug: "oauth-org-" + Math.random().toString(36).substring(7),
+      owner: owner._id,
+    });
+
+    const res = await request(app)
+      .get("/api/slack/oauth_redirect")
+      .query({ code: "valid_code", state: org._id.toString() });
+
+    // axios.post is mocked to return a successful Slack response
+    // So this should redirect (302) to the frontend with ?slackInstall=success
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain("slackInstall=success");
+
+    // Verify the org was updated in the database
+    const updatedOrg = await Organization.findById(org._id)
+      .select("+slackIntegration.botToken")
+      .lean();
+    expect(updatedOrg.slackIntegration.teamId).toBe("T12345TEST");
+    expect(updatedOrg.slackIntegration.teamName).toBe("Test Workspace");
+    expect(updatedOrg.slackIntegration.channelId).toBe("C12345TEST");
+    expect(updatedOrg.slackIntegration.botToken).toBe("xoxb-test-token");
+    expect(updatedOrg.slackIntegration.installedAt).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description
Resolves #185.

This pull request introduces the bi-directional Slack Integration for MeetOnMemory. Organizations can now connect their Slack workspaces, initiate meeting creation directly from Slack via the `/mom-create` slash command, and automatically receive rich Block Kit AI-generated Meeting Minutes (MoM) in their designated Slack channels.

The integration is built in a highly modular, decoupled fashion adhering to the repository's Service-Oriented Architecture (SOA) principles.

---

## Key Architectural & Implementation Details

### 1. Database Schema Extension & Optimization
- Modified `organizationModel.js` to store Slack configurations under `slackIntegration`:
  - `botToken`: Slack OAuth access token. Configured with `{ select: false }` to ensure it is never returned by default queries, mitigating potential token leakage.
  - `channelId`: Designated channel to publish meeting summaries.
  - `teamId` and `teamName`: Target Slack workspace information.
  - `installedAt`: Timestamp when the workspace integration was established.
- Added a **sparse index** on `"slackIntegration.teamId"` to allow $O(1)$ lookups during slash command payloads without bloating the index table for organizations that haven't integrated Slack.

### 2. Secure Signature Verification Middleware
- Captured the `rawBody` stream buffer in `server.js` using a custom verify function in `express.json` and `express.urlencoded` parsers.
- Implemented a cryptographic signature validator (`verifySlackSignature`) that:
  - Protects against replay attacks by rejecting requests older than 5 minutes.
  - Calculates the HMAC-SHA256 signature using `SLACK_SIGNING_SECRET` and the raw body stream.
  - Compares signatures using timing-safe comparison (`crypto.timingSafeEqual`) to prevent timing-attack vectors.
- Configured CSRF bypasses exclusively for incoming POST requests under `/api/slack/*` routes since Slack's API cannot furnish CSRF cookies.

### 3. Controller & Event Operations (Event-Driven Architecture)
- **Install Flow**: `GET /api/slack/install` initiates the redirection handshake, packing the target `organizationId` securely inside the OAuth `state` parameter.
- **Callback Flow**: `GET /api/slack/oauth_redirect` exchanges the authorization code for a bot token, persists the credentials, and redirects the user back to the web UI.
- **Slash Commands**: Parses slash commands like `/mom-create "Q3 Planning" @team`. Resolves the workspace's target organization via the sparse indexed `teamId`, schedules the meeting using `MeetingService.createMeeting`, and replies instantly with a structured confirmation Block Kit template.
- **Asynchronous Summary Dispatches**: Bound an event subscriber to the internal `eventBus` for the `mom.generated` event inside `slackService.js`. When the AI finishes summary generation, it builds a Block Kit message card summarizing key decisions and action items, then dispatches it asynchronously via Webhook/Chat API.

---

## File-by-File Changes Summary

| File | Status | Description |
| :--- | :--- | :--- |
| `server/models/organizationModel.js` | Modified | Added `slackIntegration` schema, selective security filtering on token fields, and sparse indexing on `teamId`. |
| `server/server.js` | Modified | Enabled `rawBody` buffering, registered Slack endpoints, and bypassed CSRF middleware checks for Slack callbacks. |
| `server/routes/slackRoutes.js` | **New** | Wires routes for Slack installation, redirect callback, and POST events. |
| `server/services/slackService.js` | **New** | Contains Slack client API helpers, signature validation logic, Block Kit payload builders, and `eventBus` listeners. |
| `server/controllers/slackController.js` | **New** | Handles OAuth redirection, slash command text-parsing, and challenge handshakes. |
| `server/tests/slack.test.js` | **New** | Test suite evaluating signature verification, slash commands parsing, challenge handshake, and OAuth redirections. |

---

## Test Verification Report

A comprehensive test suite containing 15 test cases has been added and executed to verify every acceptance criterion.

```bash
cd server
npm test -- --runInBand --testPathPatterns=slack.test.js
```

Test output
```bash
 PASS  tests/slack.test.js
  verifySlackSignature (unit)
    ✓ returns valid=true for a correctly signed request (658 ms)
    ✓ returns valid=false for a tampered body (12 ms)
    ✓ returns valid=false for a stale timestamp (replay attack) (46 ms)
    ✓ returns valid=false when signature headers are missing (45 ms)
  POST /api/slack/events
    ✓ responds to Slack URL verification challenge (194 ms)
    ✓ handles /mom-create slash command and creates a meeting when org is connected (1180 ms)
    ✓ returns ephemeral error when workspace is not connected to any org (73 ms)
    ✓ acknowledges generic event_callback with 200 OK (30 ms)
    ✓ returns 200 for unknown payload types (28 ms)
  GET /api/slack/install
    ✓ returns 401 when not authenticated (81 ms)
    ✓ returns 400 when organizationId is missing (97 ms)
  GET /api/slack/oauth_redirect
    ✓ returns 400 when no code is provided (30 ms)
    ✓ returns 400 when no state (organizationId) is provided (27 ms)
    ✓ returns 404 when organization does not exist (25 ms)
    ✓ saves Slack integration to org on successful OAuth (50 ms)

Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        19.744 s
```

## Screenshot
<img width="1180" height="1002" alt="image" src="https://github.com/user-attachments/assets/78bb0a07-74e5-4fba-aac7-402cda6195d2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack workspace integration with OAuth install and callback handling.
  * Implemented Slack event and slash-command processing to create meetings and respond in Slack using Block Kit.
  * Added Slack notifications for meeting creation and AI-generated meeting summary cards.
* **Bug Fixes**
  * Strengthened Slack request security with signature verification and timestamp replay protection, plus clearer handling of invalid/missing parameters.
  * Updated server handling to correctly preserve raw request payloads for verification and exempt Slack endpoints from CSRF checks.
* **Tests**
  * Added coverage for signature verification, Slack endpoints (events/challenges/commands), OAuth flows, and notification posting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->