### PR TITLE
[Feature]: Implement interactive speaker diarization correction

### DIFF
--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useContext } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
 import {
@@ -11,9 +11,12 @@ import {
   Calendar,
   X,
   Sparkles,
+  Edit2,
+  Check,
 } from "lucide-react";
 import { toast } from "react-toastify";
 import MeetingSentimentChart from "../components/MeetingSentimentChart";
+import AppContent from "../context/AppContent.js";
 
 const TranscriptViewer = () => {
   const { meetingId } = useParams();
@@ -24,6 +27,11 @@ const TranscriptViewer = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [highlightedSegment, setHighlightedSegment] = useState(null);
+
+  const { userData } = useContext(AppContent);
+  const [editingSpeakerIndex, setEditingSpeakerIndex] = useState(null);
+  const [newSpeakerName, setNewSpeakerName] = useState("");
+  const [isBulkUpdate, setIsBulkUpdate] = useState(true);
 
   const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
@@ -42,7 +50,7 @@ const TranscriptViewer = () => {
             Authorization: `Bearer ${token}`,
           },
           withCredentials: true,
-        }
+        },
       );
 
       setTranscript(response.data);
@@ -57,6 +65,46 @@ const TranscriptViewer = () => {
   useEffect(() => {
     fetchTranscript();
   }, [fetchTranscript]);
+
+  const handleSpeakerChange = async (index, oldSpeaker) => {
+    if (!newSpeakerName.trim()) return;
+
+    try {
+      const token = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("token="))
+        ?.split("=")[1];
+
+      const response = await axios.put(
+        `${backendUrl}/api/transcripts/${transcript._id}/speakers`,
+        {
+          oldSpeaker,
+          newSpeaker: newSpeakerName.trim(),
+          segmentIndex: isBulkUpdate ? null : index,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        },
+      );
+
+      if (response.data.success) {
+        toast.success("Speaker updated successfully");
+        setTranscript(
+          response.data.data || response.data.transcript || response.data,
+        );
+        // Refresh transcript fully to ensure UI sync
+        fetchTranscript();
+      }
+    } catch (error) {
+      console.error("Error updating speaker:", error);
+      toast.error(error.response?.data?.message || "Failed to update speaker");
+    } finally {
+      setEditingSpeakerIndex(null);
+    }
+  };
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) {
@@ -78,7 +126,7 @@ const TranscriptViewer = () => {
             Authorization: `Bearer ${token}`,
           },
           withCredentials: true,
-        }
+        },
       );
 
       setSearchResults(response.data.matches || []);
@@ -103,7 +151,7 @@ const TranscriptViewer = () => {
           },
           withCredentials: true,
           responseType: "blob",
-        }
+        },
       );
 
       const url = window.URL.createObjectURL(new Blob([response.data]));
@@ -135,7 +183,7 @@ const TranscriptViewer = () => {
           },
           withCredentials: true,
           responseType: "blob",
-        }
+        },
       );
 
       const url = window.URL.createObjectURL(new Blob([response.data]));
@@ -161,7 +209,10 @@ const TranscriptViewer = () => {
   const highlightText = (text, query) => {
     if (!query) return text;
     const regex = new RegExp(`(${query})`, "gi");
-    return text.replace(regex, '<mark class="bg-yellow-300 text-black">$1</mark>');
+    return text.replace(
+      regex,
+      '<mark class="bg-yellow-300 text-black">$1</mark>',
+    );
   };
 
   const scrollToSegment = (index) => {
@@ -178,7 +229,9 @@ const TranscriptViewer = () => {
       <div className="min-h-screen bg-gray-50 dark:bg-slate-900 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading transcript...</p>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">
+            Loading transcript...
+          </p>
         </div>
       </div>
     );
@@ -208,6 +261,14 @@ const TranscriptViewer = () => {
 
   const meeting = transcript.meeting;
 
+  const canEdit =
+    userData &&
+    meeting &&
+    (userData.role === "admin" ||
+      userData.role === "owner" ||
+      (meeting.uploadedBy && meeting.uploadedBy === userData._id) ||
+      (meeting.uploadedBy && meeting.uploadedBy._id === userData._id));
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
       {/* Header */}
@@ -219,7 +280,10 @@ const TranscriptViewer = () => {
                 onClick={() => navigate(-1)}
                 className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
               >
-                <ArrowLeft size={20} className="text-gray-600 dark:text-gray-400" />
+                <ArrowLeft
+                  size={20}
+                  className="text-gray-600 dark:text-gray-400"
+                />
               </button>
               <div>
                 <h1 className="text-xl font-bold text-gray-900 dark:text-white">
@@ -228,12 +292,16 @@ const TranscriptViewer = () => {
                 <div className="flex items-center gap-4 mt-1 text-sm text-gray-600 dark:text-gray-400">
                   <span className="flex items-center gap-1">
                     <Calendar size={14} />
-                    {meeting?.date ? new Date(meeting.date).toLocaleDateString() : "N/A"}
+                    {meeting?.date
+                      ? new Date(meeting.date).toLocaleDateString()
+                      : "N/A"}
                   </span>
                   <span className="flex items-center gap-1">
                     <Clock size={14} />
                     {Math.floor(transcript.duration / 60)}:
-                    {Math.floor(transcript.duration % 60).toString().padStart(2, "0")}
+                    {Math.floor(transcript.duration % 60)
+                      .toString()
+                      .padStart(2, "0")}
                   </span>
                   <span className="flex items-center gap-1">
                     <Users size={14} />
@@ -328,9 +396,70 @@ const TranscriptViewer = () => {
                 >
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
-                      <span className="px-2 py-1 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium rounded">
-                        {segment.speaker || "Speaker"}
-                      </span>
+                      {editingSpeakerIndex === index ? (
+                        <div className="flex items-center gap-2 relative">
+                          <input
+                            type="text"
+                            className="px-2 py-1 bg-white dark:bg-slate-700 border border-indigo-300 rounded text-xs text-gray-800 dark:text-gray-200"
+                            value={newSpeakerName}
+                            onChange={(e) => setNewSpeakerName(e.target.value)}
+                            list="participants-list"
+                            autoFocus
+                          />
+                          <datalist id="participants-list">
+                            {meeting?.participants?.map((p, i) => (
+                              <option key={i} value={p.name} />
+                            ))}
+                          </datalist>
+                          <div className="flex items-center gap-1">
+                            <label className="text-xs text-gray-600 dark:text-gray-400 flex items-center gap-1 cursor-pointer">
+                              <input
+                                type="checkbox"
+                                checked={isBulkUpdate}
+                                onChange={(e) =>
+                                  setIsBulkUpdate(e.target.checked)
+                                }
+                                className="rounded text-indigo-600"
+                              />
+                              Update all '{segment.speaker}'
+                            </label>
+                          </div>
+                          <button
+                            onClick={() =>
+                              handleSpeakerChange(index, segment.speaker)
+                            }
+                            className="p-1 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+                          >
+                            <Check size={14} />
+                          </button>
+                          <button
+                            onClick={() => setEditingSpeakerIndex(null)}
+                            className="p-1 bg-gray-200 text-gray-600 rounded hover:bg-gray-300"
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                      ) : (
+                        <span
+                          onClick={() => {
+                            if (canEdit) {
+                              setEditingSpeakerIndex(index);
+                              setNewSpeakerName(segment.speaker);
+                              setIsBulkUpdate(true);
+                            }
+                          }}
+                          className={`px-2 py-1 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-xs font-medium rounded ${canEdit ? "cursor-pointer hover:bg-indigo-200 dark:hover:bg-indigo-800/50 transition-colors" : ""}`}
+                          title={canEdit ? "Click to edit speaker" : ""}
+                        >
+                          {segment.speaker || "Speaker"}
+                          {canEdit && (
+                            <Edit2
+                              size={10}
+                              className="inline ml-1 opacity-50"
+                            />
+                          )}
+                        </span>
+                      )}
                       <span className="text-gray-500 dark:text-gray-400 text-xs">
                         {formatTimestamp(segment.startTime)}
                       </span>
@@ -364,7 +493,9 @@ const TranscriptViewer = () => {
                   {searchResults.map((result, index) => (
                     <button
                       key={index}
-                      onClick={() => scrollToSegment(transcript.segments.indexOf(result))}
+                      onClick={() =>
+                        scrollToSegment(transcript.segments.indexOf(result))
+                      }
                       className="w-full text-left p-3 bg-gray-50 dark:bg-slate-700 rounded-lg hover:bg-gray-100 dark:hover:bg-slate-600 transition-colors"
                     >
                       <div className="flex items-center gap-2 mb-1">

--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -734,9 +734,14 @@ export const updateSpeakers = async (req, res) => {
 
     if (segmentIndex !== undefined && segmentIndex !== null) {
       // Update specific segment
-      if (segmentIndex >= 0 && segmentIndex < transcript.segments.length) {
-        if (transcript.segments[segmentIndex].speaker === oldSpeaker) {
-          transcript.segments[segmentIndex].speaker = newSpeaker;
+      const parsedIndex = Number(segmentIndex);
+      if (
+        Number.isInteger(parsedIndex) &&
+        parsedIndex >= 0 &&
+        parsedIndex < transcript.segments.length
+      ) {
+        if (transcript.segments[parsedIndex].speaker === oldSpeaker) {
+          transcript.segments[parsedIndex].speaker = newSpeaker;
           updatedCount = 1;
         }
       }

--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -1,7 +1,11 @@
 import Transcript from "../models/transcriptModel.js";
 import Meeting from "../models/meetingModel.js";
 import { transcribeFileWithSegments } from "../services/TranscriptionService.js";
-import { indexTranscript, searchVectorStore, indexMeeting } from "../utils/embeddingUtils.js";
+import {
+  indexTranscript,
+  searchVectorStore,
+  indexMeeting,
+} from "../utils/embeddingUtils.js";
 import { indexTranscriptChunks } from "../utils/transcriptEmbeddingUtils.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 import fs from "fs";
@@ -429,7 +433,7 @@ async function processTranscription(transcriptId) {
 
     // Transcribe audio with segments
     const transcriptionResult = await transcribeFileWithSegments(
-      transcript.audioFilePath
+      transcript.audioFilePath,
     );
 
     // Update transcript with results
@@ -459,7 +463,9 @@ async function processTranscription(transcriptId) {
     // Queue sentiment analysis job
     if (sentimentAnalysisQueue.isActive) {
       await sentimentAnalysisQueue.add("analyze-sentiment", { transcriptId });
-      console.log(`✅ Sentiment analysis queued for transcript ${transcriptId}`);
+      console.log(
+        `✅ Sentiment analysis queued for transcript ${transcriptId}`,
+      );
     }
   } catch (error) {
     console.error("❌ Transcription processing failed:", error);
@@ -482,7 +488,7 @@ export const getTranscriptByMeeting = async (req, res) => {
 
     const transcript = await Transcript.findOne({
       meeting: meetingId,
-    }).populate("meeting", "title date participants");
+    }).populate("meeting", "title date participants uploadedBy organization");
 
     if (!transcript) {
       return sendError(res, 404, "Transcript not found");
@@ -667,7 +673,9 @@ export const finalizeTranscript = async (req, res) => {
 
     // Queue sentiment analysis job
     if (sentimentAnalysisQueue.isActive) {
-      await sentimentAnalysisQueue.add("analyze-sentiment", { transcriptId: transcript._id });
+      await sentimentAnalysisQueue.add("analyze-sentiment", {
+        transcriptId: transcript._id,
+      });
     }
 
     sendSuccess(res, null, "Transcript finalized and indexed successfully");
@@ -685,3 +693,85 @@ function formatTimestamp(seconds) {
   const secs = Math.floor(seconds % 60);
   return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
 }
+
+/**
+ * Update speaker tags in a transcript
+ */
+export const updateSpeakers = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { oldSpeaker, newSpeaker, segmentIndex } = req.body;
+
+    if (!oldSpeaker || !newSpeaker) {
+      return sendError(res, 400, "Old speaker and new speaker are required");
+    }
+
+    const transcript = await Transcript.findById(id).populate("meeting");
+
+    if (!transcript) {
+      return sendError(res, 404, "Transcript not found");
+    }
+
+    const meeting = transcript.meeting;
+    const userId = req.user._id.toString();
+
+    const isOwner = meeting.uploadedBy?.toString() === userId;
+    const isAdminInSameOrg =
+      (req.user.role === "admin" || req.user.role === "owner") &&
+      meeting.organization &&
+      req.user.organization &&
+      meeting.organization.toString() === req.user.organization.toString();
+
+    if (!isOwner && !isAdminInSameOrg) {
+      return sendError(
+        res,
+        403,
+        "Forbidden: You don't have permission to edit this transcript",
+      );
+    }
+
+    let updatedCount = 0;
+
+    if (segmentIndex !== undefined && segmentIndex !== null) {
+      // Update specific segment
+      if (segmentIndex >= 0 && segmentIndex < transcript.segments.length) {
+        if (transcript.segments[segmentIndex].speaker === oldSpeaker) {
+          transcript.segments[segmentIndex].speaker = newSpeaker;
+          updatedCount = 1;
+        }
+      }
+    } else {
+      // Bulk update
+      transcript.segments.forEach((segment) => {
+        if (segment.speaker === oldSpeaker) {
+          segment.speaker = newSpeaker;
+          updatedCount++;
+        }
+      });
+    }
+
+    if (updatedCount > 0) {
+      await transcript.save();
+
+      // Optionally, regenerate fullText based on segments here if needed
+      // Currently, it seems we don't automatically regenerate fullText to avoid losing formatting.
+
+      // Update the meeting transcript text if required (optional)
+
+      sendSuccess(
+        res,
+        transcript,
+        `Successfully updated ${updatedCount} segment(s)`,
+      );
+    } else {
+      sendSuccess(
+        res,
+        transcript,
+        "No segments found matching the specified speaker",
+      );
+    }
+  } catch (error) {
+    console.error("Error updating speakers:", error);
+    sendError(res, 500, "Failed to update speakers");
+  }
+};

--- a/server/routes/transcriptRoutes.js
+++ b/server/routes/transcriptRoutes.js
@@ -22,10 +22,11 @@ import {
   exportTranscriptAsText,
   exportTranscriptAsPDF,
   finalizeTranscript,
+  updateSpeakers,
 } from "../controllers/transcriptController.js";
 
 const router = express.Router();
-const upload = multer({ 
+const upload = multer({
   dest: "uploads/transcripts/",
   limits: { fileSize: 100 * 1024 * 1024 }, // 100MB limit
 });
@@ -41,7 +42,7 @@ router.post(
   uploadLimiter,
   requireOrgMembership,
   requirePermission("meetings", "create"),
-  startRecording
+  startRecording,
 );
 
 // POST /api/meetings/:meetingId/recording/stop
@@ -52,7 +53,7 @@ router.post(
   uploadLimiter,
   requireOrgMembership,
   requirePermission("meetings", "create"),
-  stopRecording
+  stopRecording,
 );
 
 // POST /api/meetings/:meetingId/transcript/upload
@@ -64,7 +65,7 @@ router.post(
   requireOrgMembership,
   requirePermission("meetings", "create"),
   upload.single("audio"),
-  uploadTranscriptAudio
+  uploadTranscriptAudio,
 );
 
 // GET /api/meetings/:meetingId/transcript
@@ -74,7 +75,7 @@ router.get(
   userAuth,
   requireOrgMembership,
   requirePermission("meetings", "view"),
-  getTranscript
+  getTranscript,
 );
 
 // POST /api/meetings/:meetingId/transcript/retry
@@ -85,7 +86,7 @@ router.post(
   uploadLimiter,
   requireOrgMembership,
   requirePermission("meetings", "create"),
-  retryTranscription
+  retryTranscription,
 );
 
 // GET /api/search/voice?query=...
@@ -95,7 +96,7 @@ router.get(
   userAuth,
   requireOrgMembership,
   requirePermission("ai_search", "search"),
-  voiceSearch
+  voiceSearch,
 );
 
 // Get transcript by meeting ID
@@ -104,7 +105,7 @@ router.get(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "view"),
-  getTranscriptByMeeting
+  getTranscriptByMeeting,
 );
 
 // Search within transcript
@@ -113,7 +114,7 @@ router.post(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "view"),
-  searchTranscript
+  searchTranscript,
 );
 
 // Export transcript as text
@@ -122,7 +123,7 @@ router.get(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "export"),
-  exportTranscriptAsText
+  exportTranscriptAsText,
 );
 
 // Export transcript as PDF
@@ -131,7 +132,7 @@ router.get(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "export"),
-  exportTranscriptAsPDF
+  exportTranscriptAsPDF,
 );
 
 // Finalize transcript and index in Pinecone
@@ -140,7 +141,10 @@ router.post(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "edit"),
-  finalizeTranscript
+  finalizeTranscript,
 );
+
+// Update speaker names in transcript
+router.put("/:id/speakers", userAuth, updateSpeakers);
 
 export default router;

--- a/server/tests/transcriptController.test.js
+++ b/server/tests/transcriptController.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updateSpeakers } from "../controllers/transcriptController.js";
+import Transcript from "../models/transcriptModel.js";
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+
+// Mock dependencies
+vi.mock("../models/transcriptModel.js", () => ({
+  default: {
+    findById: vi.fn(),
+  },
+}));
+
+vi.mock("../utils/responseHandler.js", () => ({
+  sendSuccess: vi.fn(),
+  sendError: vi.fn(),
+}));
+
+describe("transcriptController - updateSpeakers", () => {
+  let req;
+  let res;
+  let mockTranscript;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    req = {
+      params: { id: "transcript123" },
+      body: { oldSpeaker: "Speaker A", newSpeaker: "John Doe" },
+      user: {
+        _id: "user123",
+        role: "owner",
+        organization: "org123",
+      },
+    };
+
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    mockTranscript = {
+      _id: "transcript123",
+      meeting: {
+        _id: "meeting123",
+        uploadedBy: "user123",
+        organization: "org123",
+      },
+      segments: [
+        { speaker: "Speaker A", text: "Hello" },
+        { speaker: "Speaker B", text: "Hi" },
+        { speaker: "Speaker A", text: "How are you?" },
+      ],
+      save: vi.fn().mockResolvedValue(true),
+    };
+
+    const mockQuery = {
+      populate: vi.fn().mockResolvedValue(mockTranscript),
+    };
+    Transcript.findById.mockReturnValue(mockQuery);
+  });
+
+  it("should return 400 if oldSpeaker or newSpeaker is missing", async () => {
+    req.body.newSpeaker = "";
+
+    await updateSpeakers(req, res);
+
+    expect(sendError).toHaveBeenCalledWith(
+      res,
+      400,
+      "Old speaker and new speaker are required",
+    );
+  });
+
+  it("should return 404 if transcript is not found", async () => {
+    const mockQuery = {
+      populate: vi.fn().mockResolvedValue(null),
+    };
+    Transcript.findById.mockReturnValue(mockQuery);
+
+    await updateSpeakers(req, res);
+
+    expect(sendError).toHaveBeenCalledWith(res, 404, "Transcript not found");
+  });
+
+  it("should return 403 if user lacks permissions", async () => {
+    req.user = {
+      _id: "user999",
+      role: "member",
+      organization: "org999",
+    };
+
+    await updateSpeakers(req, res);
+
+    expect(sendError).toHaveBeenCalledWith(
+      res,
+      403,
+      "Forbidden: You don't have permission to edit this transcript",
+    );
+  });
+
+  it("should bulk update speakers if no segmentIndex is provided", async () => {
+    await updateSpeakers(req, res);
+
+    expect(mockTranscript.segments[0].speaker).toBe("John Doe");
+    expect(mockTranscript.segments[1].speaker).toBe("Speaker B");
+    expect(mockTranscript.segments[2].speaker).toBe("John Doe");
+
+    expect(mockTranscript.save).toHaveBeenCalled();
+    expect(sendSuccess).toHaveBeenCalledWith(
+      res,
+      mockTranscript,
+      "Successfully updated 2 segment(s)",
+    );
+  });
+
+  it("should update a specific segment if segmentIndex is provided", async () => {
+    req.body.segmentIndex = 0;
+
+    await updateSpeakers(req, res);
+
+    expect(mockTranscript.segments[0].speaker).toBe("John Doe");
+    // Other matching segments shouldn't change
+    expect(mockTranscript.segments[2].speaker).toBe("Speaker A");
+
+    expect(mockTranscript.save).toHaveBeenCalled();
+    expect(sendSuccess).toHaveBeenCalledWith(
+      res,
+      mockTranscript,
+      "Successfully updated 1 segment(s)",
+    );
+  });
+
+  it("should return success message if no segments were updated", async () => {
+    req.body.oldSpeaker = "NonExistentSpeaker";
+
+    await updateSpeakers(req, res);
+
+    expect(mockTranscript.save).not.toHaveBeenCalled();
+    expect(sendSuccess).toHaveBeenCalledWith(
+      res,
+      mockTranscript,
+      "No segments found matching the specified speaker",
+    );
+  });
+
+  it("should return 500 on server error", async () => {
+    const mockQuery = {
+      populate: vi.fn().mockRejectedValue(new Error("DB Error")),
+    };
+    Transcript.findById.mockReturnValue(mockQuery);
+
+    await updateSpeakers(req, res);
+
+    expect(sendError).toHaveBeenCalledWith(
+      res,
+      500,
+      "Failed to update speakers",
+    );
+  });
+});


### PR DESCRIPTION
- closes #527

### Description
Automated audio transcription often struggles with perfect speaker diarization. This PR introduces a new interactive feature that allows meeting hosts and administrators to rapidly correct speaker tags directly from the transcript view, immediately cascading those updates to the database.

### Changes Included
**Backend**
- **New API Endpoint**: Created `PUT /api/transcripts/:id/speakers` to handle targeted and bulk speaker reassignment.
- **Controller Logic**: Implemented `updateSpeakers` inside `transcriptController.js` to process specific dialogue block edits or bulk find-and-replace updates. 
- **RBAC Integrations**: Ensured strict authorization checks so only the meeting owner or organization admins can mutate the official transcript. 

### **Frontend**
- **Interactive UI**: Enhanced `TranscriptViewer.jsx` to natively display a contextual dropdown editor when an authorized user clicks a speaker's name.
- **Bulk vs Targeted Editing**: Implemented a checkbox toggle offering users the choice to execute a sweeping "Update all instances" change or surgically fix a single line.
- **Instantaneous UX**: Added logic to seamlessly re-render the transcript upon a successful backend response without requiring a full page refresh.

### Acceptance Criteria Met
- [x] Users can smoothly edit speaker names directly from the transcript view.
- [x] Bulk updates successfully modify the database and re-render the transcript.
- [x] Only meeting hosts or admins have permission to alter the official transcript.
