### PR TITLE
fix: use authenticated user in email verification flow (#604)

### DIFF
--- a/server/controllers/authControllers.js
+++ b/server/controllers/authControllers.js
@@ -73,7 +73,7 @@ export const logout = async (req, res) => {
 // --------------------------- SEND VERIFY OTP ---------------------------
 export const sendVerifyOtp = async (req, res) => {
   try {
-    const { userId } = req;
+    const userId = req.user.id;
 
     await AuthService.sendVerifyOtp(userId);
 
@@ -95,7 +95,7 @@ export const sendVerifyOtp = async (req, res) => {
 // --------------------------- VERIFY EMAIL ---------------------------
 export const verifyEmail = async (req, res) => {
   const { otp } = req.body;
-  const { userId } = req;
+  const userId = req.user.id;
   if (!validateFields({ userId, otp }, res)) return;
 
   try {

--- a/server/tests/authVerifyEmailRegression.test.js
+++ b/server/tests/authVerifyEmailRegression.test.js
@@ -1,0 +1,96 @@
+import { jest } from "@jest/globals";
+
+/**
+ * Regression for Issue #604:
+ * userAuth attaches req.user, but verification handlers previously read
+ * req.userId (always undefined), breaking authenticated email verification.
+ */
+jest.unstable_mockModule("../services/calendarService.js", () => ({
+  getGoogleAuthUrl: jest.fn(),
+}));
+
+jest.unstable_mockModule("../services/AuthService.js", () => ({
+  default: {
+    sendVerifyOtp: jest.fn(),
+    verifyEmail: jest.fn(),
+  },
+}));
+
+const AuthService = (await import("../services/AuthService.js")).default;
+const { sendVerifyOtp, verifyEmail } =
+  await import("../controllers/authControllers.js");
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("Email verification auth identity (#604)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sendVerifyOtp uses req.user.id set by userAuth (not req.userId)", async () => {
+    AuthService.sendVerifyOtp.mockResolvedValue(undefined);
+
+    // Mimic userAuth: only req.user is populated — req.userId is absent.
+    const req = { user: { id: "user-abc-123" } };
+    const res = mockRes();
+
+    await sendVerifyOtp(req, res);
+
+    expect(AuthService.sendVerifyOtp).toHaveBeenCalledWith("user-abc-123");
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: "Verification OTP sent on email",
+      }),
+    );
+  });
+
+  it("verifyEmail uses req.user.id set by userAuth (not req.userId)", async () => {
+    AuthService.verifyEmail.mockResolvedValue(undefined);
+
+    const req = {
+      user: { id: "user-abc-123" },
+      body: { otp: "654321" },
+    };
+    const res = mockRes();
+
+    await verifyEmail(req, res);
+
+    expect(AuthService.verifyEmail).toHaveBeenCalledWith({
+      userId: "user-abc-123",
+      otp: "654321",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: "Email verified successfully!",
+      }),
+    );
+  });
+
+  it("verifyEmail returns Missing details when otp is absent", async () => {
+    const req = {
+      user: { id: "user-abc-123" },
+      body: {},
+    };
+    const res = mockRes();
+
+    await verifyEmail(req, res);
+
+    expect(AuthService.verifyEmail).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Missing details",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Description

Closes #604

### Summary

This PR fixes the email verification flow by using the authenticated user provided by the authentication middleware instead of the undefined `req.userId`.

### Changes Made

- Updated email verification handlers to use `req.user.id`.
- Added a regression test covering the authenticated email verification flow.

### Root Cause

The authentication middleware populates `req.user`, but the verification handlers were still reading `req.userId`, which was always undefined. This caused authenticated email verification requests to fail.

### Testing

- [x] Added regression tests for the email verification flow.
- [x] Verified authentication service tests pass.
- [x] ESLint passes.
- [x] Full backend test suite executed. Existing unrelated Jest ESM failures remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email verification flows by correctly using the authenticated user identity.
  * Preserved existing success and validation responses for OTP sending and email verification.

* **Tests**
  * Added regression coverage for successful verification requests and missing OTP validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->