### PR TITLE
Fix incorrect default base URL used for export download links

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,7 +1,7 @@
 PORT=4000
 NODE_ENV=development
 CLIENT_URL=http://localhost:5173
-
+BASE_URL=http://localhost:4000
 # Database
 MONGODB_URI=mongodb+srv://<username>:<password>@cluster.mongodb.net/
 

--- a/server/jobs/exportDataJob.js
+++ b/server/jobs/exportDataJob.js
@@ -103,9 +103,8 @@ export default async function exportDataJob(job, _app) {
       expiresIn: "24h",
     });
 
-    // In production, BASE_URL should be configured correctly in .env
-    const baseUrl = process.env.BASE_URL || "http://localhost:3000";
-    const downloadUrl = `${baseUrl}/api/user/download-export/${downloadToken}`;
+// BASE_URL should be set to the server's public URL in .env for production
+    const baseUrl = process.env.BASE_URL || `http://localhost:${process.env.PORT || 4000}`;    const downloadUrl = `${baseUrl}/api/user/download-export/${downloadToken}`;
 
     // Send Email
     const mailOptions = {

--- a/server/jobs/exportDataJob.js
+++ b/server/jobs/exportDataJob.js
@@ -103,8 +103,10 @@ export default async function exportDataJob(job, _app) {
       expiresIn: "24h",
     });
 
-// BASE_URL should be set to the server's public URL in .env for production
-    const baseUrl = process.env.BASE_URL || `http://localhost:${process.env.PORT || 4000}`;    const downloadUrl = `${baseUrl}/api/user/download-export/${downloadToken}`;
+    // BASE_URL should be set to the server's public URL in .env for production
+    const baseUrl =
+      process.env.BASE_URL || `http://localhost:${process.env.PORT || 4000}`;
+    const downloadUrl = `${baseUrl}/api/user/download-export/${downloadToken}`;
 
     // Send Email
     const mailOptions = {


### PR DESCRIPTION
## Summary
Fixed the export download link generation in `server/jobs/exportDataJob.js`, which previously fell back to an incorrect hardcoded default URL (`http://localhost:3000`) when `BASE_URL` was not set, causing broken download links outside local development.

## Changes
- Updated the `baseUrl` fallback in `exportDataJob.js` to use the server's own configured `PORT` (defaulting to `4000`, matching the rest of the backend) instead of the incorrect hardcoded `http://localhost:3000`.
- Added a `BASE_URL` entry to `server/.env.example` so the required environment variable is documented and can be set correctly per environment (e.g. the real production server URL).

## Testing
- Verified that with `BASE_URL` unset locally, the generated download link now correctly points to `http://localhost:4000/api/user/download-export/...`, matching the server's actual port.
- Verified that setting `BASE_URL` in `.env` overrides the default as expected, so production deployments will generate correct download links.

Fixes #632 

@imuniqueshiv I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.