### PR TITLE
fix: correct permission checks for invitation acceptance and rejection

### DIFF
--- a/server/routes/invitationRoutes.js
+++ b/server/routes/invitationRoutes.js
@@ -41,20 +41,8 @@ router.get(
   requirePermission("team_members", "view"),
   getUserInvitations,
 );
-router.post(
-  "/:token/accept",
-  userAuth,
-  writeLimiter,
-  requirePermission("organizations", "leave"),
-  acceptInvitation,
-);
-router.post(
-  "/:token/reject",
-  userAuth,
-  writeLimiter,
-  requirePermission("organizations", "leave"),
-  rejectInvitation,
-);
+router.post("/:token/accept", userAuth, writeLimiter, acceptInvitation);
+router.post("/:token/reject", userAuth, writeLimiter, rejectInvitation);
 router.delete(
   "/:id",
   userAuth,


### PR DESCRIPTION
# ✉️ Fix Permission Checks for Invitation Acceptance and Rejection (#622)

## 📌 Related Issue
Fixes #622

---

## 📝 Description

### 🐛 Problem
Previously, the invitation acceptance (`POST /api/invitations/:token/accept`) and rejection (`POST /api/invitations/:token/reject`) routes in [server/routes/invitationRoutes.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/routes/invitationRoutes.js) enforced an unrelated permission check: `requirePermission("organizations", "leave")`.

This caused legitimate users (such as newly registered users who are not yet active members of an organization or users without organization leave permissions) to be blocked with a `403 Forbidden` error when trying to accept or decline invitations sent to their email addresses.

### 💡 Solution
1. Removed `requirePermission("organizations", "leave")` middleware from the invitation acceptance (`/:token/accept`) and rejection (`/:token/reject`) routes in `server/routes/invitationRoutes.js`.
2. Kept `userAuth` and `writeLimiter` middleware intact so that endpoints remain authenticated and rate-limited.
3. Upheld recipient verification within `InvitationService.js`, which strictly checks that the authenticated user's email matches the invitation recipient (`user.email.toLowerCase() === invitation.email.toLowerCase()`).

---

## 🔍 Scope of Changes

- **Modified File:**
  - [`server/routes/invitationRoutes.js`](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/routes/invitationRoutes.js): Removed `requirePermission("organizations", "leave")` from `/:token/accept` and `/:token/reject` route handlers.

---

## 🧪 Acceptance Criteria & Verification

- [x] **Invitation Acceptance:** Authenticated users can successfully accept pending invitations addressed to them without needing organization leave permissions.
- [x] **Invitation Rejection:** Authenticated users can successfully decline pending invitations addressed to them without needing organization leave permissions.
- [x] **Permission Model:** Invitation accept/reject routes reflect the intended workflow where access is scoped by authentication and recipient email matching.
- [x] **Code Quality:** Code passes ESLint linting (`npm run lint`), Prettier formatting checks (`npx prettier --check`), and unit tests (`npx vitest run tests/InvitationService.test.js`).

---

## 🚀 How to Test

1. Authenticate as a user who has received an organization invitation via email token.
2. Send a `POST` request to `/api/invitations/:token/accept` with JWT headers. Verify the request responds with status `200 OK` and joins the organization.
3. Send a `POST` request to `/api/invitations/:token/reject` with JWT headers. Verify the request responds with status `200 OK` and marks the invitation as declined.
