### PR TITLE
fix: add missing indexMeeting import to processAudioJob

### DIFF
--- a/server/jobs/processAudioJob.js
+++ b/server/jobs/processAudioJob.js
@@ -8,6 +8,7 @@ import {
 } from "../services/knowledgeGraphService.js";
 import User from "../models/userModel.js";
 import { createAndPushNotification } from "../services/notificationService.js";
+import { indexMeeting } from "../utils/embeddingUtils.js";
 
 export default async function processAudioJob(job, app) {
   const { meetingId, transcript, date, title, userId } = job.data;


### PR DESCRIPTION
# Pull Request

## Description

Added the missing `indexMeeting` import in `processAudioJob.js` to fix a `ReferenceError` that occurs when the audio processing job runs. The function was being called at line 247 but was never imported from `embeddingUtils.js`.

## Type of Change

- [x] Bug Fix

## Related Issue

Closes #436

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio processing so newly created meetings are properly indexed and available for search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->