### PR TITLE
perf: implement /api/health endpoint and GitHub Actions keep-alive cron job to eliminate Render cold starts (#171)

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,40 @@
+name: Keep-Alive Health Check
+
+on:
+  schedule:
+    # Trigger every 14 minutes to prevent Render's free tier from spinning down (which happens after 15 mins of inactivity)
+    - cron: "*/14 * * * *"
+  workflow_dispatch: # Allows manual trigger from the GitHub Actions tab
+
+jobs:
+  ping-backend:
+    name: Ping backend health endpoint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ping /api/health
+        run: |
+          # Fetch the backend URL from Repository Secrets; default to a placeholder if not configured
+          BACKEND_URL="${{ secrets.RENDER_BACKEND_URL }}"
+          
+          if [ -z "$BACKEND_URL" ]; then
+            echo "⚠️ secrets.RENDER_BACKEND_URL is not set. Defaulting to https://meetonmemory.onrender.com"
+            BACKEND_URL="https://meetonmemory.onrender.com"
+          fi
+          
+          # Remove trailing slash if present
+          BACKEND_URL=$(echo "$BACKEND_URL" | sed 's/\/$//')
+          
+          echo "📡 Sending keep-alive request to $BACKEND_URL/api/health..."
+          
+          # Send request and extract http status code
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$BACKEND_URL/api/health")
+          
+          echo "📥 Response Status Code: $STATUS_CODE"
+          
+          if [ "$STATUS_CODE" -eq 200 ]; then
+            echo "✅ Render backend is active and responded successfully."
+          else
+            echo "❌ Backend did not respond with 200 OK."
+            exit 1
+          fi

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -8,17 +8,16 @@ on:
 
 jobs:
   ping-backend:
-    name: Ping backend health endpoint
     runs-on: ubuntu-latest
+    env:
+      BACKEND_URL: ${{ secrets.RENDER_BACKEND_URL }}
 
     steps:
       - name: Ping /api/health
         run: |
-          # Fetch the backend URL from Repository Secrets; default to a placeholder if not configured
-          BACKEND_URL="${{ secrets.RENDER_BACKEND_URL }}"
-          
+          # Use backend URL from env; default to a placeholder if not configured
           if [ -z "$BACKEND_URL" ]; then
-            echo "⚠️ secrets.RENDER_BACKEND_URL is not set. Defaulting to https://meetonmemory.onrender.com"
+            echo "⚠️ RENDER_BACKEND_URL is not set. Defaulting to https://meetonmemory.onrender.com"
             BACKEND_URL="https://meetonmemory.onrender.com"
           fi
           

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7749,23 +7749,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7863,38 +7846,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -7939,56 +7890,6 @@
         "socks": {
           "optional": true
         }
-      }
-    },
-    "node_modules/mongoose/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/mpath": {

--- a/server/server.js
+++ b/server/server.js
@@ -137,17 +137,18 @@ app.use("/api/compliance", policyComplianceRoutes);
 app.use("/api/sessions", sessionRoutes);
 app.use("/api/webhooks", webhookRoutes);
 
-// GLOBAL RATE LIMITER
-app.use(globalLimiter);
-
-// Health check endpoint
-app.get("/health", (req, res) => {
+// Health check endpoint — registered BEFORE the global rate limiter so
+// keep-alive pings (e.g. from GitHub Actions cron job) are never blocked.
+app.get(["/health", "/api/health"], (req, res) => {
   res.status(200).json({
     status: "UP",
     timestamp: new Date().toISOString(),
     env: process.env.NODE_ENV,
   });
 });
+
+// GLOBAL RATE LIMITER
+app.use(globalLimiter);
 
 const server = http.createServer(app);
 

--- a/server/services/queueService.js
+++ b/server/services/queueService.js
@@ -20,7 +20,6 @@ import jwt from "jsonwebtoken";
 import transporter from "../config/nodeMailer.js";
 
 const require = createRequire(import.meta.url);
-const archiver = require("archiver");
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -403,7 +402,9 @@ export const initDataExportWorker = (app) => {
         const fileName = `export_${userId}_${Date.now()}.zip`;
         const filePath = path.join(exportDir, fileName);
 
-        await new Promise((resolve, reject) => {
+        await new Promise(async (resolve, reject) => {
+          // archiver v8+ is a pure ES Module — must be loaded via dynamic import()
+          const { default: archiver } = await import("archiver");
           const output = fs.createWriteStream(filePath);
           const archive = archiver("zip", { zlib: { level: 9 } });
 

--- a/server/services/queueService.js
+++ b/server/services/queueService.js
@@ -402,9 +402,10 @@ export const initDataExportWorker = (app) => {
         const fileName = `export_${userId}_${Date.now()}.zip`;
         const filePath = path.join(exportDir, fileName);
 
-        await new Promise(async (resolve, reject) => {
-          // archiver v8+ is a pure ES Module — must be loaded via dynamic import()
-          const { default: archiver } = await import("archiver");
+        // archiver v8+ is a pure ES Module — must be loaded via dynamic import()
+        const { default: archiver } = await import("archiver");
+
+        await new Promise((resolve, reject) => {
           const output = fs.createWriteStream(filePath);
           const archive = archiver("zip", { zlib: { level: 9 } });
 

--- a/server/tests/health.test.js
+++ b/server/tests/health.test.js
@@ -1,0 +1,20 @@
+import request from "supertest";
+import { app } from "../server.js";
+
+describe("Health Check Endpoints", () => {
+  it("should return 200 OK for GET /health", async () => {
+    const res = await request(app).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("status", "UP");
+    expect(res.body).toHaveProperty("timestamp");
+    expect(res.body).toHaveProperty("env");
+  });
+
+  it("should return 200 OK for GET /api/health", async () => {
+    const res = await request(app).get("/api/health");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("status", "UP");
+    expect(res.body).toHaveProperty("timestamp");
+    expect(res.body).toHaveProperty("env");
+  });
+});


### PR DESCRIPTION
## Description
Resolves #171.

The Render free tier spins down backend instances after 15 minutes of inactivity, causing a 5–10 second cold-start penalty for users attempting to log in or interact with the app after a period of inactivity.

This PR resolves the issue by implementing a public, lightweight health-check endpoint paired with a scheduled GitHub Actions cron job that keeps the instance warm at all times.

---

## Implementation Details

### 1. Health-Check Endpoint — `server/server.js`
- Registered `GET /api/health` (and retained `GET /health`) to return a minimal `200 OK` response.
- **Critically, the endpoint is registered *before* the global rate limiter middleware** so that automated pings from the GitHub Actions cron job are never throttled or rate-blocked.
- The handler performs no database queries, no I/O, and no heavy computation — it returns only `{ status, timestamp, env }` making it as lightweight as possible.

### 2. GitHub Actions Keep-Alive Workflow — `.github/workflows/health-check.yml`
- Scheduled with `*/14 * * * *` (every 14 minutes) — just under Render's 15-minute inactivity timeout.
- Uses `curl` to send a GET request to `${{ secrets.RENDER_BACKEND_URL }}/api/health`.
- Gracefully falls back to a default URL if the `RENDER_BACKEND_URL` repository secret is not configured.
- Supports manual trigger via `workflow_dispatch` for on-demand testing.
- Exits with code `1` if the response is not `200 OK`, making CI failures visible.

### 3. Bug Fix — `services/queueService.js` (bonus)
- Fixed an ESM incompatibility introduced by `archiver@^8.0.0` which is now a pure ES Module and cannot be loaded via `createRequire()`.
- Replaced the top-level `const archiver = require("archiver")` with a **lazy dynamic `import()`** inside the data-export worker callback, which is both correct and more efficient (module loaded only when a data-export job actually runs).

---

## File-by-File Changes

| File | Status | Description |
|:---|:---|:---|
| `server/server.js` | Modified | `/api/health` added as alias for `/health`; both endpoints moved before `globalLimiter` |
| `.github/workflows/health-check.yml` | **New** | Cron job pinging `/api/health` every 14 minutes via `curl` |
| `server/services/queueService.js` | Modified | Fixed `archiver` ESM loading via dynamic `import()` |
| `server/tests/health.test.js` | **New** | Integration tests verifying both `/health` and `/api/health` return `200 OK` |

---

## Test Results

```bash
PASS  tests/health.test.js (13.505 s)
  Health Check Endpoints
    ✓ should return 200 OK for GET /health (278 ms)
    ✓ should return 200 OK for GET /api/health (101 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Time: 13.695 s
```

## Screenshot
<img width="1540" height="897" alt="image" src="https://github.com/user-attachments/assets/961c6b22-3665-4ec3-b825-99d768eaf1b3" />

## Setup Required (Maintainer Action)

IMPORTANT -
To activate the keep-alive cron job for the production deployment, add the following repository secret:

Navigate to: Settings -> Secrets and variables -> Actions -> New repository secret
Name: RENDER_BACKEND_URL
Value: The full Render backend URL (e.g. https://meetonmemory-backend.onrender.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled health check to monitor backend availability.
  * Health status is now available through both `/health` and `/api/health`, including status, timestamp, and environment details.

* **Bug Fixes**
  * Health checks are no longer blocked by request rate limits.
  * Improved data-export compatibility with newer archive packaging.

* **Tests**
  * Added automated coverage for both health-check endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->