### PR TITLE
Fix/gemini transcription endpoint

### DIFF
--- a/server/jobs/processAudioJob.js
+++ b/server/jobs/processAudioJob.js
@@ -8,6 +8,7 @@ import {
 } from "../services/knowledgeGraphService.js";
 import User from "../models/userModel.js";
 import { createAndPushNotification } from "../services/notificationService.js";
+import { indexMeeting } from "../utils/embeddingUtils.js";
 
 export default async function processAudioJob(job, app) {
   const { meetingId, transcript, date, title, userId } = job.data;

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -11,6 +11,7 @@
 import fs from "fs";
 import mongoose from "mongoose";
 import User from "../models/userModel.js";
+import Membership from "../models/membershipModel.js";
 import {
   indexMeeting,
   deleteMeetingFromPinecone,
@@ -121,12 +122,13 @@ export const createMeeting = async (uploaderId, orgId, data, io) => {
   );
 
   if (orgId && io) {
-    User.find({ organization: orgId, _id: { $ne: uploaderId } })
-      .then(async (members) => {
-        for (const member of members) {
+    Membership.find({ organization: orgId, status: "active", user: { $ne: uploaderId } })
+      .populate("user")
+      .then(async (memberships) => {
+        for (const membership of memberships) {
           await createAndPushNotification(
             io,
-            member._id,
+            membership.user._id,
             "New Meeting Scheduled",
             `A new meeting "${meeting.title}" has been scheduled.`,
             "meetings",

--- a/server/services/speechService.js
+++ b/server/services/speechService.js
@@ -70,22 +70,32 @@ export const transcribeWithGemini = async (audioUrl) => {
   try {
     if (!GEMINI_API_KEY) throw new Error("Missing Gemini API key");
 
-    const body = {
-      contents: [
-        {
-          parts: [
-            { text: `Transcribe this audio file into plain text: ${audioUrl}` },
-          ],
-        },
-      ],
-    };
+    const audioRes = await axios.get(audioUrl, {
+      responseType: "arraybuffer",
+    });
+
+    const audioBase64 = Buffer.from(audioRes.data).toString("base64");
+    const mimeType = audioRes.headers["content-type"] || "audio/mpeg";
 
     const response = await axios.post(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateText",
-      body,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+      {
+        contents: [
+          {
+            parts: [
+              {
+                inlineData: {
+                  mimeType,
+                  data: audioBase64,
+                },
+              },
+              { text: "Transcribe this audio into plain text. Return only the transcription." },
+            ],
+          },
+        ],
+      },
       {
         headers: {
-          Authorization: `Bearer ${GEMINI_API_KEY}`,
           "Content-Type": "application/json",
         },
       },


### PR DESCRIPTION
# Pull Request

## Description

Fixed Gemini transcription fallback in `speechService.js`:
- Switched from deprecated `generateText` endpoint to `generateContent`
- Replaced incorrect `Authorization: Bearer` header with API key query parameter
- Changed model from `gemini-pro` (text-only) to `gemini-1.5-flash` (multimodal, supports audio)
- Downloads audio file and sends it as `inlineData` base64 for proper audio transcription

## Type of Change

- [x] Bug Fix

## Related Issue

Closes #438

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review