### PR TITLE
[Refactor]: Extract authentication business logic to `AuthService` and introduce unit tests

### DIFF
--- a/server/config/nodeMailer.js
+++ b/server/config/nodeMailer.js
@@ -64,13 +64,15 @@ if (isMock) {
     },
   });
 
-  transporter.verify((error, success) => {
-    if (error) {
-      console.error("❌ SMTP Connection Error:", error);
-    } else {
-      console.log("✅ SMTP Server is ready to send emails!");
-    }
-  });
+  if (process.env.NODE_ENV !== "test") {
+    transporter.verify((error, success) => {
+      if (error) {
+        console.error("❌ SMTP Connection Error:", error);
+      } else {
+        console.log("✅ SMTP Server is ready to send emails!");
+      }
+    });
+  }
 }
 
 export default transporter;

--- a/server/controllers/authControllers.js
+++ b/server/controllers/authControllers.js
@@ -1,21 +1,7 @@
-import bcrypt from "bcryptjs";
-import jwt from "jsonwebtoken";
-import { randomInt } from "node:crypto";
-import userModel from "../models/userModel.js";
-import transporter from "../config/nodeMailer.js";
-import {
-  EMAIL_VERIFY_TEMPLATE,
-  PASSWORD_RESET_TEMPLATE,
-} from "../config/emailTemplates.js";
-import { getAuthUrl, getTokens } from "../services/calendarService.js";
+import { getAuthUrl } from "../services/calendarService.js";
+import AuthService from "../services/AuthService.js";
 
 // --------------------------- HELPERS ---------------------------
-const sendBackgroundEmail = (mailOptions, flowName) => {
-  transporter.sendMail(mailOptions).catch((err) => {
-    console.error(`Background email transmission failed [${flowName}]:`, err);
-  });
-};
-
 const validateFields = (fields, res) => {
   const missing = Object.entries(fields).filter(([_, val]) => !val);
   if (missing.length > 0) {
@@ -25,33 +11,13 @@ const validateFields = (fields, res) => {
   return true;
 };
 
-const normalizeEmail = (email) => String(email).trim().toLowerCase();
-
 // --------------------------- REGISTER ---------------------------
 export const register = async (req, res) => {
   const { name, email, password } = req.body;
   if (!validateFields({ name, email, password }, res)) return;
 
   try {
-    const cleanEmail = normalizeEmail(email);
-    const existingUser = await userModel
-      .findOne({ email: cleanEmail })
-      .select("_id")
-      .lean();
-    if (existingUser)
-      return res.json({ success: false, message: "User already exists" });
-
-    const hashedPassword = await bcrypt.hash(password, 10);
-    const user = new userModel({
-      name,
-      email: cleanEmail,
-      password: hashedPassword,
-    });
-    await user.save();
-
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
-      expiresIn: "7d",
-    });
+    const { token } = await AuthService.register({ name, email, password });
 
     res.cookie("token", token, {
       httpOnly: true,
@@ -59,16 +25,6 @@ export const register = async (req, res) => {
       sameSite: process.env.NODE_ENV === "production" ? "none" : "strict",
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
-
-    sendBackgroundEmail(
-      {
-        from: process.env.SENDER_EMAIL,
-        to: cleanEmail,
-        subject: "Welcome to MeetOnMemory!",
-        text: `Welcome to MeetOnMemory, ${name}! Your account has been successfully created.`,
-      },
-      "Register",
-    );
 
     return res
       .status(201)
@@ -85,17 +41,7 @@ export const login = async (req, res) => {
   if (!validateFields({ email, password }, res)) return;
 
   try {
-    const cleanEmail = normalizeEmail(email);
-    const user = await userModel.findOne({ email: cleanEmail }).lean();
-    if (!user) return res.json({ success: false, message: "Invalid Email" });
-
-    const isMatch = await bcrypt.compare(password, user.password);
-    if (!isMatch)
-      return res.json({ success: false, message: "Invalid Password" });
-
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
-      expiresIn: "7d",
-    });
+    const { token } = await AuthService.login({ email, password });
 
     res.cookie("token", token, {
       httpOnly: true,
@@ -129,32 +75,18 @@ export const logout = async (req, res) => {
 export const sendVerifyOtp = async (req, res) => {
   try {
     const { userId } = req;
-    const user = await userModel.findById(userId);
-
-    if (!user)
-      return res.json({ success: false, message: "Authentication failed" });
-    if (user.isAccountVerified)
-      return res.json({ success: false, message: "Account already verified" });
-
-    const otp = randomInt(100000, 1000000).toString();
-    user.verifyOtp = otp;
-    user.verifyOtpExpireAt = Date.now() + 24 * 60 * 60 * 1000;
-    await user.save();
-
-    await transporter.sendMail({
-      from: process.env.SENDER_EMAIL,
-      to: user.email,
-      subject: "Account Verification OTP",
-      html: EMAIL_VERIFY_TEMPLATE.replace("{{otp}}", otp).replace(
-        "{{email}}",
-        user.email,
-      ),
-    });
+    
+    await AuthService.sendVerifyOtp(userId);
 
     res.json({ success: true, message: "Verification OTP sent on email" });
   } catch (error) {
     console.error("SendVerifyOtp error:", error);
-    res.json({ success: false, message: "Failed to send verification OTP" });
+    // Maintain old generic error for sendVerifyOtp to not break tests if it relies on exact string
+    if (error.message === "Authentication failed" || error.message === "Account already verified") {
+      res.json({ success: false, message: error.message });
+    } else {
+      res.json({ success: false, message: "Failed to send verification OTP" });
+    }
   }
 };
 
@@ -165,21 +97,7 @@ export const verifyEmail = async (req, res) => {
   if (!validateFields({ userId, otp }, res)) return;
 
   try {
-    const user = await userModel.findById(userId);
-    if (!user)
-      return res.json({
-        success: false,
-        message: "Verification session invalid",
-      });
-    if (user.verifyOtp === "" || user.verifyOtp !== otp)
-      return res.json({ success: false, message: "Invalid OTP" });
-    if (user.verifyOtpExpireAt < Date.now())
-      return res.json({ success: false, message: "OTP expired" });
-
-    user.isAccountVerified = true;
-    user.verifyOtp = "";
-    user.verifyOtpExpireAt = 0;
-    await user.save();
+    await AuthService.verifyEmail({ userId, otp });
 
     return res.json({ success: true, message: "Email verified successfully!" });
   } catch (error) {
@@ -202,27 +120,7 @@ export const sendResetOtp = async (req, res) => {
   if (!validateFields({ email }, res)) return;
 
   try {
-    const cleanEmail = normalizeEmail(email);
-    const user = await userModel.findOne({ email: cleanEmail });
-
-    if (!user) {
-      return res.json({ success: true, message: "OTP sent to your email" });
-    }
-
-    const otp = randomInt(100000, 1000000).toString();
-    user.resetOtp = otp;
-    user.resetOtpExpireAt = Date.now() + 15 * 60 * 1000;
-    await user.save();
-
-    await transporter.sendMail({
-      from: process.env.SENDER_EMAIL,
-      to: user.email,
-      subject: "Password Reset OTP",
-      html: PASSWORD_RESET_TEMPLATE.replace("{{otp}}", otp).replace(
-        "{{email}}",
-        user.email,
-      ),
-    });
+    await AuthService.sendResetOtp({ email });
 
     res.json({ success: true, message: "OTP sent to your email" });
   } catch (error) {
@@ -240,23 +138,7 @@ export const resetPassword = async (req, res) => {
   if (!validateFields({ email, otp, newPassword }, res)) return;
 
   try {
-    const cleanEmail = normalizeEmail(email);
-    const user = await userModel.findOne({ email: cleanEmail });
-
-    if (!user)
-      return res.json({
-        success: false,
-        message: "Invalid request or expired token",
-      });
-    if (user.resetOtp === "" || user.resetOtp !== otp)
-      return res.json({ success: false, message: "Invalid OTP" });
-    if (user.resetOtpExpireAt < Date.now())
-      return res.json({ success: false, message: "OTP expired" });
-
-    user.password = await bcrypt.hash(newPassword, 10);
-    user.resetOtp = "";
-    user.resetOtpExpireAt = 0;
-    await user.save();
+    await AuthService.resetPassword({ email, otp, newPassword });
 
     return res.json({
       success: true,
@@ -270,20 +152,16 @@ export const resetPassword = async (req, res) => {
 // --------------------------- GET USER DATA (For Dashboard) ---------------------------
 export const getUserData = async (req, res) => {
   try {
-    const user = await userModel
-      .findById(req.user.id)
-      .populate("organization", "name")
-      .lean();
-
-    if (!user)
-      return res
-        .status(404)
-        .json({ success: false, message: "User not found" });
+    const user = await AuthService.getUserData(req.user.id);
 
     res.status(200).json({ success: true, user });
   } catch (error) {
     console.error("Error fetching user data:", error);
-    res.status(500).json({ success: false, message: "Server error" });
+    if (error.statusCode === 404) {
+      res.status(404).json({ success: false, message: "User not found" });
+    } else {
+      res.status(500).json({ success: false, message: "Server error" });
+    }
   }
 };
 
@@ -296,32 +174,17 @@ export const googleCalendarAuth = (req, res) => {
 export const googleCalendarCallback = async (req, res) => {
   const { code } = req.query;
   try {
-    const tokens = await getTokens(code);
-
     const token = req.cookies?.token;
-    if (!token)
-      return res
-        .status(401)
-        .json({ success: false, message: "Not authenticated" });
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const userId = decoded.id;
-
-    const user = await userModel.findById(userId);
-    if (!user)
-      return res
-        .status(404)
-        .json({ success: false, message: "User not found" });
-
-    user.googleAccessToken = tokens.access_token;
-    if (tokens.refresh_token) {
-      user.googleRefreshToken = tokens.refresh_token;
-    }
-    user.calendarSyncEnabled = true;
-    await user.save();
+    await AuthService.googleCalendarCallback({ code, token });
 
     res.redirect("http://localhost:5173/profile?sync=success");
   } catch (error) {
     console.error("Google Calendar Callback error:", error);
+    if (error.statusCode === 401) {
+      return res.status(401).json({ success: false, message: "Not authenticated" });
+    } else if (error.statusCode === 404) {
+      return res.status(404).json({ success: false, message: "User not found" });
+    }
     res.redirect("http://localhost:5173/profile?sync=error");
   }
 };

--- a/server/services/AuthService.js
+++ b/server/services/AuthService.js
@@ -1,0 +1,194 @@
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import { randomInt } from "node:crypto";
+import userModel from "../models/userModel.js";
+import transporter from "../config/nodeMailer.js";
+import {
+  EMAIL_VERIFY_TEMPLATE,
+  PASSWORD_RESET_TEMPLATE,
+} from "../config/emailTemplates.js";
+import { getTokens } from "./calendarService.js";
+import { AppError, NotFoundError } from "../utils/errors.js";
+
+const normalizeEmail = (email) => String(email).trim().toLowerCase();
+
+class AuthService {
+  static async register({ name, email, password }) {
+    const cleanEmail = normalizeEmail(email);
+    const existingUser = await userModel
+      .findOne({ email: cleanEmail })
+      .select("_id")
+      .lean();
+    if (existingUser) {
+      throw new AppError("User already exists", 400);
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = new userModel({
+      name,
+      email: cleanEmail,
+      password: hashedPassword,
+    });
+    await user.save();
+
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
+      expiresIn: "7d",
+    });
+
+    transporter.sendMail({
+      from: process.env.SENDER_EMAIL,
+      to: cleanEmail,
+      subject: "Welcome to MeetOnMemory!",
+      text: `Welcome to MeetOnMemory, ${name}! Your account has been successfully created.`,
+    }).catch((err) => {
+      console.error(`Background email transmission failed [Register]:`, err);
+    });
+
+    return { user, token };
+  }
+
+  static async login({ email, password }) {
+    const cleanEmail = normalizeEmail(email);
+    const user = await userModel.findOne({ email: cleanEmail }).lean();
+    if (!user) {
+      throw new AppError("Invalid Email", 400);
+    }
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      throw new AppError("Invalid Password", 400);
+    }
+
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, {
+      expiresIn: "7d",
+    });
+
+    return { user, token };
+  }
+
+  static async sendVerifyOtp(userId) {
+    const user = await userModel.findById(userId);
+
+    if (!user) {
+      throw new AppError("Authentication failed", 400);
+    }
+    if (user.isAccountVerified) {
+      throw new AppError("Account already verified", 400);
+    }
+
+    const otp = randomInt(100000, 1000000).toString();
+    user.verifyOtp = otp;
+    user.verifyOtpExpireAt = Date.now() + 24 * 60 * 60 * 1000;
+    await user.save();
+
+    await transporter.sendMail({
+      from: process.env.SENDER_EMAIL,
+      to: user.email,
+      subject: "Account Verification OTP",
+      html: EMAIL_VERIFY_TEMPLATE.replace("{{otp}}", otp).replace(
+        "{{email}}",
+        user.email,
+      ),
+    });
+  }
+
+  static async verifyEmail({ userId, otp }) {
+    const user = await userModel.findById(userId);
+    if (!user) {
+      throw new AppError("Verification session invalid", 400);
+    }
+    if (user.verifyOtp === "" || user.verifyOtp !== otp) {
+      throw new AppError("Invalid OTP", 400);
+    }
+    if (user.verifyOtpExpireAt < Date.now()) {
+      throw new AppError("OTP expired", 400);
+    }
+
+    user.isAccountVerified = true;
+    user.verifyOtp = "";
+    user.verifyOtpExpireAt = 0;
+    await user.save();
+  }
+
+  static async sendResetOtp({ email }) {
+    const cleanEmail = normalizeEmail(email);
+    const user = await userModel.findOne({ email: cleanEmail });
+
+    if (!user) {
+      return; // Return silently if user not found for security
+    }
+
+    const otp = randomInt(100000, 1000000).toString();
+    user.resetOtp = otp;
+    user.resetOtpExpireAt = Date.now() + 15 * 60 * 1000;
+    await user.save();
+
+    await transporter.sendMail({
+      from: process.env.SENDER_EMAIL,
+      to: user.email,
+      subject: "Password Reset OTP",
+      html: PASSWORD_RESET_TEMPLATE.replace("{{otp}}", otp).replace(
+        "{{email}}",
+        user.email,
+      ),
+    });
+  }
+
+  static async resetPassword({ email, otp, newPassword }) {
+    const cleanEmail = normalizeEmail(email);
+    const user = await userModel.findOne({ email: cleanEmail });
+
+    if (!user) {
+      throw new AppError("Invalid request or expired token", 400);
+    }
+    if (user.resetOtp === "" || user.resetOtp !== otp) {
+      throw new AppError("Invalid OTP", 400);
+    }
+    if (user.resetOtpExpireAt < Date.now()) {
+      throw new AppError("OTP expired", 400);
+    }
+
+    user.password = await bcrypt.hash(newPassword, 10);
+    user.resetOtp = "";
+    user.resetOtpExpireAt = 0;
+    await user.save();
+  }
+
+  static async getUserData(userId) {
+    const user = await userModel
+      .findById(userId)
+      .populate("organization", "name")
+      .lean();
+
+    if (!user) {
+      throw new NotFoundError("User not found");
+    }
+
+    return user;
+  }
+
+  static async googleCalendarCallback({ code, token }) {
+    const tokens = await getTokens(code);
+
+    if (!token) {
+      throw new AppError("Not authenticated", 401);
+    }
+    
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const userId = decoded.id;
+
+    const user = await userModel.findById(userId);
+    if (!user) {
+      throw new NotFoundError("User not found");
+    }
+
+    user.googleAccessToken = tokens.access_token;
+    if (tokens.refresh_token) {
+      user.googleRefreshToken = tokens.refresh_token;
+    }
+    user.calendarSyncEnabled = true;
+    await user.save();
+  }
+}
+
+export default AuthService;

--- a/server/tests/AuthService.test.js
+++ b/server/tests/AuthService.test.js
@@ -1,0 +1,179 @@
+import { jest } from '@jest/globals';
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
+import userModel from "../models/userModel.js";
+import transporter from "../config/nodeMailer.js";
+import AuthService from "../services/AuthService.js";
+import { AppError } from "../utils/errors.js";
+
+describe("AuthService", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.spyOn(transporter, 'sendMail').mockResolvedValue(true);
+    jest.spyOn(jwt, 'sign').mockReturnValue("mockJwtToken");
+  });
+
+  describe("register", () => {
+    it("should successfully register a new user and return user and token", async () => {
+      jest.spyOn(userModel, 'findOne').mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue(null),
+        }),
+      });
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue("hashedPassword123");
+      jest.spyOn(userModel.prototype, 'save').mockResolvedValue(true);
+
+      const result = await AuthService.register({
+        name: "Test User",
+        email: "test@example.com",
+        password: "password123",
+      });
+
+      expect(userModel.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
+      expect(bcrypt.hash).toHaveBeenCalledWith("password123", 10);
+      expect(userModel.prototype.save).toHaveBeenCalled();
+      expect(jwt.sign).toHaveBeenCalled();
+      expect(transporter.sendMail).toHaveBeenCalled();
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("token", "mockJwtToken");
+    });
+
+    it("should throw AppError if user already exists", async () => {
+      jest.spyOn(userModel, 'findOne').mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ _id: "existingUserId" }),
+        }),
+      });
+
+      await expect(
+        AuthService.register({
+          name: "Test User",
+          email: "existing@example.com",
+          password: "password123",
+        })
+      ).rejects.toThrow(new AppError("User already exists", 400));
+    });
+  });
+
+  describe("login", () => {
+    it("should successfully login a user and return user and token", async () => {
+      const mockUser = {
+        _id: "mockUserId",
+        email: "test@example.com",
+        password: "hashedPassword123",
+      };
+      jest.spyOn(userModel, 'findOne').mockReturnValue({
+        lean: jest.fn().mockResolvedValue(mockUser),
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(true);
+
+      const result = await AuthService.login({
+        email: "test@example.com",
+        password: "password123",
+      });
+
+      expect(userModel.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
+      expect(bcrypt.compare).toHaveBeenCalledWith("password123", "hashedPassword123");
+      expect(jwt.sign).toHaveBeenCalled();
+      expect(result).toEqual({ user: mockUser, token: "mockJwtToken" });
+    });
+
+    it("should throw AppError if user is not found", async () => {
+      jest.spyOn(userModel, 'findOne').mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        AuthService.login({
+          email: "nonexistent@example.com",
+          password: "password123",
+        })
+      ).rejects.toThrow(new AppError("Invalid Email", 400));
+    });
+
+    it("should throw AppError if password does not match", async () => {
+      jest.spyOn(userModel, 'findOne').mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ password: "hashedPassword123" }),
+      });
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false);
+
+      await expect(
+        AuthService.login({
+          email: "test@example.com",
+          password: "wrongPassword",
+        })
+      ).rejects.toThrow(new AppError("Invalid Password", 400));
+    });
+  });
+
+  describe("resetPassword", () => {
+    it("should successfully reset password", async () => {
+      const mockSave = jest.fn().mockResolvedValue(true);
+      const mockUser = {
+        email: "test@example.com",
+        resetOtp: "123456",
+        resetOtpExpireAt: Date.now() + 10000,
+        save: mockSave,
+      };
+      jest.spyOn(userModel, 'findOne').mockResolvedValue(mockUser);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue("newHashedPassword123");
+
+      await AuthService.resetPassword({
+        email: "test@example.com",
+        otp: "123456",
+        newPassword: "newPassword123",
+      });
+
+      expect(userModel.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
+      expect(bcrypt.hash).toHaveBeenCalledWith("newPassword123", 10);
+      expect(mockUser.password).toBe("newHashedPassword123");
+      expect(mockUser.resetOtp).toBe("");
+      expect(mockUser.resetOtpExpireAt).toBe(0);
+      expect(mockSave).toHaveBeenCalled();
+    });
+
+    it("should throw AppError if user not found", async () => {
+      jest.spyOn(userModel, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        AuthService.resetPassword({
+          email: "nonexistent@example.com",
+          otp: "123456",
+          newPassword: "newPassword123",
+        })
+      ).rejects.toThrow(new AppError("Invalid request or expired token", 400));
+    });
+
+    it("should throw AppError if OTP is invalid", async () => {
+      jest.spyOn(userModel, 'findOne').mockResolvedValue({
+        email: "test@example.com",
+        resetOtp: "123456",
+        resetOtpExpireAt: Date.now() + 10000,
+      });
+
+      await expect(
+        AuthService.resetPassword({
+          email: "test@example.com",
+          otp: "wrongOtp",
+          newPassword: "newPassword123",
+        })
+      ).rejects.toThrow(new AppError("Invalid OTP", 400));
+    });
+
+    it("should throw AppError if OTP is expired", async () => {
+      jest.spyOn(userModel, 'findOne').mockResolvedValue({
+        email: "test@example.com",
+        resetOtp: "123456",
+        resetOtpExpireAt: Date.now() - 10000,
+      });
+
+      await expect(
+        AuthService.resetPassword({
+          email: "test@example.com",
+          otp: "123456",
+          newPassword: "newPassword123",
+        })
+      ).rejects.toThrow(new AppError("OTP expired", 400));
+    });
+  });
+});


### PR DESCRIPTION
- closes #241

### Description

This PR addresses the "Fat Controller" anti-pattern in the authentication flow by extracting the core business logic from `server/controllers/authControllers.js` into a dedicated `server/services/AuthService.js` class. 

By applying the **Single Responsibility Principle**, the controller layer is now strictly responsible for HTTP operations (request parsing, cookie setting, and response formatting), while the service layer manages data processing, database interactions, JWT generation, and SMTP dispatching. 

Crucially, **the frontend API contract remains 100% backward-compatible**. All existing response shapes (`{ success: true, message: "..." }`) and cookie configurations are identical to the previous implementation.

### Key Changes
- **Introduced `AuthService`**: Extracted logic for `register`, `login`, `sendVerifyOtp`, `verifyEmail`, `sendResetOtp`, `resetPassword`, `getUserData`, and `googleCalendarCallback`.
- **Slimmed down `authControllers.js`**: Controllers are now minimized to a strict 3-step process (parse payload → await service → return formatted response).
- **Standardized Error Handling**: Replaced hardcoded string error returns with centralized custom error classes (`AppError` and `NotFoundError`) thrown by the service layer.
- **Added Unit Tests**: Created `server/tests/AuthService.test.js` to test core authentication flows (`register`, `login`, `resetPassword`) in isolation using `jest.spyOn()` to effectively mock `userModel`, `bcrypt`, `jwt`, and `nodemailer`.
- **Fixed Test Hanging**: Updated `config/nodeMailer.js` to prevent `transporter.verify()` from keeping the SMTP socket open when `process.env.NODE_ENV === "test"`, allowing Jest to exit gracefully without open handles.

### Testing Instructions
1. Run `npm run test` or `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/AuthService.test.js` in the `server` directory.
2. Ensure all 9 unit tests pass.
3. Observe that Jest exits instantly upon test completion without the open-handles error.
4. Test the registration, login, and password reset flows manually via the client to confirm no regressions in cookies or API response structures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined registration and login handling.
  - Added email verification and password reset flows with one-time passcodes.
  - Added Google Calendar connection support through OAuth.
  - Added user profile retrieval with associated organization details.

- **Bug Fixes**
  - Prevented email service verification from running during automated tests.
  - Improved authentication error handling and user-not-found responses.
  - Registration now remains successful when welcome emails cannot be delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->