### PR TITLE
[Refactor]: Extract file utilities from useMeetingUpload hook

### DIFF
--- a/client/src/hooks/useMeetingUpload.js
+++ b/client/src/hooks/useMeetingUpload.js
@@ -2,23 +2,7 @@ import { useState, useRef } from "react";
 import { toast } from "react-toastify";
 import { meetingApi } from "../services";
 
-const allowedTypes = [
-  "audio/wav",
-  "audio/x-wav",
-  "audio/mpeg",
-  "audio/mp3",
-  "audio/x-m4a",
-  "audio/mp4",
-  "audio/m4a",
-];
-
-const formatFileSize = (bytes) => {
-  if (bytes === 0) return "0 Bytes";
-  const k = 1024;
-  const sizes = ["Bytes", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
-};
+import { formatFileSize, isValidAudioFile } from "../utils/fileUtils";
 
 const useMeetingUpload = () => {
   const [file, setFile] = useState(null);
@@ -33,13 +17,7 @@ const useMeetingUpload = () => {
 
   const validateAndSetFile = (f) => {
     if (!f) return;
-    const fileExt = f.name.split(".").pop().toLowerCase();
-    const allowedExtensions = ["wav", "mp3", "m4a", "mp4"];
-
-    if (
-      !allowedTypes.includes(f.type) &&
-      !allowedExtensions.includes(fileExt)
-    ) {
+    if (!isValidAudioFile(f)) {
       toast.error("Unsupported file type. Please use WAV, MP3, or M4A files.");
       return;
     }

--- a/client/src/utils/fileUtils.js
+++ b/client/src/utils/fileUtils.js
@@ -1,0 +1,27 @@
+export const allowedTypes = [
+  "audio/wav",
+  "audio/x-wav",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/x-m4a",
+  "audio/mp4",
+  "audio/m4a",
+];
+
+export const allowedExtensions = ["wav", "mp3", "m4a", "mp4"];
+
+export const formatFileSize = (bytes) => {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+};
+
+export const isValidAudioFile = (file) => {
+  if (!file) return false;
+  const fileExt = file.name.split(".").pop().toLowerCase();
+  return (
+    allowedTypes.includes(file.type) || allowedExtensions.includes(fileExt)
+  );
+};

--- a/client/src/utils/fileUtils.test.js
+++ b/client/src/utils/fileUtils.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { formatFileSize, isValidAudioFile } from "./fileUtils";
+
+describe("fileUtils", () => {
+  describe("formatFileSize", () => {
+    it("formats 0 bytes correctly", () => {
+      expect(formatFileSize(0)).toBe("0 Bytes");
+    });
+    it("formats KB correctly", () => {
+      expect(formatFileSize(1024)).toBe("1 KB");
+    });
+    it("formats MB correctly", () => {
+      expect(formatFileSize(1048576)).toBe("1 MB");
+    });
+    it("formats with decimals", () => {
+      expect(formatFileSize(1536)).toBe("1.5 KB");
+    });
+  });
+
+  describe("isValidAudioFile", () => {
+    it("returns false for null file", () => {
+      expect(isValidAudioFile(null)).toBe(false);
+    });
+
+    it("returns true for valid extension", () => {
+      const file = new File([""], "test.mp3", { type: "" });
+      expect(isValidAudioFile(file)).toBe(true);
+    });
+
+    it("returns true for valid type", () => {
+      const file = new File([""], "test.txt", { type: "audio/mp3" });
+      expect(isValidAudioFile(file)).toBe(true);
+    });
+
+    it("returns false for invalid type and extension", () => {
+      const file = new File([""], "test.txt", { type: "text/plain" });
+      expect(isValidAudioFile(file)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- closes #400

### Problem Statement
Currently, inside `client/src/hooks/useMeetingUpload.js`, there are hardcoded constants (`allowedTypes`) and utility functions (`formatFileSize` and inline extension validation logic). Leaving these embedded inside a specific hook creates a single point of failure and code duplication if we ever need to validate or format audio files in a different part of the application. 

### Proposed Solution
This PR creates a single source of truth for file-related utilities and configurations to adhere to DRY principles and improve testability.

### Changes Made
- **Created Utility Module**: Added `src/utils/fileUtils.js`.
- **Extracted Constants & Formatters**: Moved `allowedTypes`, `allowedExtensions` arrays, and the `formatFileSize` function into `fileUtils.js`.
- **Extracted Validation Logic**: Abstracted the inline file validation into a pure `isValidAudioFile(file)` boolean utility.
- **Updated Hook**: Refactored `src/hooks/useMeetingUpload.js` to utilize these shared utility functions.
- **Added Tests**: Created `src/utils/fileUtils.test.js` to comprehensively unit test `formatFileSize` and `isValidAudioFile`.

### Testing
- [x] Unit tests for `formatFileSize` pass.
- [x] Unit tests for `isValidAudioFile` pass, covering missing files, invalid extensions, and invalid MIME types.
- [x] Audio file uploading logic retains its existing behavior. 
