### PR TITLE
fix: resolve production CSRF configuration for split-origin deployment

### DIFF
--- a/server/middleware/csrfProtection.js
+++ b/server/middleware/csrfProtection.js
@@ -6,7 +6,7 @@ const csrfProtection = csrf({
     key: "_csrf",
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
-    sameSite: "strict",
+    sameSite: process.env.NODE_ENV === "production" ? "none" : "strict",
   },
 });
 

--- a/server/tests/authCsrfRegression.test.js
+++ b/server/tests/authCsrfRegression.test.js
@@ -119,5 +119,26 @@ describe("Auth & CSRF regression", () => {
       expect(res.statusCode).not.toBe(403);
       expect(res.body.success).toBe(true);
     });
+
+    it("accepts organization join mutation with valid CSRF token", async () => {
+      const agent = request.agent(app);
+      const user = {
+        name: "Csrf Join",
+        email: uniqueEmail("csrf-join"),
+        password: "password123",
+      };
+
+      await agent.post("/api/auth/register").send(user);
+      const csrfRes = await agent.get("/api/csrf-token");
+      
+      const res = await agent
+        .post("/api/organizations/join")
+        .set("X-CSRF-Token", csrfRes.body.csrfToken)
+        .send({ inviteCode: "dummy-code" });
+
+      expect(res.body.code).not.toBe("CSRF_INVALID");
+      // The join will fail due to invalid invite code, but NOT due to CSRF
+      expect(res.statusCode).not.toBe(403);
+    });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves the production CSRF token issue caused by the split-origin deployment (Vercel Frontend, Render Backend). Previously, the `SameSite=Strict` cookie attribute blocked the browser from attaching the `_csrf` cookie during cross-origin protected requests, resulting in persistent 403 Forbidden errors when users attempted to create or join organizations.

### Changes
- **Configuration**: Updated `server/middleware/csrfProtection.js` to set the CSRF cookie's `SameSite` attribute to `none` in production while retaining `strict` for local development. This change correctly allows cross-origin requests to transmit the CSRF cookie.
- **Tests**: Expanded the `authCsrfRegression.test.js` suite by adding an explicit CSRF test for the organization joining flow (`/api/organizations/join`), ensuring mutations continue to pass CSRF validation securely.

## Type of Change

- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement / Bug Fix
- [ ] Other

## Related Issue

Closes #383 

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
