### PR TITLE
refactor: reuse mock adapter setup in API interceptor tests

### DIFF
--- a/client/src/utils/__tests__/apiInterceptor.test.js
+++ b/client/src/utils/__tests__/apiInterceptor.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 import "../apiInterceptor"; // This attaches the interceptor
+
+// Reusable helper for mocking HTTP error responses
 function mockHttpError(status, data = {}) {
   axios.defaults.adapter = async () => {
     return Promise.reject({
@@ -12,8 +14,11 @@ function mockHttpError(status, data = {}) {
   };
 }
 
+// Reusable helper for mocking network failures
 function mockNetworkError() {
-  mockNetworkError();
+  axios.defaults.adapter = async () => {
+    return Promise.reject(new Error("Network Error"));
+  };
 }
 
 describe("apiInterceptor", () => {
@@ -30,11 +35,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles 401 Unauthorized", async () => {
-    axios.defaults.adapter = async () => {
-      return Promise.reject({
-        response: { status: 401, data: {} },
-      });
-    };
+    mockHttpError(401);
 
     try {
       await axios.get("/test");
@@ -59,7 +60,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles 404 Not Found", async () => {
-   mockHttpError(404);
+    mockHttpError(404);
 
     try {
       await axios.get("/test");
@@ -69,7 +70,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles Server Errors (500)", async () => {
-    mockHttpError(401);
+    mockHttpError(500);
 
     try {
       await axios.get("/test");
@@ -79,9 +80,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles Network Errors (no response)", async () => {
-    axios.defaults.adapter = async () => {
-      return Promise.reject(new Error("Network Error"));
-    };
+    mockNetworkError();
 
     try {
       await axios.get("/test");

--- a/client/src/utils/__tests__/apiInterceptor.test.js
+++ b/client/src/utils/__tests__/apiInterceptor.test.js
@@ -1,6 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 import "../apiInterceptor"; // This attaches the interceptor
+function mockHttpError(status, data = {}) {
+  axios.defaults.adapter = async () => {
+    return Promise.reject({
+      response: {
+        status,
+        data,
+      },
+    });
+  };
+}
+
+function mockNetworkError() {
+  mockNetworkError();
+}
 
 describe("apiInterceptor", () => {
   let originalAdapter;
@@ -33,11 +47,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles 403 Forbidden", async () => {
-    axios.defaults.adapter = async () => {
-      return Promise.reject({
-        response: { status: 403, data: {} },
-      });
-    };
+    mockHttpError(403);
 
     try {
       await axios.get("/test");
@@ -49,11 +59,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles 404 Not Found", async () => {
-    axios.defaults.adapter = async () => {
-      return Promise.reject({
-        response: { status: 404, data: {} },
-      });
-    };
+   mockHttpError(404);
 
     try {
       await axios.get("/test");
@@ -63,11 +69,7 @@ describe("apiInterceptor", () => {
   });
 
   it("handles Server Errors (500)", async () => {
-    axios.defaults.adapter = async () => {
-      return Promise.reject({
-        response: { status: 500, data: {} },
-      });
-    };
+    mockHttpError(401);
 
     try {
       await axios.get("/test");


### PR DESCRIPTION
## Summary

This PR refactors the API interceptor tests by introducing reusable helper functions for mocking Axios adapter responses. It removes duplicated mock adapter setup while preserving the existing test behavior.

## Changes Made

- Added `mockHttpError()` helper for mocking HTTP error responses.
- Added `mockNetworkError()` helper for mocking network failures.
- Replaced repeated `axios.defaults.adapter` implementations with reusable helper functions.
- Kept all existing test assertions and behavior unchanged.

## Benefits

- Reduces code duplication.
- Improves test readability.
- Simplifies maintenance.
- Makes it easier to add new interceptor test cases in the future.

Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated testing for API error responses, including authorization, not-found, and network error scenarios.
  * Standardized error simulation across test cases to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->