### PR TITLE
feat(gemini): protect gemini AI endpoints behind authentication and authorization

### DIFF
--- a/server/routes/geminiRoutes.js
+++ b/server/routes/geminiRoutes.js
@@ -1,11 +1,20 @@
 import express from "express";
 import axios from "axios";
 import dotenv from "dotenv";
+import userAuth from "../middleware/userAuth.js";
+import { writeLimiter } from "../middleware/rateLimiter.js";
+import { requirePermission } from "../middleware/rbac.js";
+
 dotenv.config();
 
 const router = express.Router();
 
-router.post("/insights", async (req, res) => {
+router.post(
+  "/insights",
+  userAuth,
+  writeLimiter,
+  requirePermission("reports", "view"),
+  async (req, res) => {
   try {
     const { summary } = req.body;
 

--- a/server/tests/gemini.test.js
+++ b/server/tests/gemini.test.js
@@ -1,0 +1,123 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import axios from "axios";
+import { jest } from "@jest/globals";
+import { app } from "../server.js";
+import User from "../models/userModel.js";
+import Organization from "../models/organizationModel.js";
+import Membership from "../models/membershipModel.js";
+
+// Mock nodemailer to prevent SMTP verification during tests
+jest.mock("../config/nodeMailer.js", () => ({
+  sendMail: jest.fn(),
+  __esModule: true,
+  default: { sendMail: jest.fn() },
+}));
+
+describe("Gemini AI Endpoint Authentication and Authorization", () => {
+  let user;
+  let guestUser;
+  let organization;
+  let userToken;
+  let guestToken;
+  let axiosSpy;
+
+  beforeAll(() => {
+    // Mock Axios POST for Gemini generateContent call
+    axiosSpy = jest.spyOn(axios, "post").mockResolvedValue({
+      status: 200,
+      data: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: "This is a mocked professional analytics summary highlighting trends and insights.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  afterAll(() => {
+    axiosSpy.mockRestore();
+  });
+
+  beforeEach(async () => {
+    // Set up test organization
+    organization = await Organization.create({
+      name: "Acme Analytics",
+      slug: "acme-analytics-" + Math.random().toString(36).substring(7),
+      owner: new mongoose.Types.ObjectId(),
+    });
+
+    // Create normal member user
+    user = await User.create({
+      name: "Normal Member",
+      email: `member-${Math.random()}@example.com`,
+      password: "password123",
+      organization: organization._id,
+      role: "member",
+    });
+    userToken = jwt.sign(
+      { id: user._id },
+      process.env.JWT_SECRET || "fallback_secret",
+    );
+
+    await Membership.create({
+      user: user._id,
+      organization: organization._id,
+      role: "member",
+      status: "active",
+    });
+
+    // Create guest user (no report view permission)
+    guestUser = await User.create({
+      name: "Guest User",
+      email: `guest-${Math.random()}@example.com`,
+      password: "password123",
+      organization: organization._id,
+      role: "guest",
+    });
+    guestToken = jwt.sign(
+      { id: guestUser._id },
+      process.env.JWT_SECRET || "fallback_secret",
+    );
+  });
+
+  describe("POST /api/gemini/insights", () => {
+    it("should reject unauthenticated requests with 401", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+
+      expect(res.statusCode).toEqual(401);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should reject unauthorized requests from guest with 403", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set("Authorization", `Bearer ${guestToken}`)
+        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+
+      expect(res.statusCode).toEqual(403);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("should allow authenticated member with view reports permission to generate insights", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set("Authorization", `Bearer ${userToken}`)
+        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.insight).toBe("This is a mocked professional analytics summary highlighting trends and insights.");
+    });
+  });
+});

--- a/server/tests/setup.js
+++ b/server/tests/setup.js
@@ -12,6 +12,7 @@ const uri = mongoServer.getUri();
 
 process.env.TEST_MONGODB_URI = uri.replace(/\/$/, "");
 process.env.NODE_ENV = "test";
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test_jwt_secret";
 
 // ─── Teardown ──────────────────────────────────────────────────────────────
 afterAll(async () => {


### PR DESCRIPTION
# Pull Request

## Description

This PR secures the Gemini AI insights generation endpoint to prevent unauthenticated/unauthorized clients from accessing Gemini capabilities, safeguarding credits, quota limits, and system resources.

### Backend Changes:
- **Middleware Integration**: Added session authentication (`userAuth`), request rate-limiting (`writeLimiter`), and role permissions assertion (`requirePermission("reports", "view")`) on the `/api/gemini/insights` route.
- **Mock-based Regression Tests**: Created `server/tests/gemini.test.js` to assert:
  - 401 Unauthorized for unauthenticated clients.
  - 403 Forbidden for authenticated users without reports view access (e.g. guests).
  - 200 OK with mock insights text for authorized members.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #385

## Testing

Added integration tests to the test suite. All tests pass successfully.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [ ] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Protected AI insights requests with authentication, rate limiting, and report-view permissions.
  * Unauthenticated requests are rejected, while users without access receive a forbidden response.

* **Bug Fixes**
  * Added safeguards to ensure only authorized members can generate AI insights.

* **Tests**
  * Added coverage for authentication, authorization, successful insight generation, and test-environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->