### PR TITLE
feat: centralize CSRF token lifecycle

### DIFF
--- a/client/src/context/AppContext.jsx
+++ b/client/src/context/AppContext.jsx
@@ -3,8 +3,7 @@ import { toast } from "react-toastify";
 import AppContent from "./AppContent.js";
 import { RBACProvider } from "./RBACContext.jsx";
 import { useNavigate } from "react-router-dom";
-import { authApi } from "../services";
-import apiClient from "../services/apiClient.js";
+import { authApi, csrfService } from "../services";
 
 export const AppContextProvider = ({ children }) => {
   const backendUrl =
@@ -39,13 +38,8 @@ export const AppContextProvider = ({ children }) => {
 
   const getAuthState = useCallback(async () => {
     try {
-      // Fetch CSRF token first
       try {
-        const { data: csrfData } = await authApi.getCsrfToken();
-        if (csrfData && csrfData.csrfToken) {
-          apiClient.defaults.headers.common["X-CSRF-Token"] =
-            csrfData.csrfToken;
-        }
+        await csrfService.fetchToken();
       } catch (csrfErr) {
         console.error("Failed to fetch CSRF token", csrfErr);
         toast.error(
@@ -93,6 +87,7 @@ export const AppContextProvider = ({ children }) => {
       setIsLoggedin(false);
       setUserData(null);
       localStorage.removeItem("userData");
+      csrfService.clearToken();
     } catch {
       toast.error("Failed to logout");
     } finally {

--- a/client/src/services/__tests__/csrfService.test.js
+++ b/client/src/services/__tests__/csrfService.test.js
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+
+vi.mock("axios", () => {
+  const mock = {
+    get: vi.fn(),
+    create: vi.fn(() => ({
+      defaults: { headers: { common: {} } },
+      interceptors: {
+        response: { use: vi.fn() },
+      },
+    })),
+  };
+  return { default: mock };
+});
+
+vi.mock("../apiClient", () => ({
+  default: {
+    defaults: {
+      headers: {
+        common: {},
+      },
+    },
+  },
+}));
+
+import apiClient from "../apiClient";
+import {
+  clearCsrfToken,
+  csrfService,
+  fetchCsrfToken,
+  getCsrfHeaders,
+  getCsrfToken,
+  withCsrf,
+} from "../csrfService";
+
+describe("csrfService", () => {
+  beforeEach(() => {
+    clearCsrfToken();
+    vi.clearAllMocks();
+    apiClient.defaults.headers.common = {};
+  });
+
+  it("fetches and stores the CSRF token", async () => {
+    axios.get.mockResolvedValueOnce({ data: { csrfToken: "tok-1" } });
+
+    const token = await fetchCsrfToken();
+
+    expect(token).toBe("tok-1");
+    expect(getCsrfToken()).toBe("tok-1");
+    expect(apiClient.defaults.headers.common["X-CSRF-Token"]).toBe("tok-1");
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining("/api/csrf-token"),
+      { withCredentials: true },
+    );
+  });
+
+  it("reuses one in-flight fetch for concurrent callers", async () => {
+    let resolveRequest;
+    axios.get.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const first = fetchCsrfToken();
+    const second = fetchCsrfToken();
+
+    resolveRequest({ data: { csrfToken: "shared" } });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      "shared",
+      "shared",
+    ]);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the token and headers", () => {
+    apiClient.defaults.headers.common["X-CSRF-Token"] = "old";
+    clearCsrfToken();
+
+    expect(getCsrfToken()).toBeNull();
+    expect(apiClient.defaults.headers.common["X-CSRF-Token"]).toBeUndefined();
+  });
+
+  it("builds request helpers from the current token", async () => {
+    axios.get.mockResolvedValueOnce({ data: { csrfToken: "hdr" } });
+    await csrfService.fetchToken();
+
+    expect(getCsrfHeaders()).toEqual({ "X-CSRF-Token": "hdr" });
+    expect(withCsrf({ headers: { Accept: "application/json" } })).toEqual({
+      withCredentials: true,
+      headers: {
+        Accept: "application/json",
+        "X-CSRF-Token": "hdr",
+      },
+    });
+  });
+
+  it("rejects when the response has no token", async () => {
+    axios.get.mockResolvedValueOnce({ data: {} });
+
+    await expect(fetchCsrfToken()).rejects.toThrow(
+      "CSRF token missing from response",
+    );
+    expect(getCsrfToken()).toBeNull();
+  });
+});

--- a/client/src/services/authApi.js
+++ b/client/src/services/authApi.js
@@ -10,5 +10,4 @@ export const authApi = {
   verifyAccount: (data) => apiClient.post("/api/auth/verify-account", data),
   sendResetOtp: (data) => apiClient.post("/api/auth/send-reset-otp", data),
   resetPassword: (data) => apiClient.post("/api/auth/reset-password", data),
-  getCsrfToken: () => apiClient.get("/api/csrf-token"),
 };

--- a/client/src/services/csrfService.js
+++ b/client/src/services/csrfService.js
@@ -1,0 +1,84 @@
+import axios from "axios";
+import apiClient from "./apiClient";
+
+const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:4000";
+
+let csrfToken = null;
+let inFlightFetch = null;
+
+function applyToken(token) {
+  csrfToken = token || null;
+
+  if (csrfToken) {
+    apiClient.defaults.headers.common["X-CSRF-Token"] = csrfToken;
+  } else {
+    delete apiClient.defaults.headers.common["X-CSRF-Token"];
+  }
+
+  return csrfToken;
+}
+
+export function getCsrfToken() {
+  return csrfToken;
+}
+
+export function clearCsrfToken() {
+  return applyToken(null);
+}
+
+export function getCsrfHeaders() {
+  return csrfToken ? { "X-CSRF-Token": csrfToken } : {};
+}
+
+// Merge CSRF headers into an axios request config
+export function withCsrf(config = {}) {
+  return {
+    ...config,
+    withCredentials: true,
+    headers: {
+      ...(config.headers || {}),
+      ...getCsrfHeaders(),
+    },
+  };
+}
+
+async function requestToken() {
+  const { data } = await axios.get(`${backendUrl}/api/csrf-token`, {
+    withCredentials: true,
+  });
+
+  if (!data?.csrfToken) {
+    throw new Error("CSRF token missing from response");
+  }
+
+  return applyToken(data.csrfToken);
+}
+
+// Fetch (or re-fetch) a token. Concurrent callers share one request.
+export async function fetchCsrfToken() {
+  if (inFlightFetch) return inFlightFetch;
+
+  inFlightFetch = requestToken()
+    .catch((err) => {
+      clearCsrfToken();
+      throw err;
+    })
+    .finally(() => {
+      inFlightFetch = null;
+    });
+
+  return inFlightFetch;
+}
+
+export async function refreshCsrfToken() {
+  return fetchCsrfToken();
+}
+
+export const csrfService = {
+  fetchToken: fetchCsrfToken,
+  refreshToken: refreshCsrfToken,
+  getToken: getCsrfToken,
+  clearToken: clearCsrfToken,
+  getHeaders: getCsrfHeaders,
+  withCsrf,
+};

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -1,5 +1,6 @@
 export { default as apiClient } from "./apiClient";
 export * from "./authApi";
+export * from "./csrfService";
 export * from "./meetingApi";
 export * from "./organizationApi";
 export * from "./userApi";


### PR DESCRIPTION
# Changes i made 

- Added a shared `csrfService` for fetch / store / get / refresh / clear
- App bootstrap now uses that service instead of handling CSRF in context
- Removed CSRF fetch from `authApi`
- Cleared the token on logout

this pr resolves issue #361

## Testing
- [x] `npm --prefix client test -- --run src/services/__tests__/csrfService.test.js` (5 passed)
- [x] Confirmed Axios interceptors and backend were not modified

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication security by consistently obtaining and applying CSRF protection during sign-in.
  - Ensured CSRF credentials are removed during logout.
  - Prevented duplicate token requests when authentication checks occur concurrently.

- **Tests**
  - Added coverage for CSRF token retrieval, storage, reuse, clearing, request headers, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->