### PR TITLE
Fix/global rate limiter order

### DIFF
--- a/server/routes/geminiRoutes.js
+++ b/server/routes/geminiRoutes.js
@@ -31,9 +31,12 @@ Use formal, data-driven tone.
 `;
 
     const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent`,
       {
         contents: [{ parts: [{ text: prompt }] }],
+      },
+      {
+        headers: { "x-goog-api-key": process.env.GEMINI_API_KEY },
       },
     );
 

--- a/server/server.js
+++ b/server/server.js
@@ -79,6 +79,9 @@ await connectDB();
 // EXPRESS CONFIGURATION
 configureExpress(app);
 
+// GLOBAL RATE LIMITER — applied before all API routes to protect every endpoint
+app.use(globalLimiter);
+
 // ROUTES
 app.use("/api/auth", authRoutes);
 app.use(["/api/organization", "/api/organizations"], organizationRoutes);


### PR DESCRIPTION
## Description

Moved `app.use(globalLimiter)` before the route mounting block in `server/server.js`. Previously the global rate limiter was imported but never applied, leaving all API endpoints unprotected against abuse.

## Type of Change

- [x] Bug Fix

## Related Issue

Closes #558

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review