### PR TITLE
[Refactor]: Extract imperative custom cursor logic into dedicated component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -48,6 +48,7 @@ import AdminPanel from "./pages/AdminPanel.jsx";
 import AccessDenied from "./pages/AccessDenied.jsx";
 import Navbar from "./components/Navbar";
 import ScrollNavigator from "./components/ScrollNavigator";
+import CustomCursor from "./components/CustomCursor.jsx";
 
 // --- Components ---
 import ProtectedRoute from "./components/ProtectedRoute.jsx";
@@ -62,99 +63,6 @@ const App = () => {
 
   // Only activate navigation controller panel when exactly on the landing page fold
   const shouldShowScrollNavigator = location.pathname === "/";
-
-  const [isHovered, setIsHovered] = useState(false);
-  const [isMobile, setIsMobile] = useState(true);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(pointer: fine)");
-    setIsMobile(!mediaQuery.matches);
-    if (!mediaQuery.matches) return;
-
-    // Keep track of real mouse coordinates and rendering coordinates
-    const mouse = { x: 0, y: 0 };
-    const dot = { x: 0, y: 0 };
-    const ring = { x: 0, y: 0 };
-
-    // DOM references obtained directly for maximum frames-per-second performance
-    let dotEl = null;
-    let ringEl = null;
-    let animationFrameId = null;
-
-    const handleMouseMove = (e) => {
-      mouse.x = e.clientX;
-      mouse.y = e.clientY;
-      if (!dotEl) dotEl = document.querySelector(".custom-cursor");
-      if (!ringEl) ringEl = document.querySelector(".custom-cursor-ring");
-      if (dotEl && ringEl) {
-        dotEl.style.opacity = "1";
-        ringEl.style.opacity = "1";
-      }
-    };
-
-    const handleMouseOver = (e) => {
-      const target = e.target;
-      if (
-        target.tagName === "A" ||
-        target.tagName === "BUTTON" ||
-        target.closest("button") ||
-        target.closest("a") ||
-        target.getAttribute("role") === "button"
-      ) {
-        setIsHovered(true);
-      } else {
-        setIsHovered(false);
-      }
-    };
-
-    const handleMouseLeave = () => {
-      if (dotEl && ringEl) {
-        dotEl.style.opacity = "0";
-        ringEl.style.opacity = "0";
-      }
-    };
-
-    const handleMouseEnter = () => {
-      if (dotEl && ringEl) {
-        dotEl.style.opacity = "1";
-        ringEl.style.opacity = "1";
-      }
-    };
-
-    // The Tick function handles the fluid physics loop
-    const tick = () => {
-      if (!dotEl) dotEl = document.querySelector(".custom-cursor");
-      if (!ringEl) ringEl = document.querySelector(".custom-cursor-ring");
-
-      if (dotEl && ringEl) {
-        // Inner dot follows instantly (1:1 ratio)
-        dot.x = mouse.x;
-        dot.y = mouse.y;
-        dotEl.style.transform = `translate3d(${dot.x}px, ${dot.y}px, 0) translate(-50%, -50%)`;
-
-        // Outer circle glides smoothly lagging behind (using 15% interpolation speed)
-        ring.x += (mouse.x - ring.x) * 0.15;
-        ring.y += (mouse.y - ring.y) * 0.15;
-        ringEl.style.transform = `translate3d(${ring.x}px, ${ring.y}px, 0) translate(-50%, -50%)`;
-      }
-
-      animationFrameId = requestAnimationFrame(tick);
-    };
-
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseover", handleMouseOver);
-    document.addEventListener("mouseleave", handleMouseLeave);
-    document.addEventListener("mouseenter", handleMouseEnter);
-    animationFrameId = requestAnimationFrame(tick);
-
-    return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseover", handleMouseOver);
-      document.removeEventListener("mouseleave", handleMouseLeave);
-      document.removeEventListener("mouseenter", handleMouseEnter);
-      cancelAnimationFrame(animationFrameId);
-    };
-  }, []);
 
   return (
     <div className="flex flex-col min-h-screen bg-white dark:bg-gray-900">
@@ -406,14 +314,7 @@ const App = () => {
         {/* Global Footer */}
         {shouldShowFooter && <Footer />}
 
-        {!isMobile && (
-          <>
-            <div className={`custom-cursor ${isHovered ? "hovered" : ""}`} />
-            <div
-              className={`custom-cursor-ring ${isHovered ? "hovered" : ""}`}
-            />
-          </>
-        )}
+        <CustomCursor />
       </ErrorBoundary>
     </div>
   );

--- a/client/src/components/CustomCursor.jsx
+++ b/client/src/components/CustomCursor.jsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from "react";
+
+const CustomCursor = () => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isMobile, setIsMobile] = useState(true);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(pointer: fine)");
+    setIsMobile(!mediaQuery.matches);
+    if (!mediaQuery.matches) return;
+
+    // Keep track of real mouse coordinates and rendering coordinates
+    const mouse = { x: 0, y: 0 };
+    const dot = { x: 0, y: 0 };
+    const ring = { x: 0, y: 0 };
+
+    // DOM references obtained directly for maximum frames-per-second performance
+    let dotEl = null;
+    let ringEl = null;
+    let animationFrameId = null;
+
+    const handleMouseMove = (e) => {
+      mouse.x = e.clientX;
+      mouse.y = e.clientY;
+      if (!dotEl) dotEl = document.querySelector(".custom-cursor");
+      if (!ringEl) ringEl = document.querySelector(".custom-cursor-ring");
+      if (dotEl && ringEl) {
+        dotEl.style.opacity = "1";
+        ringEl.style.opacity = "1";
+      }
+    };
+
+    const handleMouseOver = (e) => {
+      const target = e.target;
+      if (
+        target.tagName === "A" ||
+        target.tagName === "BUTTON" ||
+        target.closest("button") ||
+        target.closest("a") ||
+        target.getAttribute("role") === "button"
+      ) {
+        setIsHovered(true);
+      } else {
+        setIsHovered(false);
+      }
+    };
+
+    const handleMouseLeave = () => {
+      if (dotEl && ringEl) {
+        dotEl.style.opacity = "0";
+        ringEl.style.opacity = "0";
+      }
+    };
+
+    const handleMouseEnter = () => {
+      if (dotEl && ringEl) {
+        dotEl.style.opacity = "1";
+        ringEl.style.opacity = "1";
+      }
+    };
+
+    // The Tick function handles the fluid physics loop
+    const tick = () => {
+      if (!dotEl) dotEl = document.querySelector(".custom-cursor");
+      if (!ringEl) ringEl = document.querySelector(".custom-cursor-ring");
+
+      if (dotEl && ringEl) {
+        // Inner dot follows instantly (1:1 ratio)
+        dot.x = mouse.x;
+        dot.y = mouse.y;
+        dotEl.style.transform = `translate3d(${dot.x}px, ${dot.y}px, 0) translate(-50%, -50%)`;
+
+        // Outer circle glides smoothly lagging behind (using 15% interpolation speed)
+        ring.x += (mouse.x - ring.x) * 0.15;
+        ring.y += (mouse.y - ring.y) * 0.15;
+        ringEl.style.transform = `translate3d(${ring.x}px, ${ring.y}px, 0) translate(-50%, -50%)`;
+      }
+
+      animationFrameId = requestAnimationFrame(tick);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseover", handleMouseOver);
+    document.addEventListener("mouseleave", handleMouseLeave);
+    document.addEventListener("mouseenter", handleMouseEnter);
+    animationFrameId = requestAnimationFrame(tick);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseover", handleMouseOver);
+      document.removeEventListener("mouseleave", handleMouseLeave);
+      document.removeEventListener("mouseenter", handleMouseEnter);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, []);
+
+  if (isMobile) return null;
+
+  return (
+    <>
+      <div className={`custom-cursor ${isHovered ? "hovered" : ""}`} />
+      <div className={`custom-cursor-ring ${isHovered ? "hovered" : ""}`} />
+    </>
+  );
+};
+
+export default CustomCursor;

--- a/client/src/components/CustomCursor.test.jsx
+++ b/client/src/components/CustomCursor.test.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import CustomCursor from "./CustomCursor";
+
+// Mock window.matchMedia since it's not supported in JSDOM by default
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: true, // Simulate a desktop environment with a fine pointer
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // Deprecated
+      removeListener: vi.fn(), // Deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("CustomCursor", () => {
+  it("renders without crashing on desktop devices", () => {
+    const { container } = render(<CustomCursor />);
+
+    // Check if the cursor divs are rendered
+    expect(container.querySelector(".custom-cursor")).toBeInTheDocument();
+    expect(container.querySelector(".custom-cursor-ring")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- closes #396

### **Problem Statement:**
The `client/src/App.jsx` root component contained a massive `useEffect` block responsible for manipulating the DOM imperatively to create a 60fps custom cursor. Placing this logic directly inside `App.jsx` bloated the file, violated the Single Responsibility Principle, and mixed declarative UI with imperative DOM updates, making the root component difficult to maintain.

### **Proposed Changes:**
- **Component Extraction:** Created a new `CustomCursor.jsx` component inside `client/src/components/` to encapsulate the cursor's state (`isHovered`, `isMobile`), physics logic, and event listeners.
- **Root Cleanup:** Stripped the massive `useEffect` and related state out of `App.jsx`.
- **JSX Refactoring:** Moved the `.custom-cursor` and `.custom-cursor-ring` DOM elements into the new component and simply rendered `<CustomCursor />` at the bottom of the `App` component routing tree.
- **Automated Testing:** Added a simple Vitest smoke test (`CustomCursor.test.jsx`) to ensure the newly isolated component renders correctly in a desktop environment. 

### **Validation:**

- [x] Verified the physics of the cursor (1:1 ratio for inner dot, 0.15 interpolation for outer ring lag) remain identical and smooth.
- [x] Verified the 60fps frame rate is maintained by successfully bypassing the React render cycle using `requestAnimationFrame`.
- [x] Verified that cleanup functions correctly remove all `window` and `document` event listeners upon unmounting to prevent memory leaks.
- [x] Automated tests passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable custom cursor for desktop devices with smooth motion and interactive hover effects.
  * Automatically hides the custom cursor on mobile and coarse-pointer devices.

* **Tests**
  * Added coverage confirming the custom cursor renders correctly in desktop-like environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->