### PR TITLE
fix: replace fs.unlinkSync with fs.promises.unlink to prevent event loop blocking

### DIFF
--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -229,7 +229,7 @@ export const uploadAndTranscribeMeeting = async (
   scheduleIndexMeeting(meeting);
 
   try {
-    fs.unlinkSync(validatePath(filePath));
+    await fs.promises.unlink(validatePath(filePath));
   } catch (e) {
     console.warn("⚠️ Could not delete temp file:", e.message);
   }
@@ -270,7 +270,7 @@ export const uploadAudioForExistingMeeting = async (
   scheduleIndexMeeting(meeting);
 
   try {
-    fs.unlinkSync(validatePath(filePath));
+    await fs.promises.unlink(validatePath(filePath));
   } catch (e) {
     console.warn("⚠️ Could not delete temp file:", e.message);
   }


### PR DESCRIPTION
## Description

This PR replaces two blocking `fs.unlinkSync()` calls in `MeetingService.js` with non-blocking `await fs.promises.unlink()` to prevent the Node.js event loop from stalling during audio file cleanup.

Currently, after a meeting audio file is transcribed, the temporary upload file is deleted using `fs.unlinkSync()` — a synchronous, blocking operation. This call halts the entire Node.js event loop until the OS finishes deleting the file. Under concurrent upload load (multiple users uploading audio simultaneously), every upload blocks all other active requests — including API calls, auth checks, and socket events — for the duration of the disk I/O.

Since both `uploadAndTranscribeMeeting` and `uploadAudioForExistingMeeting` are already `async` functions, switching to `await fs.promises.unlink()` requires no structural changes — only replacing two lines.

---

## Related Issue

* Closes #573

---

## Component(s) Affected

* [x] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [ ] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [ ] `npm run lint`
* [ ] `npm run build`
* [x] Manual verification

### Manually verified

* Uploaded a meeting audio file and confirmed transcription completes successfully.
* Verified the temporary upload file is deleted after transcription.
* Confirmed no functional change in behavior — only the execution model changes from synchronous to asynchronous.
* Confirmed the `catch` block still logs `⚠️ Could not delete temp file:` if deletion fails.
* Verified both code paths: `uploadAndTranscribeMeeting` (new meeting upload) and `uploadAudioForExistingMeeting` (existing meeting audio update).

### Edge cases considered

* File already deleted before cleanup runs — caught by existing `try/catch`.
* File path validation (`validatePath`) still runs before the async unlink call.
* Server process shutdown mid-deletion — same behavior as before.
* No change to error propagation: cleanup failures are logged as warnings, not thrown.

---

## Screenshots / Videos (required for any UI change)

* [x] Not applicable — no UI change

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR does not modify any backend endpoints or request/response models.

---

## Documentation Updates

* [x] Not applicable

---

## Out of Scope

* No changes to transcription logic.
* No changes to file upload handling or Multer configuration.
* No changes to error handling behavior beyond the sync→async switch.

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [x] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] Any behavior change includes a new or updated test
* [x] I removed debug prints, commented-out dead code, and unused imports I introduced
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file cleanup during meeting transcription by performing deletion asynchronously.
  * Transcription completion is less likely to be blocked by file cleanup, while cleanup failures remain non-fatal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->