### PR TITLE
test: add auth and CSRF regression coverage

### DIFF
--- a/AUTH_CSRF_REGRESSION_CHECKLIST.md
+++ b/AUTH_CSRF_REGRESSION_CHECKLIST.md
@@ -1,0 +1,58 @@
+# Auth & CSRF Regression Checklist
+
+Manual checks for production authentication and CSRF behavior.
+Automated coverage lives in:
+
+- `server/tests/authCsrfRegression.test.js`
+- `server/tests/csrfErrors.test.js`
+- `client/src/services/__tests__/csrfService.test.js`
+- `client/src/services/__tests__/apiClient.test.js`
+- `client/src/context/__tests__/AppContext.session.test.jsx`
+- `client/src/components/__tests__/ProtectedRoute.test.jsx`
+
+## Browsers
+
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Edge
+- [ ] Brave
+- [ ] Safari
+- [ ] Android Chrome
+- [ ] Incognito / Private window
+
+## Session flows
+
+- [ ] Register creates a session and lands in the app without a hard refresh
+- [ ] Login restores the session without a hard refresh
+- [ ] Logout clears the session and blocks protected routes
+- [ ] Hard refresh keeps the user signed in
+- [ ] Opening a second tab stays signed in
+- [ ] Expired/invalid session redirects to login cleanly
+
+## CSRF & cookies
+
+- [ ] Authenticated POST/PATCH/PUT/DELETE requests succeed with a valid CSRF token
+- [ ] Mutating requests fail cleanly when the CSRF token is missing/stale, then succeed after refresh
+- [ ] Auth cookie is `HttpOnly`
+- [ ] Production cookie uses `Secure` + appropriate `SameSite`
+- [ ] Cookies persist across refresh on the deployed HTTPS origin
+
+## Protected features
+
+- [ ] Organization create / join
+- [ ] Membership requests
+- [ ] AI Search
+- [ ] Meeting upload
+- [ ] Policy upload
+- [ ] Other authenticated write endpoints used in the release
+
+## Notes
+
+Record browser, date, and any failures below:
+
+```
+Browser:
+Date:
+Result:
+Notes:
+```

--- a/client/src/context/__tests__/AppContext.session.test.jsx
+++ b/client/src/context/__tests__/AppContext.session.test.jsx
@@ -1,0 +1,141 @@
+import React, { useContext } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { AppContextProvider } from "../AppContext";
+import AppContent from "../AppContent";
+
+const mockFetchToken = vi.fn();
+const mockClearToken = vi.fn();
+const mockGetAuthState = vi.fn();
+const mockGetUserData = vi.fn();
+const mockLogout = vi.fn();
+
+vi.mock("../../services", () => ({
+  csrfService: {
+    fetchToken: (...args) => mockFetchToken(...args),
+    clearToken: (...args) => mockClearToken(...args),
+  },
+  authApi: {
+    getAuthState: (...args) => mockGetAuthState(...args),
+    getUserData: (...args) => mockGetUserData(...args),
+    logout: (...args) => mockLogout(...args),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const Probe = () => {
+  const { loading, isLoggedin, userData, logoutUser } = useContext(AppContent);
+
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="logged-in">{String(isLoggedin)}</div>
+      <div data-testid="user-name">{userData?.name || ""}</div>
+      <div data-testid="org-name">{userData?.organization?.name || ""}</div>
+      <button type="button" onClick={() => logoutUser()} data-testid="logout">
+        Logout
+      </button>
+    </div>
+  );
+};
+
+describe("AppContext session regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchToken.mockResolvedValue("csrf-token");
+    mockLogout.mockResolvedValue({ data: { success: true } });
+
+    const store = {};
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key) => store[key] ?? null),
+      setItem: vi.fn((key, value) => {
+        store[key] = String(value);
+      }),
+      removeItem: vi.fn((key) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        Object.keys(store).forEach((key) => delete store[key]);
+      }),
+    });
+  });
+
+  it("restores auth, user, and organization after a page refresh", async () => {
+    mockGetAuthState.mockResolvedValue({ data: { success: true } });
+    mockGetUserData.mockResolvedValue({
+      data: {
+        success: true,
+        user: {
+          name: "Sanjana",
+          organization: { name: "MeetOnMemory" },
+          hasCompletedOnboarding: true,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <AppContextProvider>
+          <Probe />
+        </AppContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(mockFetchToken).toHaveBeenCalled();
+    expect(screen.getByTestId("logged-in")).toHaveTextContent("true");
+    expect(screen.getByTestId("user-name")).toHaveTextContent("Sanjana");
+    expect(screen.getByTestId("org-name")).toHaveTextContent("MeetOnMemory");
+  });
+
+  it("clears auth state and CSRF token on logout", async () => {
+    mockGetAuthState
+      .mockResolvedValueOnce({ data: { success: true } })
+      .mockResolvedValue({ data: { success: false } });
+    mockGetUserData.mockResolvedValue({
+      data: {
+        success: true,
+        user: {
+          name: "Sanjana",
+          organization: { name: "MeetOnMemory" },
+          hasCompletedOnboarding: true,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <AppContextProvider>
+          <Probe />
+        </AppContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logged-in")).toHaveTextContent("true");
+    });
+
+    screen.getByTestId("logout").click();
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockClearToken).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logged-in")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("user-name")).toHaveTextContent("");
+  });
+});

--- a/client/src/services/__tests__/csrfService.test.js
+++ b/client/src/services/__tests__/csrfService.test.js
@@ -105,4 +105,18 @@ describe("csrfService", () => {
     );
     expect(getCsrfToken()).toBeNull();
   });
+
+  it("rotates the token on refresh", async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { csrfToken: "tok-old" } })
+      .mockResolvedValueOnce({ data: { csrfToken: "tok-new" } });
+
+    await csrfService.fetchToken();
+    expect(getCsrfToken()).toBe("tok-old");
+
+    const refreshed = await csrfService.refreshToken();
+    expect(refreshed).toBe("tok-new");
+    expect(getCsrfToken()).toBe("tok-new");
+    expect(apiClient.defaults.headers.common["X-CSRF-Token"]).toBe("tok-new");
+  });
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -42,6 +42,7 @@
         "pdf-parse": "^2.4.5",
         "pdfkit": "^0.19.1",
         "pptx2json": "^0.0.10",
+        "rate-limit-redis": "^4.2.0",
         "redis": "^6.1.0",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.3",
@@ -7749,23 +7750,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7863,38 +7847,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -7939,56 +7891,6 @@
         "socks": {
           "optional": true
         }
-      }
-    },
-    "node_modules/mongoose/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongoose/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/mongoose/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/mpath": {
@@ -9034,6 +8936,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {

--- a/server/tests/authCsrfRegression.test.js
+++ b/server/tests/authCsrfRegression.test.js
@@ -1,0 +1,123 @@
+import request from "supertest";
+import { app } from "../server.js";
+
+const uniqueEmail = (prefix) =>
+  `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}@example.com`;
+
+describe("Auth & CSRF regression", () => {
+  it("registers, keeps the session cookie, and clears it on logout", async () => {
+    const agent = request.agent(app);
+    const user = {
+      name: "Session User",
+      email: uniqueEmail("session"),
+      password: "password123",
+    };
+
+    const registerRes = await agent.post("/api/auth/register").send(user);
+    expect(registerRes.statusCode).toBe(201);
+    expect(registerRes.body.success).toBe(true);
+
+    const cookies = registerRes.headers["set-cookie"];
+    expect(cookies).toBeDefined();
+    expect(cookies.some((cookie) => cookie.startsWith("token="))).toBe(true);
+    expect(cookies.some((cookie) => /HttpOnly/i.test(cookie))).toBe(true);
+
+    const authRes = await agent.get("/api/auth/is-auth");
+    expect(authRes.statusCode).toBe(200);
+    expect(authRes.body.success).toBe(true);
+
+    const userRes = await agent.get("/api/auth/user-data");
+    expect(userRes.statusCode).toBe(200);
+    expect(userRes.body.success).toBe(true);
+    expect(userRes.body.user.email).toBe(user.email);
+
+    const logoutRes = await agent.post("/api/auth/logout").send({});
+    expect(logoutRes.statusCode).toBe(200);
+    expect(logoutRes.body.success).toBe(true);
+
+    const afterLogout = await agent.get("/api/auth/is-auth");
+    expect(afterLogout.statusCode).toBe(401);
+    expect(afterLogout.body.success).toBe(false);
+  });
+
+  it("logs in an existing user and restores auth state", async () => {
+    const agent = request.agent(app);
+    const user = {
+      name: "Login User",
+      email: uniqueEmail("login"),
+      password: "password123",
+    };
+
+    await agent.post("/api/auth/register").send(user);
+    await agent.post("/api/auth/logout").send({});
+
+    const loginRes = await agent.post("/api/auth/login").send({
+      email: user.email,
+      password: user.password,
+    });
+
+    expect(loginRes.statusCode).toBe(200);
+    expect(loginRes.body.success).toBe(true);
+
+    const authRes = await agent.get("/api/auth/is-auth");
+    expect(authRes.body.success).toBe(true);
+  });
+
+  describe("CSRF enforcement on protected mutations", () => {
+    const previousEnv = process.env.NODE_ENV;
+
+    beforeAll(() => {
+      // csrf middleware skips protection when NODE_ENV === "test"
+      process.env.NODE_ENV = "development";
+    });
+
+    afterAll(() => {
+      process.env.NODE_ENV = previousEnv;
+    });
+
+    it("rejects protected mutations without a CSRF token", async () => {
+      const agent = request.agent(app);
+      const user = {
+        name: "Csrf Missing",
+        email: uniqueEmail("csrf-missing"),
+        password: "password123",
+      };
+
+      await agent.post("/api/auth/register").send(user);
+
+      const res = await agent.post("/api/organizations").send({
+        name: `Org ${Date.now()}`,
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toMatchObject({
+        success: false,
+        code: "CSRF_INVALID",
+      });
+    });
+
+    it("accepts a protected mutation after fetching a fresh CSRF token", async () => {
+      const agent = request.agent(app);
+      const user = {
+        name: "Csrf Valid",
+        email: uniqueEmail("csrf-valid"),
+        password: "password123",
+      };
+
+      await agent.post("/api/auth/register").send(user);
+
+      const csrfRes = await agent.get("/api/csrf-token");
+      expect(csrfRes.statusCode).toBe(200);
+      expect(csrfRes.body.csrfToken).toBeTruthy();
+
+      const res = await agent
+        .post("/api/organizations")
+        .set("X-CSRF-Token", csrfRes.body.csrfToken)
+        .send({ name: `Org ${Date.now()}` });
+
+      expect(res.body.code).not.toBe("CSRF_INVALID");
+      expect(res.statusCode).not.toBe(403);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Changes i made 

- Added server regression tests for login/logout session persistence and CSRF protection
- Added client tests for session restore after refresh and logout cleanup
- Extended CSRF service coverage for token refresh
- Added a manual browser/session checklist for production verification
Part of epic #366
This PR resolves issue #365

## Testings i did

- [x] Client auth/CSRF regression tests passed
- [x] Server auth/CSRF regression tests passed
- [x] No auth feature / UI / architecture changes

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes are limited to the issue scope
