### PR TITLE
fix: Resolve Browse Organizations page overlap with navbar after login

### DIFF
--- a/client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx
+++ b/client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx
@@ -168,7 +168,7 @@ const BrowseOrganizations = () => {
   return (
     <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
       <Navbar />
-      <div className="flex-grow container mx-auto px-4 py-8">
+      <div className="flex-grow container mx-auto px-4 pt-28 pb-8">
         <div className="max-w-7xl mx-auto">
           {/* Header */}
           <div className="text-center mb-8">


### PR DESCRIPTION
## Summary

After logging in, the Discover Organizations page (`/browse-organizations`) content overlaps with the fixed navigation bar due to insufficient top padding.

## Problem

The page container used `py-8` (32px top/bottom padding), but the fixed navbar is 64px. This caused the page hero/header section to render underneath the navbar, creating a cramped and visually broken layout.

## Fix

Changed the container padding from `py-8` to `pt-28 pb-8` (112px top, 32px bottom) to properly clear the fixed navbar. This matches the spacing pattern used consistently across other authenticated pages:

- Dashboard: `pt-28`
- Tasks: `pt-28`
- TeamMembers: `pt-28`
- Profile: `pt-28`
- Settings: `pt-28`
- AiSearch: `pt-28`

## Changes

- `client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx`: Changed container class from `px-4 py-8` to `px-4 pt-28 pb-8`

## Acceptance Criteria

- [x] No content overlaps with the fixed navbar
- [x] Proper top spacing is applied after login
- [x] Layout is consistent with other authenticated pages
- [x] Responsive behavior remains correct

Fixes #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Browse Organizations page spacing to provide more room above the main content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->