### PR TITLE
fix(tasks): enable task status updates from the Tasks page (Closes #629)

### DIFF
--- a/client/src/components/tasks/TaskCard.jsx
+++ b/client/src/components/tasks/TaskCard.jsx
@@ -1,14 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Calendar,
   User,
   Building2,
   FileText,
   ExternalLink,
+  ChevronDown,
+  Loader2,
 } from "lucide-react";
 import { STATUS_STYLES, PRIORITY_STYLES } from "../../utils/taskStyles";
 
-export default function TaskCard({ task, setSelectedTask, navigate }) {
+export default function TaskCard({
+  task,
+  setSelectedTask,
+  navigate,
+  updateTaskStatus,
+}) {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const handleStatusChange = async (e) => {
+    e.stopPropagation();
+    const newStatus = e.target.value;
+    if (updateTaskStatus && newStatus !== task.status) {
+      setIsUpdating(true);
+      await updateTaskStatus(task.id, newStatus);
+      setIsUpdating(false);
+    }
+  };
+
   const statusStyle = STATUS_STYLES[task.status] || STATUS_STYLES["open"];
   const priorityStyle =
     PRIORITY_STYLES[task.priority] || PRIORITY_STYLES.medium;
@@ -43,12 +62,37 @@ export default function TaskCard({ task, setSelectedTask, navigate }) {
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-slate-600 dark:text-slate-400">
             {/* Status */}
-            <span
-              className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-xs font-medium border ${statusStyle.bgColor} ${statusStyle.textColor} ${statusStyle.borderColor}`}
-            >
-              <StatusIcon className="w-3.5 h-3.5" />
-              {statusStyle.label}
-            </span>
+            <div className="relative inline-flex items-center">
+              {isUpdating ? (
+                <Loader2
+                  className={`absolute left-2 w-3.5 h-3.5 animate-spin ${statusStyle.textColor}`}
+                />
+              ) : (
+                <StatusIcon
+                  className={`absolute left-2 w-3.5 h-3.5 pointer-events-none ${statusStyle.textColor}`}
+                />
+              )}
+              <select
+                value={task.status}
+                onClick={(e) => e.stopPropagation()}
+                onChange={handleStatusChange}
+                disabled={isUpdating}
+                className={`appearance-none pl-7 pr-6 py-1 rounded-lg text-xs font-medium border cursor-pointer outline-none focus:ring-2 focus:ring-blue-500/50 transition-colors disabled:opacity-70 disabled:cursor-not-allowed ${statusStyle.bgColor} ${statusStyle.textColor} ${statusStyle.borderColor}`}
+              >
+                {Object.entries(STATUS_STYLES).map(([statusKey, style]) => (
+                  <option
+                    key={statusKey}
+                    value={statusKey}
+                    className="bg-white dark:bg-slate-900 text-slate-900 dark:text-white"
+                  >
+                    {style.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown
+                className={`absolute right-2 w-3 h-3 pointer-events-none opacity-70 ${statusStyle.textColor}`}
+              />
+            </div>
 
             {/* Due Date */}
             {task.dueDate && (

--- a/client/src/hooks/useTasks.js
+++ b/client/src/hooks/useTasks.js
@@ -178,6 +178,28 @@ export default function useTasks() {
     }
   };
 
+  const updateTaskStatus = async (taskId, newStatus) => {
+    try {
+      const res = await knowledgeApi.updateActionItemStatus(taskId, newStatus);
+      if (res.data?.success) {
+        setTasks((prev) =>
+          prev.map((t) => (t.id === taskId ? { ...t, status: newStatus } : t)),
+        );
+        toast.success("Task status updated");
+        return true;
+      } else {
+        toast.error(res.data?.message || "Failed to update task status");
+        return false;
+      }
+    } catch (err) {
+      console.error("Error updating task status:", err);
+      toast.error(
+        err.response?.data?.message || "Failed to update task status",
+      );
+      return false;
+    }
+  };
+
   const clearFilters = () => {
     setSearchQuery("");
     setStatusFilter("all");
@@ -217,6 +239,7 @@ export default function useTasks() {
     assignedUsers,
     sortedTasks,
     handleSort,
+    updateTaskStatus,
     clearFilters,
     hasActiveFilters,
   };

--- a/client/src/pages/Tasks.jsx
+++ b/client/src/pages/Tasks.jsx
@@ -104,6 +104,7 @@ const Tasks = () => {
                 task={task}
                 setSelectedTask={taskState.setSelectedTask}
                 navigate={navigate}
+                updateTaskStatus={taskState.updateTaskStatus}
               />
             ))}
           </div>

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -5,6 +5,8 @@ export const knowledgeApi = {
     apiClient.get(
       `/api/knowledge/action-items?status=${status}&sortBy=${sortBy}`,
     ),
+  updateActionItemStatus: (id, status) =>
+    apiClient.patch(`/api/knowledge/action-items/${id}`, { status }),
   getDecisions: (sortBy = "createdAt", status) =>
     apiClient.get(
       `/api/knowledge/decisions?sortBy=${sortBy}${status ? `&status=${status}` : ""}`,


### PR DESCRIPTION
## Summary

This PR enables updating task statuses directly from the Tasks page by integrating the existing backend PATCH endpoint.

## Changes

* Added an `updateActionItemStatus` API helper in `client/src/services/knowledgeApi.js`.
* Implemented task status update logic in `client/src/hooks/useTasks.js`.
* Passed the update handler through `client/src/pages/Tasks.jsx`.
* Replaced the read-only status badge in `client/src/components/tasks/TaskCard.jsx` with a status selector that reuses the existing `STATUS_STYLES` configuration.
* Updated the UI to refresh task state after a successful status update.

## Testing

* ✅ `npm run lint`
* ✅ `npm run build`
* ✅ Formatted modified files with Prettier

## Issue

Closes #629
