### PR TITLE
fix: replace hardcoded localhost URL in Google Calendar integration

### DIFF
--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -126,8 +126,9 @@ const Calendar = () => {
           <div className="flex items-center gap-3 w-full md:w-auto">
             <button
               onClick={() => {
-                window.location.href =
-                  "http://localhost:4000/api/auth/google-calendar";
+                const backendUrl =
+                  import.meta.env.VITE_BACKEND_URL || "http://localhost:4000";
+                window.location.href = `${backendUrl}/api/auth/google-calendar`;
               }}
               className="inline-flex items-center gap-2 px-4 py-2 text-xs font-bold text-slate-700 bg-white border border-slate-200 hover:bg-slate-50 active:bg-slate-100 rounded-xl transition-all shadow-sm cursor-pointer w-full md:w-auto justify-center"
             >


### PR DESCRIPTION
# Pull Request

## Description

This PR replaces the hardcoded localhost backend URL used for Google Calendar synchronization with the configured backend environment variable, ensuring the feature works correctly in both local development and production deployments.

### Changes Made
- Replaced the hardcoded `http://localhost:4000` URL in `client/src/pages/Calendar.jsx`.
- Used the existing environment configuration pattern:
  - `import.meta.env.VITE_BACKEND_URL || "http://localhost:4000"`
- Preserved local development by retaining the localhost fallback.

---

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

---

## Related Issue

Closes #626

---

## Testing

### Testing Performed
- Verified `npm run lint` passes successfully.
- Verified `npm run build` completes successfully.
- Confirmed the Google Calendar sync redirect now uses the configured backend URL.
- Confirmed localhost fallback continues to work for local development.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new errors or warnings introduced

---

## Screenshots

Not applicable (configuration change).

---

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required (not required)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review