### PR TITLE
fix(auth): correct permission checks for accepting and rejecting invitations

### DIFF
--- a/server/routes/invitationRoutes.js
+++ b/server/routes/invitationRoutes.js
@@ -45,14 +45,12 @@ router.post(
   "/:token/accept",
   userAuth,
   writeLimiter,
-  requirePermission("organizations", "leave"),
   acceptInvitation,
 );
 router.post(
   "/:token/reject",
   userAuth,
   writeLimiter,
-  requirePermission("organizations", "leave"),
   rejectInvitation,
 );
 router.delete(


### PR DESCRIPTION
## Problem
Currently, accepting (`/:token/accept`) or rejecting (`/:token/reject`) an organization invitation requires the `organizations:leave` permission check. This is an unrelated permission that prevents legitimate external users (who do not belong to the organization and thus lack the leave permission) from accepting or declining invitations.

## Solution
Removed the `requirePermission("organizations", "leave")` middleware from the acceptance and rejection routes in `server/routes/invitationRoutes.js`. No additional organization-level permission check is required on the routes themselves because:
- The endpoints are guarded by the `userAuth` middleware to ensure the caller is logged in.
- The `InvitationService` explicitly checks that the authenticated user's email matches the recipient's email before proceeding with acceptance or rejection.

## Changes
- **Modified**: [invitationRoutes.js](file:///c:/Users/shrut/Downloads/MeetOnMemory/server/routes/invitationRoutes.js)
  - Removed `requirePermission("organizations", "leave")` check from the accept and reject invitation routes.

## Verification
- Ran the unit tests using Vitest (`npm run test:unit`) to confirm the invitation service unit tests pass successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation acceptance and rejection actions are now accessible without requiring the organization-leave permission.
  * Existing authentication and rate-limiting protections remain in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->