### PR TITLE
fix: move Gemini API key from URL query string to header

### DIFF
--- a/server/routes/geminiRoutes.js
+++ b/server/routes/geminiRoutes.js
@@ -31,9 +31,12 @@ Use formal, data-driven tone.
 `;
 
     const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent`,
       {
         contents: [{ parts: [{ text: prompt }] }],
+      },
+      {
+        headers: { "x-goog-api-key": process.env.GEMINI_API_KEY },
       },
     );
 


### PR DESCRIPTION
# Pull Request

## Description

Moved the Gemini API key from a URL query parameter (?key=...) to the x-goog-api-key request header in server/routes/geminiRoutes.js. This prevents the key from leaking in server logs, proxy logs, and referer headers.

Type of Change
- Security Improvement

Related Issue
Closes #557

Testing
- Tested locally
- Existing functionality verified
- No new warnings or errors

Checklist
- Code follows project conventions
- Documentation updated where required
- No unnecessary files included
- Changes have been tested
- Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key handling for insights requests by sending credentials securely through request headers instead of the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->