### PR TITLE
fix: exclude future policies from compliance

### DIFF
--- a/server/controllers/policyComplianceController.js
+++ b/server/controllers/policyComplianceController.js
@@ -22,7 +22,7 @@ export const getDecisionCompliance = async (req, res) => {
     // Verify the decision belongs to the caller's organization before
     // returning anything — never leak cross-organization data.
     const decision =
-      await Decision.findById(decisionId).select("organization text");
+      await Decision.findById(decisionId).select("organization text createdAt");
 
     if (
       !decision ||
@@ -32,9 +32,15 @@ export const getDecisionCompliance = async (req, res) => {
       return sendError(res, 404, "Decision not found");
     }
 
+    const effectivePolicies = await Policy.find({
+      organization,
+      createdAt: { $lte: decision.createdAt },
+    }).select("_id");
+
     const records = await PolicyCompliance.find({
       decisionId,
       organization,
+      policyId: { $in: effectivePolicies.map((policy) => policy._id) },
     })
       .populate("policyId", "name version summary")
       .sort({ similarityScore: -1 });

--- a/server/services/policyComplianceService.js
+++ b/server/services/policyComplianceService.js
@@ -40,6 +40,11 @@ const MATCH_SIMILARITY_THRESHOLD = 0.55;
 // Cap how many candidate policies get sent to the (costlier) LLM pass per decision.
 const MAX_MATCHES_PER_DECISION = 5;
 
+export const isPolicyEffectiveForDecision = (policy, decision) => {
+  if (!policy?.createdAt || !decision?.createdAt) return true;
+  return new Date(policy.createdAt) <= new Date(decision.createdAt);
+};
+
 // ─────────────────────────────────────────────────────────────
 // Helper — strip markdown code fences Gemini sometimes adds
 // (mirrors policyController.js's extractJson so behavior is consistent)
@@ -276,9 +281,10 @@ async function evaluateCandidate(candidate, decision, meeting, organizationId) {
   const policy = await Policy.findById(candidate.policyId);
   if (
     !policy ||
-    policy.organization?.toString() !== organizationId.toString()
+    policy.organization?.toString() !== organizationId.toString() ||
+    !isPolicyEffectiveForDecision(policy, decision)
   ) {
-    return null; // stale vector or cross-org leak guard
+    return null; // stale vector, cross-org leak guard, or future policy
   }
 
   const [{ classification, reasoning }, existing] = await Promise.all([

--- a/server/tests/policyComplianceService.test.js
+++ b/server/tests/policyComplianceService.test.js
@@ -1,6 +1,7 @@
 import {
   parseClassification,
   buildClassificationPrompt,
+  isPolicyEffectiveForDecision,
 } from "../services/policyComplianceService.js";
 import fixtures from "./fixtures/policyComplianceFixtures.json" with { type: "json" };
 
@@ -55,6 +56,26 @@ describe("parseClassification", () => {
     const result = parseClassification(raw);
     expect(result.classification).toBe("unrelated");
     expect(result.reasoning).toBe("");
+  });
+});
+
+describe("isPolicyEffectiveForDecision", () => {
+  test("excludes policies created after the decision", () => {
+    expect(
+      isPolicyEffectiveForDecision(
+        { createdAt: new Date("2026-06-01T00:00:00.000Z") },
+        { createdAt: new Date("2026-05-15T00:00:00.000Z") },
+      ),
+    ).toBe(false);
+  });
+
+  test("includes policies that existed when the decision was recorded", () => {
+    expect(
+      isPolicyEffectiveForDecision(
+        { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+        { createdAt: new Date("2026-05-15T00:00:00.000Z") },
+      ),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #471

# Pull Request

## Description

Prevents policy compliance from evaluating a decision against a policy that was created after the decision. Existing invalid relationships are also excluded from decision-compliance responses.

### Changes

- **Compliance matching**: Skip candidate policies that were not effective when the decision was recorded.
- **Compliance API**: Return only records tied to policies created on or before the decision date.
- **Testing**: Add regression cases for future and effective policies.

## Type of Change

- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #471

## Testing

- [x] Static syntax checks passed
- [x] Diff whitespace check passed
- [x] Regression tests added

The existing policy-compliance test process imports the embedding stack and did not complete within the local 60-second execution limit.

## Screenshots

N/A - Backend changes only

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
