### PR TITLE
fix(org): ensure membership record is created during organization creation (#623)

### DIFF
--- a/client/src/hooks/useWebRTC.js
+++ b/client/src/hooks/useWebRTC.js
@@ -4,7 +4,7 @@ import Peer from "simple-peer";
 import { toast } from "react-toastify";
 import { useNavigate } from "react-router-dom";
 
-export default function useWebRTC(roomId, callbacks) {
+export default function useWebRTC(roomId, callbacks, userData) {
   const navigate = useNavigate();
   const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
@@ -43,7 +43,22 @@ export default function useWebRTC(roomId, callbacks) {
       }, 100);
 
       socketRef.current = io(backendUrl, { transports: ["websocket"] });
-      const userInfo = { name: "You" };
+
+      socketRef.current.on("connect_error", (err) => {
+        console.error("Socket connection error:", err.message);
+        toast.error(`Connection failed: ${err.message || "Unauthorized"}`);
+        setLoading(false);
+        navigate("/dashboard");
+      });
+
+      socketRef.current.on("error", (data) => {
+        console.error("Socket error:", data.message);
+        toast.error(`Meeting Error: ${data.message || "Access denied"}`);
+        setLoading(false);
+        navigate("/dashboard");
+      });
+
+      const userInfo = { name: userData?.name || userData?.email || "Participant" };
 
       socketRef.current.emit("join-meeting", { roomId, userInfo });
 
@@ -173,7 +188,7 @@ export default function useWebRTC(roomId, callbacks) {
         userToSignal,
         callerID,
         signal,
-        userInfo: { name: "You" },
+        userInfo: { name: userData?.name || userData?.email || "Participant" },
       });
     });
 

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useParams } from "react-router-dom";
+import AppContent from "../context/AppContent";
 import { toast } from "react-toastify";
 import { Loader2, CheckCircle2 } from "lucide-react";
 import ErrorState from "../components/ErrorState.jsx";
@@ -14,6 +15,7 @@ import useLiveTranscription from "../hooks/useLiveTranscription";
 
 const MeetingRoom = () => {
   const { roomId } = useParams();
+  const { userData } = useContext(AppContent);
   const [duration, setDuration] = useState(0);
   const [showNotes, setShowNotes] = useState(false);
 
@@ -48,7 +50,7 @@ const MeetingRoom = () => {
     setCaptions,
     setTranscriptSegments,
     setTranscriptionEnabled,
-  });
+  }, userData);
 
   // Transcription
   const { toggleTranscription } = useLiveTranscription(
@@ -158,7 +160,7 @@ const MeetingRoom = () => {
                   {!cameraOn && (
                     <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
                       <div className="w-20 h-20 bg-indigo-600 rounded-full flex items-center justify-center text-3xl font-bold text-white shadow-xl">
-                        You
+                        {userData?.name ? userData.name.split(" ").map(n => n[0]).join("").toUpperCase() : "You"}
                       </div>
                     </div>
                   )}
@@ -166,7 +168,7 @@ const MeetingRoom = () => {
                     <span
                       className={`w-2 h-2 rounded-full ${micOn ? "bg-green-500" : "bg-red-500"}`}
                     />
-                    <span>You</span>
+                    <span>{userData?.name || "You"} (You)</span>
                   </div>
                 </div>
 

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -5,6 +5,7 @@ import ProtectedRoute from "../components/ProtectedRoute.jsx";
 import AccessDenied from "../pages/AccessDenied.jsx";
 
 // --- Protected Pages ---
+import MeetingRoom from "../pages/MeetingRoom.jsx";
 import MeetingListPage from "../pages/MeetingListPage.jsx";
 import OrganizationHub from "../pages/OrganizationHub.jsx";
 import JoinOrganizationPage from "../pages/JoinOrganizationPage.jsx";
@@ -197,6 +198,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="meetings" action="view">
           <TranscriptViewer />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/meeting-room/:roomId"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <MeetingRoom />
         </ProtectedRoute>
       }
     />

--- a/client/src/routes/PublicRoutes.jsx
+++ b/client/src/routes/PublicRoutes.jsx
@@ -12,7 +12,7 @@ import Terms from "../pages/Terms.jsx";
 import Security from "../pages/Security.jsx";
 import Contact from "../pages/Contact.jsx";
 import CookiePolicy from "../pages/CookiePolicy.jsx";
-import MeetingRoom from "../pages/MeetingRoom.jsx";
+
 import Status from "../pages/Status.jsx";
 import HelpCenter from "../pages/HelpCenter.jsx";
 import Careers from "../pages/Careers.jsx";
@@ -36,7 +36,7 @@ const PublicRoutes = (
       path="/organizations/:slug"
       element={<PublicOrganizationProfile />}
     />
-    <Route path="/meeting-room/:roomId" element={<MeetingRoom />} />
+
     <Route path="/shared/:hash" element={<PublicSharedView />} />
   </React.Fragment>
 );


### PR DESCRIPTION
## Description
This PR addresses the issue where creating a new organization updated the `Organization` and `User` documents but did not consistently write the corresponding `Membership` record for the creator. 

## Related Issues
Closes #623

## Problem
Without a corresponding `Membership` record, the organization creator would lack proper membership mapping in the `memberships` collection, causing inconsistencies in RBAC checks, member listings, and dashboard authorization.

## Proposed Changes
### Backend & Services
- **`server/services/OrganizationService.js`**: Updated the organization creation block in the `createOrJoinOrganization` service method to consistently create a `Membership` record for the creator with the `admin` role and `active` status immediately after organization creation.

## Checklist
- [x] Tested that a new membership document is created in the database upon organization initialization.
- [x] Verified that the organization owner/creator is assigned the `admin` role in their membership record.
- [x] Confirmed that the existing organization creation and join flows function as expected without regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting rooms are now available through protected access at `/meeting-room/:roomId`.
  * Local participant names and initial-based avatars are shown in video overlays.
  * Participant identity information is shared during peer connections.

* **Bug Fixes**
  * Connection and socket errors now display notifications and return users to the dashboard when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->