### PR TITLE
fix: align AI Search frontend endpoint with backend route

### DIFF
--- a/client/src/pages/AiSearch.jsx
+++ b/client/src/pages/AiSearch.jsx
@@ -141,7 +141,7 @@ const AiSearch = () => {
         });
         setResults(res.data.results || []);
       } else {
-        const res = await apiClient.post("/api/ai-search", { query, filters });
+        const res = await apiClient.post("/api/ai", { query, filters });
         const data = res.data;
 
         let sortedResults = data.results || [];

--- a/server/routes/aiRoutes.js
+++ b/server/routes/aiRoutes.js
@@ -14,7 +14,7 @@ const router = express.Router();
 // Apply rate limiting to all routes
 router.use(apiLimiter);
 
-// POST /api/ai-search
+// POST /api/ai
 router.post(
   "/",
   userAuth,

--- a/server/routes/aiRoutes.js
+++ b/server/routes/aiRoutes.js
@@ -37,7 +37,7 @@ router.post(
       logger.info("Received AI search query", {
         userId: req.user ? req.user._id : "anonymous",
         queryLength: query ? query.length : 0,
-        hasFilters: !!filters
+        hasFilters: !!filters,
       });
 
       // ✅ Call vector search with filters
@@ -82,7 +82,7 @@ router.post(
       // ✅ Debug log
       logger.info("Returning authorized AI search results", {
         resultCount: authorizedResults.length,
-        userId: req.user ? req.user._id : "anonymous"
+        userId: req.user ? req.user._id : "anonymous",
       });
 
       // ✅ Send response
@@ -94,7 +94,7 @@ router.post(
     } catch (error) {
       logger.error("AI Search Error", error, {
         userId: req.user ? req.user._id : "anonymous",
-        queryLength: req.body?.query ? req.body.query.length : 0
+        queryLength: req.body?.query ? req.body.query.length : 0,
       });
       res.status(500).json({
         error: error.message || "Search failed",


### PR DESCRIPTION
## 🤖 Fix AI Search API Route Mismatch

Closes #607

---

### Summary

The AI Search feature was completely non-functional in production because the frontend was POSTing to `/api/ai-search` — an endpoint that was never registered on the backend. The backend mounts `aiRoutes.js` at `/api/ai` in `server.js`. This PR aligns the frontend to call the correct route.

---

### Root Cause

| Layer | Endpoint |
|---|---|
| Frontend (`AiSearch.jsx` line 144) | `POST /api/ai-search` ❌ |
| Backend (`server.js` line 91 → `aiRoutes.js`) | `POST /api/ai` ✅ |

Every standard-mode search triggered a 404 because `/api/ai-search` was never mounted. The hybrid search path (`POST /api/search/hybrid`) was unaffected since it uses a separate route.

---

### Changes

#### `client/src/pages/AiSearch.jsx`
- Updated the hardcoded endpoint inside `handleSearch()` from `/api/ai-search` to `/api/ai`:

```diff
- const res = await apiClient.post("/api/ai-search", { query, filters });
+ const res = await apiClient.post("/api/ai", { query, filters });


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated standard AI search requests to use the correct backend endpoint.
  * Preserved the existing request payload shape, including filters and result sorting/handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->