### PR TITLE
fix: remove insecure JWT secret fallbacks

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -176,7 +176,7 @@ export const downloadExport = async (req, res) => {
       return res.status(400).json({ success: false, message: "No token provided." });
     }
 
-    const jwtSecret = process.env.JWT_SECRET || "fallback_secret";
+    const jwtSecret = process.env.JWT_SECRET;
     
     let decoded;
     try {

--- a/server/jobs/exportDataJob.js
+++ b/server/jobs/exportDataJob.js
@@ -90,7 +90,7 @@ export default async function exportDataJob(job, app) {
     console.log(`✅ Data export for user ${userId} saved to ${filePath}`);
 
     // Generate Secure Download Link
-    const jwtSecret = process.env.JWT_SECRET || "fallback_secret";
+    const jwtSecret = process.env.JWT_SECRET;
     const downloadToken = jwt.sign({ userId, fileName }, jwtSecret, { expiresIn: "24h" });
     
     // In production, BASE_URL should be configured correctly in .env

--- a/server/server.js
+++ b/server/server.js
@@ -56,6 +56,11 @@ const app = express();
 app.set("trust proxy", 1); // Trust first proxy hop (Render, Vercel)
 const PORT = process.env.PORT || 4000;
 
+if (!process.env.JWT_SECRET) {
+  console.error("FATAL ERROR: JWT_SECRET environment variable is missing.");
+  process.exit(1);
+}
+
 // DATABASE & CACHE
 await connectDB();
 


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the hardcoded JWT fallback values to ensure secure token generation and verification. It also introduces a fail-fast check during application startup so that the application safely crashes if the `JWT_SECRET` environment variable is not defined, preventing silent failures and reducing security risks.

### Changes
- **Security**: Removed `|| "fallback_secret"` logic in `server/controllers/userController.js` and `server/jobs/exportDataJob.js`.
- **Startup**: Added a check in `server/server.js` to ensure `process.env.JWT_SECRET` is present on initialization.

## Type of Change

- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #390

## Testing

Verified the application correctly reads the JWT secret from the environment and fails securely during startup when the variable is absent. Existing unit tests have been run and verified.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for exported-data download links by requiring the configured JWT secret.
  * Prevented the application from starting when the required JWT secret is missing, avoiding insecure default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->