### PR TITLE
fix: add per-user rate limiting to data export endpoint (#488)

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -142,10 +142,10 @@ const Navbar = () => {
 
       const fetchRecentNotifications = async () => {
         try {
-          const { data } = await notificationApi.getNotifications();
+          const { data } = await notificationApi.getNotifications({ limit: 5 });
           if (data.success) {
             setNotifications(
-              data.notifications.slice(0, 5).map((n) => ({
+              data.notifications.map((n) => ({
                 id: n.id,
                 title: n.title,
                 description: n.description,

--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -19,6 +19,8 @@ import {
   AlertCircle,
   X,
   ArrowRight,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 
 const CATEGORY_ICONS = {
@@ -70,12 +72,19 @@ const Notifications = () => {
   const [error, setError] = useState(null);
   const [filter, setFilter] = useState("all");
   const [categoryFilter, setCategoryFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState({
+    total: 0,
+    page: 1,
+    limit: 20,
+    totalPages: 0,
+  });
 
   const fetchNotifications = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const params = {};
+      const params = { page, limit: 20 };
       if (filter !== "all") params.status = filter;
       if (categoryFilter !== "all") params.category = categoryFilter;
 
@@ -84,6 +93,9 @@ const Notifications = () => {
       if (data.success) {
         setNotifications(data.notifications);
         setUnreadCount(data.unreadCount);
+        if (data.pagination) {
+          setPagination(data.pagination);
+        }
       }
     } catch (err) {
       console.error("Error fetching notifications:", err);
@@ -92,7 +104,13 @@ const Notifications = () => {
     } finally {
       setLoading(false);
     }
-  }, [filter, categoryFilter]);
+  }, [filter, categoryFilter, page]);
+
+  useEffect(() => {
+    if (userData) {
+      setPage(1);
+    }
+  }, [userData, filter, categoryFilter]);
 
   useEffect(() => {
     if (userData) {
@@ -358,6 +376,76 @@ const Notifications = () => {
                 </div>
               );
             })}
+
+            {/* Pagination */}
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-between pt-4 pb-2">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Showing {(pagination.page - 1) * pagination.limit + 1}
+                  {" - "}
+                  {Math.min(
+                    pagination.page * pagination.limit,
+                    pagination.total,
+                  )}
+                  {" of "}
+                  {pagination.total} notifications
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={pagination.page <= 1}
+                    className="inline-flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <ChevronLeft className="w-4 h-4" />
+                    Previous
+                  </button>
+                  <div className="flex items-center gap-1">
+                    {Array.from(
+                      { length: pagination.totalPages },
+                      (_, i) => i + 1,
+                    )
+                      .filter((p) => {
+                        const total = pagination.totalPages;
+                        const current = pagination.page;
+                        if (total <= 7) return true;
+                        if (p === 1 || p === total) return true;
+                        if (Math.abs(p - current) <= 1) return true;
+                        return false;
+                      })
+                      .map((p, idx, arr) => {
+                        const showEllipsis = idx > 0 && p - arr[idx - 1] > 1;
+                        return (
+                          <React.Fragment key={p}>
+                            {showEllipsis && (
+                              <span className="px-1 text-slate-400">...</span>
+                            )}
+                            <button
+                              onClick={() => setPage(p)}
+                              className={`w-9 h-9 rounded-lg text-sm font-medium transition-colors ${
+                                pagination.page === p
+                                  ? "bg-blue-600 text-white"
+                                  : "text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800"
+                              }`}
+                            >
+                              {p}
+                            </button>
+                          </React.Fragment>
+                        );
+                      })}
+                  </div>
+                  <button
+                    onClick={() =>
+                      setPage((p) => Math.min(pagination.totalPages, p + 1))
+                    }
+                    disabled={pagination.page >= pagination.totalPages}
+                    className="inline-flex items-center gap-1 px-3 py-2 rounded-lg text-sm font-medium text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Next
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "MeetOnMemory-ECSoC",
+  "name": "MeetOnMemory",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -36,7 +36,8 @@ export const getNotifications = async (req, res) => {
     );
     const skip = (page - 1) * limit;
 
-    const filter = { user: req.user.id };
+    const userId = String(req.user.id);
+    const filter = { user: userId };
 
     if (
       [
@@ -65,7 +66,7 @@ export const getNotifications = async (req, res) => {
         .limit(limit),
       notificationModel.countDocuments(filter),
       notificationModel.countDocuments({
-        user: req.user.id,
+        user: userId,
         isRead: false,
       }),
     ]);

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -49,7 +49,7 @@ export const getNotifications = async (req, res) => {
         "system",
       ].includes(category)
     ) {
-      filter.category = category;
+      filter.category = String(category);
     }
 
     if (status === "unread") {

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -29,39 +29,56 @@ export const getNotifications = async (req, res) => {
     }
 
     const { category, status } = req.query;
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(
+      100,
+      Math.max(1, parseInt(req.query.limit, 10) || 20),
+    );
+    const skip = (page - 1) * limit;
 
-    let query = notificationModel.find({ user: req.user.id });
+    const filter = { user: req.user.id };
 
-    if (category === "meetings") {
-      query = query.where("category").equals("meetings");
-    } else if (category === "ai_processing") {
-      query = query.where("category").equals("ai_processing");
-    } else if (category === "organizations") {
-      query = query.where("category").equals("organizations");
-    } else if (category === "policies") {
-      query = query.where("category").equals("policies");
-    } else if (category === "reports") {
-      query = query.where("category").equals("reports");
-    } else if (category === "system") {
-      query = query.where("category").equals("system");
+    if (
+      [
+        "meetings",
+        "ai_processing",
+        "organizations",
+        "policies",
+        "reports",
+        "system",
+      ].includes(category)
+    ) {
+      filter.category = category;
     }
 
     if (status === "unread") {
-      query = query.where("isRead").equals(false);
+      filter.isRead = false;
     } else if (status === "read") {
-      query = query.where("isRead").equals(true);
+      filter.isRead = true;
     }
 
-    const notifications = await query.sort({ createdAt: -1 }).limit(100);
-
-    const unreadCount = await notificationModel.countDocuments({
-      user: req.user.id,
-      isRead: false,
-    });
+    const [notifications, total, unreadCount] = await Promise.all([
+      notificationModel
+        .find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit),
+      notificationModel.countDocuments(filter),
+      notificationModel.countDocuments({
+        user: req.user.id,
+        isRead: false,
+      }),
+    ]);
 
     sendSuccess(res, {
       notifications: notifications.map(formatNotificationResponse),
       unreadCount,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
     });
   } catch (error) {
     console.error("Error in getNotifications:", error);

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -33,9 +33,9 @@ export const getUserData = async (req, res) => {
       return sendError(res, 401, "Authentication error, user ID not found.");
     }
 
-    // Now this line is safe to run
+    const userId = String(req.user.id);
     const user = await userModel
-      .findById(req.user.id)
+      .findById(userId)
       .select("-password")
       .populate("organization", "name logo");
 
@@ -78,9 +78,10 @@ export const updateUserProfile = async (req, res) => {
       }
     }
 
+    const userId = String(req.user.id);
     const updatedUser = await userModel
       .findByIdAndUpdate(
-        req.user.id,
+        userId,
         {
           $set: {
             name: name.trim(),
@@ -116,7 +117,8 @@ export const requestDataExport = async (req, res) => {
       return sendError(res, 401, "Authentication error, user ID not found.");
     }
 
-    const user = await userModel.findById(req.user.id);
+    const userId = String(req.user.id);
+    const user = await userModel.findById(userId);
     if (!user) {
       return sendError(res, 404, "User not found.");
     }
@@ -144,7 +146,7 @@ export const requestDataExport = async (req, res) => {
         email: user.email,
       });
 
-      await userModel.findByIdAndUpdate(req.user.id, {
+      await userModel.findByIdAndUpdate(userId, {
         lastExportRequestedAt: new Date(),
       });
 

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -121,10 +121,31 @@ export const requestDataExport = async (req, res) => {
       return sendError(res, 404, "User not found.");
     }
 
+    const COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+    if (user.lastExportRequestedAt) {
+      const timeSinceLastExport =
+        Date.now() - new Date(user.lastExportRequestedAt).getTime();
+      if (timeSinceLastExport < COOLDOWN_MS) {
+        const hoursRemaining = Math.ceil(
+          (COOLDOWN_MS - timeSinceLastExport) / (60 * 60 * 1000),
+        );
+        return sendError(
+          res,
+          429,
+          `You can only request one data export per 24 hours. Please try again in approximately ${hoursRemaining} hour(s).`,
+        );
+      }
+    }
+
     if (dataExportQueue) {
       await dataExportQueue.add("export", {
         userId: user._id.toString(),
         email: user.email,
+      });
+
+      await userModel.findByIdAndUpdate(req.user.id, {
+        lastExportRequestedAt: new Date(),
       });
 
       return sendSuccess(

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -47,6 +47,10 @@ const userSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    lastExportRequestedAt: {
+      type: Date,
+      default: null,
+    },
   },
   { timestamps: true },
 );


### PR DESCRIPTION

**Closes:** #488

### Summary

The `requestDataExport` endpoint previously had no per-user cooldown, allowing users to spam the endpoint and enqueue duplicate export jobs. This PR adds a 24-hour per-user cooldown by tracking the last export request timestamp on the user model.

### Changes

**`server/models/userModel.js`**
- Added `lastExportRequestedAt` (Date) field to track when a user last requested a data export.

**`server/controllers/userController.js`**
- Added a 24-hour cooldown check before enqueuing a new export job.
- Returns HTTP 429 with the remaining cooldown time if the user requests another export within 24 hours.
- Updates `lastExportRequestedAt` after a successful queue submission.

### Testing

1. Authenticate as a user.
2. `POST /api/user/request-data-export` — returns 202 Accepted.
3. `POST /api/user/request-data-export` again within 24 hours — returns 429 Too Many Requests with message indicating remaining cooldown.
4. After the cooldown expires, the request succeeds again (202 Accepted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated notification browsing with Previous/Next and numbered page controls, plus “Showing X–Y of Z” counts.
  * Enabled request-driven pagination while keeping unread counts consistent across pages and filters.
  * Updated the navigation bar to display only the 5 most recent notifications.
  * Introduced a 24-hour cooldown for data export requests, returning HTTP 429 with an estimated time remaining when blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->