### PR TITLE
fix: add prefers-reduced-motion guard to CustomCursor for WCAG 2.1 accessibility compliance

### DIFF
--- a/client/src/components/CustomCursor.jsx
+++ b/client/src/components/CustomCursor.jsx
@@ -4,6 +4,21 @@ const CustomCursor = () => {
   const [isHovered, setIsHovered] = useState(false);
   const [isMobile, setIsMobile] = useState(true);
 
+  // Respect the user's OS-level motion preference — WCAG 2.1 SC 2.3.3
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  // Listen for dynamic changes (user toggles accessibility setting while page is open)
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e) => setPrefersReducedMotion(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
   useEffect(() => {
     const mediaQuery = window.matchMedia("(pointer: fine)");
     setIsMobile(!mediaQuery.matches);
@@ -93,6 +108,11 @@ const CustomCursor = () => {
       cancelAnimationFrame(animationFrameId);
     };
   }, []);
+
+  // Do not render the custom cursor if the user prefers reduced motion.
+  // This prevents motion-triggered discomfort for users with vestibular disorders
+  // and ensures the native OS cursor (including high-contrast accessibility cursors) is shown.
+  if (prefersReducedMotion) return null;
 
   if (isMobile) return null;
 

--- a/client/src/components/CustomCursor.test.jsx
+++ b/client/src/components/CustomCursor.test.jsx
@@ -3,29 +3,63 @@ import { render } from "@testing-library/react";
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import CustomCursor from "./CustomCursor";
 
-// Mock window.matchMedia since it's not supported in JSDOM by default
-beforeAll(() => {
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    value: vi.fn().mockImplementation((query) => ({
-      matches: true, // Simulate a desktop environment with a fine pointer
-      media: query,
-      onchange: null,
-      addListener: vi.fn(), // Deprecated
-      removeListener: vi.fn(), // Deprecated
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })),
-  });
-});
+// Query-aware matchMedia mock:
+// - (pointer: fine)                   → matches: true  (desktop with fine pointer)
+// - (prefers-reduced-motion: reduce)  → matches: false (user has NOT requested reduced motion)
+// This accurately simulates a standard desktop environment for the happy-path test.
+const createMatchMediaMock = (prefersReducedMotion = false) =>
+  vi.fn().mockImplementation((query) => ({
+    matches:
+      query === "(pointer: fine)"
+        ? true
+        : query === "(prefers-reduced-motion: reduce)"
+          ? prefersReducedMotion
+          : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
 
 describe("CustomCursor", () => {
-  it("renders without crashing on desktop devices", () => {
-    const { container } = render(<CustomCursor />);
+  describe("on a standard desktop (no reduced motion preference)", () => {
+    beforeAll(() => {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: createMatchMediaMock(false),
+      });
+    });
 
-    // Check if the cursor divs are rendered
-    expect(container.querySelector(".custom-cursor")).toBeInTheDocument();
-    expect(container.querySelector(".custom-cursor-ring")).toBeInTheDocument();
+    it("renders cursor elements on desktop devices", () => {
+      const { container } = render(<CustomCursor />);
+
+      // Check if the cursor divs are rendered
+      expect(container.querySelector(".custom-cursor")).toBeInTheDocument();
+      expect(
+        container.querySelector(".custom-cursor-ring"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when the user prefers reduced motion", () => {
+    beforeAll(() => {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: createMatchMediaMock(true),
+      });
+    });
+
+    it("renders nothing to respect the accessibility preference", () => {
+      const { container } = render(<CustomCursor />);
+
+      // Component must return null — no cursor elements should exist in the DOM
+      expect(container.querySelector(".custom-cursor")).not.toBeInTheDocument();
+      expect(
+        container.querySelector(".custom-cursor-ring"),
+      ).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Description

This PR adds a `prefers-reduced-motion` media query guard to `CustomCursor.jsx` so that the animated custom cursor is disabled for users who have enabled reduced motion in their OS accessibility settings.

Currently, `CustomCursor.jsx` renders a custom animated cursor for all pointer-capable users without checking whether the user has requested reduced motion. Users with vestibular disorders (e.g., vertigo, labyrinthitis) configure `prefers-reduced-motion: reduce` in their OS settings specifically to suppress motion-heavy UI effects. When ignored, animated cursors can trigger motion sickness, nausea, and disorientation. Additionally, the custom cursor hides the native OS cursor, breaking high-contrast and accessibility cursor themes used by visually impaired users.

This PR adds two changes to `CustomCursor.jsx`:

1. **Initial state detection** — reads the `prefers-reduced-motion` media query value on component mount using a lazy `useState` initializer.
2. **Dynamic listener** — attaches a `MediaQueryList` `change` event listener via `useEffect` so the component reacts if the user toggles the accessibility setting while the page is open, without requiring a full page reload.

When `prefersReducedMotion` is `true`, the component returns `null` early, allowing the native browser/OS cursor to display instead. All existing behavior for pointer-capable, non-reduced-motion users is completely unchanged.

---

## Related Issue

* Closes #576

---

## Component(s) Affected

* [ ] Backend (`server/`)
* [ ] Mobile app (`rhythma_flutter/`)
* [x] Web app (`web/`)
* [ ] Landing page (`landing-page/`)
* [ ] Docs only (README, CONTRIBUTING, architecture, etc.)
* [ ] CI / tooling

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor (no behavior change)
* [ ] Tests
* [ ] Other:

---

## Testing Performed

### Commands executed

* [ ] `npm test`
* [ ] `npm run lint`
* [ ] `npm run build`
* [x] Manual verification

### Manually verified

* **With `prefers-reduced-motion: reduce` enabled** (Windows: Settings → Accessibility → Visual Effects → Animation effects OFF):
  - Opened the MeetOnMemory landing page.
  - Confirmed the custom cursor does **not** render.
  - Confirmed the native OS cursor is visible and functional.
  - Confirmed no JavaScript errors in the browser console.

* **With `prefers-reduced-motion` not set** (default):
  - Confirmed the custom cursor renders and behaves exactly as before.
  - Confirmed hover states, ring animation, and opacity transitions are all intact.

* **Dynamic toggle test**:
  - Opened the page, then toggled the OS reduced-motion setting.
  - Confirmed the cursor disappears/reappears without a page reload.

### Edge cases considered

* SSR / server-side rendering safety — `typeof window !== "undefined"` guard in the lazy initializer prevents crashes in SSR environments.
* Mobile devices — `isMobile` check still runs independently; mobile users are unaffected.
* Users with `prefers-reduced-motion: no-preference` (explicit opt-in) — treated as `false`, cursor renders normally.
* MediaQueryList cleanup — `removeEventListener` is called in the `useEffect` cleanup to prevent memory leaks.

---

## Screenshots / Videos (required for any UI change)

* [x] Not applicable — the change disables a UI element for accessibility; no visual demonstration needed beyond the verified absence of the cursor under reduced motion settings.

---

## API Documentation (required for any new/changed backend endpoint)

Not applicable. This PR does not modify any backend endpoints.

---

## Documentation Updates

* [x] Not applicable

---

## References

* [WCAG 2.1 SC 2.3.3 — Animation from Interactions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html)
* [MDN — prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)

---

## Checklist

* [x] I have read `CONTRIBUTING.md`
* [x] I rebased/merged the latest `main` into this branch
* [x] I tested my changes locally (see Testing Performed above)
* [x] Any behavior change includes a new or updated test
* [x] I removed debug prints, commented-out dead code, and unused imports I introduced
* [x] This PR is scoped to one logical change
* [x] I did not commit any secrets, credentials, or real `.env` files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom cursor effects are now automatically disabled when the device’s reduced-motion accessibility setting is enabled.

* **Bug Fixes**
  * Improved accessibility by preventing cursor animations for users who prefer reduced motion.

* **Tests**
  * Added coverage for standard desktop behavior and reduced-motion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->