### PR TITLE
fix: clean up merge artifacts in knowledgeGraphService (#335)

### DIFF
--- a/server/models/decisionModel.js
+++ b/server/models/decisionModel.js
@@ -125,6 +125,3 @@ const decisionSchema = new mongoose.Schema(
 const Decision =
   mongoose.models.Decision || mongoose.model("Decision", decisionSchema);
 export default Decision;
-
-
-export default Decision;

--- a/server/services/knowledgeGraphService.js
+++ b/server/services/knowledgeGraphService.js
@@ -4,9 +4,6 @@ import { embedText } from "../utils/embeddingUtils.js";
 import { calculateRelationshipConfidence } from "../utils/relationshipScoring.js";
 import { applyImportanceScore } from "./importanceScoringService.js";
 
-import { calculateRelationshipConfidence } from "../utils/relationshipScoring.js";
-
-
 const SIMILARITY_THRESHOLD = 0.85;
 const CONFIDENCE_THRESHOLD = 70; // conservative, per issue's technical considerations
 
@@ -62,9 +59,6 @@ async function findBestMatch(Model, text, embedding, organization) {
     }
   }
 
-  return bestScore >= SIMILARITY_THRESHOLD ? best : null;
-}
-
   if (bestScore < SIMILARITY_THRESHOLD) {
     return null;
   }
@@ -80,22 +74,7 @@ async function findBestMatch(Model, text, embedding, organization) {
     }),
   };
 }
-if (bestScore < SIMILARITY_THRESHOLD) {
-  return null;
-}
 
-return {
-  match: best,
-  similarity: bestScore,
-  confidence: calculateRelationshipConfidence({
-    similarity: bestScore,
-    createdAt: best.createdAt,
-    explicitSignal:
-      best.status === "resolved" ||
-      best.status === "superseded",
-  }),
-};
-}
 /**
  * Called after a meeting's structuredMoM is generated/updated.
  * Extracts decisions/action_items, embeds them, links to prior related entries.
@@ -121,17 +100,12 @@ export async function processStructuredMoM(meeting, mom) {
       results.decisions.push(existingDecision);
       continue;
     }
+
     const decision = await Decision.create({
       text,
       sourceMeetingId: meeting._id,
       organization,
       embedding,
-      relatesTo: match ? [match._id] : [],
-    });
-
-    if (match) {
-      match.relatesTo.push(decision._id);
-      await match.save();
       relatesTo:
         match && match.confidence >= CONFIDENCE_THRESHOLD
           ? [
@@ -151,29 +125,6 @@ export async function processStructuredMoM(meeting, mom) {
       // degree (and therefore importance score) changed too.
       await applyImportanceScore(match.match);
     }
-      relatesTo:
-        match && match.confidence >= CONFIDENCE_THRESHOLD
-          ? [
-              {
-                target: match.match._id,
-                confidence: match.confidence,
-                computedAt: new Date(),
-              },
-          ]
-        : [],
-    });
-
-    if (match && match.confidence >= CONFIDENCE_THRESHOLD) {
-        upsertRelationship(
-           match.match,
-           decision._id,
-           match.confidence,
-        );
-          
-
-        await match.match.save();
-  }
-
 
     await applyImportanceScore(decision);
     results.decisions.push(decision);
@@ -211,6 +162,7 @@ export async function processStructuredMoM(meeting, mom) {
       results.actionItems.push(existingActionItem);
       continue;
     }
+
     const actionItem = await ActionItem.create({
       text,
       owner,
@@ -218,12 +170,6 @@ export async function processStructuredMoM(meeting, mom) {
       sourceMeetingId: meeting._id,
       organization,
       embedding,
-      relatesTo: match ? [match._id] : [],
-    });
-
-    if (match) {
-      match.relatesTo.push(actionItem._id);
-      await match.save();
       relatesTo:
         match && match.confidence >= CONFIDENCE_THRESHOLD
           ? [
@@ -236,40 +182,13 @@ export async function processStructuredMoM(meeting, mom) {
           : [],
     });
 
-    if (match) {
-      if (match.confidence >= CONFIDENCE_THRESHOLD) {
-        upsertRelationship(match.match, actionItem._id, match.confidence);
+    if (match && match.confidence >= CONFIDENCE_THRESHOLD) {
+      upsertRelationship(match.match, actionItem._id, match.confidence);
 
-        // The matched action item just gained a relationship, so its
-        // graph degree (and therefore importance score) changed too.
-        await applyImportanceScore(match.match);
-      }
+      // The matched action item just gained a relationship, so its
+      // graph degree (and therefore importance score) changed too.
+      await applyImportanceScore(match.match);
     }
-
-     relatesTo:
-       match && match.confidence >= CONFIDENCE_THRESHOLD
-         ? [
-             {
-               target: match.match._id,
-               confidence: match.confidence,
-               computedAt: new Date(),
-             },
-           ]
-         : [],
-    });
-
-    if (match) {
-       if (match.confidence >= CONFIDENCE_THRESHOLD) {
-         upsertRelationship(
-           match.match,
-           actionItem._id,
-           match.confidence,
-          );
-
-          await match.match.save();
-        }
-    } 
-
 
     await applyImportanceScore(actionItem);
     results.actionItems.push(actionItem);
@@ -296,20 +215,19 @@ export async function getDecisionLineage(decisionId) {
     if (!decision) return;
     chain.push(decision);
 
-    for (const relatedId of decision.relatesTo) {
-      await walk(relatedId);
     const sortedRelations = [...decision.relatesTo]
       .filter((r) => r.confidence >= CONFIDENCE_THRESHOLD)
       .sort((a, b) => b.confidence - a.confidence);
-      
+
     for (const relation of sortedRelations) {
       await walk(relation.target);
     }
+  }
 
-    await walk(decisionId);
-    chain.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
-      return chain;
-    }
+  await walk(decisionId);
+  chain.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+  return chain;
+}
 
 /**
  * Attempts to detect resolution mentions of open action items within a new meeting's transcript/summary.


### PR DESCRIPTION
## Summary
- Remove duplicated imports, orphaned merge fragments, and malformed braces in `server/services/knowledgeGraphService.js` that caused `SyntaxError: Identifier 'calculateRelationshipConfidence' has already been declared`.
- Restore a single coherent implementation that keeps relationship-confidence scoring and importance scoring together.
- Remove a duplicate `export default` in `decisionModel.js` that blocked ESM loading.

## Test plan
- [ ] `node --check server/services/knowledgeGraphService.js`
- [ ] `node --check server/models/decisionModel.js`
- [ ] Backend starts (`npm start` in `server/`) without SyntaxError
- [ ] Decision/action-item relationship linking still works for high-confidence matches

Fixes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of relationships between decisions and action items by applying confidence-based matching.
  * Prevented low-confidence matches from creating or updating knowledge graph connections.
  * Improved decision lineage results by filtering uncertain relationships and presenting related decisions in chronological order.
  * Improved model initialization reliability to help prevent duplicate registration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->