### PR TITLE
fix: correct organization navigation route in membership requests

### DIFF
--- a/client/src/pages/MembershipRequests.jsx
+++ b/client/src/pages/MembershipRequests.jsx
@@ -96,7 +96,7 @@ const MembershipRequests = () => {
   };
 
   const handleViewOrganization = (organizationSlug) => {
-    navigate(`/organization/${organizationSlug}`);
+    navigate(`/organizations/${organizationSlug}`);
   };
 
   const formatDate = (dateString) => {


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the organization navigation link in the Membership Requests page by updating it to use the correct public organization route.

### Changes Made
- Updated the navigation path in `client/src/pages/MembershipRequests.jsx`.
- Replaced:
  - `/organization/:slug`
- With:
  - `/organizations/:slug`
- Aligned the navigation with the existing route defined in `client/src/routes/PublicRoutes.jsx`.

---

## Type of Change

- [x] Bug Fix

---

## Related Issue

Closes #625

---

## Testing

### Testing Performed
- Verified `npm run lint` passes successfully.
- Verified `npm run build` completes successfully.
- Confirmed organization links from the Membership Requests page navigate to the correct public organization route.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new errors or warnings introduced

---

## Screenshots

Not applicable (routing fix).

---

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required (not required)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review