### PR TITLE
Fix Bug 501: Ensure logout API call completes before navigation

### DIFF
--- a/client/src/context/AppContext.jsx
+++ b/client/src/context/AppContext.jsx
@@ -87,12 +87,12 @@ export const AppContextProvider = ({ children }) => {
 
   const logoutUser = async () => {
     try {
-      toast.success("Logged out successfully");
-      navigate("/");
-
       await authApi.logout();
       clearAuthState();
       csrfService.clearToken();
+
+      toast.success("Logged out successfully");
+      navigate("/");
     } catch {
       toast.error("Failed to logout");
     }


### PR DESCRIPTION
## Description
This PR resolves an issue in the authentication flow where `logoutUser` would blindly trigger `navigate("/")` before waiting for the `authApi.logout()` API call to finish. This led to edge cases where, if the API request failed (e.g., due to a network drop), the user would be redirected but their authentication state would remain uncleared.

**Changes made:**
- Refactored `logoutUser` inside `client/src/context/AppContext.jsx`.
- Placed the `navigate("/")` redirect and the success toast *after* `await authApi.logout()`, `clearAuthState()`, and `csrfService.clearToken()` resolve successfully.
- If the logout process errors out, the catch block now catches the error *without* prematurely redirecting the user.

Fixes #501

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Verified that standard logouts continue to function properly and redirect cleanly to the homepage.
- Verified that blocking or dropping the `logout` API request throws the "Failed to logout" toast but keeps the user securely on their current page to retry without a broken UI state.

- [x] Tested locally on frontend
- [ ] Tested locally on backend

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout reliability by completing server logout and clearing authentication data before displaying confirmation and returning to the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->