### PR TITLE
Fix Bug 440: Prevent organization data leak by selecting safe fields in getOrganizationById

### DIFF
--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -654,6 +654,7 @@ export const getOrganizationById = async (idOrSlug) => {
     : { slug: String(idOrSlug) };
 
   const organization = await Organization.findOne(query)
+    .select("name slug description logo visibility owner createdAt")
     .populate("owner", "name email")
     .lean();
 


### PR DESCRIPTION
## Description
This PR resolves a critical data leak in the `getOrganizationById` endpoint. Previously, the endpoint returned the full organization document via `.lean()` without any field selection, inadvertently exposing highly sensitive information such as `slackIntegration.botToken`, `metadata`, and other private internal arrays to the client.

**Changes made:**
- Appended a strict `.select("name slug description logo visibility owner createdAt")` whitelist clause to the `findOne` query in `server/services/OrganizationService.js`.
- The endpoint now exclusively returns safe, public-facing organization fields, aligning its output securely with other organization listing queries.

Fixes #440

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Tested the `getOrganizationById` endpoint (via Postman/cURL) and verified that sensitive fields like `slackIntegration` and `metadata` are no longer present in the JSON response payload.
- Verified that required rendering fields (`name`, `slug`, `description`, `owner`) are still correctly populated and returned.

- [ ] Tested locally on frontend
- [x] Tested locally on backend

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Organization details now return only the standard public fields, providing a more focused and consistent response.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->