### PR TITLE
fix: harden keep-alive health check workflow

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -2,8 +2,8 @@ name: Keep-Alive Health Check
 
 on:
   schedule:
-    # Trigger every 14 minutes to prevent Render's free tier from spinning down (which happens after 15 mins of inactivity)
-    - cron: "*/14 * * * *"
+    # Every 10 minutes — Render free tier sleeps after ~15 mins of inactivity
+    - cron: "*/10 * * * *"
   workflow_dispatch: # Allows manual trigger from the GitHub Actions tab
 
 jobs:
@@ -20,20 +20,32 @@ jobs:
             echo "⚠️ RENDER_BACKEND_URL is not set. Defaulting to https://meetonmemory.onrender.com"
             BACKEND_URL="https://meetonmemory.onrender.com"
           fi
-          
+
           # Remove trailing slash if present
           BACKEND_URL=$(echo "$BACKEND_URL" | sed 's/\/$//')
-          
+
           echo "📡 Sending keep-alive request to $BACKEND_URL/api/health..."
-          
-          # Send request and extract http status code
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$BACKEND_URL/api/health")
-          
+
+          # Cold starts can take 13–15s; allow retries and a longer overall timeout
+          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 20 \
+            --max-time 45 \
+            --retry 3 \
+            --retry-delay 5 \
+            --retry-all-errors \
+            "$BACKEND_URL/api/health")
+          CURL_EXIT=$?
+
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "❌ Timeout/network failure (curl exit code: $CURL_EXIT, http_code: $STATUS_CODE)"
+            exit 1
+          fi
+
           echo "📥 Response Status Code: $STATUS_CODE"
-          
+
           if [ "$STATUS_CODE" -eq 200 ]; then
             echo "✅ Render backend is active and responded successfully."
           else
-            echo "❌ Backend did not respond with 200 OK."
+            echo "❌ HTTP failure — backend responded with status $STATUS_CODE (expected 200)."
             exit 1
           fi


### PR DESCRIPTION
## Changes i made 
- Increased curl max-time to 45s and added a 20s connect timeout
- Added retry support for temporary cold-start / network delays
- Updated the schedule from every 14 minutes to every 10 minutes
- Improved logging so timeout/network failures are distinct from HTTP failures

This pr resolves issue #336

## Testings i did
- [x] Reviewed workflow YAML locally
- [x] Confirmed only `.github/workflows/health-check.yml` was changed

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope