### PR TITLE
fix: require authentication before starting google calendar oauth #621

### DIFF
--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -40,7 +40,7 @@ router.get("/is-auth", userAuth, isAuthenticated);
 
 // ✅ Google Calendar Auth
 router.get("/test-123", (req, res) => res.send("working"));
-router.get("/google-calendar", googleCalendarAuth);
+router.get("/google-calendar", userAuth, googleCalendarAuth);
 router.get("/google-calendar/callback", googleCalendarCallback);
 
 export default router;

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -55,4 +55,48 @@ describe("Auth Endpoints", () => {
     const tokenCookie = cookies.find((cookie) => cookie.startsWith("token="));
     expect(tokenCookie).toBeDefined();
   });
+
+  describe("Google Calendar OAuth", () => {
+    beforeAll(() => {
+      process.env.GOOGLE_CLIENT_ID = "mock-client-id";
+      process.env.GOOGLE_CLIENT_SECRET = "mock-client-secret";
+      process.env.GOOGLE_REDIRECT_URI =
+        "http://localhost:4000/api/auth/google-calendar/callback";
+    });
+
+    it("should reject unauthorized request to google-calendar", async () => {
+      const res = await request(app).get("/api/auth/google-calendar");
+      expect(res.statusCode).toEqual(401);
+      expect(res.body).toHaveProperty("success", false);
+      expect(res.body.message).toMatch(/No token found|Please login first/i);
+    });
+
+    it("should redirect for authorized request to google-calendar", async () => {
+      const agent = request.agent(app);
+
+      // Register first
+      const regCsrf = await agent.get("/api/csrf-token");
+      await agent
+        .post("/api/auth/register")
+        .set("X-CSRF-Token", regCsrf.body.csrfToken)
+        .send(testUser);
+
+      // Login to set cookie
+      const loginCsrf = await agent.get("/api/csrf-token");
+      await agent
+        .post("/api/auth/login")
+        .set("X-CSRF-Token", loginCsrf.body.csrfToken)
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      // Make the authorized GET request to /api/auth/google-calendar
+      const res = await agent.get("/api/auth/google-calendar");
+
+      expect(res.statusCode).toEqual(302);
+      expect(res.headers.location).toContain("accounts.google.com");
+      expect(res.headers.location).toContain("client_id=mock-client-id");
+    });
+  });
 });


### PR DESCRIPTION
Resolves #621

### Summary
The Google Calendar OAuth initialization endpoint (`/api/auth/google-calendar`) was previously accessible to unauthorized clients. This PR integrates the `userAuth` middleware on this route so that the OAuth initiation flow can only be started by authenticated users, preventing unauthorized account-linking attempts.

### Changes
- Added `userAuth` middleware to the GET `/google-calendar` endpoint in `server/routes/authRoutes.js`.
- Added unit/integration tests in `server/tests/auth.test.js` to assert that:
  - Unauthorized requests are rejected with a `401` status code.
  - Authorized requests with a valid token cookie redirect to Google's consent screen (302).

### Verification
- Ran backend tests locally via Jest (`npm run test tests/auth.test.js`), and all test cases passed successfully.
- Ran Prettier and ESLint check on the modified files to ensure styling and syntax rules are followed.