### PR TITLE
fix: align email verification API route (#605)

### DIFF
--- a/client/src/services/__tests__/authApi.test.js
+++ b/client/src/services/__tests__/authApi.test.js
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPost = vi.fn();
+const mockGet = vi.fn();
+
+vi.mock("../apiClient", () => ({
+  default: {
+    post: (...args) => mockPost(...args),
+    get: (...args) => mockGet(...args),
+  },
+}));
+
+import { authApi } from "../authApi";
+
+describe("authApi email verification endpoint (#605)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ data: { success: true } });
+  });
+
+  it("verifyAccount posts to /api/auth/verify-email (matches backend route)", async () => {
+    const payload = { otp: "123456" };
+
+    await authApi.verifyAccount(payload);
+
+    expect(mockPost).toHaveBeenCalledWith("/api/auth/verify-email", payload);
+    expect(mockPost).not.toHaveBeenCalledWith(
+      "/api/auth/verify-account",
+      expect.anything(),
+    );
+  });
+});

--- a/client/src/services/authApi.js
+++ b/client/src/services/authApi.js
@@ -7,7 +7,7 @@ export const authApi = {
   getAuthState: () => apiClient.get("/api/auth/is-auth"),
   getUserData: () => apiClient.get("/api/auth/user-data"),
   sendVerifyOtp: () => apiClient.post("/api/auth/send-verify-otp", {}),
-  verifyAccount: (data) => apiClient.post("/api/auth/verify-account", data),
+  verifyAccount: (data) => apiClient.post("/api/auth/verify-email", data),
   sendResetOtp: (data) => apiClient.post("/api/auth/send-reset-otp", data),
   resetPassword: (data) => apiClient.post("/api/auth/reset-password", data),
 };


### PR DESCRIPTION
## Description

Closes #605

### Summary

This PR aligns the frontend email verification endpoint with the backend route.

### Changes Made

- Updated `authApi.verifyAccount()` to use `/api/auth/verify-email`.
- Added a regression test to verify the correct endpoint is used.

### Root Cause

The frontend was sending email verification requests to `/api/auth/verify-account`, while the backend exposes `/api/auth/verify-email`. This mismatch caused verification requests to fail.

### Testing

- [x] ESLint passed.
- [x] Added regression test for the API endpoint.
- [x] Verified the frontend now targets `/api/auth/verify-email`.
- [ ] Existing unrelated Vitest runner issue prevents the full frontend test suite from completing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account email verification by sending requests to the correct verification endpoint.

* **Tests**
  * Added coverage to confirm the verification request uses the correct endpoint and payload.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->