### PR TITLE
Fix/notification membership query

### DIFF
--- a/server/jobs/processAudioJob.js
+++ b/server/jobs/processAudioJob.js
@@ -8,6 +8,7 @@ import {
 } from "../services/knowledgeGraphService.js";
 import User from "../models/userModel.js";
 import { createAndPushNotification } from "../services/notificationService.js";
+import { indexMeeting } from "../utils/embeddingUtils.js";
 
 export default async function processAudioJob(job, app) {
   const { meetingId, transcript, date, title, userId } = job.data;

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -11,6 +11,7 @@
 import fs from "fs";
 import mongoose from "mongoose";
 import User from "../models/userModel.js";
+import Membership from "../models/membershipModel.js";
 import {
   indexMeeting,
   deleteMeetingFromPinecone,
@@ -121,12 +122,13 @@ export const createMeeting = async (uploaderId, orgId, data, io) => {
   );
 
   if (orgId && io) {
-    User.find({ organization: orgId, _id: { $ne: uploaderId } })
-      .then(async (members) => {
-        for (const member of members) {
+    Membership.find({ organization: orgId, status: "active", user: { $ne: uploaderId } })
+      .populate("user")
+      .then(async (memberships) => {
+        for (const membership of memberships) {
           await createAndPushNotification(
             io,
-            member._id,
+            membership.user._id,
             "New Meeting Scheduled",
             `A new meeting "${meeting.title}" has been scheduled.`,
             "meetings",


### PR DESCRIPTION
# Pull Request

## Description

Changed notification delivery in `MeetingService.js` to query through the `Membership` model instead of `User.organization`. Previously, only users with `organization` set on their User doc received notifications, missing members whose membership exists solely in the Membership model.

## Type of Change

- [x] Bug Fix

## Related Issue

Closes #437

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review