### PR TITLE
fix: strengthen Slack OAuth installation validation

### DIFF
--- a/server/controllers/slackController.js
+++ b/server/controllers/slackController.js
@@ -13,6 +13,9 @@
  */
 
 import Organization from "../models/organizationModel.js";
+import User from "../models/userModel.js";
+import jwt from "jsonwebtoken";
+import { hasPermission } from "../utils/rbacPermissions.js";
 import * as MeetingService from "../services/MeetingService.js";
 import {
   verifySlackSignature,
@@ -80,13 +83,20 @@ export const slackInstall = async (req, res, next) => {
       });
     }
 
+    // Generate JWT for state to protect against CSRF and verify authorization on callback
+    const stateToken = jwt.sign(
+      { orgId: organizationId, userId: req.user._id.toString() },
+      process.env.JWT_SECRET,
+      { expiresIn: "15m" }
+    );
+
     const redirectUri = process.env.SLACK_REDIRECT_URI;
     const scopes = "commands,chat:write,channels:read";
 
     const params = new URLSearchParams({
       client_id: clientId,
       scope: scopes,
-      state: organizationId,
+      state: stateToken,
       ...(redirectUri && { redirect_uri: redirectUri }),
     });
 
@@ -108,13 +118,23 @@ export const slackInstall = async (req, res, next) => {
  */
 export const slackOAuthRedirect = async (req, res, next) => {
   try {
-    const { code, state: organizationId, error: slackError } = req.query;
+    const { code, state: stateToken, error: slackError } = req.query;
 
     const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
 
-    if (organizationId && (typeof organizationId !== "string" || !/^[0-9a-fA-F]{24}$/.test(organizationId))) {
-      return res.status(400).json({ success: false, message: "Invalid organizationId format." });
+    if (!stateToken || typeof stateToken !== "string") {
+      return res.status(400).json({ success: false, message: "Missing OAuth state." });
     }
+
+    let decodedState;
+    try {
+      decodedState = jwt.verify(stateToken, process.env.JWT_SECRET);
+    } catch (err) {
+      return res.status(400).json({ success: false, message: "Invalid or expired OAuth state." });
+    }
+
+    const organizationId = decodedState.orgId;
+    const userId = decodedState.userId;
 
     // Handle user-denied or Slack error cases
     if (slackError) {
@@ -130,10 +150,14 @@ export const slackOAuthRedirect = async (req, res, next) => {
         .json({ success: false, message: "Missing or invalid OAuth code from Slack." });
     }
 
-    if (!organizationId) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Missing organizationId in OAuth state." });
+    // Verify the user who initiated the install is still authorized for this org
+    const user = await User.findById(userId);
+    if (!user || user.organization?.toString() !== organizationId) {
+      return res.status(403).json({ success: false, message: "Unauthorized organization binding." });
+    }
+
+    if (!hasPermission(user.role || "guest", "settings", "edit")) {
+      return res.status(403).json({ success: false, message: "Insufficient permissions to install integrations." });
     }
 
     // Verify the organization exists before persisting anything

--- a/server/tests/slack.test.js
+++ b/server/tests/slack.test.js
@@ -286,51 +286,94 @@ describe("GET /api/slack/install", () => {
 // Integration tests — /api/slack/oauth_redirect
 
 describe("GET /api/slack/oauth_redirect", () => {
+  const JWT_SECRET = process.env.JWT_SECRET || "test_jwt_secret";
+
+  const createValidState = (orgId, userId) => {
+    return jwt.sign({ orgId: orgId.toString(), userId: userId.toString() }, JWT_SECRET, { expiresIn: "15m" });
+  };
+
   it("returns 400 when no code is provided", async () => {
+    const fakeOrgId = new mongoose.Types.ObjectId();
+    const fakeUserId = new mongoose.Types.ObjectId();
+    const stateToken = createValidState(fakeOrgId, fakeUserId);
+
     const res = await request(app)
       .get("/api/slack/oauth_redirect")
-      .query({ state: new mongoose.Types.ObjectId().toString() });
+      .query({ state: stateToken });
 
     expect(res.status).toBe(400);
     expect(res.body.message).toMatch(/code/i);
   });
 
-  it("returns 400 when no state (organizationId) is provided", async () => {
+  it("returns 400 when no state is provided", async () => {
     const res = await request(app)
       .get("/api/slack/oauth_redirect")
       .query({ code: "fake_code" });
 
     expect(res.status).toBe(400);
-    expect(res.body.message).toMatch(/organizationId/i);
+    expect(res.body.message).toMatch(/oauth state/i);
   });
 
-  it("returns 404 when organization does not exist", async () => {
-    const fakeOrgId = new mongoose.Types.ObjectId().toString();
+  it("returns 403 when user is not authorized for the organization", async () => {
+    // Seed user without organization or permissions
+    const user = await User.create({
+      name: "Unauthorized User",
+      email: `unauth-${Math.random()}@example.com`,
+      password: "password123",
+      role: "guest",
+    });
+    const fakeOrgId = new mongoose.Types.ObjectId();
+    const stateToken = createValidState(fakeOrgId, user._id);
 
     const res = await request(app)
       .get("/api/slack/oauth_redirect")
-      .query({ code: "fake_code", state: fakeOrgId });
+      .query({ code: "fake_code", state: stateToken });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/unauthorized organization binding/i);
+  });
+
+  it("returns 404 when organization does not exist", async () => {
+    const fakeOrgId = new mongoose.Types.ObjectId();
+    const owner = await User.create({
+      name: "Fake Org Owner",
+      email: `fakeorg-${Math.random()}@example.com`,
+      password: "password123",
+      role: "admin",
+      organization: fakeOrgId, // Bind user to the fake org
+    });
+
+    const stateToken = createValidState(fakeOrgId, owner._id);
+
+    const res = await request(app)
+      .get("/api/slack/oauth_redirect")
+      .query({ code: "fake_code", state: stateToken });
 
     expect(res.status).toBe(404);
     expect(res.body.message).toMatch(/organization not found/i);
   });
 
   it("saves Slack integration to org on successful OAuth", async () => {
-    // Seed org
+    // Seed org and authorized owner
     const owner = await User.create({
       name: "OAuth Owner",
       email: `oauthowner-${Math.random()}@example.com`,
       password: "password123",
+      role: "admin",
     });
     const org = await Organization.create({
       name: "OAuth Org",
       slug: "oauth-org-" + Math.random().toString(36).substring(7),
       owner: owner._id,
     });
+    // Associate user with the org so they pass the binding check
+    await User.findByIdAndUpdate(owner._id, { organization: org._id });
+
+    const stateToken = createValidState(org._id, owner._id);
 
     const res = await request(app)
       .get("/api/slack/oauth_redirect")
-      .query({ code: "valid_code", state: org._id.toString() });
+      .query({ code: "valid_code", state: stateToken });
 
     // axios.post is mocked to return a successful Slack response
     // So this should redirect (302) to the frontend with ?slackInstall=success


### PR DESCRIPTION
# Pull Request

## Description

This PR strengthens the security of the Slack OAuth installation flow by implementing robust validation of the OAuth state parameter and verifying the user's organization authorization.

### Changes
- **Security**: Upgraded the OAuth `state` parameter from a plain organization ID to a signed JWT containing both the `orgId` and the `userId`. This ensures state integrity and guards against CSRF.
- **Authorization**: Added checks during the OAuth redirect callback to ensure that the user initiating the installation is still a valid member of the target organization and possesses the requisite `settings:edit` permission.
- **Tests**: Refactored the `/api/slack/oauth_redirect` integration tests to construct valid JWT states and seed users with correct roles, ensuring regressions are caught.

## Type of Change

- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #389

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
