### PR TITLE
feat: automatically apply ECSoC26 label to contributor submissions (#462)

### DIFF
--- a/.github/scripts/index.js
+++ b/.github/scripts/index.js
@@ -8,3 +8,5 @@ export {
 } from "./pr.js";
 export { processIssueCommentGuidance } from "./issue-comments.js";
 export { processIssueLifecycle } from "./lifecycle.js";
+export { autoLabelEcs } from "./label-ecs.js";
+

--- a/.github/scripts/label-ecs.js
+++ b/.github/scripts/label-ecs.js
@@ -1,0 +1,72 @@
+import { MAINTAINER_ASSOCIATIONS } from "./constants.js";
+import { isExpectedRepository, safeCall } from "./helpers.js";
+
+/**
+ * Automatically applies the 'ECSoC26' label to contributor-created Issues and Pull Requests.
+ * Skipping labeling if the author is a maintainer (OWNER, MEMBER, COLLABORATOR).
+ */
+export async function autoLabelEcs({ github, context, core }) {
+  if (!isExpectedRepository(context)) {
+    core.info("Skipping: Action is not running in the expected repository.");
+    return;
+  }
+
+  const isIssue = context.eventName === "issues";
+  const isPR = context.eventName === "pull_request" || context.eventName === "pull_request_target";
+
+  if (!isIssue && !isPR) {
+    core.info(`Skipping: Unsupported event type "${context.eventName}".`);
+    return;
+  }
+
+  const payload = context.payload;
+  const target = isIssue ? payload.issue : payload.pull_request;
+
+  if (!target) {
+    core.warning("Skipping: Target payload (issue or pull_request) is missing.");
+    return;
+  }
+
+  const author = target.user.login;
+  const association = target.author_association;
+
+  core.info(`Evaluating creation of #${target.number} by @${author} (association: ${association})`);
+
+  // Exclude maintainers/collaborators with admin/write access
+  if (MAINTAINER_ASSOCIATIONS.includes(association)) {
+    core.info(`Skipping auto-labeling: Author @${author} has maintainer association "${association}".`);
+    return;
+  }
+
+  // Check if the label 'ECSoC26' is already present
+  const labels = target.labels || [];
+  const hasLabel = labels.some((l) => l.name === "ECSoC26");
+
+  if (hasLabel) {
+    core.info(`Skipping: 'ECSoC26' label is already present on #${target.number}.`);
+    return;
+  }
+
+  // Apply the 'ECSoC26' label
+  const issueNumber = target.number;
+  core.info(`Applying 'ECSoC26' label to #${issueNumber}...`);
+
+  const result = await safeCall(
+    core,
+    "issues.addLabels",
+    () =>
+      github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issueNumber,
+        labels: ["ECSoC26"],
+      }),
+    null
+  );
+
+  if (result) {
+    core.info(`Successfully applied 'ECSoC26' label to #${issueNumber}.`);
+  } else {
+    core.setFailed(`Failed to apply 'ECSoC26' label to #${issueNumber}.`);
+  }
+}

--- a/.github/scripts/tests/automation.test.js
+++ b/.github/scripts/tests/automation.test.js
@@ -10,6 +10,8 @@ import {
 } from "../pr.js";
 import { processIssueLifecycle } from "../lifecycle.js";
 import { processClaimExpiration } from "../expiration.js";
+import { autoLabelEcs } from "../label-ecs.js";
+
 
 function createCore() {
   return { info() {}, warning() {}, error() {} };
@@ -338,3 +340,117 @@ test("expiration: reminder and expiration paths", async () => {
   await processClaimExpiration({ github, context, core: createCore() });
   assert.equal(github.state.assignees[50], undefined);
 });
+
+test("autoLabelEcs: labels contributor-created issue with ECSoC26", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const labelsAdded = [];
+  const github = {
+    rest: {
+      issues: {
+        async addLabels({ owner, repo, issue_number, labels }) {
+          labelsAdded.push({ issue_number, labels });
+          return { data: labels };
+        },
+      },
+    },
+  };
+  const context = {
+    eventName: "issues",
+    repo: { owner: "org", repo: "repo" },
+    payload: {
+      issue: {
+        number: 42,
+        user: { login: "contributor" },
+        author_association: "NONE",
+        labels: [],
+      },
+    },
+  };
+  const core = {
+    info() {},
+    warning() {},
+    setFailed(msg) {
+      assert.fail(`Should not call setFailed: ${msg}`);
+    },
+  };
+
+  await autoLabelEcs({ github, context, core });
+  assert.equal(labelsAdded.length, 1);
+  assert.equal(labelsAdded[0].issue_number, 42);
+  assert.deepEqual(labelsAdded[0].labels, ["ECSoC26"]);
+});
+
+test("autoLabelEcs: skips auto-labeling if author is a maintainer", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const labelsAdded = [];
+  const github = {
+    rest: {
+      issues: {
+        async addLabels({ owner, repo, issue_number, labels }) {
+          labelsAdded.push({ issue_number, labels });
+          return { data: labels };
+        },
+      },
+    },
+  };
+  const context = {
+    eventName: "issues",
+    repo: { owner: "org", repo: "repo" },
+    payload: {
+      issue: {
+        number: 43,
+        user: { login: "maintainer" },
+        author_association: "OWNER",
+        labels: [],
+      },
+    },
+  };
+  const core = {
+    info() {},
+    warning() {},
+    setFailed(msg) {
+      assert.fail(`Should not call setFailed: ${msg}`);
+    },
+  };
+
+  await autoLabelEcs({ github, context, core });
+  assert.equal(labelsAdded.length, 0);
+});
+
+test("autoLabelEcs: skips auto-labeling if label is already present", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const labelsAdded = [];
+  const github = {
+    rest: {
+      issues: {
+        async addLabels({ owner, repo, issue_number, labels }) {
+          labelsAdded.push({ issue_number, labels });
+          return { data: labels };
+        },
+      },
+    },
+  };
+  const context = {
+    eventName: "issues",
+    repo: { owner: "org", repo: "repo" },
+    payload: {
+      issue: {
+        number: 44,
+        user: { login: "contributor" },
+        author_association: "NONE",
+        labels: [{ name: "ECSoC26" }],
+      },
+    },
+  };
+  const core = {
+    info() {},
+    warning() {},
+    setFailed(msg) {
+      assert.fail(`Should not call setFailed: ${msg}`);
+    },
+  };
+
+  await autoLabelEcs({ github, context, core });
+  assert.equal(labelsAdded.length, 0);
+});
+

--- a/.github/workflows/10-auto-label-ecs.yml
+++ b/.github/workflows/10-auto-label-ecs.yml
@@ -1,0 +1,30 @@
+name: "10 Auto Label ECSoC26"
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: label-ecs-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Apply ECSoC26 label if eligible
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { autoLabelEcs } = await import(`${process.cwd()}/.github/scripts/label-ecs.js`);
+            await autoLabelEcs({ github, context, core });

--- a/docs/ecs-label-automation.md
+++ b/docs/ecs-label-automation.md
@@ -1,0 +1,26 @@
+# ECSoC26 Labeling Automation
+
+To streamline repository management and maintain consistent labeling during **Elite Coders Summer of Code 2026 (ECSoC26)**, this repository implements an automated workflow that automatically applies the official `ECSoC26` label to eligible issues and pull requests created by external contributors.
+
+## How It Works
+
+1. **Trigger Events**:
+   - The workflow is triggered when a new **Issue** is opened (`issues.opened`).
+   - The workflow is triggered when a new **Pull Request** is opened (`pull_request_target.opened`).
+
+2. **Casing & Target Label**:
+   - Applies the exact label: `ECSoC26`.
+
+3. **Eligibility Check**:
+   - The automation checks the author's association with the repository:
+     - **Eligible Contributors**: Authors with an association of `NONE`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, or `CONTRIBUTOR`.
+     - **Excluded Users**: Authors with an association of `OWNER`, `MEMBER`, or `COLLABORATOR` (repository owners, organization members, maintainers, and administrative collaborators).
+
+4. **Idempotence**:
+   - If the issue or pull request already has the `ECSoC26` label, the workflow runs safely without making duplicate API calls or adding duplicate labels.
+
+## Implementation Details
+
+- **Workflow File**: `.github/workflows/10-auto-label-ecs.yml`
+- **Execution Script**: `.github/scripts/label-ecs.js`
+- **Permissions Required**: `issues: write`, `pull-requests: write`, `contents: read`


### PR DESCRIPTION
## Description

This PR implements an automated GitHub Actions workflow to automatically apply the official `ECSoC26` label to eligible contributor-created issues and pull requests, saving manual effort for maintainers:
- **Automation Trigger**: Triggers on `issues.opened` and `pull_request_target.opened`. Using `pull_request_target` ensures the workflow has write permissions to label pull requests opened from external forks.
- **Maintainer Exclusion**: Skips auto-labeling if the author has an association of `OWNER`, `MEMBER`, or `COLLABORATOR` (repository owners, organization members, and administrative collaborators).
- **Idempotence**: Checks if the `ECSoC26` label is already present before applying, avoiding duplicate label events.
- **Documentation**: Created `docs/ecs-label-automation.md` explaining the workflow, triggers, and conditions.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #462

## Testing

- Added comprehensive unit tests in `.github/scripts/tests/automation.test.js` covering:
  - Label assignment for external contributor-created issues.
  - Skips for maintainer/owner-created issues.
  - Skips when the label is already present.
- Ran tests locally (`node .github/scripts/tests/automation.test.js`), all passed successfully.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

## Screenshot
<img width="1068" height="611" alt="image" src="https://github.com/user-attachments/assets/72fa78ab-9312-4daa-ad64-1828a7346ff8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New issues and pull requests are automatically labeled **ECSoC26** when eligible.
  * Existing labels and contributions from maintainers are respected.

* **Documentation**
  * Added documentation describing the labeling workflow, eligibility rules, and required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->