### PR TITLE
[Refacto]r: Decouple TeamMembers page logic and extract UI components

### DIFF
--- a/client/src/components/team/InviteMemberForm.jsx
+++ b/client/src/components/team/InviteMemberForm.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { Mail, X, Send } from "lucide-react";
+import { toast } from "react-toastify";
+
+const InviteMemberForm = ({ onClose, onSendInvite }) => {
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState("member");
+  const [inviteExpiresIn, setInviteExpiresIn] = useState(7);
+  const [inviteMessage, setInviteMessage] = useState("");
+  const [sendingInvite, setSendingInvite] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!inviteEmail) {
+      toast.error("Email is required");
+      return;
+    }
+
+    try {
+      setSendingInvite(true);
+      await onSendInvite(
+        {
+          email: inviteEmail,
+          role: inviteRole,
+          expiresIn: Number(inviteExpiresIn),
+          message: inviteMessage,
+        },
+        () => {
+          onClose();
+        },
+      );
+    } finally {
+      setSendingInvite(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 shadow-xl animate-in zoom-in-95 slide-in-from-bottom-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Close Button */}
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer"
+        >
+          <X className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+        </button>
+
+        {/* Modal Header */}
+        <div className="p-6 pb-4 border-b border-slate-100 dark:border-slate-800">
+          <h2 className="text-xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+            <Mail className="h-5 w-5 text-blue-600" />
+            Invite Team Member
+          </h2>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+            Send an email invitation to onboard a new member to your
+            organization.
+          </p>
+        </div>
+
+        {/* Modal Form */}
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          <div>
+            <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
+              Email Address *
+            </label>
+            <input
+              type="email"
+              required
+              placeholder="name@company.com"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-850 text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-sm"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
+                Role *
+              </label>
+              <select
+                value={inviteRole}
+                onChange={(e) => setInviteRole(e.target.value)}
+                className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all text-sm cursor-pointer"
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
+                Expires In (Days)
+              </label>
+              <input
+                type="number"
+                min="1"
+                max="30"
+                value={inviteExpiresIn}
+                onChange={(e) => setInviteExpiresIn(e.target.value)}
+                className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all text-sm"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
+              Personal Message
+            </label>
+            <textarea
+              placeholder="Hey, join our workspace on MeetOnMemory!"
+              value={inviteMessage}
+              onChange={(e) => setInviteMessage(e.target.value)}
+              rows="3"
+              maxLength="500"
+              className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-sm resize-none"
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2.5 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 text-slate-700 dark:text-slate-300 font-bold transition-all text-sm cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={sendingInvite}
+              className="flex-1 px-4 py-2.5 rounded-xl bg-blue-600 text-white font-bold hover:bg-blue-700 disabled:bg-blue-400 transition-all text-sm shadow-md shadow-blue-600/20 cursor-pointer flex items-center justify-center gap-1.5"
+            >
+              {sendingInvite ? (
+                <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white" />
+              ) : (
+                <Send className="w-3.5 h-3.5" />
+              )}
+              Send Invitation
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default InviteMemberForm;

--- a/client/src/components/team/TeamMemberTable.jsx
+++ b/client/src/components/team/TeamMemberTable.jsx
@@ -1,0 +1,257 @@
+import React, { useState } from "react";
+import {
+  Users,
+  Calendar,
+  Shield,
+  Copy,
+  CheckCircle,
+  XCircle,
+  X,
+  Mail,
+  Clock,
+} from "lucide-react";
+import { toast } from "react-toastify";
+
+const ROLE_STYLES = {
+  admin:
+    "bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800",
+  member:
+    "bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 border-sky-200 dark:border-sky-800",
+};
+
+const ROLE_LABELS = {
+  admin: "Admin",
+  member: "Member",
+};
+
+const TeamMemberTable = ({ members, searchQuery, roleFilter }) => {
+  const [selectedMember, setSelectedMember] = useState(null);
+
+  const handleCopyEmail = (email) => {
+    navigator.clipboard.writeText(email);
+    toast.success("Email copied to clipboard");
+  };
+
+  const getInitials = (name) => {
+    if (!name) return "U";
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return "N/A";
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  if (members.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <Users className="h-16 w-16 text-slate-300 dark:text-slate-600 mb-4" />
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
+          No members found
+        </h3>
+        <p className="text-slate-500 dark:text-slate-400">
+          {searchQuery || roleFilter !== "all"
+            ? "Try adjusting your search or filters"
+            : "Your organization has no members yet"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        {members.map((member) => (
+          <div
+            key={member._id}
+            onClick={() => setSelectedMember(member)}
+            className="group relative flex items-center gap-4 p-4 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-md transition-all cursor-pointer"
+          >
+            {/* Avatar */}
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-semibold text-lg">
+              {getInitials(member.name)}
+            </div>
+
+            {/* Member Info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <h3 className="font-semibold text-slate-900 dark:text-white truncate">
+                  {member.name || "Unknown"}
+                </h3>
+                {member.isAccountVerified && (
+                  <CheckCircle
+                    className="h-4 w-4 text-green-500 shrink-0"
+                    title="Verified"
+                  />
+                )}
+              </div>
+              <p className="text-sm text-slate-500 dark:text-slate-400 truncate">
+                {member.email}
+              </p>
+            </div>
+
+            {/* Role Badge */}
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider ${ROLE_STYLES[member.role?.toLowerCase()] || ROLE_STYLES.member}`}
+            >
+              <Shield className="h-3 w-3" />
+              {ROLE_LABELS[member.role?.toLowerCase()] ||
+                member.role ||
+                "Member"}
+            </span>
+
+            {/* Join Date */}
+            <div className="hidden sm:flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
+              <Calendar className="h-4 w-4" />
+              <span>{formatDate(member.createdAt)}</span>
+            </div>
+
+            {/* Quick Actions */}
+            <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleCopyEmail(member.email);
+                }}
+                className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                title="Copy email"
+              >
+                <Copy className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Member Details Modal */}
+      {selectedMember && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in"
+          onClick={() => setSelectedMember(null)}
+        >
+          <div
+            className="relative w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 shadow-xl animate-in zoom-in-95 slide-in-from-bottom-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Close Button */}
+            <button
+              onClick={() => setSelectedMember(null)}
+              className="absolute right-4 top-4 p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+            >
+              <X className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+            </button>
+
+            {/* Modal Content */}
+            <div className="p-6">
+              {/* Avatar */}
+              <div className="flex flex-col items-center mb-6">
+                <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-bold text-2xl mb-4">
+                  {getInitials(selectedMember.name)}
+                </div>
+                <h2 className="text-xl font-bold text-slate-900 dark:text-white">
+                  {selectedMember.name || "Unknown"}
+                </h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  {selectedMember.email}
+                </p>
+              </div>
+
+              {/* Details */}
+              <div className="space-y-4">
+                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
+                  <div className="flex items-center gap-3">
+                    <Shield className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      Role
+                    </span>
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider ${ROLE_STYLES[selectedMember.role?.toLowerCase()] || ROLE_STYLES.member}`}
+                  >
+                    {ROLE_LABELS[selectedMember.role?.toLowerCase()] ||
+                      selectedMember.role ||
+                      "Member"}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
+                  <div className="flex items-center gap-3">
+                    <Mail className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      Email
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => handleCopyEmail(selectedMember.email)}
+                    className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                  >
+                    <span className="truncate max-w-[150px]">
+                      {selectedMember.email}
+                    </span>
+                    <Copy className="h-4 w-4 shrink-0" />
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
+                  <div className="flex items-center gap-3">
+                    <Clock className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      Joined
+                    </span>
+                  </div>
+                  <span className="text-sm text-slate-600 dark:text-slate-400">
+                    {formatDate(selectedMember.createdAt)}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
+                  <div className="flex items-center gap-3">
+                    <CheckCircle className="h-5 w-5 text-slate-500 dark:text-slate-400" />
+                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                      Status
+                    </span>
+                  </div>
+                  <span className="flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400">
+                    {selectedMember.isAccountVerified ? (
+                      <>
+                        <CheckCircle className="h-4 w-4 text-green-500" />
+                        Verified
+                      </>
+                    ) : (
+                      <>
+                        <XCircle className="h-4 w-4 text-amber-500" />
+                        Pending
+                      </>
+                    )}
+                  </span>
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="mt-6 pt-4 border-t border-slate-200 dark:border-slate-700">
+                <button
+                  onClick={() => setSelectedMember(null)}
+                  className="w-full px-4 py-2.5 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-semibold hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default TeamMemberTable;

--- a/client/src/components/team/__tests__/InviteMemberForm.test.jsx
+++ b/client/src/components/team/__tests__/InviteMemberForm.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import InviteMemberForm from "../InviteMemberForm";
+
+// Mock react-toastify
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("InviteMemberForm", () => {
+  const mockOnClose = vi.fn();
+  const mockOnSendInvite = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders correctly", () => {
+    render(
+      <InviteMemberForm
+        onClose={mockOnClose}
+        onSendInvite={mockOnSendInvite}
+      />,
+    );
+    expect(screen.getByText("Invite Team Member")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("name@company.com")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button or cancel is clicked", () => {
+    render(
+      <InviteMemberForm
+        onClose={mockOnClose}
+        onSendInvite={mockOnSendInvite}
+      />,
+    );
+
+    const cancelButton = screen.getByText("Cancel");
+    fireEvent.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error if email is not provided", async () => {
+    render(
+      <InviteMemberForm
+        onClose={mockOnClose}
+        onSendInvite={mockOnSendInvite}
+      />,
+    );
+
+    // Attempt to submit without email (HTML5 validation should ideally stop it,
+    // but in case it goes through or we test the handler)
+    const form = screen
+      .getByRole("button", { name: /send invitation/i })
+      .closest("form");
+
+    // Simulate handler being called without email (bypassing native validation for the sake of the test)
+    fireEvent.submit(form);
+
+    // Note: since email is marked required, if we use fireEvent.submit it triggers the synthetic event
+    // The component's handleSubmit has `if (!inviteEmail) { toast.error... }`
+    await waitFor(() => {
+      expect(mockOnSendInvite).not.toHaveBeenCalled();
+    });
+  });
+
+  it("calls onSendInvite with correct data when submitted", async () => {
+    render(
+      <InviteMemberForm
+        onClose={mockOnClose}
+        onSendInvite={mockOnSendInvite}
+      />,
+    );
+
+    const emailInput = screen.getByPlaceholderText("name@company.com");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    const roleSelect = screen.getByRole("combobox");
+    fireEvent.change(roleSelect, { target: { value: "admin" } });
+
+    const form = screen
+      .getByRole("button", { name: /send invitation/i })
+      .closest("form");
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(mockOnSendInvite).toHaveBeenCalledTimes(1);
+      expect(mockOnSendInvite).toHaveBeenCalledWith(
+        {
+          email: "test@example.com",
+          role: "admin",
+          expiresIn: 7, // default
+          message: "", // default
+        },
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/client/src/components/team/__tests__/TeamMemberTable.test.jsx
+++ b/client/src/components/team/__tests__/TeamMemberTable.test.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TeamMemberTable from "../TeamMemberTable";
+
+// Mock react-toastify
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
+
+describe("TeamMemberTable", () => {
+  const mockMembers = [
+    {
+      _id: "1",
+      name: "Alice Smith",
+      email: "alice@example.com",
+      role: "admin",
+      isAccountVerified: true,
+      createdAt: "2023-01-01T00:00:00.000Z",
+    },
+    {
+      _id: "2",
+      name: "Bob Jones",
+      email: "bob@example.com",
+      role: "member",
+      isAccountVerified: false,
+      createdAt: "2023-02-01T00:00:00.000Z",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state when no members provided", () => {
+    render(<TeamMemberTable members={[]} searchQuery="" roleFilter="all" />);
+    expect(screen.getByText("No members found")).toBeInTheDocument();
+  });
+
+  it("renders a list of members", () => {
+    render(
+      <TeamMemberTable members={mockMembers} searchQuery="" roleFilter="all" />,
+    );
+
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Bob Jones")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+  });
+
+  it("opens member details modal on click", () => {
+    render(
+      <TeamMemberTable members={mockMembers} searchQuery="" roleFilter="all" />,
+    );
+
+    // Click on Alice Smith's row (the h3 element or the row itself)
+    const aliceRow = screen.getByText("Alice Smith").closest("div.group");
+    fireEvent.click(aliceRow);
+
+    // Modal should open
+    // We expect the heading inside modal to appear, and we also see 'Close' button
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+  });
+
+  it("closes member details modal when close button is clicked", () => {
+    render(
+      <TeamMemberTable members={mockMembers} searchQuery="" roleFilter="all" />,
+    );
+
+    const aliceRow = screen.getByText("Alice Smith").closest("div.group");
+    fireEvent.click(aliceRow);
+
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    fireEvent.click(closeButton);
+
+    // Modal should close (close button should not be in document)
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/hooks/__tests__/useTeamManagement.test.jsx
+++ b/client/src/hooks/__tests__/useTeamManagement.test.jsx
@@ -1,0 +1,115 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useTeamManagement from "../useTeamManagement";
+import { organizationApi, invitationApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+// Mock API services
+vi.mock("../../services", () => ({
+  organizationApi: {
+    getMembers: vi.fn(),
+  },
+  invitationApi: {
+    getOrganizationInvitations: vi.fn(),
+    createInvitation: vi.fn(),
+    resendInvitation: vi.fn(),
+    revokeInvitation: vi.fn(),
+    expireInvitation: vi.fn(),
+  },
+}));
+
+// Mock react-toastify
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useTeamManagement", () => {
+  const mockUserData = {
+    role: "admin",
+    organization: { _id: "org1" },
+  };
+
+  const wrapper = ({ children }) => (
+    <AppContent.Provider value={{ userData: mockUserData }}>
+      {children}
+    </AppContent.Provider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    organizationApi.getMembers.mockResolvedValue({
+      data: { success: true, members: [] },
+    });
+    invitationApi.getOrganizationInvitations.mockResolvedValue({
+      data: { success: true, invitations: [] },
+    });
+  });
+
+  it("initializes and fetches members automatically", async () => {
+    const mockMembers = [{ _id: "1", name: "Test User" }];
+    organizationApi.getMembers.mockResolvedValueOnce({
+      data: { success: true, members: mockMembers },
+    });
+
+    const { result } = renderHook(() => useTeamManagement("members"), {
+      wrapper,
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isAdmin).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.members).toEqual(mockMembers);
+    expect(organizationApi.getMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches invitations when active tab is invitations and user is admin", async () => {
+    const mockInvitations = [{ _id: "inv1", email: "test@invite.com" }];
+    invitationApi.getOrganizationInvitations.mockResolvedValueOnce({
+      data: { success: true, invitations: mockInvitations },
+    });
+
+    const { result } = renderHook(() => useTeamManagement("invitations"), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.invitesLoading).toBe(false);
+    });
+
+    expect(result.current.invitations).toEqual(mockInvitations);
+    expect(invitationApi.getOrganizationInvitations).toHaveBeenCalledWith(
+      "org1",
+    );
+  });
+
+  it("handles send invite", async () => {
+    invitationApi.createInvitation.mockResolvedValueOnce({
+      data: { success: true },
+    });
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() => useTeamManagement("invitations"), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.handleSendInvite(
+        { email: "test@example.com" },
+        onSuccess,
+      );
+    });
+
+    expect(invitationApi.createInvitation).toHaveBeenCalledWith({
+      organizationId: "org1",
+      email: "test@example.com",
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useTeamManagement.js
+++ b/client/src/hooks/useTeamManagement.js
@@ -1,0 +1,143 @@
+import { useState, useCallback, useEffect, useContext } from "react";
+import { organizationApi, invitationApi } from "../services";
+import { toast } from "react-toastify";
+import AppContent from "../context/AppContent";
+
+export const useTeamManagement = (activeTab) => {
+  const [members, setMembers] = useState([]);
+  const [invitations, setInvitations] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [invitesLoading, setInvitesLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const { userData } = useContext(AppContent);
+  const isAdmin = userData?.role === "admin" || userData?.role === "owner";
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const { data } = await organizationApi.getMembers();
+
+      if (data.success) {
+        setMembers(data.members);
+      } else {
+        setError(data.message || "Failed to fetch members");
+      }
+    } catch (err) {
+      console.error("Error fetching members:", err);
+      setError("Failed to fetch members. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchInvitations = useCallback(async () => {
+    if (!userData?.organization) return;
+    const orgId = userData.organization._id || userData.organization;
+    try {
+      setInvitesLoading(true);
+      const { data } = await invitationApi.getOrganizationInvitations(orgId);
+      if (data.success) {
+        setInvitations(data.invitations || []);
+      }
+    } catch (err) {
+      console.error("Error fetching invitations:", err);
+    } finally {
+      setInvitesLoading(false);
+    }
+  }, [userData]);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  useEffect(() => {
+    if (activeTab === "invitations" && isAdmin) {
+      fetchInvitations();
+    }
+  }, [activeTab, fetchInvitations, isAdmin]);
+
+  const handleSendInvite = async (inviteData, onSuccess) => {
+    const orgId = userData?.organization?._id || userData?.organization;
+    if (!orgId) {
+      toast.error("No active organization selected");
+      return;
+    }
+
+    try {
+      const { data } = await invitationApi.createInvitation({
+        organizationId: orgId,
+        ...inviteData,
+      });
+
+      if (data.success) {
+        toast.success("Invitation sent successfully!");
+        if (activeTab === "invitations") {
+          fetchInvitations();
+        }
+        if (onSuccess) onSuccess();
+      }
+    } catch (err) {
+      console.error("Error sending invitation:", err);
+      toast.error(err.response?.data?.message || "Failed to send invitation");
+      throw err;
+    }
+  };
+
+  const handleResendInvite = async (id) => {
+    try {
+      const { data } = await invitationApi.resendInvitation(id);
+      if (data.success) {
+        toast.success("Invitation resent successfully!");
+        fetchInvitations();
+      }
+    } catch (err) {
+      console.error("Error resending invitation:", err);
+      toast.error(err.response?.data?.message || "Failed to resend invitation");
+    }
+  };
+
+  const handleCancelInvite = async (id) => {
+    try {
+      const { data } = await invitationApi.revokeInvitation(id);
+      if (data.success) {
+        toast.success("Invitation cancelled successfully!");
+        fetchInvitations();
+      }
+    } catch (err) {
+      console.error("Error cancelling invitation:", err);
+      toast.error(err.response?.data?.message || "Failed to cancel invitation");
+    }
+  };
+
+  const handleExpireInvite = async (id) => {
+    try {
+      const { data } = await invitationApi.expireInvitation(id);
+      if (data.success) {
+        toast.success("Invitation expired successfully!");
+        fetchInvitations();
+      }
+    } catch (err) {
+      console.error("Error expiring invitation:", err);
+      toast.error(err.response?.data?.message || "Failed to expire invitation");
+    }
+  };
+
+  return {
+    members,
+    invitations,
+    loading,
+    invitesLoading,
+    error,
+    isAdmin,
+    fetchMembers,
+    fetchInvitations,
+    handleSendInvite,
+    handleResendInvite,
+    handleCancelInvite,
+    handleExpireInvite,
+  };
+};
+
+export default useTeamManagement;

--- a/client/src/pages/TeamMembers.jsx
+++ b/client/src/pages/TeamMembers.jsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Navbar from "../components/Navbar.jsx";
-import { organizationApi, invitationApi } from "../services";
 import {
   Users,
   Search,
@@ -8,7 +7,6 @@ import {
   Mail,
   Calendar,
   Shield,
-  Copy,
   X,
   ChevronDown,
   Clock,
@@ -19,174 +17,39 @@ import {
   Ban,
   AlertTriangle,
 } from "lucide-react";
-import { toast } from "react-toastify";
-import AppContent from "../context/AppContent";
-
-const ROLE_STYLES = {
-  admin:
-    "bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800",
-  member:
-    "bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400 border-sky-200 dark:border-sky-800",
-};
-
-const ROLE_LABELS = {
-  admin: "Admin",
-  member: "Member",
-};
+import { useTeamManagement } from "../hooks/useTeamManagement";
+import InviteMemberForm from "../components/team/InviteMemberForm";
+import TeamMemberTable from "../components/team/TeamMemberTable";
 
 const TeamMembers = () => {
-  const [members, setMembers] = useState([]);
+  const [activeTab, setActiveTab] = useState("members"); // "members" | "invitations"
+
+  const {
+    members,
+    invitations,
+    loading,
+    invitesLoading,
+    error,
+    isAdmin,
+    fetchMembers,
+    handleSendInvite,
+    handleResendInvite,
+    handleCancelInvite,
+    handleExpireInvite,
+  } = useTeamManagement(activeTab);
+
   const [filteredMembers, setFilteredMembers] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedMember, setSelectedMember] = useState(null);
   const [showFilters, setShowFilters] = useState(false);
   const [sortBy] = useState("name");
   const [sortOrder] = useState("asc");
   const [roleFilter, setRoleFilter] = useState("all");
 
-  const { userData } = useContext(AppContent);
-  const [activeTab, setActiveTab] = useState("members"); // "members" | "invitations"
-  const [invitations, setInvitations] = useState([]);
-  const [invitesLoading, setInvitesLoading] = useState(false);
-
-  // Invite Modal State
   const [showInviteModal, setShowInviteModal] = useState(false);
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState("member");
-  const [inviteExpiresIn, setInviteExpiresIn] = useState(7);
-  const [inviteMessage, setInviteMessage] = useState("");
-  const [sendingInvite, setSendingInvite] = useState(false);
-
-  const isAdmin = userData?.role === "admin" || userData?.role === "owner";
-
-  const fetchInvitations = useCallback(async () => {
-    if (!userData?.organization) return;
-    const orgId = userData.organization._id || userData.organization;
-    try {
-      setInvitesLoading(true);
-      const { data } = await invitationApi.getOrganizationInvitations(orgId);
-      if (data.success) {
-        setInvitations(data.invitations || []);
-      }
-    } catch (err) {
-      console.error("Error fetching invitations:", err);
-    } finally {
-      setInvitesLoading(false);
-    }
-  }, [userData]);
-
-  useEffect(() => {
-    if (activeTab === "invitations" && isAdmin) {
-      fetchInvitations();
-    }
-  }, [activeTab, fetchInvitations, isAdmin]);
-
-  const handleSendInvite = async (e) => {
-    e.preventDefault();
-    if (!inviteEmail) {
-      toast.error("Email is required");
-      return;
-    }
-    const orgId = userData?.organization?._id || userData?.organization;
-    if (!orgId) {
-      toast.error("No active organization selected");
-      return;
-    }
-
-    try {
-      setSendingInvite(true);
-      const { data } = await invitationApi.createInvitation({
-        organizationId: orgId,
-        email: inviteEmail,
-        role: inviteRole,
-        expiresIn: Number(inviteExpiresIn),
-        message: inviteMessage,
-      });
-
-      if (data.success) {
-        toast.success("Invitation sent successfully!");
-        setShowInviteModal(false);
-        setInviteEmail("");
-        setInviteMessage("");
-        setInviteRole("member");
-        setInviteExpiresIn(7);
-        if (activeTab === "invitations") {
-          fetchInvitations();
-        }
-      }
-    } catch (err) {
-      console.error("Error sending invitation:", err);
-      toast.error(err.response?.data?.message || "Failed to send invitation");
-    } finally {
-      setSendingInvite(false);
-    }
-  };
-
-  const handleResendInvite = async (id) => {
-    try {
-      const { data } = await invitationApi.resendInvitation(id);
-      if (data.success) {
-        toast.success("Invitation resent successfully!");
-        fetchInvitations();
-      }
-    } catch (err) {
-      console.error("Error resending invitation:", err);
-      toast.error(err.response?.data?.message || "Failed to resend invitation");
-    }
-  };
-
-  const handleCancelInvite = async (id) => {
-    try {
-      const { data } = await invitationApi.revokeInvitation(id);
-      if (data.success) {
-        toast.success("Invitation cancelled successfully!");
-        fetchInvitations();
-      }
-    } catch (err) {
-      console.error("Error cancelling invitation:", err);
-      toast.error(err.response?.data?.message || "Failed to cancel invitation");
-    }
-  };
-
-  const handleExpireInvite = async (id) => {
-    try {
-      const { data } = await invitationApi.expireInvitation(id);
-      if (data.success) {
-        toast.success("Invitation expired successfully!");
-        fetchInvitations();
-      }
-    } catch (err) {
-      console.error("Error expiring invitation:", err);
-      toast.error(err.response?.data?.message || "Failed to expire invitation");
-    }
-  };
-
-  const fetchMembers = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const { data } = await organizationApi.getMembers();
-
-      if (data.success) {
-        setMembers(data.members);
-        setFilteredMembers(data.members);
-      } else {
-        setError(data.message || "Failed to fetch members");
-      }
-    } catch (err) {
-      console.error("Error fetching members:", err);
-      setError("Failed to fetch members. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
 
   const applyFiltersAndSort = useCallback(() => {
     let result = [...members];
 
-    // Apply search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       result = result.filter(
@@ -197,12 +60,10 @@ const TeamMembers = () => {
       );
     }
 
-    // Apply role filter
     if (roleFilter !== "all") {
       result = result.filter((member) => member.role === roleFilter);
     }
 
-    // Apply sorting
     result.sort((a, b) => {
       let comparison = 0;
       switch (sortBy) {
@@ -224,20 +85,9 @@ const TeamMembers = () => {
     setFilteredMembers(result);
   }, [members, searchQuery, roleFilter, sortBy, sortOrder]);
 
-  const handleCopyEmail = (email) => {
-    navigator.clipboard.writeText(email);
-    toast.success("Email copied to clipboard");
-  };
-
-  const getInitials = (name) => {
-    if (!name) return "U";
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
-  };
+  useEffect(() => {
+    applyFiltersAndSort();
+  }, [applyFiltersAndSort]);
 
   const formatDate = (dateString) => {
     if (!dateString) return "N/A";
@@ -248,14 +98,6 @@ const TeamMembers = () => {
       year: "numeric",
     });
   };
-
-  useEffect(() => {
-    fetchMembers();
-  }, [fetchMembers]);
-
-  useEffect(() => {
-    applyFiltersAndSort();
-  }, [applyFiltersAndSort]);
 
   if (loading) {
     return (
@@ -309,11 +151,9 @@ const TeamMembers = () => {
                 Team Members
               </h1>
               <p className="text-sm text-slate-500 dark:text-slate-400 font-semibold">
-                {activeTab === "members" ? (
-                  `${filteredMembers.length} ${filteredMembers.length === 1 ? "member" : "members"}`
-                ) : (
-                  `${invitations.length} ${invitations.length === 1 ? "invitation" : "invitations"}`
-                )}
+                {activeTab === "members"
+                  ? `${filteredMembers.length} ${filteredMembers.length === 1 ? "member" : "members"}`
+                  : `${invitations.length} ${invitations.length === 1 ? "invitation" : "invitations"}`}
               </p>
             </div>
           </div>
@@ -397,83 +237,11 @@ const TeamMembers = () => {
               </div>
             </div>
 
-            {/* Members List */}
-            {filteredMembers.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-16 text-center">
-                <Users className="h-16 w-16 text-slate-300 dark:text-slate-600 mb-4" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">
-                  No members found
-                </h3>
-                <p className="text-slate-500 dark:text-slate-400">
-                  {searchQuery || roleFilter !== "all"
-                    ? "Try adjusting your search or filters"
-                    : "Your organization has no members yet"}
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {filteredMembers.map((member) => (
-                  <div
-                    key={member._id}
-                    onClick={() => setSelectedMember(member)}
-                    className="group relative flex items-center gap-4 p-4 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:border-slate-300 dark:hover:border-slate-600 hover:shadow-md transition-all cursor-pointer"
-                  >
-                    {/* Avatar */}
-                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-semibold text-lg">
-                      {getInitials(member.name)}
-                    </div>
-
-                    {/* Member Info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-semibold text-slate-900 dark:text-white truncate">
-                          {member.name || "Unknown"}
-                        </h3>
-                        {member.isAccountVerified && (
-                          <CheckCircle
-                            className="h-4 w-4 text-green-500 shrink-0"
-                            title="Verified"
-                          />
-                        )}
-                      </div>
-                      <p className="text-sm text-slate-500 dark:text-slate-400 truncate">
-                        {member.email}
-                      </p>
-                    </div>
-
-                    {/* Role Badge */}
-                    <span
-                      className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider ${ROLE_STYLES[member.role?.toLowerCase()] || ROLE_STYLES.member}`}
-                    >
-                      <Shield className="h-3 w-3" />
-                      {ROLE_LABELS[member.role?.toLowerCase()] ||
-                        member.role ||
-                        "Member"}
-                    </span>
-
-                    {/* Join Date */}
-                    <div className="hidden sm:flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
-                      <Calendar className="h-4 w-4" />
-                      <span>{formatDate(member.createdAt)}</span>
-                    </div>
-
-                    {/* Quick Actions */}
-                    <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCopyEmail(member.email);
-                        }}
-                        className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
-                        title="Copy email"
-                      >
-                        <Copy className="h-4 w-4 text-slate-500 dark:text-slate-400" />
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+            <TeamMemberTable
+              members={filteredMembers}
+              searchQuery={searchQuery}
+              roleFilter={roleFilter}
+            />
           </>
         ) : (
           <>
@@ -489,7 +257,8 @@ const TeamMembers = () => {
                   No invitations sent
                 </h3>
                 <p className="text-slate-500 dark:text-slate-400 mb-4 text-sm">
-                  Invite members by email to onboard them into your organization.
+                  Invite members by email to onboard them into your
+                  organization.
                 </p>
                 <button
                   onClick={() => setShowInviteModal(true)}
@@ -538,7 +307,6 @@ const TeamMembers = () => {
                     </div>
 
                     <div className="flex items-center gap-3 shrink-0 justify-between md:justify-end">
-                      {/* Status Badge */}
                       <span
                         className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-bold ${
                           invite.status === "pending"
@@ -552,15 +320,24 @@ const TeamMembers = () => {
                                   : "bg-slate-50 text-slate-500 border border-slate-200 dark:bg-slate-900 dark:text-slate-400 dark:border-slate-800"
                         }`}
                       >
-                        {invite.status === "pending" && <Clock className="w-3 h-3" />}
-                        {invite.status === "accepted" && <CheckCircle className="w-3 h-3" />}
-                        {invite.status === "declined" && <XCircle className="w-3 h-3" />}
-                        {invite.status === "expired" && <AlertTriangle className="w-3 h-3" />}
-                        {invite.status === "cancelled" && <Ban className="w-3 h-3" />}
+                        {invite.status === "pending" && (
+                          <Clock className="w-3 h-3" />
+                        )}
+                        {invite.status === "accepted" && (
+                          <CheckCircle className="w-3 h-3" />
+                        )}
+                        {invite.status === "declined" && (
+                          <XCircle className="w-3 h-3" />
+                        )}
+                        {invite.status === "expired" && (
+                          <AlertTriangle className="w-3 h-3" />
+                        )}
+                        {invite.status === "cancelled" && (
+                          <Ban className="w-3 h-3" />
+                        )}
                         <span className="capitalize">{invite.status}</span>
                       </span>
 
-                      {/* Actions */}
                       {invite.status === "pending" && (
                         <div className="flex items-center gap-1">
                           <button
@@ -595,238 +372,11 @@ const TeamMembers = () => {
         )}
       </main>
 
-      {/* Member Details Modal */}
-      {selectedMember && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in"
-          onClick={() => setSelectedMember(null)}
-        >
-          <div
-            className="relative w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 shadow-xl animate-in zoom-in-95 slide-in-from-bottom-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Close Button */}
-            <button
-              onClick={() => setSelectedMember(null)}
-              className="absolute right-4 top-4 p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
-            >
-              <X className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-            </button>
-
-            {/* Modal Content */}
-            <div className="p-6">
-              {/* Avatar */}
-              <div className="flex flex-col items-center mb-6">
-                <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-600 text-white font-bold text-2xl mb-4">
-                  {getInitials(selectedMember.name)}
-                </div>
-                <h2 className="text-xl font-bold text-slate-900 dark:text-white">
-                  {selectedMember.name || "Unknown"}
-                </h2>
-                <p className="text-sm text-slate-500 dark:text-slate-400">
-                  {selectedMember.email}
-                </p>
-              </div>
-
-              {/* Details */}
-              <div className="space-y-4">
-                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
-                  <div className="flex items-center gap-3">
-                    <Shield className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                      Role
-                    </span>
-                  </div>
-                  <span
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider ${ROLE_STYLES[selectedMember.role?.toLowerCase()] || ROLE_STYLES.member}`}
-                  >
-                    {ROLE_LABELS[selectedMember.role?.toLowerCase()] ||
-                      selectedMember.role ||
-                      "Member"}
-                  </span>
-                </div>
-
-                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
-                  <div className="flex items-center gap-3">
-                    <Mail className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                      Email
-                    </span>
-                  </div>
-                  <button
-                    onClick={() => handleCopyEmail(selectedMember.email)}
-                    className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
-                  >
-                    <span className="truncate max-w-[150px]">
-                      {selectedMember.email}
-                    </span>
-                    <Copy className="h-4 w-4 shrink-0" />
-                  </button>
-                </div>
-
-                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
-                  <div className="flex items-center gap-3">
-                    <Clock className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                      Joined
-                    </span>
-                  </div>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">
-                    {formatDate(selectedMember.createdAt)}
-                  </span>
-                </div>
-
-                <div className="flex items-center justify-between p-3 rounded-lg bg-slate-50 dark:bg-slate-800">
-                  <div className="flex items-center gap-3">
-                    <CheckCircle className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                      Status
-                    </span>
-                  </div>
-                  <span className="flex items-center gap-1.5 text-sm text-slate-600 dark:text-slate-400">
-                    {selectedMember.isAccountVerified ? (
-                      <>
-                        <CheckCircle className="h-4 w-4 text-green-500" />
-                        Verified
-                      </>
-                    ) : (
-                      <>
-                        <XCircle className="h-4 w-4 text-amber-500" />
-                        Pending
-                      </>
-                    )}
-                  </span>
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="mt-6 pt-4 border-t border-slate-200 dark:border-slate-700">
-                <button
-                  onClick={() => setSelectedMember(null)}
-                  className="w-full px-4 py-2.5 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-semibold hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
-                >
-                  Close
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Invite Member Modal */}
       {showInviteModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in"
-          onClick={() => setShowInviteModal(false)}
-        >
-          <div
-            className="relative w-full max-w-md rounded-2xl bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 shadow-xl animate-in zoom-in-95 slide-in-from-bottom-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Close Button */}
-            <button
-              onClick={() => setShowInviteModal(false)}
-              className="absolute right-4 top-4 p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer"
-            >
-              <X className="h-5 w-5 text-slate-500 dark:text-slate-400" />
-            </button>
-
-            {/* Modal Header */}
-            <div className="p-6 pb-4 border-b border-slate-100 dark:border-slate-800">
-              <h2 className="text-xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
-                <Mail className="h-5 w-5 text-blue-600" />
-                Invite Team Member
-              </h2>
-              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-                Send an email invitation to onboard a new member to your organization.
-              </p>
-            </div>
-
-            {/* Modal Form */}
-            <form onSubmit={handleSendInvite} className="p-6 space-y-4">
-              <div>
-                <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
-                  Email Address *
-                </label>
-                <input
-                  type="email"
-                  required
-                  placeholder="name@company.com"
-                  value={inviteEmail}
-                  onChange={(e) => setInviteEmail(e.target.value)}
-                  className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-850 text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-sm"
-                />
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
-                    Role *
-                  </label>
-                  <select
-                    value={inviteRole}
-                    onChange={(e) => setInviteRole(e.target.value)}
-                    className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all text-sm cursor-pointer"
-                  >
-                    <option value="member">Member</option>
-                    <option value="admin">Admin</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
-                    Expires In (Days)
-                  </label>
-                  <input
-                    type="number"
-                    min="1"
-                    max="30"
-                    value={inviteExpiresIn}
-                    onChange={(e) => setInviteExpiresIn(e.target.value)}
-                    className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all text-sm"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-xs font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider mb-1.5">
-                  Personal Message
-                </label>
-                <textarea
-                  placeholder="Hey, join our workspace on MeetOnMemory!"
-                  value={inviteMessage}
-                  onChange={(e) => setInviteMessage(e.target.value)}
-                  rows="3"
-                  maxLength="500"
-                  className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-sm resize-none"
-                />
-              </div>
-
-              {/* Actions */}
-              <div className="flex gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={() => setShowInviteModal(false)}
-                  className="flex-1 px-4 py-2.5 rounded-xl bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 text-slate-700 dark:text-slate-300 font-bold transition-all text-sm cursor-pointer"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={sendingInvite}
-                  className="flex-1 px-4 py-2.5 rounded-xl bg-blue-600 text-white font-bold hover:bg-blue-700 disabled:bg-blue-400 transition-all text-sm shadow-md shadow-blue-600/20 cursor-pointer flex items-center justify-center gap-1.5"
-                >
-                  {sendingInvite ? (
-                    <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white" />
-                  ) : (
-                    <Send className="w-3.5 h-3.5" />
-                  )}
-                  Send Invitation
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+        <InviteMemberForm
+          onClose={() => setShowInviteModal(false)}
+          onSendInvite={handleSendInvite}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
- closes #328

### Description
This PR refactors the `TeamMembers.jsx` page to improve maintainability, reduce component bloat, and separate business logic from UI rendering. The file had grown too large by managing complex API calls, inline validation, and dense table/form rendering all in one place. 

By abstracting these concerns into dedicated modular components and a custom hook, the page is now highly declarative, easier to read, and less brittle for future feature additions.

### Changes Made
- **Created `useTeamManagement` Custom Hook**: Extracted all API interaction logic (fetching members/invitations, sending/revoking invites) and state management into `client/src/hooks/useTeamManagement.js`.
- **Extracted `InviteMemberForm`**: Moved the invitation form UI, validation, and local state out of the main page and into `client/src/components/team/InviteMemberForm.jsx`.
- **Extracted `TeamMemberTable`**: Moved the dense member listing and the member details modal into `client/src/components/team/TeamMemberTable.jsx`.
- **Refactored `TeamMembers.jsx`**: Stripped out the heavy logic. The page now cleanly handles tabs, search/filtering states, and assembles the sub-components.
- **Added Automated Tests**: 
  - `InviteMemberForm.test.jsx`
  - `TeamMemberTable.test.jsx` 
  - `useTeamManagement.test.jsx`

### How to Test
1. Pull down this branch and ensure dependencies are installed.
2. Run the unit test suite to verify the logic and components render correctly:
   ```bash
   cd client
   npx vitest run \
     src/components/team/__tests__/InviteMemberForm.test.jsx \
     src/components/team/__tests__/TeamMemberTable.test.jsx \
     src/hooks/__tests__/useTeamManagement.test.jsx
