### PR TITLE
feat: centralize authentication bootstrap

### DIFF
--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -24,7 +24,7 @@ const ProtectedRoute = ({
   }
 
   // If user not logged in — block access to protected routes
-  if (!isLoggedin) {
+  if (!isLoggedin || !userData) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 

--- a/client/src/components/__tests__/ProtectedRoute.test.jsx
+++ b/client/src/components/__tests__/ProtectedRoute.test.jsx
@@ -63,6 +63,21 @@ describe("ProtectedRoute", () => {
     expect(screen.getByTestId("location-display")).toHaveTextContent("/login");
   });
 
+  it("redirects to login when logged in but user data is missing", () => {
+    vi.spyOn(useRBACHook, "useRBAC").mockReturnValue({
+      hasPermission: vi.fn(),
+    });
+
+    renderWithProviders(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+      { loading: false, isLoggedin: true, userData: null },
+    );
+
+    expect(screen.getByTestId("location-display")).toHaveTextContent("/login");
+  });
+
   it("redirects to /organizations if onboarding is not completed and not on an onboarding page", () => {
     vi.spyOn(useRBACHook, "useRBAC").mockReturnValue({
       hasPermission: vi.fn(),

--- a/client/src/context/AppContext.jsx
+++ b/client/src/context/AppContext.jsx
@@ -12,8 +12,13 @@ export const AppContextProvider = ({ children }) => {
   const [isLoggedin, setIsLoggedin] = useState(false);
   const [userData, setUserData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
   const navigate = useNavigate();
+
+  const clearAuthState = useCallback(() => {
+    setIsLoggedin(false);
+    setUserData(null);
+    localStorage.removeItem("userData");
+  }, []);
 
   const getUserData = useCallback(async () => {
     try {
@@ -36,62 +41,60 @@ export const AppContextProvider = ({ children }) => {
     }
   }, []);
 
-  const getAuthState = useCallback(async () => {
-    try {
+  // Single bootstrap path for refresh, login, and registration
+  const initializeAuth = useCallback(
+    async ({ quiet = false } = {}) => {
       try {
-        await csrfService.fetchToken();
-      } catch (csrfErr) {
-        console.error("Failed to fetch CSRF token", csrfErr);
-        toast.error(
-          "Failed to initialize secure session. Please check your connection and refresh.",
-        );
-      }
+        try {
+          await csrfService.fetchToken();
+        } catch (csrfErr) {
+          console.error("Failed to fetch CSRF token", csrfErr);
+          if (!quiet) {
+            toast.error(
+              "Failed to initialize secure session. Please check your connection and refresh.",
+            );
+          }
+        }
 
-      const { data } = await authApi.getAuthState();
+        const { data } = await authApi.getAuthState();
+        if (!data.success) {
+          clearAuthState();
+          return null;
+        }
 
-      if (data.success) {
+        const user = await getUserData();
+        if (!user) {
+          clearAuthState();
+          return null;
+        }
+
         setIsLoggedin(true);
-        await getUserData();
-      } else {
-        setIsLoggedin(false);
-        setUserData(null);
-        localStorage.removeItem("userData");
-      }
-    } catch {
-      setIsLoggedin(false);
-      setUserData(null);
-      localStorage.removeItem("userData");
-
-      if (!isLoggingOut) {
+        return user;
+      } catch {
         console.log("User not authenticated");
+        clearAuthState();
+        return null;
+      } finally {
+        setLoading(false);
       }
-    } finally {
-      setLoading(false);
-    }
-  }, [getUserData, isLoggingOut]);
+    },
+    [clearAuthState, getUserData],
+  );
 
   useEffect(() => {
-    getAuthState();
-  }, [getAuthState]);
+    initializeAuth({ quiet: true });
+  }, [initializeAuth]);
 
   const logoutUser = async () => {
     try {
-      setIsLoggingOut(true);
-
       toast.success("Logged out successfully");
-
-      navigate("/"); //FORCE REDIRECT TO LANDING PAGE (Prevents the 404 page)
+      navigate("/");
 
       await authApi.logout();
-
-      setIsLoggedin(false);
-      setUserData(null);
-      localStorage.removeItem("userData");
+      clearAuthState();
       csrfService.clearToken();
     } catch {
       toast.error("Failed to logout");
-    } finally {
-      setIsLoggingOut(false);
     }
   };
 
@@ -102,6 +105,7 @@ export const AppContextProvider = ({ children }) => {
     userData,
     setUserData,
     getUserData,
+    initializeAuth,
     logoutUser,
     loading,
   };

--- a/client/src/context/__tests__/AppContext.test.jsx
+++ b/client/src/context/__tests__/AppContext.test.jsx
@@ -1,0 +1,140 @@
+import React, { useContext } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { AppContextProvider } from "../AppContext";
+import AppContent from "../AppContent";
+
+const mockFetchToken = vi.fn();
+const mockClearToken = vi.fn();
+const mockGetAuthState = vi.fn();
+const mockGetUserData = vi.fn();
+
+vi.mock("../../services", () => ({
+  csrfService: {
+    fetchToken: (...args) => mockFetchToken(...args),
+    clearToken: (...args) => mockClearToken(...args),
+  },
+  authApi: {
+    getAuthState: (...args) => mockGetAuthState(...args),
+    getUserData: (...args) => mockGetUserData(...args),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const Probe = () => {
+  const { loading, isLoggedin, userData, initializeAuth } =
+    useContext(AppContent);
+
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="logged-in">{String(isLoggedin)}</div>
+      <div data-testid="user-name">{userData?.name || ""}</div>
+      <button
+        type="button"
+        onClick={() => initializeAuth()}
+        data-testid="rebootstrap"
+      >
+        Rebootstrap
+      </button>
+    </div>
+  );
+};
+
+describe("AppContext initializeAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchToken.mockResolvedValue("csrf-token");
+
+    const store = {};
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key) => store[key] ?? null),
+      setItem: vi.fn((key, value) => {
+        store[key] = String(value);
+      }),
+      removeItem: vi.fn((key) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        Object.keys(store).forEach((key) => delete store[key]);
+      }),
+    });
+  });
+
+  it("restores an authenticated session on mount", async () => {
+    mockGetAuthState.mockResolvedValue({ data: { success: true } });
+    mockGetUserData.mockResolvedValue({
+      data: {
+        success: true,
+        user: {
+          name: "Sanjana",
+          organization: { name: "MeetOnMemory" },
+          hasCompletedOnboarding: true,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <AppContextProvider>
+          <Probe />
+        </AppContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(mockFetchToken).toHaveBeenCalled();
+    expect(screen.getByTestId("logged-in")).toHaveTextContent("true");
+    expect(screen.getByTestId("user-name")).toHaveTextContent("Sanjana");
+  });
+
+  it("clears auth state for anonymous sessions", async () => {
+    mockGetAuthState.mockResolvedValue({ data: { success: false } });
+
+    render(
+      <MemoryRouter>
+        <AppContextProvider>
+          <Probe />
+        </AppContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("logged-in")).toHaveTextContent("false");
+    expect(screen.getByTestId("user-name")).toHaveTextContent("");
+  });
+
+  it("does not mark the user logged in when user data fails to load", async () => {
+    mockGetAuthState.mockResolvedValue({ data: { success: true } });
+    mockGetUserData.mockResolvedValue({ data: { success: false } });
+
+    render(
+      <MemoryRouter>
+        <AppContextProvider>
+          <Probe />
+        </AppContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("logged-in")).toHaveTextContent("false");
+    expect(screen.getByTestId("user-name")).toHaveTextContent("");
+  });
+});

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -10,7 +10,8 @@ import { authApi } from "../services";
 const Login = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { setIsLoggedin, getUserData, setUserData } = useContext(AppContent);
+  const { initializeAuth, isLoggedin, userData, loading } =
+    useContext(AppContent);
   const { t } = useTranslation();
 
   const [state, setState] = useState("Login");
@@ -28,6 +29,34 @@ const Login = () => {
     }
   }, [location.search]);
 
+  // Already signed in — leave the login page
+  useEffect(() => {
+    if (!loading && isLoggedin && userData) {
+      navigate(
+        userData.hasCompletedOnboarding ? "/dashboard" : "/organizations",
+        { replace: true },
+      );
+    }
+  }, [loading, isLoggedin, userData, navigate]);
+
+  const finishAuth = async (welcomeName) => {
+    const user = await initializeAuth();
+    if (!user) {
+      toast.error("Could not restore your session. Please try again.");
+      return;
+    }
+
+    toast.success(`Welcome, ${welcomeName || user.name}!`);
+
+    const from = location.state?.from?.pathname;
+    if (from) {
+      navigate(from, { replace: true });
+      return;
+    }
+
+    navigate(user.hasCompletedOnboarding ? "/dashboard" : "/organizations");
+  };
+
   const onSubmitHandler = async (e) => {
     e.preventDefault();
     setIsLoading(true);
@@ -40,9 +69,15 @@ const Login = () => {
           password,
         });
 
-        if (!data.success)
-          return toast.error(data.message || "Register failed");
+        if (!data.success) {
+          toast.error(data.message || "Register failed");
+          return;
+        }
+
         toast.success("Account created successfully!");
+        // Register already sets the session cookie
+        await finishAuth(name);
+        return;
       }
 
       const { data: loginData } = await authApi.login({
@@ -51,16 +86,7 @@ const Login = () => {
       });
 
       if (loginData.success) {
-        const user = await getUserData();
-
-        if (user) {
-          setUserData(user);
-          setIsLoggedin(true);
-          localStorage.setItem("userData", JSON.stringify(user));
-          toast.success(`Welcome, ${user.name}!`);
-        }
-
-        navigate("/organizations");
+        await finishAuth();
       } else {
         toast.error(loginData.message || "Login failed");
       }
@@ -97,7 +123,9 @@ const Login = () => {
         {/* Header */}
         <div className="text-center mb-8">
           <h1 className="text-3xl sm:text-4xl font-bold text-white tracking-tight mb-2">
-            {state === "Sign Up" ? t("login.createAccount") : t("login.welcomeBack")}
+            {state === "Sign Up"
+              ? t("login.createAccount")
+              : t("login.welcomeBack")}
           </h1>
           <p className="text-slate-400 text-sm sm:text-base leading-relaxed">
             {state === "Sign Up"
@@ -198,7 +226,11 @@ const Login = () => {
                 autocomple
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute inset-y-0 right-0 pr-3.5 flex cursor-pointer items-center text-slate-500 hover:text-indigo-400 transition-colors duration-200 outline-none focus:text-indigo-400"
-                aria-label={showPassword ? t("login.hidePassword") : t("login.showPassword")}
+                aria-label={
+                  showPassword
+                    ? t("login.hidePassword")
+                    : t("login.showPassword")
+                }
               >
                 {showPassword ? (
                   <EyeOff className="w-5 h-5" />
@@ -235,8 +267,10 @@ const Login = () => {
                     : t("login.signingIn")}
                 </span>
               </>
+            ) : state === "Sign Up" ? (
+              t("login.signUp")
             ) : (
-              state === "Sign Up" ? t("login.signUp") : t("login.loginBtn")
+              t("login.loginBtn")
             )}
           </button>
         </form>


### PR DESCRIPTION
## Changes i made 

- Added a shared `initializeAuth` bootstrap in AppContext
- Login and registration now restore CSRF, session, user, and organization through that path
- Protected routes require restored user data before rendering
- Already authenticated users are redirected away from `/login`
Part of epic #366
this pr closes issue #364

## Testings i did
- [x] `npm --prefix client test -- --run src/context/__tests__/AppContext.test.jsx src/components/__tests__/ProtectedRoute.test.jsx` (11 passed)
- [x] Backend auth / cookie config / Axios interceptors were not modified

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope
