### PR TITLE
fix: prevent webhook secrets from being returned in API responses

### DIFF
--- a/server/controllers/webhookController.js
+++ b/server/controllers/webhookController.js
@@ -193,17 +193,13 @@ export const createWebhook = async (req, res, next) => {
 
     const webhook = await Webhook.create(webhookData);
 
+    const webhookResponse = webhook.toObject();
+    delete webhookResponse.secret;
+
     return sendSuccess(
       res,
       {
-        webhook: {
-          _id: webhook._id,
-          organizationId: webhook.organizationId,
-          targetUrl: webhook.targetUrl,
-          events: webhook.events,
-          secret: webhook.secret,
-          isActive: webhook.isActive,
-        },
+        webhook: webhookResponse,
       },
       "Webhook registered successfully.",
       201,
@@ -296,7 +292,14 @@ export const updateWebhook = async (req, res, next) => {
 
     await webhook.save();
 
-    return sendSuccess(res, { webhook }, "Webhook updated successfully.");
+    const webhookResponse = webhook.toObject();
+    delete webhookResponse.secret;
+
+    return sendSuccess(
+      res,
+      { webhook: webhookResponse },
+      "Webhook updated successfully.",
+    );
   } catch (error) {
     next(error);
   }

--- a/server/tests/webhook.test.js
+++ b/server/tests/webhook.test.js
@@ -122,7 +122,7 @@ describe("Webhook Endpoints & Dispatcher", () => {
       expect(res.statusCode).toEqual(201);
       expect(res.body.success).toBe(true);
       expect(res.body.webhook.targetUrl).toBe("https://example.com/webhook");
-      expect(res.body.webhook.secret).toBe("test_secret_key");
+      expect(res.body.webhook.secret).toBeUndefined();
     });
 
     it("should reject webhook creation by non-admin member", async () => {
@@ -193,6 +193,7 @@ describe("Webhook Endpoints & Dispatcher", () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.webhook.targetUrl).toBe("https://example.com/new");
       expect(res.body.webhook.isActive).toBe(false);
+      expect(res.body.webhook.secret).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
# 🔒 Prevent Webhook Secrets from Being Returned in API Responses (#615)

## 📌 Related Issue
Fixes #615

---

## 📝 Description

### 🐛 Problem
Webhook creation (`POST /api/webhooks`) and update (`PATCH /api/webhooks/:id`) endpoints previously exposed the webhook `secret` key in plaintext in HTTP API responses. Exposing signing secrets in responses after creation or update poses a security risk of credential leakage.

### 💡 Solution
1. Sanitized the returned webhook payloads in `createWebhook` and `updateWebhook` controllers inside [server/controllers/webhookController.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/controllers/webhookController.js) by stripping out the `secret` property before returning `sendSuccess(...)`.
2. Ensured that sensitive HMAC signing secrets remain securely persisted in MongoDB while preserving `select: false` on the `Webhook` model schema.
3. Updated test suite assertions in [server/tests/webhook.test.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/tests/webhook.test.js) to verify that `secret` is omitted (`undefined`) in API responses for both webhook creation and updates.

---

## 🔍 Scope of Changes

- **Modified Files:**
  - [`server/controllers/webhookController.js`](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/controllers/webhookController.js): Stripped `secret` from `createWebhook` and `updateWebhook` response objects.
  - [`server/tests/webhook.test.js`](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/tests/webhook.test.js): Updated API response assertions to verify `secret` is undefined.

---

## 🧪 Acceptance Criteria & Verification

- [x] **Secret Removal:** Webhook secrets are excluded from `createWebhook` and `updateWebhook` API responses.
- [x] **Functionality Intact:** Webhook creation, subscription management, payload dispatching, and HMAC signature computation continue to work as expected.
- [x] **Secure Storage:** Secrets remain safely stored in MongoDB for signature generation.
- [x] **Code Quality:** Code passes ESLint (`npm run lint`), Prettier check (`npx prettier --check`), and test validation.

---

## 🚀 How to Test

1. Authenticate as an organization admin and send a `POST` request to `/api/webhooks` with target URL, events, and secret.
2. Confirm the HTTP `201 Created` response contains the created webhook metadata but `secret` is not present in `res.body.webhook`.
3. Send a `PATCH` request to `/api/webhooks/:id` to update the webhook settings.
4. Confirm the HTTP `200 OK` response contains updated properties while `secret` remains omitted from `res.body.webhook`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook creation and update responses no longer expose webhook secrets, improving credential security.
  * Webhook settings can still be updated as before, while sensitive secret values remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->