### PR TITLE
fix: resolve Dashboard crash caused by useContainerWidth API (#603)

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -50,7 +50,7 @@ const Dashboard = () => {
   const { t } = useTranslation();
   const { userData } = useContext(AppContent);
   const navigate = useNavigate();
-  const [containerWidth, containerRef] = useContainerWidth();
+  const { width: containerWidth, containerRef } = useContainerWidth();
 
   const [layouts, setLayouts] = useState(null);
   const saveTimeoutRef = useRef(null);

--- a/client/src/pages/__tests__/Dashboard.test.jsx
+++ b/client/src/pages/__tests__/Dashboard.test.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AppContent from "../../context/AppContent";
+import Dashboard from "../Dashboard";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../components/organization/TopContributorsWidget", () => ({
+  default: () => <div data-testid="top-contributors">Top Contributors</div>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+vi.mock("../../services/userApi", () => ({
+  userApi: {
+    getDashboardPreferences: vi.fn().mockResolvedValue({
+      data: { success: true, dashboardPreferences: null },
+    }),
+    updateDashboardPreferences: vi.fn().mockResolvedValue({
+      data: { success: true },
+    }),
+  },
+}));
+
+vi.mock("react-grid-layout/css/styles.css", () => ({}));
+vi.mock("react-resizable/css/styles.css", () => ({}));
+
+// Mirror react-grid-layout@2.x API: useContainerWidth returns an object, not a tuple.
+vi.mock("react-grid-layout", () => ({
+  Responsive: ({ children }) => (
+    <div data-testid="responsive-grid">{children}</div>
+  ),
+  useContainerWidth: () => ({
+    width: 1280,
+    mounted: true,
+    containerRef: { current: null },
+    measureWidth: () => {},
+  }),
+}));
+
+describe("Dashboard", () => {
+  const mockUserData = {
+    name: "Alice",
+    role: "admin",
+    organization: { name: "MeetOnMemory", _id: "org-1" },
+  };
+
+  it("renders without throwing when useContainerWidth returns an object", async () => {
+    render(
+      <MemoryRouter>
+        <AppContent.Provider value={{ userData: mockUserData }}>
+          <Dashboard />
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dashboard hero")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("responsive-grid")).toBeInTheDocument();
+      expect(screen.getByText("dashboard.uploadMeetings")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Closes #603

### Summary

This PR fixes the Dashboard runtime crash caused by incorrect consumption of `useContainerWidth()` from `react-grid-layout@2.2.3`.

### Changes Made

- Updated `useContainerWidth()` to use object destructuring instead of array destructuring.
- Added a focused regression test to ensure the Dashboard renders successfully and prevent similar runtime regressions.

### Root Cause

The installed version of `react-grid-layout` returns an object:

```js
{
  width,
  mounted,
  containerRef,
  measureWidth
}
```

The Dashboard was consuming it using array destructuring, causing a runtime `TypeError` when navigating to the Dashboard.

### Testing

- [x] Verified the Dashboard renders without runtime errors.
- [x] Added a regression test for the Dashboard.
- [x] Rebased onto the latest upstream `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard layout handling to maintain compatibility with the latest responsive grid sizing behavior.

* **Tests**
  * Added coverage confirming the Dashboard renders correctly, including navigation, hero content, responsive grid layout, and translated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->