### PR TITLE
Mitigate NoSQL injection in conflict storage queries

### DIFF
--- a/server/services/conflictDetection/ConflictStorage.js
+++ b/server/services/conflictDetection/ConflictStorage.js
@@ -5,7 +5,7 @@
 // dedupes against conflicts already under review, and applies a user's
 // resolution back onto the knowledge graph.
 // ==============================================
-
+import mongoose from "mongoose";
 import ConflictSet from "../../models/conflictModel.js";
 import { assertSupportedModel } from "../consolidation/consolidationRegistry.js";
 
@@ -227,11 +227,14 @@ export async function listConflictSets(
 ) {
   const query = {};
 
-  if (
-    organization === null ||
-    typeof organization === "string" ||
-    (organization && typeof organization === "object")
+  if (organization === null) {
+    query.organization = null;
+  } else if (
+    typeof organization === "string" &&
+    mongoose.Types.ObjectId.isValid(organization)
   ) {
+    query.organization = organization;
+  } else if (organization instanceof mongoose.Types.ObjectId) {
     query.organization = organization;
   }
 

--- a/server/services/conflictDetection/ConflictStorage.js
+++ b/server/services/conflictDetection/ConflictStorage.js
@@ -9,6 +9,13 @@
 import ConflictSet from "../../models/conflictModel.js";
 import { assertSupportedModel } from "../consolidation/consolidationRegistry.js";
 
+const VALID_CONFLICT_STATUSES = new Set([
+  "open",
+  "resolved",
+  "dismissed",
+  "all",
+]);
+
 function snapshotMember(record) {
   return {
     memoryId: record._id,
@@ -218,13 +225,34 @@ export async function listConflictSets(
   modelType,
   { organization = null, status = "open", limit = 50 } = {},
 ) {
-  const query = { organization: organization || null };
-  if (modelType) query.modelType = modelType;
-  if (status && status !== "all") query.status = status;
+  const query = {};
+
+  if (
+    organization === null ||
+    typeof organization === "string" ||
+    (organization && typeof organization === "object")
+  ) {
+    query.organization = organization;
+  }
+
+  if (typeof modelType === "string" && modelType.trim() !== "") {
+    query.modelType = modelType;
+  }
+
+  if (
+    typeof status === "string" &&
+    VALID_CONFLICT_STATUSES.has(status) &&
+    status !== "all"
+  ) {
+    query.status = status;
+  }
+
+  const safeLimit =
+    Number.isInteger(limit) && limit > 0 ? Math.min(limit, 200) : 50;
 
   return ConflictSet.find(query)
     .sort({ confidence: -1, detectedAt: -1 })
-    .limit(Math.min(limit, 200));
+    .limit(safeLimit);
 }
 
 export async function getConflictSetById(conflictId) {

--- a/server/tests/Conflictdetectionservice.test.js
+++ b/server/tests/Conflictdetectionservice.test.js
@@ -482,7 +482,7 @@ describe("listConflictSets input validation", () => {
         organization: organizationId,
         status: { $ne: "open" },
       }),
-    ).resolves.not.toThrow();
+    ).resolves.toEqual(expect.any(Array));
   });
 
   test("uses the default limit for invalid values", async () => {
@@ -491,6 +491,6 @@ describe("listConflictSets input validation", () => {
         organization: organizationId,
         limit: { $gt: 100 },
       }),
-    ).resolves.not.toThrow();
+    ).resolves.toEqual(expect.any(Array));
   });
 });

--- a/server/tests/Conflictdetectionservice.test.js
+++ b/server/tests/Conflictdetectionservice.test.js
@@ -474,3 +474,23 @@ describe("resolveConflictSet", () => {
     ).rejects.toThrow(/must reference one of this conflict set's members/);
   });
 });
+
+describe("listConflictSets input validation", () => {
+  test("ignores non-string status values", async () => {
+    await expect(
+      listConflictSets("decision", {
+        organization: organizationId,
+        status: { $ne: "open" },
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  test("uses the default limit for invalid values", async () => {
+    await expect(
+      listConflictSets("decision", {
+        organization: organizationId,
+        limit: { $gt: 100 },
+      }),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description

This PR mitigates a potential NoSQL injection vulnerability in `listConflictSets` by validating user-controlled inputs before constructing MongoDB queries.

### Changes
- Added validation for `status` using an allowlist.
- Validated `organization` while preserving valid ObjectId values.
- Validated and bounded `limit`.
- Added regression tests for invalid `status` and `limit`.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #505

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Tests
- Prettier
- ESLint
- `Conflictdetectionservice.test.js` (23/23 tests passed)

## Checklist

- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review