### PR TITLE
fix: standardize backend CSRF error responses

### DIFF
--- a/server/middleware/csrfProtection.js
+++ b/server/middleware/csrfProtection.js
@@ -1,4 +1,5 @@
 import csrf from "csurf";
+import { sendCsrfInvalid } from "../utils/csrfErrors.js";
 
 const csrfProtection = csrf({
   cookie: {
@@ -25,7 +26,14 @@ export const csrfMiddleware = (req, res, next) => {
   ) {
     return next();
   }
-  return csrfProtection(req, res, next);
+
+  return csrfProtection(req, res, (err) => {
+    if (!err) return next();
+    if (err.code === "EBADCSRFTOKEN") {
+      return sendCsrfInvalid(res);
+    }
+    return next(err);
+  });
 };
 
 export const csrfTokenProvider = csrfProtection;

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,5 +1,6 @@
 import { ZodError } from "zod";
 import { AppError } from "../utils/errors.js";
+import { sendCsrfInvalid } from "../utils/csrfErrors.js";
 
 /**
  * Global Express error-handling middleware.
@@ -15,17 +16,14 @@ import { AppError } from "../utils/errors.js";
  *  • ZodError — schema parse failure → 400 with per-field issue list.
  *  • Mongoose ValidationError — maps to 400 with field messages.
  *  • Mongoose CastError — maps to 400 "Invalid ID" response.
- *  • CSRF token failure (EBADCSRFTOKEN) — maps to 403.
+ *  • CSRF token failure (EBADCSRFTOKEN) — maps to 403 + CSRF_INVALID.
  *  • Everything else — 500 Internal Server Error (message hidden in prod).
  */
 // eslint-disable-next-line no-unused-vars
 const errorHandler = (err, req, res, next) => {
   // ── CSRF ────────────────────────────────────────────────────
   if (err.code === "EBADCSRFTOKEN") {
-    return res.status(403).json({
-      success: false,
-      message: "CSRF token validation failed.",
-    });
+    return sendCsrfInvalid(res);
   }
 
   // ── Zod schema validation errors ────────────────────────────

--- a/server/tests/csrfErrors.test.js
+++ b/server/tests/csrfErrors.test.js
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+import {
+  buildCsrfInvalidResponse,
+  CSRF_INVALID,
+  CSRF_INVALID_MESSAGE,
+  sendCsrfInvalid,
+} from "../utils/csrfErrors.js";
+import errorHandler from "../middleware/errorHandler.js";
+
+describe("CSRF error responses", () => {
+  it("builds the standardized CSRF_INVALID payload", () => {
+    expect(buildCsrfInvalidResponse()).toEqual({
+      success: false,
+      code: CSRF_INVALID,
+      message: CSRF_INVALID_MESSAGE,
+    });
+  });
+
+  it("sends a 403 CSRF_INVALID response", () => {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    sendCsrfInvalid(res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: "CSRF_INVALID",
+      message: "CSRF token validation failed.",
+    });
+  });
+
+  it("maps EBADCSRFTOKEN through the global error handler", () => {
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    errorHandler({ code: "EBADCSRFTOKEN" }, {}, res, () => {});
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      code: "CSRF_INVALID",
+      message: "CSRF token validation failed.",
+    });
+  });
+});

--- a/server/utils/csrfErrors.js
+++ b/server/utils/csrfErrors.js
@@ -1,0 +1,15 @@
+export const CSRF_INVALID = "CSRF_INVALID";
+
+export const CSRF_INVALID_MESSAGE = "CSRF token validation failed.";
+
+export function buildCsrfInvalidResponse(message = CSRF_INVALID_MESSAGE) {
+  return {
+    success: false,
+    code: CSRF_INVALID,
+    message,
+  };
+}
+
+export function sendCsrfInvalid(res) {
+  return res.status(403).json(buildCsrfInvalidResponse());
+}


### PR DESCRIPTION
## Changes I made

- Added a shared CSRF error helper with machine-readable `CSRF_INVALID` code
- CSRF middleware and the global error handler now return the same response shape
- Kept the existing message text for compatibility with current clients

Part of epic #366

This pr closes issue #363

## Testings i did
- [x] `npm --prefix server test -- tests/csrfErrors.test.js --runInBand` (3 passed)
- [x] Frontend / Axios interceptors were not modified

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope
