### PR TITLE
fix(router): replace catch-all redirect with dedicated 404 page (Closes #630)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,7 +7,8 @@ import "react-toastify/dist/ReactToastify.css";
 import PublicRoutes from "./routes/PublicRoutes.jsx";
 import ProtectedRoutes from "./routes/ProtectedRoutes.jsx";
 
-import Home from "./pages/Home.jsx"; // 👈 Fallback page
+import Home from "./pages/Home.jsx";
+import NotFound from "./pages/NotFound.jsx";
 
 import Navbar from "./components/Navbar";
 import ScrollNavigator from "./components/ScrollNavigator";
@@ -48,8 +49,8 @@ const App = () => {
           <Routes>
             {PublicRoutes}
             {ProtectedRoutes}
-            {/* ✅ Fallback route — send unknown routes to Home */}
-            <Route path="*" element={<Home />} />
+            {/* ✅ Fallback route — send unknown routes to 404 */}
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
 

--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Navbar from "../components/Navbar";
+
+const NotFound = () => {
+  return (
+    <div className="relative min-h-screen flex flex-col bg-white dark:bg-gray-900">
+      <Navbar />
+      <div className="flex-grow flex flex-col items-center justify-center p-8 text-center pt-24">
+        <h1 className="text-6xl font-bold text-gray-900 dark:text-gray-100 mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-300 mb-6">Page Not Found</h2>
+        <p className="text-gray-600 dark:text-gray-400 max-w-md mb-8">
+          The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.
+        </p>
+        <Link
+          to="/"
+          className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 font-medium"
+        >
+          Go Home
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Summary

Replaces the catch-all homepage fallback with a dedicated 404 page.

## Changes

- Added a dedicated `NotFound` page.
- Updated the wildcard route in `client/src/App.jsx` to render the 404 page.
- Preserved all existing valid routes and deep-link behaviour.

## Testing

- ✅ npm run lint
- ✅ npm run build

## Closes

Closes #630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 page for unavailable or invalid URLs.
  * Included a “Go Home” link to help visitors return to the landing page.

* **Bug Fixes**
  * Updated unmatched routes to display the 404 page instead of incorrectly loading the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->