### PR TITLE
fix(auth): allow users to submit membership requests (Closes #619)

### DIFF
--- a/server/routes/membershipRequestRoutes.js
+++ b/server/routes/membershipRequestRoutes.js
@@ -26,7 +26,6 @@ router.use(userAuth);
 router.post(
   "/",
   writeLimiter,
-  requirePermission("team_members", "invite"),
   createMembershipRequest,
 );
 
@@ -59,7 +58,6 @@ router.patch(
 router.patch(
   "/:id/cancel",
   writeLimiter,
-  requirePermission("team_members", "invite"),
   cancelMembershipRequest,
 );
 


### PR DESCRIPTION

## Summary

This PR fixes the membership request permission logic by removing the invitation permission requirement from user-initiated membership request routes.

## Changes

* Removed the `team_members.invite` permission check from the membership request creation route.
* Removed the `team_members.invite` permission check from the membership request cancellation route.
* Kept authentication via `userAuth` intact.
* Preserved administrator-only permissions for approving and rejecting membership requests.

## Result

* ✅ Authenticated users can submit membership requests.
* ✅ Users can cancel their own pending membership requests.
* ✅ Invitation and approval permissions remain restricted to organization administrators.
* ✅ Existing approval workflow continues to function as before.

## Testing

* Reviewed route protection to ensure only the intended middleware was removed.
* Verified that approval and rejection endpoints continue to require `team_members.invite`.
* Confirmed that request ownership and duplicate request validation remain enforced by the existing service layer.

## Issue

Closes #619
