### PR TITLE
Standardize frontend URL environment variable to CLIENT_URL

### DIFF
--- a/server/controllers/slackController.js
+++ b/server/controllers/slackController.js
@@ -125,8 +125,7 @@ export const slackOAuthRedirect = async (req, res, next) => {
   try {
     const { code, state: stateToken, error: slackError } = req.query;
 
-    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
-
+    const frontendUrl = process.env.CLIENT_URL || "http://localhost:5173";
     if (!stateToken || typeof stateToken !== "string") {
       return sendError(res, 400, "Missing OAuth state.");
     }

--- a/server/services/slackService.js
+++ b/server/services/slackService.js
@@ -162,7 +162,7 @@ export const postBlockMessage = async (
  * @returns {Array} Block Kit blocks array
  */
 export const buildMeetingCreatedBlocks = (meeting, createdBy) => {
-  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+  const frontendUrl = process.env.CLIENT_URL || "http://localhost:5173";
   const meetingUrl = `${frontendUrl}/meetings/${meeting._id}`;
 
   return [
@@ -224,7 +224,7 @@ export const buildMeetingCreatedBlocks = (meeting, createdBy) => {
  * @returns {Array} Block Kit blocks array
  */
 export const buildMoMSummaryBlocks = (meeting) => {
-  const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
+  const frontendUrl = process.env.CLIENT_URL || "http://localhost:5173";
   const meetingUrl = `${frontendUrl}/meetings/${meeting._id}`;
   const mom = meeting.structuredMoM || {};
 


### PR DESCRIPTION
## Summary
The backend was using two different environment variable names — `CLIENT_URL` and `FRONTEND_URL` — to refer to the same frontend application URL, depending on which file you looked at. This caused configuration inconsistency and could break OAuth redirects or Slack links in deployments where only one of the two variables was set.

## Changes
- `server/controllers/slackController.js`: Changed `process.env.FRONTEND_URL` to `process.env.CLIENT_URL` in `slackOAuthRedirect`.
- `server/services/slackService.js`: Changed `process.env.FRONTEND_URL` to `process.env.CLIENT_URL` in both `buildMeetingCreatedBlocks` and `buildMoMSummaryBlocks` (this file wasn't listed in the issue's scope, but it had the exact same inconsistency, so it needed the same fix to fully standardize on one variable).
- `server/controllers/authControllers.js` and `server/config/corsOptions.js` were already using `CLIENT_URL` correctly, so no changes were needed there.
- `server/.env.example` already only documents `CLIENT_URL`, so no documentation changes were necessary.

## Testing
- Verified all frontend-URL references across the backend now consistently use `process.env.CLIENT_URL` with the same fallback (`http://localhost:5173`).
- Verified OAuth redirect URLs (Google/Outlook sync in `authControllers.js`) and Slack OAuth/message links (`slackController.js`, `slackService.js`) all resolve from the same single environment variable.
- Verified CORS configuration (`corsOptions.js`) is unaffected since it already used `CLIENT_URL`.

Fixes #633 
@imuniqueshiv 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.