### PR TITLE
feat: add global axios CSRF and auth interceptors

### DIFF
--- a/client/src/hooks/useExport.js
+++ b/client/src/hooks/useExport.js
@@ -1,25 +1,17 @@
-import { useState, useContext } from "react";
-import axios from "axios";
+import { useState } from "react";
 import { toast } from "react-toastify";
-import AppContent from "../context/AppContent";
+import { meetingApi } from "../services";
 
 const useExport = () => {
-  const { backendUrl } = useContext(AppContent);
   const [isExporting, setIsExporting] = useState(false);
 
   const exportMeeting = async (meeting, format) => {
-    if (isExporting) return; // Prevent duplicate requests
+    if (isExporting) return;
+
     try {
       setIsExporting(true);
 
-      const response = await axios.get(
-        `${backendUrl}/api/meetings/${meeting._id}/export?format=${format}`,
-        {
-          withCredentials: true,
-          responseType: "blob",
-          timeout: 60000,
-        },
-      );
+      const response = await meetingApi.exportMeeting(meeting._id, format);
 
       const blob = new Blob([response.data], {
         type: response.headers["content-type"],

--- a/client/src/services/__tests__/apiClient.test.js
+++ b/client/src/services/__tests__/apiClient.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCsrfToken = vi.fn();
+const mockRefreshCsrfToken = vi.fn();
+
+vi.mock("../csrfService.js", () => ({
+  getCsrfToken: (...args) => mockGetCsrfToken(...args),
+  refreshCsrfToken: (...args) => mockRefreshCsrfToken(...args),
+}));
+
+describe("apiClient interceptors", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockGetCsrfToken.mockReturnValue("tok-abc");
+    mockRefreshCsrfToken.mockResolvedValue("tok-abc");
+  });
+
+  it("attaches credentials and the latest CSRF token on requests", async () => {
+    const { default: apiClient } = await import("../apiClient.js");
+
+    const config = await apiClient.interceptors.request.handlers[0].fulfilled({
+      headers: {},
+    });
+
+    expect(config.withCredentials).toBe(true);
+    expect(config.headers["X-CSRF-Token"]).toBe("tok-abc");
+  });
+
+  it("refreshes the CSRF token and retries once on CSRF failure", async () => {
+    const { default: apiClient } = await import("../apiClient.js");
+    const retryResponse = { data: { ok: true } };
+
+    mockRefreshCsrfToken.mockResolvedValue("tok-new");
+    mockGetCsrfToken.mockReturnValue("tok-new");
+
+    const requestSpy = vi
+      .spyOn(apiClient, "request")
+      .mockResolvedValue(retryResponse);
+
+    const originalRequest = {
+      headers: {},
+      url: "/api/test",
+      method: "post",
+    };
+
+    const result = await apiClient.interceptors.response.handlers[0].rejected({
+      config: originalRequest,
+      response: {
+        status: 403,
+        data: { message: "CSRF token validation failed." },
+      },
+    });
+
+    expect(mockRefreshCsrfToken).toHaveBeenCalledTimes(1);
+    expect(originalRequest._retry).toBe(true);
+    expect(originalRequest.headers["X-CSRF-Token"]).toBe("tok-new");
+    expect(requestSpy).toHaveBeenCalled();
+    expect(result).toEqual(retryResponse);
+  });
+
+  it("does not retry CSRF failures more than once", async () => {
+    const { default: apiClient } = await import("../apiClient.js");
+
+    await expect(
+      apiClient.interceptors.response.handlers[0].rejected({
+        config: { headers: {}, _retry: true },
+        response: {
+          status: 403,
+          data: { message: "CSRF token validation failed." },
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "Session security token expired. Please refresh the page.",
+    });
+
+    expect(mockRefreshCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it("maps 401 responses to a friendly session message", async () => {
+    const { default: apiClient } = await import("../apiClient.js");
+
+    await expect(
+      apiClient.interceptors.response.handlers[0].rejected({
+        config: { headers: {} },
+        response: {
+          status: 401,
+          data: {},
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "Session expired. Please log in again.",
+    });
+  });
+});

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { getCsrfToken, refreshCsrfToken } from "./csrfService.js";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:4000";
 
@@ -7,68 +8,88 @@ const apiClient = axios.create({
   withCredentials: true,
 });
 
-// Response Interceptor for global error handling
-apiClient.interceptors.response.use(
-  (response) => {
-    return response;
+const CSRF_FAILED_MESSAGE = "CSRF token validation failed.";
+
+function isCsrfError(error) {
+  const status = error.response?.status;
+  const message = error.response?.data?.message;
+  return status === 419 || (status === 403 && message === CSRF_FAILED_MESSAGE);
+}
+
+function applyFriendlyMessage(error, friendlyMessage) {
+  if (!error.response) {
+    error.response = { data: { message: friendlyMessage }, status: 0 };
+  } else if (error.response.data) {
+    error.response.data.message = friendlyMessage;
+  } else {
+    error.response.data = { message: friendlyMessage };
+  }
+  error.message = friendlyMessage;
+}
+
+// Attach credentials + latest CSRF token on every request
+apiClient.interceptors.request.use(
+  (config) => {
+    config.withCredentials = true;
+
+    const token = getCsrfToken();
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers["X-CSRF-Token"] = token;
+    }
+
+    return config;
   },
+  (error) => Promise.reject(error),
+);
+
+apiClient.interceptors.response.use(
+  (response) => response,
   async (error) => {
+    const originalRequest = error.config;
     let friendlyMessage = "An unexpected error occurred. Please try again.";
 
-    // CSRF Retry Logic
-    if (
-      error.response &&
-      error.response.status === 403 &&
-      error.response.data &&
-      error.response.data.message === "CSRF token validation failed."
-    ) {
-      const originalRequest = error.config;
+    // Refresh CSRF once, then retry the failed request
+    if (isCsrfError(error) && originalRequest && !originalRequest._retry) {
+      originalRequest._retry = true;
 
-      if (!originalRequest._retry) {
-        originalRequest._retry = true;
-        try {
-          const { data } = await axios.get(`${backendUrl}/api/csrf-token`, {
-            withCredentials: true,
-          });
-          if (data && data.csrfToken) {
-            // Update default headers and the original request
-            apiClient.defaults.headers.common["X-CSRF-Token"] = data.csrfToken;
-            originalRequest.headers["X-CSRF-Token"] = data.csrfToken;
-            // Retry the request
-            return apiClient(originalRequest);
-          }
-        } catch (csrfErr) {
-          console.error("Failed to refresh CSRF token", csrfErr);
-          friendlyMessage =
-            "Session security token expired. Please refresh the page.";
+      try {
+        await refreshCsrfToken();
+        const token = getCsrfToken();
+
+        if (token) {
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers["X-CSRF-Token"] = token;
+          return apiClient.request(originalRequest);
         }
-      } else {
+
+        friendlyMessage =
+          "Session security token expired. Please refresh the page.";
+      } catch (csrfErr) {
+        console.error("Failed to refresh CSRF token", csrfErr);
         friendlyMessage =
           "Session security token expired. Please refresh the page.";
       }
-    }
-
-    if (!error.response) {
-      // Network error (offline or server not reachable)
+    } else if (isCsrfError(error) && originalRequest?._retry) {
+      friendlyMessage =
+        "Session security token expired. Please refresh the page.";
+    } else if (!error.response) {
       if (!navigator.onLine) {
-        friendlyMessage = "Network offline. Please check your internet connection.";
+        friendlyMessage =
+          "Network offline. Please check your internet connection.";
       } else {
-        friendlyMessage = "Unable to reach the server. This may be a network issue or a CORS policy restriction.";
+        friendlyMessage =
+          "Unable to reach the server. This may be a network issue or a CORS policy restriction.";
       }
-      // Mock the response so local catch blocks using error.response?.data?.message work
-      error.response = { data: { message: friendlyMessage }, status: 0 };
     } else {
       switch (error.response.status) {
         case 401:
           friendlyMessage =
-            error.response.data && error.response.data.message
-              ? error.response.data.message
-              : "Session expired. Please log in again.";
+            error.response.data?.message ||
+            "Session expired. Please log in again.";
           break;
         case 403:
-          if (
-            error.response.data?.message !== "CSRF token validation failed."
-          ) {
+          if (error.response.data?.message !== CSRF_FAILED_MESSAGE) {
             friendlyMessage =
               "You do not have permission to perform this action.";
           }
@@ -86,23 +107,14 @@ apiClient.interceptors.response.use(
           friendlyMessage = "Server unavailable. Please try again later.";
           break;
         default:
-          // Use backend provided message if available, otherwise keep default
-          if (error.response.data && error.response.data.message) {
+          if (error.response.data?.message) {
             friendlyMessage = error.response.data.message;
           }
           break;
       }
-
-      // Inject the friendly message back into the response so local catch blocks display it
-      if (error.response.data) {
-        error.response.data.message = friendlyMessage;
-      } else {
-        error.response.data = { message: friendlyMessage };
-      }
     }
 
-    error.message = friendlyMessage;
-
+    applyFriendlyMessage(error, friendlyMessage);
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
## Changes i made

- Added a request interceptor that attaches credentials and the latest CSRF token
- Response interceptor refreshes expired CSRF tokens and retries once
- Consistent friendly messages for 401 / 403 / 419 / network failures
- Export hook now uses `apiClient` via `meetingApi`
Depends on the CSRF lifecycle PR for #361  


This pr resolves issue  #362

## Testings i did

- [x] `npm --prefix client test -- --run src/services/__tests__/apiClient.test.js src/services/__tests__/csrfService.test.js` (9 passed)
- [x] Backend CSRF middleware was not modified

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope
