### PR TITLE
[Refactor]: Extract Drag & Drop and API logic from useMeetingUpload

### DIFF
--- a/client/src/hooks/__tests__/useDragAndDrop.test.js
+++ b/client/src/hooks/__tests__/useDragAndDrop.test.js
@@ -1,0 +1,53 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import useDragAndDrop from "../useDragAndDrop";
+
+describe("useDragAndDrop hook", () => {
+  it("should initialize with isDragging as false", () => {
+    const { result } = renderHook(() => useDragAndDrop());
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it("should set isDragging to true on dragOver", () => {
+    const { result } = renderHook(() => useDragAndDrop());
+
+    act(() => {
+      result.current.handlers.onDragOver({ preventDefault: vi.fn() });
+    });
+
+    expect(result.current.isDragging).toBe(true);
+  });
+
+  it("should set isDragging to false on dragLeave", () => {
+    const { result } = renderHook(() => useDragAndDrop());
+
+    act(() => {
+      result.current.handlers.onDragOver({ preventDefault: vi.fn() });
+    });
+    expect(result.current.isDragging).toBe(true);
+
+    act(() => {
+      result.current.handlers.onDragLeave({ preventDefault: vi.fn() });
+    });
+
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it("should set isDragging to false and call onDropCallback on drop", () => {
+    const onDropCallback = vi.fn();
+    const { result } = renderHook(() => useDragAndDrop(onDropCallback));
+
+    act(() => {
+      result.current.handlers.onDragOver({ preventDefault: vi.fn() });
+    });
+
+    const mockEvent = { preventDefault: vi.fn() };
+    act(() => {
+      result.current.handlers.onDrop(mockEvent);
+    });
+
+    expect(result.current.isDragging).toBe(false);
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(onDropCallback).toHaveBeenCalledWith(mockEvent);
+  });
+});

--- a/client/src/hooks/__tests__/useUploadMeetingApi.test.js
+++ b/client/src/hooks/__tests__/useUploadMeetingApi.test.js
@@ -1,0 +1,76 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useUploadMeetingApi from "../useUploadMeetingApi";
+import { meetingApi } from "../../services";
+import { toast } from "react-toastify";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    uploadMeeting: vi.fn(),
+  },
+}));
+
+describe("useUploadMeetingApi hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should initialize with default states", () => {
+    const { result } = renderHook(() => useUploadMeetingApi());
+
+    expect(result.current.uploadProgress).toBe(0);
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("should show error if no file is provided", async () => {
+    const { result } = renderHook(() => useUploadMeetingApi());
+
+    await act(async () => {
+      await result.current.uploadMeeting(null, "Test Title", vi.fn());
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Please select an audio file first.",
+    );
+  });
+
+  it("should successfully upload a file and call onSuccess", async () => {
+    const mockResponse = { data: { success: true, transcript: "Hello" } };
+    meetingApi.uploadMeeting.mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useUploadMeetingApi());
+    const file = new File(["dummy content"], "test.mp3", { type: "audio/mp3" });
+    const onSuccess = vi.fn();
+
+    await act(async () => {
+      await result.current.uploadMeeting(file, "Title", onSuccess);
+    });
+
+    expect(meetingApi.uploadMeeting).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Transcription complete!");
+    expect(onSuccess).toHaveBeenCalledWith(mockResponse.data);
+    expect(result.current.isUploading).toBe(false);
+  });
+
+  it("should handle upload failure", async () => {
+    const mockResponse = { data: { success: false, message: "Upload failed" } };
+    meetingApi.uploadMeeting.mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useUploadMeetingApi());
+    const file = new File(["dummy content"], "test.mp3", { type: "audio/mp3" });
+
+    await act(async () => {
+      await result.current.uploadMeeting(file, "Title", vi.fn());
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Upload failed");
+    expect(result.current.isUploading).toBe(false);
+  });
+});

--- a/client/src/hooks/useDragAndDrop.js
+++ b/client/src/hooks/useDragAndDrop.js
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+const useDragAndDrop = (onDropCallback) => {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const onDragOver = (e) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const onDragLeave = (e) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    setIsDragging(false);
+    if (onDropCallback) {
+      onDropCallback(e);
+    }
+  };
+
+  return {
+    isDragging,
+    handlers: {
+      onDragOver,
+      onDragLeave,
+      onDrop,
+    },
+  };
+};
+
+export default useDragAndDrop;

--- a/client/src/hooks/useMeetingUpload.js
+++ b/client/src/hooks/useMeetingUpload.js
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import { toast } from "react-toastify";
-import { meetingApi } from "../services";
+import useDragAndDrop from "./useDragAndDrop";
+import useUploadMeetingApi from "./useUploadMeetingApi";
 
 const allowedTypes = [
   "audio/wav",
@@ -22,13 +23,9 @@ const formatFileSize = (bytes) => {
 
 const useMeetingUpload = () => {
   const [file, setFile] = useState(null);
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [isUploading, setIsUploading] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
   const [transcript, setTranscript] = useState("");
   const [meetingId, setMeetingId] = useState(null);
 
-  // Expose refs if needed by UI
   const fileInputRef = useRef(null);
 
   const validateAndSetFile = (f) => {
@@ -51,22 +48,13 @@ const useMeetingUpload = () => {
     if (f) validateAndSetFile(f);
   };
 
-  const handleDragOver = (e) => {
-    e.preventDefault();
-    setIsDragging(true);
-  };
-
-  const handleDragLeave = (e) => {
-    e.preventDefault();
-    setIsDragging(false);
-  };
-
-  const handleDrop = (e) => {
-    e.preventDefault();
-    setIsDragging(false);
+  const handleDropCallback = (e) => {
     const f = e.dataTransfer.files[0];
     if (f) validateAndSetFile(f);
   };
+
+  const { isDragging, handlers } = useDragAndDrop(handleDropCallback);
+  const { uploadProgress, isUploading, uploadMeeting } = useUploadMeetingApi();
 
   const resetUpload = (setSummary, setTitle) => {
     setFile(null);
@@ -79,50 +67,18 @@ const useMeetingUpload = () => {
     }
   };
 
-  const handleUpload = async (title, setTitle) => {
+  const handleUpload = (title, setTitle) => {
     if (!file) {
       toast.error("Please select an audio file first.");
       return;
     }
-
-    try {
-      setIsUploading(true);
-      setUploadProgress(0);
-      setTranscript("");
-      setMeetingId(null);
-
-      const formData = new FormData();
-      formData.append("file", file);
-      if (title) formData.append("title", title);
-
-      const res = await meetingApi.uploadMeeting(formData, {
-        onUploadProgress: (progressEvent) => {
-          const percent = Math.round(
-            (progressEvent.loaded * 100) / progressEvent.total,
-          );
-          setUploadProgress(percent);
-        },
-      });
-
-      if (res.data?.success) {
-        toast.success("Transcription complete!");
-        setTranscript(res.data.transcript || "");
-        setMeetingId(res.data.meetingId || null);
-        if (res.data.autoTitle && setTitle) setTitle(res.data.autoTitle);
-      } else {
-        toast.error(res.data?.message || "Upload failed");
-      }
-    } catch (err) {
-      console.error("Upload error:", err);
-      toast.error(
-        err.response?.data?.message ||
-          err.message ||
-          "Server error during upload",
-      );
-    } finally {
-      setIsUploading(false);
-      setUploadProgress(0);
-    }
+    setTranscript("");
+    setMeetingId(null);
+    uploadMeeting(file, title, (data) => {
+      setTranscript(data.transcript || "");
+      setMeetingId(data.meetingId || null);
+      if (data.autoTitle && setTitle) setTitle(data.autoTitle);
+    });
   };
 
   return {
@@ -138,9 +94,9 @@ const useMeetingUpload = () => {
     fileInputRef,
     validateAndSetFile,
     handleFileChange,
-    handleDragOver,
-    handleDragLeave,
-    handleDrop,
+    handleDragOver: handlers.onDragOver,
+    handleDragLeave: handlers.onDragLeave,
+    handleDrop: handlers.onDrop,
     resetUpload,
     handleUpload,
     formatFileSize,

--- a/client/src/hooks/useUploadMeetingApi.js
+++ b/client/src/hooks/useUploadMeetingApi.js
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { toast } from "react-toastify";
+import { meetingApi } from "../services";
+
+const useUploadMeetingApi = () => {
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadMeeting = async (file, title, onSuccess) => {
+    if (!file) {
+      toast.error("Please select an audio file first.");
+      return;
+    }
+
+    try {
+      setIsUploading(true);
+      setUploadProgress(0);
+
+      const formData = new FormData();
+      formData.append("file", file);
+      if (title) formData.append("title", title);
+
+      const res = await meetingApi.uploadMeeting(formData, {
+        onUploadProgress: (progressEvent) => {
+          const percent = Math.round(
+            (progressEvent.loaded * 100) / progressEvent.total,
+          );
+          setUploadProgress(percent);
+        },
+      });
+
+      if (res.data?.success) {
+        toast.success("Transcription complete!");
+        if (onSuccess) onSuccess(res.data);
+      } else {
+        toast.error(res.data?.message || "Upload failed");
+      }
+    } catch (err) {
+      console.error("Upload error:", err);
+      toast.error(
+        err.response?.data?.message ||
+          err.message ||
+          "Server error during upload",
+      );
+    } finally {
+      setIsUploading(false);
+      setUploadProgress(0);
+    }
+  };
+
+  return { uploadProgress, isUploading, uploadMeeting };
+};
+
+export default useUploadMeetingApi;


### PR DESCRIPTION
- closes #399

### Overview
Refactored the `useMeetingUpload` "God Hook" to adhere to the Single Responsibility Principle. The monolithic hook has been broken down into smaller, domain-specific hooks while maintaining backward compatibility with the `UploadMeeting` UI component.

### Changes Made
- **Created `useDragAndDrop` Hook**: Extracted DOM drag-and-drop state (`isDragging`) and standard event handlers (`onDragOver`, `onDragLeave`, `onDrop`) into an isolated hook.
- **Created `useUploadMeetingApi` Hook**: Extracted the file uploading logic, Axios API requests via `meetingApi`, `FormData` handling, and upload progress state (`isUploading`, `uploadProgress`).
- **Refactored `useMeetingUpload`**: Transformed the original hook into a thin orchestrator. It now cleanly consumes the domain-specific hooks and manages top-level component state without breaking the existing return signature.
- **No JSX Changes Required**: Ensured the `UploadMeeting` component requires absolutely zero structural changes as it receives the exact same handler props.

### Testing
- Implemented unit tests for the newly created hooks:
  - `src/hooks/__tests__/useDragAndDrop.test.js`
  - `src/hooks/__tests__/useUploadMeetingApi.test.js`
- Verified existing `useMeetingUpload` unit tests continue to pass correctly.
- Full local test suite run passed successfully (`vitest`).
