### PR TITLE
Exit server process when MongoDB connection fails

### DIFF
--- a/server/config/mongodb.js
+++ b/server/config/mongodb.js
@@ -2,14 +2,19 @@ import mongoose from "mongoose";
 
 const connectDB = async () => {
   try {
-    mongoose.connection.on("connected", () =>
-      console.log("Database connected"),
-    );
+    mongoose.connection.on("connected", () => {
+      console.log("Database connected");
+    });
 
     const rawUri =
       process.env.NODE_ENV === "test" && process.env.TEST_MONGODB_URI
         ? process.env.TEST_MONGODB_URI
         : process.env.MONGODB_URI;
+
+    if (!rawUri) {
+      console.error("MongoDB URI is not set in environment variables.");
+      process.exit(1);
+    }
 
     // Strip trailing slash to avoid double-slash database name
     const dbUri = rawUri.endsWith("/") ? rawUri.slice(0, -1) : rawUri;
@@ -23,19 +28,23 @@ const connectDB = async () => {
     const connectionUri = uriPathSegments > 3 ? dbUri : `${dbUri}/${dbName}`;
 
     await mongoose.connect(connectionUri);
+
     const sanitizedUri = dbUri.replace(
       /(mongodb(?:\+srv)?:\/\/[^:]+:)([^@]+)(@)/,
-      "$1****$3",
+      "$1****$3"
     );
 
     // Extract and log the resolved database name
     const resolvedDbName = connectionUri.split("/").pop();
     console.log("Mongo URI:", sanitizedUri);
     console.log("Database:", resolvedDbName);
-} catch (error) {
+  } catch (error) {
     console.error("MongoDB connection failed:", error.message);
-    console.error("Exiting process because the server cannot run without a database connection.");
+    console.error(
+      "Exiting process because the server cannot run without a database connection."
+    );
     process.exit(1);
-  }};
+  }
+};
 
 export default connectDB;

--- a/server/config/mongodb.js
+++ b/server/config/mongodb.js
@@ -32,12 +32,10 @@ const connectDB = async () => {
     const resolvedDbName = connectionUri.split("/").pop();
     console.log("Mongo URI:", sanitizedUri);
     console.log("Database:", resolvedDbName);
-  } catch (error) {
+} catch (error) {
     console.error("MongoDB connection failed:", error.message);
-    console.warn(
-      "Server running without database connection. Some features may not work.",
-    );
-  }
-};
+    console.error("Exiting process because the server cannot run without a database connection.");
+    process.exit(1);
+  }};
 
 export default connectDB;

--- a/server/config/mongodb.js
+++ b/server/config/mongodb.js
@@ -31,7 +31,7 @@ const connectDB = async () => {
 
     const sanitizedUri = dbUri.replace(
       /(mongodb(?:\+srv)?:\/\/[^:]+:)([^@]+)(@)/,
-      "$1****$3"
+      "$1****$3",
     );
 
     // Extract and log the resolved database name
@@ -41,7 +41,7 @@ const connectDB = async () => {
   } catch (error) {
     console.error("MongoDB connection failed:", error.message);
     console.error(
-      "Exiting process because the server cannot run without a database connection."
+      "Exiting process because the server cannot run without a database connection.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
Updated `server/config/mongodb.js` so the application exits immediately if it fails to connect to MongoDB, instead of continuing to run without a database connection.

## Changes
- In the `catch` block of `connectDB()`, replaced the warning log with a clear error log followed by `process.exit(1)`.
- Since `server.js` already calls `await connectDB()` before configuring Express and mounting routes, the server will now never start listening for requests unless the database connection succeeds.

## Testing
- Verified that with an invalid `MONGODB_URI`, the process logs a clear failure message and exits with code 1 instead of continuing to run.
- Verified that with a valid `MONGODB_URI`, the server connects and starts normally as before.

Fixes #631 

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The server now stops safely when it cannot connect to the database.
  * Added clearer error messaging to indicate that a database connection is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->