### PR TITLE
fix: allow authenticated users to access organization invitation links

### DIFF
--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -46,10 +46,15 @@ const ProtectedRoute = ({
     "/create-organization",
     "/join-organization",
   ];
+  const isJoinWithToken =
+    location.pathname === "/join-organization" &&
+    new URLSearchParams(location.search).has("token");
+
   if (
     userData &&
     userData.hasCompletedOnboarding &&
-    onboardingOnlyPages.includes(location.pathname)
+    onboardingOnlyPages.includes(location.pathname) &&
+    !isJoinWithToken
   ) {
     return <Navigate to="/dashboard" replace />;
   }


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue where authenticated users who have already completed onboarding were redirected away from valid organization invitation links.

### Changes Made

- Added a check to detect invitation links containing a `token` query parameter.
- Allowed authenticated users to access `/join-organization` when a valid invitation token is present.
- Preserved the existing onboarding protection and redirect behavior for all other onboarding-only routes.

## Type of Change

- [x] Bug Fix


## Related Issue

Closes #618

## Testing

### Performed

- Verified authenticated users who have completed onboarding can access organization invitation links.
- Verified existing onboarding redirects continue to work for other onboarding-only pages.
- Confirmed no new warnings or errors were introduced.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (routing/authentication fix).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required (not required for this change)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users with a valid invitation token can now access the organization-joining page, even after completing onboarding.
  * Other onboarding-only pages continue to redirect to the dashboard when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->