### PR TITLE
authorize access to private organizations on organization endpoints #611

### DIFF
--- a/server/controllers/organizationController.js
+++ b/server/controllers/organizationController.js
@@ -278,8 +278,10 @@ export const createOrganization = async (req, res) => {
 export const getOrganizations = async (req, res) => {
   try {
     const { visibility, page = 1, limit = 20 } = req.query;
+    const userId = req.user?.id || null;
 
     const result = await OrganizationService.getOrganizations(
+      userId,
       visibility,
       page,
       limit,
@@ -298,8 +300,10 @@ export const getOrganizations = async (req, res) => {
  */
 export const getOrganizationById = async (req, res) => {
   try {
+    const userId = req.user?.id || null;
     const result = await OrganizationService.getOrganizationById(
       req.params.idOrSlug,
+      userId,
     );
 
     sendSuccess(res, result);

--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -400,6 +400,10 @@ export const getPublicOrganizationBySlug = async (slug) => {
     throw new NotFoundError("Organization not found.");
   }
 
+  if (organization.visibility !== "public") {
+    throw new ForbiddenError("Not authorized to access this organization.");
+  }
+
   // Get member count from Membership model (without exposing member details)
   const memberCount = await Membership.countDocuments({
     organization: organization._id,
@@ -670,7 +674,7 @@ export const createOrganization = async (
 /**
  * ✅ Get All Organizations (Paginated)
  */
-export const getOrganizations = async (visibility, page = 1, limit = 20) => {
+export const getOrganizations = async (userId, visibility, page = 1, limit = 20) => {
   // Validate visibility value
   const validVisibility =
     visibility && isValidVisibility(visibility)
@@ -684,10 +688,43 @@ export const getOrganizations = async (visibility, page = 1, limit = 20) => {
   const pageNum = Math.max(1, parseInt(page) || 1);
   const limitNum = Math.min(100, Math.max(1, parseInt(limit) || 20));
 
-  // Build safe query filter with only validated values
+  const userOrgIds = [];
+  if (userId) {
+    const userMemberships = await Membership.find({
+      user: userId,
+      status: "active",
+    }).select("organization").lean();
+    userOrgIds.push(...userMemberships.map((m) => m.organization));
+  }
+
+  // Build safe query filter with only validated values and authorized access
   const safeFilter = {};
   if (validVisibility) {
-    safeFilter.visibility = validVisibility;
+    if (validVisibility === "public") {
+      safeFilter.visibility = "public";
+    } else {
+      if (!userId) {
+        safeFilter._id = null;
+      } else {
+        safeFilter.visibility = validVisibility;
+        safeFilter.$or = [
+          { owner: userId },
+          { _id: { $in: userOrgIds } },
+          { members: userId },
+        ];
+      }
+    }
+  } else {
+    if (!userId) {
+      safeFilter.visibility = "public";
+    } else {
+      safeFilter.$or = [
+        { visibility: "public" },
+        { owner: userId },
+        { _id: { $in: userOrgIds } },
+        { members: userId },
+      ];
+    }
   }
 
   const organizations = await Organization.find(safeFilter)
@@ -798,7 +835,7 @@ export const getOrganizationSettings = async (userId, orgIdOrSlug = null) => {
 /**
  * ✅ Get Organization by ID or Slug
  */
-export const getOrganizationById = async (idOrSlug) => {
+export const getOrganizationById = async (idOrSlug, userId) => {
   // Validate input - only allow alphanumeric, hyphens, and underscores for slug
   const slugRegex = /^[a-zA-Z0-9-_]+$/;
   if (!slugRegex.test(idOrSlug)) {
@@ -813,7 +850,7 @@ export const getOrganizationById = async (idOrSlug) => {
 
   const organization = await Organization.findOne(query)
     .select(
-      "name slug description about website contactEmail industry location logo visibility joinPolicy owner createdAt updatedAt metadata",
+      "name slug description about website contactEmail industry location logo visibility joinPolicy owner members createdAt updatedAt metadata",
     )
     .populate("owner", "name email")
     .lean();
@@ -822,17 +859,42 @@ export const getOrganizationById = async (idOrSlug) => {
     throw new NotFoundError("Organization not found.");
   }
 
+  // Authorize access to private/invite-only organizations
+  if (organization.visibility !== "public") {
+    if (!userId) {
+      throw new ForbiddenError("Not authorized to access this organization.");
+    }
+
+    const isOwner = organization.owner?._id
+      ? organization.owner._id.toString() === userId.toString()
+      : organization.owner?.toString() === userId.toString();
+
+    const membership = await Membership.findOne({
+      user: userId,
+      organization: organization._id,
+      status: "active",
+    }).lean();
+
+    const isLegacy = isLegacyMember(organization, userId);
+
+    if (!isOwner && !membership && !isLegacy) {
+      throw new ForbiddenError("Not authorized to access this organization.");
+    }
+  }
+
   const memberCount = await Membership.countDocuments({
     organization: organization._id,
     status: "active",
   });
 
+  const { members, ...organizationData } = organization;
+
   return {
     success: true,
     organization: {
-      ...organization,
+      ...organizationData,
       memberCount:
-        memberCount || (organization.members ? organization.members.length : 1),
+        memberCount || (members ? members.length : 1),
     },
   };
 };

--- a/server/tests/OrganizationService.test.js
+++ b/server/tests/OrganizationService.test.js
@@ -591,4 +591,178 @@ describe("OrganizationService", () => {
       ).rejects.toThrow("Invalid website URL format.");
     });
   });
+
+  // ── getPublicOrganizationBySlug ─────────────────────────────
+  describe("getPublicOrganizationBySlug", () => {
+    it("should return public organization when it is public", async () => {
+      const mockOrg = {
+        _id: "org1",
+        name: "Public Org",
+        slug: "public-org",
+        visibility: "public",
+        metadata: { website: "https://example.com" },
+      };
+      Organization.findOne.mockResolvedValue(mockOrg);
+      Membership.countDocuments.mockResolvedValue(3);
+
+      const result = await OrganizationService.getPublicOrganizationBySlug("public-org");
+      expect(result.success).toBe(true);
+      expect(result.organization.name).toBe("Public Org");
+      expect(result.organization.memberCount).toBe(3);
+    });
+
+    it("should throw ForbiddenError when organization is private", async () => {
+      const mockOrg = {
+        _id: "org2",
+        name: "Private Org",
+        slug: "private-org",
+        visibility: "private",
+      };
+      Organization.findOne.mockResolvedValue(mockOrg);
+
+      await expect(
+        OrganizationService.getPublicOrganizationBySlug("private-org")
+      ).rejects.toThrow("Not authorized to access this organization.");
+    });
+  });
+
+  // ── getOrganizations (Paginated) ───────────────────────────
+  describe("getOrganizations", () => {
+    it("should return public organizations for unauthorized/anonymous access", async () => {
+      const mockOrgs = [{ _id: "org1", name: "Public Org", visibility: "public" }];
+      const mockQueryChain = {
+        sort: vi.fn().mockReturnThis(),
+        skip: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrgs),
+      };
+      Organization.find.mockReturnValue(mockQueryChain);
+      Organization.countDocuments.mockResolvedValue(1);
+
+      const result = await OrganizationService.getOrganizations(null, "public", 1, 20);
+      expect(result.success).toBe(true);
+      expect(result.organizations).toHaveLength(1);
+      expect(Organization.find).toHaveBeenCalledWith(expect.objectContaining({ visibility: "public" }));
+    });
+
+    it("should filter by user memberships when requesting private/invite-only organizations", async () => {
+      const mockOrgs = [{ _id: "org2", name: "My Private Org", visibility: "private" }];
+      const mockQueryChain = {
+        sort: vi.fn().mockReturnThis(),
+        skip: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrgs),
+      };
+      Organization.find.mockReturnValue(mockQueryChain);
+      Organization.countDocuments.mockResolvedValue(1);
+      Membership.find.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue([{ organization: "org2" }]),
+      });
+
+      const result = await OrganizationService.getOrganizations("user123", "private", 1, 20);
+      expect(result.success).toBe(true);
+      expect(result.organizations).toHaveLength(1);
+      expect(Membership.find).toHaveBeenCalledWith({ user: "user123", status: "active" });
+      expect(Organization.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          visibility: "private",
+          $or: expect.any(Array),
+        })
+      );
+    });
+  });
+
+  // ── getOrganizationById ─────────────────────────────────────
+  describe("getOrganizationById", () => {
+    it("should return public organization metadata to any user", async () => {
+      const mockOrg = {
+        _id: "org1",
+        name: "Public Org",
+        visibility: "public",
+        members: ["user1"],
+      };
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        populate: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrg),
+      };
+      Organization.findOne.mockReturnValue(mockQuery);
+      Membership.countDocuments.mockResolvedValue(1);
+
+      const result = await OrganizationService.getOrganizationById("org1", "user2");
+      expect(result.success).toBe(true);
+      expect(result.organization.name).toBe("Public Org");
+    });
+
+    it("should return private organization metadata to its owner", async () => {
+      const mockOrg = {
+        _id: "org2",
+        name: "Private Org",
+        visibility: "private",
+        owner: { _id: "owner123", name: "Owner" },
+        members: ["owner123"],
+      };
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        populate: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrg),
+      };
+      Organization.findOne.mockReturnValue(mockQuery);
+      Membership.countDocuments.mockResolvedValue(1);
+
+      const result = await OrganizationService.getOrganizationById("org2", "owner123");
+      expect(result.success).toBe(true);
+      expect(result.organization.name).toBe("Private Org");
+    });
+
+    it("should return private organization metadata to its member", async () => {
+      const mockOrg = {
+        _id: "org2",
+        name: "Private Org",
+        visibility: "private",
+        owner: "owner123",
+        members: [],
+      };
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        populate: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrg),
+      };
+      Organization.findOne.mockReturnValue(mockQuery);
+      Membership.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue({ user: "member123", status: "active" }),
+      });
+      Membership.countDocuments.mockResolvedValue(2);
+
+      const result = await OrganizationService.getOrganizationById("org2", "member123");
+      expect(result.success).toBe(true);
+      expect(result.organization.name).toBe("Private Org");
+    });
+
+    it("should throw ForbiddenError when non-member requests private organization", async () => {
+      const mockOrg = {
+        _id: "org2",
+        name: "Private Org",
+        visibility: "private",
+        owner: "owner123",
+        members: [],
+      };
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        populate: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue(mockOrg),
+      };
+      Organization.findOne.mockReturnValue(mockQuery);
+      Membership.findOne.mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      });
+
+      await expect(
+        OrganizationService.getOrganizationById("org2", "intruder123")
+      ).rejects.toThrow("Not authorized to access this organization.");
+    });
+  });
 });

--- a/server/tests/organizationController.test.js
+++ b/server/tests/organizationController.test.js
@@ -3,6 +3,8 @@ import {
   createOrJoinOrganization,
   getOrganizationSettings,
   updateOrganization,
+  getOrganizations,
+  getOrganizationById,
 } from "../controllers/organizationController.js";
 import * as OrganizationService from "../services/OrganizationService.js";
 
@@ -11,6 +13,8 @@ vi.mock("../services/OrganizationService.js", () => ({
   createOrJoinOrganization: vi.fn(),
   getOrganizationSettings: vi.fn(),
   updateOrganization: vi.fn(),
+  getOrganizations: vi.fn(),
+  getOrganizationById: vi.fn(),
 }));
 
 describe("organizationController - createOrJoinOrganization", () => {
@@ -211,5 +215,45 @@ describe("organizationController - getOrganizationSettings & updateOrganization"
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true }),
     );
+  });
+
+  describe("organizationController - getOrganizations & getOrganizationById", () => {
+    it("getOrganizations should fetch user's accessible organizations", async () => {
+      req.query = { visibility: "private", page: "1", limit: "10" };
+      const mockResult = {
+        success: true,
+        organizations: [{ _id: "org1", name: "Org 1" }],
+      };
+      OrganizationService.getOrganizations.mockResolvedValue(mockResult);
+
+      await getOrganizations(req, res);
+
+      expect(OrganizationService.getOrganizations).toHaveBeenCalledWith(
+        "user123",
+        "private",
+        "1",
+        "10"
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining(mockResult));
+    });
+
+    it("getOrganizationById should fetch organization by ID passing user context", async () => {
+      req.params.idOrSlug = "org123";
+      const mockResult = {
+        success: true,
+        organization: { _id: "org123", name: "Org 1" },
+      };
+      OrganizationService.getOrganizationById.mockResolvedValue(mockResult);
+
+      await getOrganizationById(req, res);
+
+      expect(OrganizationService.getOrganizationById).toHaveBeenCalledWith(
+        "org123",
+        "user123"
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining(mockResult));
+    });
   });
 });


### PR DESCRIPTION
Changes
Service Layer (
OrganizationService.js
):

getPublicOrganizationBySlug(slug): Restricts lookup to only public organizations. Returns a ForbiddenError if the requested organization's visibility is private or invite-only.
getOrganizations(userId, visibility, page, limit): Restricts paginated lists of private/invite-only organizations to only those where the requesting user is a member (checked via Membership collection), the owner, or part of the legacy members list. Public organizations remain visible.
getOrganizationById(idOrSlug, userId): Restricts organization metadata lookup to authorized users (owner, active member, or legacy member) if the organization visibility is not public. Excludes the legacy members array from the returned data to avoid leaking member details.
Controller Layer (
organizationController.js
):

Updated getOrganizations and getOrganizationById controller methods to extract req.user.id and pass it down to the service layer.
Automated Tests:

Added unit tests to 
OrganizationService.test.js
 verifying privacy enforcement for public slug lookup, paginated lists, and lookups by ID/slug.
Added unit tests to 
organizationController.test.js
 to check controller-to-service delegation of user context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization listings and details now respect visibility and user access permissions.
  * Public organizations remain accessible to everyone, while private and invite-only organizations are limited to owners and authorized members.
  * Organization details include a member count without exposing member records.
  * Unauthorized access to restricted organizations is now blocked.

* **Tests**
  * Added coverage for visibility filtering, authorization, pagination, and controller responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->