### PR TITLE
fix: support meetingId in transcript RBAC (#606)

### DIFF
--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -113,7 +113,8 @@ export const requireOwnerOrAdmin = (Model) => {
         });
       }
 
-      const docId = req.params.id;
+      // Prefer :id (meetings/policies); fall back to :meetingId (transcript routes).
+      const docId = req.params.id || req.params.meetingId;
       if (!docId) {
         return res
           .status(400)
@@ -168,7 +169,8 @@ export const requireOwner = (Model) => {
           .json({ success: false, message: "Unauthorized" });
       }
 
-      const docId = req.params.id;
+      // Prefer :id (meetings/policies); fall back to :meetingId (transcript routes).
+      const docId = req.params.id || req.params.meetingId;
       if (!docId) {
         return res
           .status(400)
@@ -224,7 +226,8 @@ export const requireOrgAccess = (Model) => {
         });
       }
 
-      const docId = req.params.id;
+      // Prefer :id (meetings/policies); fall back to :meetingId (transcript routes).
+      const docId = req.params.id || req.params.meetingId;
       if (!docId) {
         return res
           .status(400)

--- a/server/tests/rbacMeetingIdRegression.test.js
+++ b/server/tests/rbacMeetingIdRegression.test.js
@@ -1,0 +1,120 @@
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import { requireOrgAccess } from "../middleware/rbac.js";
+
+/**
+ * Regression for Issue #606:
+ * Transcript routes declare :meetingId while requireOrgAccess historically
+ * only read req.params.id, causing "Document ID required" authorization failures.
+ */
+describe("requireOrgAccess meetingId param (#606)", () => {
+  const meetingId = new mongoose.Types.ObjectId().toString();
+  const orgId = new mongoose.Types.ObjectId().toString();
+  const userId = new mongoose.Types.ObjectId().toString();
+  const otherOrgId = new mongoose.Types.ObjectId().toString();
+
+  const mockRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const createModel = (doc) => ({
+    findById: jest.fn().mockResolvedValue(doc),
+  });
+
+  it("resolves the resource from req.params.meetingId (transcript routes)", async () => {
+    const doc = {
+      _id: meetingId,
+      organization: orgId,
+      uploadedBy: new mongoose.Types.ObjectId().toString(),
+    };
+    const Model = createModel(doc);
+    const middleware = requireOrgAccess(Model);
+    const req = {
+      user: { _id: userId, organization: orgId, role: "member" },
+      params: { meetingId },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(Model.findById).toHaveBeenCalledWith(meetingId);
+    expect(req.doc).toBe(doc);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("still resolves the resource from req.params.id (meeting/policy routes)", async () => {
+    const doc = {
+      _id: meetingId,
+      organization: orgId,
+      uploadedBy: userId,
+    };
+    const Model = createModel(doc);
+    const middleware = requireOrgAccess(Model);
+    const req = {
+      user: { _id: userId, organization: orgId, role: "member" },
+      params: { id: meetingId },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(Model.findById).toHaveBeenCalledWith(meetingId);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks users outside the organization", async () => {
+    const doc = {
+      _id: meetingId,
+      organization: orgId,
+      uploadedBy: new mongoose.Types.ObjectId().toString(),
+    };
+    const Model = createModel(doc);
+    const middleware = requireOrgAccess(Model);
+    const req = {
+      user: { _id: userId, organization: otherOrgId, role: "member" },
+      params: { meetingId },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Forbidden: You don't have access to this resource",
+      }),
+    );
+  });
+
+  it("returns 400 when neither id nor meetingId is present", async () => {
+    const Model = createModel(null);
+    const middleware = requireOrgAccess(Model);
+    const req = {
+      user: { _id: userId, organization: orgId, role: "member" },
+      params: {},
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    await middleware(req, res, next);
+
+    expect(Model.findById).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Document ID required",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Description

Closes #606

### Summary

This PR fixes transcript authorization by allowing the RBAC middleware to resolve transcript routes that use `:meetingId`.

### Changes Made

- Updated RBAC middleware to resolve `req.params.id || req.params.meetingId`.
- Added a regression test covering transcript authorization with `:meetingId`.

### Root Cause

Transcript routes use `:meetingId`, while the RBAC middleware only read `req.params.id`. As a result, the middleware could not resolve the document identifier and returned a `400 Document ID required` error before authorization checks were performed.

### Testing

- [x] ESLint passed.
- [x] RBAC regression tests passed.
- [x] Transcription service tests passed.
- [x] Verified both `:id` and `:meetingId` authorization paths.
- [ ] Existing unrelated local Vitest runner issue still affects `transcriptController.test.js`.