### PR TITLE
fix: allow members to update their own profile

### DIFF
--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -23,14 +23,14 @@ userRouter.use(apiLimiter);
 userRouter.get(
   "/data",
   userAuth,
-  requirePermission("settings", "view"),
+  requirePermission("settings", "self_view"),
   getUserData,
 );
 userRouter.put(
   "/update",
   userAuth,
   writeLimiter,
-  requirePermission("settings", "edit"),
+  requirePermission("settings", "self_edit"),
   updateUserProfile,
 );
 

--- a/server/utils/rbacPermissions.js
+++ b/server/utils/rbacPermissions.js
@@ -68,6 +68,8 @@ export const PERMISSIONS = {
   settings: {
     view: ["owner", "admin", "moderator"],
     edit: ["owner", "admin"],
+    self_view: ["owner", "admin", "moderator", "member", "guest"],
+    self_edit: ["owner", "admin", "moderator", "member", "guest"],
   },
   // Reports permissions
   reports: {


### PR DESCRIPTION
# Pull Request

## Description

This PR allows members to update and view their own profile without requiring organization-level settings permissions, while keeping existing administrative permissions intact.

### Changes Made
- Added new `settings.self_view` and `settings.self_edit` RBAC permissions for authenticated users.
- Updated the following routes:
  - `GET /api/user/data` → `settings.self_view`
  - `PUT /api/user/update` → `settings.self_edit`
- Kept the existing `settings.edit` permission unchanged for organization-level settings.
- Reused the existing controller ownership checks (`req.user.id`) to ensure users can only access and update their own profile.

---

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

---

## Related Issue

Closes #616

---

## Testing

### Testing Performed
- Verified `npm run lint` passes successfully.
- Verified `npm run build` completes successfully.
- Confirmed members can:
  - View their own profile.
  - Update their own profile.
- Confirmed organization-level settings remain protected.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new errors or warnings introduced

---

## Screenshots

Not applicable (backend RBAC change).

---

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required (not required)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review