### PR TITLE
[Architecture]: Refactor server.js middleware configurations & fix ESM test mocks

### DIFF
--- a/server/config/corsOptions.js
+++ b/server/config/corsOptions.js
@@ -1,0 +1,21 @@
+export const allowedOrigins = [
+  "http://localhost:5173",
+  "http://localhost:5174",
+  "http://127.0.0.1:5173",
+  "http://127.0.0.1:5174",
+  process.env.CLIENT_URL,
+].filter(Boolean);
+
+export const corsOptions = {
+  origin: function (origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      console.warn(`Blocked by CORS: ${origin}`);
+      callback(new Error("Not allowed by CORS"));
+    }
+  },
+  credentials: true,
+  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+  allowedHeaders: ["Content-Type", "Authorization", "X-CSRF-Token"],
+};

--- a/server/middleware/csrfProtection.js
+++ b/server/middleware/csrfProtection.js
@@ -1,0 +1,31 @@
+import csrf from "csurf";
+
+const csrfProtection = csrf({
+  cookie: {
+    key: "_csrf",
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+  },
+});
+
+export const csrfMiddleware = (req, res, next) => {
+  const isSafeMethod = ["GET", "HEAD", "OPTIONS"].includes(req.method);
+  const isAuthRoute = req.path.startsWith("/api/auth");
+  const isSyncPath = req.path.startsWith("/sync");
+  // Slack cannot send CSRF tokens — exclude all Slack endpoints
+  const isSlackRoute = req.path.startsWith("/api/slack");
+
+  if (
+    isSafeMethod ||
+    isAuthRoute ||
+    isSyncPath ||
+    isSlackRoute ||
+    process.env.NODE_ENV === "test"
+  ) {
+    return next();
+  }
+  return csrfProtection(req, res, next);
+};
+
+export const csrfTokenProvider = csrfProtection;

--- a/server/middleware/slackWebhookParser.js
+++ b/server/middleware/slackWebhookParser.js
@@ -1,0 +1,8 @@
+import express from "express";
+
+export const slackWebhookParser = express.json({
+  limit: "50mb",
+  verify: (req, _res, buf) => {
+    req.rawBody = buf;
+  },
+});

--- a/server/server.js
+++ b/server/server.js
@@ -2,7 +2,6 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import cookieParser from "cookie-parser";
-import csrf from "csurf";
 import { Server } from "socket.io";
 import http from "http";
 
@@ -60,79 +59,21 @@ const PORT = process.env.PORT || 4000;
 // DATABASE & CACHE
 await connectDB();
 
+import { corsOptions, allowedOrigins } from "./config/corsOptions.js";
+import { csrfMiddleware, csrfTokenProvider } from "./middleware/csrfProtection.js";
+
 // MIDDLEWARES
-const allowedOrigins = [
-  "http://localhost:5173",
-  "http://localhost:5174",
-  "http://127.0.0.1:5173",
-  "http://127.0.0.1:5174",
-  process.env.CLIENT_URL,
-].filter(Boolean);
+app.use(cors(corsOptions));
 
-app.use(
-  cors({
-    origin: function (origin, callback) {
-      if (!origin || allowedOrigins.includes(origin)) {
-        callback(null, true);
-      } else {
-        console.warn(`Blocked by CORS: ${origin}`);
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    credentials: true,
-    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
-    allowedHeaders: ["Content-Type", "Authorization", "X-CSRF-Token"],
-  }),
-);
-
-// Capture the raw request body so Slack's signing-secret HMAC verification
-// can read it before the JSON/urlencoded parsers consume the stream.
-app.use(express.json({
-  limit: "50mb",
-  verify: (req, _res, buf) => {
-    req.rawBody = buf;
-  },
-}));
-app.use(express.urlencoded({
-  extended: true,
-  limit: "50mb",
-  verify: (req, _res, buf) => {
-    req.rawBody = buf;
-  },
-}));
+app.use(express.json({ limit: "50mb" }));
+app.use(express.urlencoded({ extended: true, limit: "50mb" }));
 app.use(cookieParser());
 
 // Enforce CSRF protection on mutation routes
-const csrfProtection = csrf({
-  cookie: {
-    key: "_csrf",
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "strict",
-  },
-});
-
-app.use((req, res, next) => {
-  const isSafeMethod = ["GET", "HEAD", "OPTIONS"].includes(req.method);
-  const isAuthRoute = req.path.startsWith("/api/auth");
-  const isSyncPath = req.path.startsWith("/sync");
-  // Slack cannot send CSRF tokens — exclude all Slack endpoints
-  const isSlackRoute = req.path.startsWith("/api/slack");
-
-  if (
-    isSafeMethod ||
-    isAuthRoute ||
-    isSyncPath ||
-    isSlackRoute ||
-    process.env.NODE_ENV === "test"
-  ) {
-    return next();
-  }
-  return csrfProtection(req, res, next);
-});
+app.use(csrfMiddleware);
 
 // CSRF token provider
-app.get("/api/csrf-token", csrfProtection, (req, res) => {
+app.get("/api/csrf-token", csrfTokenProvider, (req, res) => {
   res.json({ csrfToken: req.csrfToken() });
 });
 
@@ -156,9 +97,11 @@ app.use("/api/user", userRoutes);
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/knowledge", knowledgeRoutes);
 app.use("/api/compliance", policyComplianceRoutes);
+import { slackWebhookParser } from "./middleware/slackWebhookParser.js";
+
 app.use("/api/sessions", sessionRoutes);
 app.use("/api/webhooks", webhookRoutes);
-app.use("/api/slack", slackRoutes);
+app.use("/api/slack", slackWebhookParser, slackRoutes);
 
 // Health check endpoint — registered BEFORE the global rate limiter so
 // keep-alive pings (e.g. from GitHub Actions cron job) are never blocked.

--- a/server/tests/nodeMailer.test.js
+++ b/server/tests/nodeMailer.test.js
@@ -1,11 +1,20 @@
-import nodemailer from "nodemailer";
+import { jest } from "@jest/globals";
+const nodemailerMock = {
+  createTransport: jest.fn().mockReturnValue({
+    sendMail: jest.fn().mockResolvedValue({ messageId: "real-id" }),
+    verify: jest.fn().mockImplementation((cb) => cb(null, true)),
+  }),
+};
 
-jest.mock("nodemailer", () => {
+jest.unstable_mockModule("nodemailer", () => {
   return {
-    createTransport: jest.fn().mockReturnValue({
-      sendMail: jest.fn().mockResolvedValue({ messageId: "real-id" }),
-      verify: jest.fn().mockImplementation((cb) => cb(null, true)),
-    }),
+    default: nodemailerMock,
+  };
+});
+
+jest.unstable_mockModule("dotenv", () => {
+  return {
+    default: { config: jest.fn() },
   };
 });
 
@@ -62,15 +71,15 @@ describe("nodeMailer lazy initialization test", () => {
     const { default: transporter } = await import(`../config/nodeMailer.js?test=3`);
 
     // Re-verify that createTransport was NOT called simply by loading/setting env
-    expect(nodemailer.createTransport).not.toHaveBeenCalled();
+    expect(nodemailerMock.createTransport).not.toHaveBeenCalled();
 
     // Call sendMail (which should trigger lazy initialization of real transporter)
     const mailOptions = { to: "user@example.com", subject: "Real SMTP Test", text: "Real mail contents" };
     const res = await transporter.sendMail(mailOptions);
 
     // Assert createTransport was called with correct configuration
-    expect(nodemailer.createTransport).toHaveBeenCalledTimes(1);
-    expect(nodemailer.createTransport).toHaveBeenCalledWith({
+    expect(nodemailerMock.createTransport).toHaveBeenCalledTimes(1);
+    expect(nodemailerMock.createTransport).toHaveBeenCalledWith({
       host: "smtp.example.com",
       port: 465,
       secure: true,


### PR DESCRIPTION
- closes #289

### Description
This PR addresses the bloating of the main `server.js` entry point by extracting inline middleware configurations into dedicated, modular files. It also fixes a pre-existing Jest test failure related to ES module compatibility.

### Changes Made

**1. Modularized Configuration**
*   **CORS**: Extracted the allowed origins array and `cors` middleware options into `server/config/corsOptions.js`.
*   **CSRF**: Moved the `csurf` initialization and custom path-exclusion logic (e.g., bypassing CSRF for `/api/slack`, `/api/auth`, and `/sync`) into `server/middleware/csrfProtection.js`. 
*   **Slack Webhook Parser**: Created `server/middleware/slackWebhookParser.js` to handle raw-body parsing required for Slack's HMAC verification. This was previously cluttering the global `express.json()` definition and is now properly scoped *only* to `/api/slack` routes.

**2. Test Suite Fixes**
*   **`nodeMailer.test.js`**: Fixed the mock evaluation failure that occurred when running Jest with Node's `--experimental-vm-modules`. Replaced the static `jest.mock()` with `jest.unstable_mockModule()` to properly intercept ESM imports for `nodemailer` and `dotenv`, bringing the test suite back to a completely green state.

### Motivation and Context
`server.js` had grown to over 260 lines and was housing configuration logic that made it brittle. By extracting these components, `server.js` is significantly shorter, more declarative, and much less prone to accidental security regressions when modifying global routing.

### Testing Instructions
1. Verify backend tests pass successfully: `npm run test`
2. Verify cross-origin requests are properly handled based on `CLIENT_URL`.
3. Verify that `/api/csrf-token` yields a valid token, and mutation routes correctly enforce it.
4. Simulate a Slack event to `/api/slack/events` to ensure the raw body is parsed and signature verification is successful.
