### PR TITLE
fix: allow members to manage their own notifications

### DIFF
--- a/server/routes/notificationRoutes.js
+++ b/server/routes/notificationRoutes.js
@@ -30,7 +30,7 @@ notificationRouter.get(
 notificationRouter.patch(
   "/mark-all-read",
   writeLimiter,
-  requirePermission("notifications", "manage"),
+  requirePermission("notifications", "self_manage"),
   markAllAsRead,
 );
 notificationRouter.patch(
@@ -54,7 +54,7 @@ notificationRouter.put(
 notificationRouter.delete(
   "/:id",
   writeLimiter,
-  requirePermission("notifications", "manage"),
+  requirePermission("notifications", "self_manage"),
   deleteNotification,
 );
 

--- a/server/utils/rbacPermissions.js
+++ b/server/utils/rbacPermissions.js
@@ -99,6 +99,7 @@ export const PERMISSIONS = {
   notifications: {
     view: ["owner", "admin", "moderator", "member", "guest"],
     manage: ["owner", "admin"],
+    self_manage: ["owner", "admin", "moderator", "member", "guest"],
   },
   // Audit Logs permissions
   audit_logs: {


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the notification permission flow by allowing members to manage their own notifications while preserving existing administrative permissions.

### Changes Made
- Added a new `notifications.self_manage` RBAC permission for authenticated users.
- Updated the following routes to use `self_manage`:
  - `PATCH /api/notifications/mark-all-read`
  - `DELETE /api/notifications/:id`
- Kept the existing `notifications.manage` permission unchanged for admin-only actions.
- Leveraged the existing ownership checks in the notification controller (`user: req.user.id`) to ensure users can only modify their own notifications.

---

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

---

## Related Issue

Closes #617

---

## Testing

### Testing Performed
- Verified `npm run lint` passes successfully.
- Verified `npm run build` completes successfully.
- Confirmed members can:
  - Mark all of their own notifications as read.
  - Delete their own notifications.
- Confirmed existing admin-only notification permissions remain unchanged.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

---

## Screenshots

Not applicable (backend permission change).

---

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required (not required)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notification permissions so authorized users can mark all notifications as read or delete their own notifications without requiring broader notification-management access.
  * Added a self-service notification permission and enabled it for the relevant notification actions across supported roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->