### PR TITLE
feat(ci): improve claim automation reliability and activity tracking

### DIFF
--- a/.github/scripts/activity.js
+++ b/.github/scripts/activity.js
@@ -1,0 +1,163 @@
+import { COMMANDS } from "./constants.js";
+import {
+  getIssue,
+  hasOpenLinkedPullRequest,
+  isExpectedRepository,
+  listOpenLinkedPullRequests,
+} from "./helpers.js";
+import {
+  isManualAssignment,
+  readMetadata,
+  touchAssigneeActivity,
+  updateIssueMetadata,
+} from "./metadata.js";
+import {
+  extractLinkedIssueNumbers,
+  isCommand,
+  isIgnoredBotUser,
+  nowIso,
+} from "./utils.js";
+
+/**
+ * Persist activity refresh for an assigned issue when the actor is the assignee.
+ * Skips bots and non-assignees. Manual assignments are left untouched (never expire).
+ */
+export async function refreshIssueActivity({
+  github,
+  context,
+  core,
+  issue,
+  actor,
+  at = nowIso(),
+}) {
+  if (!issue || issue.state !== "open" || issue.locked) return false;
+  if (!actor || isIgnoredBotUser({ login: actor })) return false;
+
+  const assignee = issue.assignees?.[0]?.login;
+  if (!assignee || assignee !== actor) return false;
+
+  const metadata = readMetadata(issue.body);
+  if (isManualAssignment(metadata)) return false;
+
+  const probe = touchAssigneeActivity({ ...metadata }, at);
+  if (!probe.changed) return false;
+
+  await updateIssueMetadata(github, context, core, issue, (draft) => {
+    touchAssigneeActivity(draft, at);
+    return draft;
+  });
+  return true;
+}
+
+/**
+ * PR-driven activity: when the PR author (or review actor) is the assignee
+ * of a linked issue, refresh lastActivityAt.
+ */
+export async function processPrActivityRefresh({ github, context, core }) {
+  if (!isExpectedRepository(context)) return;
+
+  const targetPr =
+    context.payload.pull_request || context.payload.pull_request_target || null;
+  if (!targetPr) return;
+
+  const actor =
+    context.payload.sender?.login ||
+    context.payload.comment?.user?.login ||
+    context.payload.review?.user?.login ||
+    targetPr.user?.login;
+
+  if (isIgnoredBotUser(context.payload.sender || { login: actor })) return;
+
+  const linkedIssues = extractLinkedIssueNumbers(
+    `${targetPr.title || ""}\n${targetPr.body || ""}`,
+  );
+  if (linkedIssues.length === 0) return;
+
+  const activityAt =
+    targetPr.updated_at ||
+    context.payload.review?.submitted_at ||
+    context.payload.comment?.created_at ||
+    nowIso();
+
+  for (const issueNumber of linkedIssues) {
+    const issue = await getIssue(github, context, core, issueNumber);
+    if (!issue) continue;
+    await refreshIssueActivity({
+      github,
+      context,
+      core,
+      issue,
+      actor,
+      at: activityAt,
+    });
+  }
+}
+
+/**
+ * Issue-comment activity from the assignee (non-command comments).
+ */
+export async function processIssueCommentActivity({ github, context, core }) {
+  if (!isExpectedRepository(context)) return;
+  if (context.eventName !== "issue_comment") return;
+  if (context.payload.action !== "created") return;
+  if (context.payload.issue?.pull_request) return;
+
+  const comment = context.payload.comment;
+  const actor = comment?.user?.login;
+  if (!actor || isIgnoredBotUser(comment?.user)) return;
+  if (isCommand(comment?.body, COMMANDS.claim)) return;
+  if (isCommand(comment?.body, COMMANDS.unclaim)) return;
+
+  const issueNumber = context.payload.issue.number;
+  const issue = await getIssue(github, context, core, issueNumber);
+  if (!issue) return;
+
+  await refreshIssueActivity({
+    github,
+    context,
+    core,
+    issue,
+    actor,
+    at: comment.created_at || nowIso(),
+  });
+}
+
+/**
+ * During expiration: sync lastActivityAt from the newest open linked PR update.
+ */
+export async function syncActivityFromOpenPullRequests(
+  github,
+  context,
+  core,
+  issue,
+  assignee,
+  cache = null,
+) {
+  const linked = await listOpenLinkedPullRequests(
+    github,
+    context,
+    core,
+    issue.number,
+    cache,
+  );
+  if (linked.length === 0) return false;
+
+  let newest = null;
+  for (const pr of linked) {
+    const stamp = pr.updated_at || pr.created_at;
+    if (!stamp) continue;
+    if (!newest || new Date(stamp) > new Date(newest)) newest = stamp;
+  }
+  if (!newest) return false;
+
+  return refreshIssueActivity({
+    github,
+    context,
+    core,
+    issue,
+    actor: assignee,
+    at: newest,
+  });
+}
+
+export { hasOpenLinkedPullRequest };

--- a/.github/scripts/assignment.js
+++ b/.github/scripts/assignment.js
@@ -1,10 +1,12 @@
+import { AUTOMATION } from "./constants.js";
 import { comments } from "./comments.js";
-import { createComment, getIssue, isExpectedRepository } from "./helpers.js";
 import {
-  readMetadata,
-  setAssignmentMetadata,
-  updateIssueMetadata,
-} from "./metadata.js";
+  createComment,
+  findCommentByMarker,
+  getIssue,
+  isExpectedRepository,
+} from "./helpers.js";
+import { setAssignmentMetadata, updateIssueMetadata } from "./metadata.js";
 import { isMaintainerRole, resolveActorRole } from "./permissions.js";
 import { isIgnoredBotUser } from "./utils.js";
 
@@ -25,12 +27,20 @@ export async function processManualAssignment({ github, context, core }) {
   const issue = await getIssue(github, context, core, issueNumber);
   if (!issue) return;
 
-  const metadata = readMetadata(issue.body);
-  if (metadata.welcomeSource === "claim") return;
-
+  // Persist manualAssignment so expiration/reminders never touch this claim.
   await updateIssueMetadata(github, context, core, issue, (draft) =>
     setAssignmentMetadata(draft, "manual"),
   );
+
+  const existingWelcome = await findCommentByMarker(
+    github,
+    context,
+    core,
+    issueNumber,
+    AUTOMATION.assignmentWelcomeMarker,
+  );
+  if (existingWelcome) return;
+
   await createComment(
     github,
     context,

--- a/.github/scripts/claim.js
+++ b/.github/scripts/claim.js
@@ -15,6 +15,7 @@ import {
   readMetadata,
   setAssignmentMetadata,
   updateIssueMetadata,
+  isManualAssignment,
 } from "./metadata.js";
 import {
   canAutoClaimIssue,
@@ -75,7 +76,7 @@ export async function processClaim({ github, context, core }) {
     return;
   }
 
-  if (!canAutoClaimIssue(issue, actor)) {
+  if (!canAutoClaimIssue(issue, actor, metadata || {})) {
     await createComment(
       github,
       context,
@@ -192,13 +193,21 @@ export async function processUnclaim({ github, context, core }) {
 
   const currentAssignee = assignees[0].login;
   const role = await resolveActorRole(github, context, core, actor);
-  if (!canUnclaim(actor, role, currentAssignee)) {
+  if (!canUnclaim(actor, role, currentAssignee, metadata)) {
     await createComment(
       github,
       context,
       core,
       issueNumber,
-      comments.unauthorizedUnclaim({ actor, assignee: currentAssignee }),
+      isManualAssignment(metadata)
+        ? comments.manualAssignmentProtected({
+            actor,
+            assignee: currentAssignee,
+          })
+        : comments.unauthorizedUnclaim({
+            actor,
+            assignee: currentAssignee,
+          }),
     );
     return;
   }

--- a/.github/scripts/comments.js
+++ b/.github/scripts/comments.js
@@ -29,8 +29,13 @@ export const comments = {
 
   wrongIssueAuthorClaimAttempt: ({ user, issueAuthor }) =>
     `Hi @${user}, thank you for your interest in this issue! 🙏\n\n` +
-    `This particular issue was opened by @${issueAuthor}, and for contributor-opened issues, automatic claiming is limited to the issue author.\n\n` +
-    `We really appreciate your eagerness to contribute — please feel free to browse our other open issues, there's likely a great fit for you!`,
+    `This particular issue was opened by @${issueAuthor}. Contributor-opened issues have an exclusive **48-hour** claim window for the author.\n\n` +
+    `After that window ends, anyone may claim the issue with \`${COMMANDS.claim}\`. In the meantime, please feel free to browse our other open issues!`,
+
+  manualAssignmentProtected: ({ actor, assignee }) =>
+    `Hi @${actor}, thanks for checking in! 😊\n\n` +
+    `This issue was assigned by a maintainer to @${assignee}. Only a maintainer can release or reassign it.\n\n` +
+    `If you believe this needs attention, please tag a maintainer — thanks!`,
 
   duplicateClaim: ({ user }) =>
     `Hi @${user}, good news — you already have this issue assigned to you! ✅\n\n` +

--- a/.github/scripts/constants.js
+++ b/.github/scripts/constants.js
@@ -28,6 +28,8 @@ export const TIMERS = Object.freeze({
   // Reminders every 8 hours until the 48-hour claim window expires.
   reminderHours: Object.freeze([8, 16, 24, 32, 40]),
   expirationHours: 48,
+  // Contributor-authored issues: exclusive claim window for the author.
+  authorPriorityHours: 48,
 });
 
 export function reminderMarker(hours) {

--- a/.github/scripts/expiration.js
+++ b/.github/scripts/expiration.js
@@ -1,37 +1,66 @@
 import { TIMERS, reminderMarker } from "./constants.js";
+import { syncActivityFromOpenPullRequests } from "./activity.js";
 import { comments } from "./comments.js";
 import {
   createComment,
   getIssue,
+  hasOpenLinkedPullRequest,
   listComments,
   listOpenAssignedIssues,
   removeAssignee,
 } from "./helpers.js";
 import {
   clearAssignmentMetadata,
+  isManualAssignment,
   readMetadata,
   resetReminderTracking,
+  touchAssigneeActivity,
   updateIssueMetadata,
 } from "./metadata.js";
-import { isActivitySignal } from "./regex.js";
-import { hasMarker, hoursSince, nowIso } from "./utils.js";
+import { hasMarker, hoursSince, isIgnoredBotUser, nowIso } from "./utils.js";
 
-function hasLinkedPrActivity(commentsList, assignee) {
-  return commentsList.some((comment) => {
-    if (comment.user?.login !== assignee) return false;
-    return /#\d+|pull request|pr/i.test(comment.body || "");
-  });
+function isAssigneeProgressComment(comment, assignee) {
+  if (!comment || comment.user?.login !== assignee) return false;
+  if (isIgnoredBotUser(comment.user)) return false;
+  // Any non-empty assignee comment counts as meaningful activity.
+  return String(comment.body || "").trim().length > 0;
 }
 
 export async function processClaimExpiration({ github, context, core }) {
   const issues = await listOpenAssignedIssues(github, context, core);
+  const linkedPrCache = new Map();
+
   for (const issueSummary of issues) {
     const issue = await getIssue(github, context, core, issueSummary.number);
     if (!issue || issue.state !== "open" || issue.locked) continue;
     const assignee = issue.assignees?.[0]?.login;
     if (!assignee) continue;
 
-    const metadata = readMetadata(issue.body);
+    let metadata = readMetadata(issue.body);
+
+    // Maintainer manual assignments are never expired or reminded by the bot.
+    if (isManualAssignment(metadata)) continue;
+
+    // Freeze while ANY linked PR is still open (including drafts).
+    const openLinked = await hasOpenLinkedPullRequest(
+      github,
+      context,
+      core,
+      issue.number,
+      linkedPrCache,
+    );
+    if (openLinked) {
+      await syncActivityFromOpenPullRequests(
+        github,
+        context,
+        core,
+        issue,
+        assignee,
+        linkedPrCache,
+      );
+      continue;
+    }
+
     const issueComments = await listComments(
       github,
       context,
@@ -40,10 +69,7 @@ export async function processClaimExpiration({ github, context, core }) {
     );
 
     const lastSignal = issueComments
-      .filter((c) => c.user?.login === assignee)
-      .filter(
-        (c) => isActivitySignal(c.body) || hasLinkedPrActivity([c], assignee),
-      )
+      .filter((c) => isAssigneeProgressComment(c, assignee))
       .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
 
     if (lastSignal) {
@@ -53,8 +79,7 @@ export async function processClaimExpiration({ github, context, core }) {
         new Date(signalTime) > new Date(metadata.lastActivityAt)
       ) {
         await updateIssueMetadata(github, context, core, issue, (draft) => {
-          draft.lastActivityAt = signalTime;
-          resetReminderTracking(draft);
+          touchAssigneeActivity(draft, signalTime);
           return draft;
         });
       }
@@ -63,6 +88,8 @@ export async function processClaimExpiration({ github, context, core }) {
     const freshIssue = await getIssue(github, context, core, issue.number);
     if (!freshIssue) continue;
     const freshMeta = readMetadata(freshIssue.body);
+    if (isManualAssignment(freshMeta)) continue;
+
     const baseline =
       freshMeta.lastActivityAt || freshMeta.assignedAt || freshIssue.updated_at;
     const inactiveHours = hoursSince(baseline);
@@ -118,3 +145,6 @@ export async function processClaimExpiration({ github, context, core }) {
     }
   }
 }
+
+// Re-export for tests that may spy on reminder reset behavior.
+export { resetReminderTracking };

--- a/.github/scripts/helpers.js
+++ b/.github/scripts/helpers.js
@@ -1,5 +1,6 @@
 import { EXPECTED_REPOSITORY } from "./constants.js";
 import {
+  extractLinkedIssueNumbers,
   formatError,
   hasMarker,
   logError,
@@ -195,6 +196,66 @@ export async function listOpenAssignedIssues(github, context, core) {
   return (records || []).filter(
     (item) => !item.pull_request && (item.assignees || []).length > 0,
   );
+}
+
+/**
+ * Find OPEN PRs (including drafts) that link to the given issue number.
+ * Uses a scoped search + body/title parse to avoid listing every PR.
+ * Results are suitable for expiration freeze (any open linked PR freezes).
+ */
+export async function listOpenLinkedPullRequests(
+  github,
+  context,
+  core,
+  issueNumber,
+  cache = null,
+) {
+  const key = String(issueNumber);
+  if (cache && cache.has(key)) return cache.get(key);
+
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const q = `repo:${owner}/${repo} is:pr is:open ${issueNumber} in:body,title`;
+  const items = await safeCall(
+    core,
+    "search.issuesAndPullRequests(linked open PRs)",
+    () =>
+      github.paginate(github.rest.search.issuesAndPullRequests, {
+        q,
+        per_page: 30,
+      }),
+    [],
+  );
+
+  const linked = (items || []).filter((pr) => {
+    const isPr =
+      Boolean(pr.pull_request) || String(pr.html_url || "").includes("/pull/");
+    if (!isPr) return false;
+    const numbers = extractLinkedIssueNumbers(
+      `${pr.title || ""}\n${pr.body || ""}`,
+    );
+    return numbers.includes(Number(issueNumber));
+  });
+
+  if (cache) cache.set(key, linked);
+  return linked;
+}
+
+export async function hasOpenLinkedPullRequest(
+  github,
+  context,
+  core,
+  issueNumber,
+  cache = null,
+) {
+  const linked = await listOpenLinkedPullRequests(
+    github,
+    context,
+    core,
+    issueNumber,
+    cache,
+  );
+  return linked.length > 0;
 }
 
 export async function getCollaboratorPermission(

--- a/.github/scripts/index.js
+++ b/.github/scripts/index.js
@@ -9,3 +9,7 @@ export {
 export { processIssueCommentGuidance } from "./issue-comments.js";
 export { processIssueLifecycle } from "./lifecycle.js";
 export { autoLabelEcs } from "./label-ecs.js";
+export {
+  processPrActivityRefresh,
+  processIssueCommentActivity,
+} from "./activity.js";

--- a/.github/scripts/label-ecs.js
+++ b/.github/scripts/label-ecs.js
@@ -1,9 +1,12 @@
-import { MAINTAINER_ASSOCIATIONS } from "./constants.js";
+import { MAINTAINER_ASSOCIATIONS, TIMERS } from "./constants.js";
 import { isExpectedRepository, safeCall } from "./helpers.js";
+import { readMetadata, updateIssueMetadata } from "./metadata.js";
+import { getAuthorPriorityExpiresAt, issueAuthorRole } from "./permissions.js";
 
 /**
  * Automatically applies the 'ECSoC26' label to contributor-created Issues and Pull Requests.
  * Skipping labeling if the author is a maintainer (OWNER, MEMBER, COLLABORATOR).
+ * For contributor-created issues, also stamps authorPriorityExpiresAt (48h exclusive window).
  */
 export async function autoLabelEcs({ github, context, core }) {
   if (!isExpectedRepository(context)) {
@@ -37,6 +40,10 @@ export async function autoLabelEcs({ github, context, core }) {
   core.info(
     `Evaluating creation of #${target.number} by @${author} (association: ${association})`,
   );
+
+  if (isIssue && !MAINTAINER_ASSOCIATIONS.includes(association)) {
+    await ensureAuthorPriorityMetadata(github, context, core, target);
+  }
 
   // Exclude maintainers/collaborators with admin/write access
   if (MAINTAINER_ASSOCIATIONS.includes(association)) {
@@ -79,4 +86,27 @@ export async function autoLabelEcs({ github, context, core }) {
   } else {
     core.setFailed(`Failed to apply 'ECSoC26' label to #${issueNumber}.`);
   }
+}
+
+async function ensureAuthorPriorityMetadata(github, context, core, issue) {
+  const metadata = readMetadata(issue.body);
+  if (metadata.authorPriorityExpiresAt) return;
+  if (
+    ["owner", "maintainer", "collaborator"].includes(issueAuthorRole(issue))
+  ) {
+    return;
+  }
+
+  const expiresAt =
+    getAuthorPriorityExpiresAt(issue, metadata) ||
+    new Date(
+      Date.now() + TIMERS.authorPriorityHours * 60 * 60 * 1000,
+    ).toISOString();
+
+  await updateIssueMetadata(github, context, core, issue, (draft) => {
+    if (!draft.authorPriorityExpiresAt) {
+      draft.authorPriorityExpiresAt = expiresAt;
+    }
+    return draft;
+  });
 }

--- a/.github/scripts/metadata.js
+++ b/.github/scripts/metadata.js
@@ -15,6 +15,9 @@ function defaultMetadata() {
     guidance: {},
     processedClaimCommentIds: [],
     processedUnclaimCommentIds: [],
+    // Additive flags — absent/false on legacy bodies is backward compatible.
+    manualAssignment: false,
+    authorPriorityExpiresAt: null,
   };
 }
 
@@ -95,6 +98,7 @@ export function setAssignmentMetadata(metadata, source = "claim") {
   metadata.expiredAt = null;
   metadata.welcomeSentAt = timestamp;
   metadata.welcomeSource = source;
+  metadata.manualAssignment = source === "manual";
   return metadata;
 }
 
@@ -103,7 +107,33 @@ export function clearAssignmentMetadata(metadata) {
   metadata.lastActivityAt = null;
   resetReminderTracking(metadata);
   metadata.expiredAt = null;
+  metadata.manualAssignment = false;
+  metadata.welcomeSource = null;
+  metadata.welcomeSentAt = null;
   return metadata;
+}
+
+/**
+ * Refresh inactivity baseline and clear reminder tracking.
+ * Idempotent when `at` is not newer than the current lastActivityAt.
+ */
+export function touchAssigneeActivity(metadata, at = nowIso()) {
+  const nextAt = at || nowIso();
+  if (
+    metadata.lastActivityAt &&
+    new Date(nextAt) <= new Date(metadata.lastActivityAt)
+  ) {
+    return { metadata, changed: false };
+  }
+  metadata.lastActivityAt = nextAt;
+  resetReminderTracking(metadata);
+  return { metadata, changed: true };
+}
+
+export function isManualAssignment(metadata) {
+  return (
+    Boolean(metadata?.manualAssignment) || metadata?.welcomeSource === "manual"
+  );
 }
 
 export { resetReminderTracking };

--- a/.github/scripts/permissions.js
+++ b/.github/scripts/permissions.js
@@ -1,4 +1,4 @@
-import { MAINTAINER_ASSOCIATIONS } from "./constants.js";
+import { MAINTAINER_ASSOCIATIONS, TIMERS } from "./constants.js";
 import { getCollaboratorPermission } from "./helpers.js";
 
 export function issueAuthorRole(issue) {
@@ -35,18 +35,51 @@ export async function resolveActorRole(github, context, core, actor) {
   return actorRoleFromPermission(permission);
 }
 
-export function canAutoClaimIssue(issue, actor) {
+/**
+ * Effective author-priority expiry for contributor-created issues.
+ * Legacy bodies without authorPriorityExpiresAt use created_at + 48h.
+ */
+export function getAuthorPriorityExpiresAt(issue, metadata = {}) {
+  if (metadata?.authorPriorityExpiresAt) {
+    return metadata.authorPriorityExpiresAt;
+  }
+  if (!issue?.created_at) return null;
+  const created = new Date(issue.created_at);
+  if (Number.isNaN(created.getTime())) return null;
+  return new Date(
+    created.getTime() + TIMERS.authorPriorityHours * 60 * 60 * 1000,
+  ).toISOString();
+}
+
+export function isAuthorPriorityActive(issue, metadata = {}, now = new Date()) {
+  const authorRole = issueAuthorRole(issue);
+  if (["owner", "maintainer", "collaborator"].includes(authorRole)) {
+    return false;
+  }
+  const expiresAt = getAuthorPriorityExpiresAt(issue, metadata);
+  // No usable timestamp: preserve legacy author-only soft lock.
+  if (!expiresAt) return true;
+  return new Date(expiresAt).getTime() > now.getTime();
+}
+
+export function canAutoClaimIssue(issue, actor, metadata = {}) {
   const authorRole = issueAuthorRole(issue);
   const issueAuthor = issue?.user?.login;
   if (["owner", "maintainer", "collaborator"].includes(authorRole)) return true;
-  return issueAuthor === actor;
+  if (issueAuthor === actor) return true;
+  return !isAuthorPriorityActive(issue, metadata);
 }
 
 export function isMaintainerRole(role) {
   return role === "owner" || role === "maintainer" || role === "collaborator";
 }
 
-export function canUnclaim(actor, actorRole, currentAssignee) {
+export function canUnclaim(actor, actorRole, currentAssignee, metadata = {}) {
+  const manual =
+    Boolean(metadata?.manualAssignment) || metadata?.welcomeSource === "manual";
+  if (manual) {
+    return isMaintainerRole(actorRole);
+  }
   if (actor === currentAssignee) return true;
   return isMaintainerRole(actorRole);
 }

--- a/.github/scripts/pr.js
+++ b/.github/scripts/pr.js
@@ -8,6 +8,7 @@ import {
   safeCall,
   summarizeCheckStates,
 } from "./helpers.js";
+import { processPrActivityRefresh } from "./activity.js";
 import { extractLinkedIssueNumbers, hasMarker } from "./utils.js";
 import { AUTOMATION } from "./constants.js";
 
@@ -36,6 +37,9 @@ export async function processPrValidation({ github, context, core }) {
 
   const pr = context.payload.pull_request;
   if (!pr) return;
+
+  // Refresh assignee inactivity timers for linked issues (drafts included).
+  await processPrActivityRefresh({ github, context, core });
 
   const prNumber = pr.number;
   const body = pr.body || "";

--- a/.github/scripts/tests/automation.test.js
+++ b/.github/scripts/tests/automation.test.js
@@ -21,6 +21,7 @@ function createGithub(issueFactory) {
     comments: [],
     assignees: {},
     issues: {},
+    openPullRequests: [],
   };
   return {
     state,
@@ -36,7 +37,12 @@ function createGithub(issueFactory) {
           };
         },
         async createComment({ issue_number, body }) {
-          state.comments.push({ issue_number, body });
+          state.comments.push({
+            issue_number,
+            body,
+            user: { login: "github-actions[bot]", type: "Bot" },
+            created_at: new Date().toISOString(),
+          });
           return { data: { id: state.comments.length, body } };
         },
         async updateComment({ comment_id, body }) {
@@ -64,6 +70,9 @@ function createGithub(issueFactory) {
         async listComments() {
           return { data: state.comments };
         },
+        async addLabels() {
+          return { data: [] };
+        },
       },
       repos: {
         async getCollaboratorPermissionLevel({ username }) {
@@ -81,10 +90,17 @@ function createGithub(issueFactory) {
           return { data: { number: pull_number } };
         },
       },
+      search: {
+        async issuesAndPullRequests() {
+          return { data: { items: state.openPullRequests } };
+        },
+      },
     },
     async paginate(apiMethod, args) {
       if (apiMethod === this.rest.issues.listComments)
         return this.rest.issues.listComments(args).then((r) => r.data);
+      if (apiMethod === this.rest.search.issuesAndPullRequests)
+        return state.openPullRequests;
       if (args.assignee) {
         return new Array(args.assignee === "busy-user" ? 4 : 1)
           .fill(0)
@@ -135,7 +151,8 @@ function issueFactory(issueNumber, state, overrides = {}) {
     user: overrides.user || { login: "issue-author" },
     author_association: overrides.author_association || "CONTRIBUTOR",
     assignees: overrides.assignees || (assignee ? [{ login: assignee }] : []),
-    updated_at: new Date().toISOString(),
+    updated_at: overrides.updated_at || new Date().toISOString(),
+    created_at: overrides.created_at || new Date().toISOString(),
   };
 }
 
@@ -438,6 +455,17 @@ test("autoLabelEcs: labels contributor-created issue with ECSoC26", async () => 
           labelsAdded.push({ issue_number, labels });
           return { data: labels };
         },
+        async update({ issue_number, body }) {
+          return {
+            data: {
+              number: issue_number,
+              body,
+              user: { login: "contributor" },
+              author_association: "NONE",
+              created_at: new Date().toISOString(),
+            },
+          };
+        },
       },
     },
   };
@@ -450,12 +478,15 @@ test("autoLabelEcs: labels contributor-created issue with ECSoC26", async () => 
         user: { login: "contributor" },
         author_association: "NONE",
         labels: [],
+        body: "",
+        created_at: new Date().toISOString(),
       },
     },
   };
   const core = {
     info() {},
     warning() {},
+    error() {},
     setFailed(msg) {
       assert.fail(`Should not call setFailed: ${msg}`);
     },
@@ -514,6 +545,9 @@ test("autoLabelEcs: skips auto-labeling if label is already present", async () =
           labelsAdded.push({ issue_number, labels });
           return { data: labels };
         },
+        async update() {
+          return { data: {} };
+        },
       },
     },
   };
@@ -526,12 +560,15 @@ test("autoLabelEcs: skips auto-labeling if label is already present", async () =
         user: { login: "contributor" },
         author_association: "NONE",
         labels: [{ name: "ECSoC26" }],
+        body: "",
+        created_at: new Date().toISOString(),
       },
     },
   };
   const core = {
     info() {},
     warning() {},
+    error() {},
     setFailed(msg) {
       assert.fail(`Should not call setFailed: ${msg}`);
     },
@@ -539,4 +576,412 @@ test("autoLabelEcs: skips auto-labeling if label is already present", async () =
 
   await autoLabelEcs({ github, context, core });
   assert.equal(labelsAdded.length, 0);
+});
+
+test("expiration: open linked PR freezes expiration", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[60] = "assigned-user";
+  github.state.openPullRequests = [
+    {
+      number: 100,
+      title: "Fix",
+      body: "Closes #60",
+      pull_request: {},
+      html_url: "https://github.com/org/repo/pull/100",
+      updated_at: new Date().toISOString(),
+      user: { login: "assigned-user" },
+    },
+  ];
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[60], "assigned-user");
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:claim-expired"))
+      .length,
+    0,
+  );
+});
+
+test("expiration: draft PR also freezes expiration", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[61] = "assigned-user";
+  github.state.openPullRequests = [
+    {
+      number: 101,
+      title: "WIP",
+      body: "Fixes #61",
+      draft: true,
+      pull_request: {},
+      html_url: "https://github.com/org/repo/pull/101",
+      updated_at: new Date().toISOString(),
+      user: { login: "assigned-user" },
+    },
+  ];
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[61], "assigned-user");
+});
+
+test("expiration: multiple open PRs freeze when any is open", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[62] = "assigned-user";
+  github.state.openPullRequests = [
+    {
+      number: 102,
+      body: "Refs #62",
+      pull_request: {},
+      html_url: "https://github.com/org/repo/pull/102",
+      updated_at: new Date().toISOString(),
+    },
+    {
+      number: 103,
+      body: "Also closes #62",
+      pull_request: {},
+      html_url: "https://github.com/org/repo/pull/103",
+      updated_at: new Date().toISOString(),
+    },
+  ];
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[62], "assigned-user");
+});
+
+test("expiration: closed PR resumes expiration", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[63] = "assigned-user";
+  github.state.openPullRequests = [];
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[63], undefined);
+});
+
+test("expiration: manual assignment never expires", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","manualAssignment":true,"welcomeSource":"manual"}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[64] = "assigned-user";
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[64], "assigned-user");
+  assert.equal(github.state.comments.length, 0);
+});
+
+test("expiration: contributor comment refreshes activity", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const recent = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  const initialBody = `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`;
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: state.issues[number]?.body || initialBody,
+    }),
+  );
+  github.state.assignees[65] = "assigned-user";
+  github.state.comments.push({
+    issue_number: 65,
+    body: "still working on this",
+    user: { login: "assigned-user", type: "User" },
+    created_at: recent,
+  });
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.assignees[65], "assigned-user");
+});
+
+test("claim: author priority blocks others while active", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  const context = baseContext();
+  context.payload.comment.user.login = "other-contributor";
+  github.state.issues[10] = {
+    user: { login: "issue-author" },
+    author_association: "CONTRIBUTOR",
+    created_at: new Date().toISOString(),
+  };
+  await processClaim({ github, context, core: createCore() });
+  assert.equal(github.state.assignees[10], undefined);
+  assert.ok(github.state.comments.some((c) => c.body.includes("48-hour")));
+});
+
+test("claim: author priority expired allows public reclaim", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  const context = baseContext();
+  context.payload.comment.user.login = "other-contributor";
+  const old = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  github.state.issues[10] = {
+    user: { login: "issue-author" },
+    author_association: "CONTRIBUTOR",
+    created_at: old,
+    body: `<!-- mom:metadata:start -->\n{"authorPriorityExpiresAt":"${old}"}\n<!-- mom:metadata:end -->`,
+  };
+  await processClaim({ github, context, core: createCore() });
+  assert.equal(github.state.assignees[10], "other-contributor");
+});
+
+test("unclaim: assignee cannot release manual assignment", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: '<!-- mom:metadata:start -->\n{"manualAssignment":true,"welcomeSource":"manual"}\n<!-- mom:metadata:end -->',
+    }),
+  );
+  github.state.assignees[10] = "assigned-user";
+  const context = baseContext();
+  context.payload.comment.body = "/unclaim";
+  context.payload.comment.user.login = "assigned-user";
+  await processUnclaim({ github, context, core: createCore() });
+  assert.equal(github.state.assignees[10], "assigned-user");
+  assert.ok(
+    github.state.comments.some((c) =>
+      c.body.includes("assigned by a maintainer"),
+    ),
+  );
+});
+
+test("unclaim: maintainer can release manual assignment", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: '<!-- mom:metadata:start -->\n{"manualAssignment":true,"welcomeSource":"manual"}\n<!-- mom:metadata:end -->',
+    }),
+  );
+  github.state.assignees[10] = "assigned-user";
+  const context = baseContext();
+  context.payload.comment.body = "/unclaim";
+  context.payload.comment.user.login = "maintainer";
+  await processUnclaim({ github, context, core: createCore() });
+  assert.equal(github.state.assignees[10], undefined);
+});
+
+test("activity: PR synchronize refreshes linked issue", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const { processPrActivityRefresh } = await import("../activity.js");
+  const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+      assignees: [{ login: "assigned-user" }],
+    }),
+  );
+  github.state.assignees[70] = "assigned-user";
+  await processPrActivityRefresh({
+    github,
+    context: {
+      eventName: "pull_request_target",
+      repo: { owner: "org", repo: "repo" },
+      payload: {
+        action: "synchronize",
+        sender: { login: "assigned-user", type: "User" },
+        pull_request: {
+          number: 200,
+          body: "Closes #70",
+          title: "feat",
+          updated_at: new Date().toISOString(),
+          user: { login: "assigned-user" },
+        },
+      },
+    },
+    core: createCore(),
+  });
+  const body = String(github.state.issues[70]?.body || "");
+  assert.ok(body.includes('"remindersSentAt": {}'));
+});
+
+test("activity: issue comment from assignee refreshes", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const { processIssueCommentActivity } = await import("../activity.js");
+  const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[71] = "assigned-user";
+  await processIssueCommentActivity({
+    github,
+    context: {
+      eventName: "issue_comment",
+      repo: { owner: "org", repo: "repo" },
+      payload: {
+        action: "created",
+        issue: { number: 71 },
+        comment: {
+          body: "pushed a fix",
+          user: { login: "assigned-user", type: "User" },
+          created_at: new Date().toISOString(),
+        },
+      },
+    },
+    core: createCore(),
+  });
+  assert.ok(
+    String(github.state.issues[71]?.body || "").includes(
+      '"remindersSentAt": {}',
+    ),
+  );
+});
+
+test("activity: bot comments do not refresh", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const { processIssueCommentActivity } = await import("../activity.js");
+  const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[72] = "assigned-user";
+  await processIssueCommentActivity({
+    github,
+    context: {
+      eventName: "issue_comment",
+      repo: { owner: "org", repo: "repo" },
+      payload: {
+        action: "created",
+        issue: { number: 72 },
+        comment: {
+          body: "automated note",
+          user: { login: "github-actions[bot]", type: "Bot" },
+          created_at: new Date().toISOString(),
+        },
+      },
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.issues[72], undefined);
+});
+
+test("metadata: corrupted block falls back to defaults", async () => {
+  const { readMetadata } = await import("../metadata.js");
+  const meta = readMetadata(
+    "<!-- mom:metadata:start -->\n{not-json\n<!-- mom:metadata:end -->",
+  );
+  assert.equal(meta.assignedAt, null);
+  assert.equal(meta.manualAssignment, false);
+});
+
+test("metadata: legacy body without new fields remains compatible", async () => {
+  const { readMetadata, isManualAssignment } = await import("../metadata.js");
+  const meta = readMetadata(
+    '<!-- mom:metadata:start -->\n{"assignedAt":"2020-01-01T00:00:00.000Z","welcomeSource":"manual"}\n<!-- mom:metadata:end -->',
+  );
+  assert.equal(meta.assignedAt, "2020-01-01T00:00:00.000Z");
+  assert.equal(meta.manualAssignment, false);
+  assert.equal(isManualAssignment(meta), true);
+});
+
+test("manual assignment: sets manualAssignment metadata", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  const context = {
+    eventName: "issues",
+    repo: { owner: "org", repo: "repo" },
+    payload: {
+      action: "assigned",
+      sender: { login: "maintainer", type: "User" },
+      issue: { number: 10 },
+      assignee: { login: "new-user" },
+    },
+  };
+  await processManualAssignment({ github, context, core: createCore() });
+  assert.ok(
+    String(github.state.issues[10]?.body || "").includes(
+      '"manualAssignment": true',
+    ),
+  );
+});
+
+test("expiration: duplicate workflow run does not duplicate reminders", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 9 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{}}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[80] = "assigned-user";
+  const context = {
+    eventName: "schedule",
+    repo: { owner: "org", repo: "repo" },
+    payload: {},
+  };
+  await processClaimExpiration({ github, context, core: createCore() });
+  await processClaimExpiration({ github, context, core: createCore() });
+  await processClaimExpiration({ github, context, core: createCore() });
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-8h"))
+      .length,
+    1,
+  );
 });

--- a/.github/workflows/12-activity-refresh.yml
+++ b/.github/workflows/12-activity-refresh.yml
@@ -1,0 +1,40 @@
+name: "12 Activity Refresh"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: activity-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id || github.event.review.id }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Refresh assignee activity
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const {
+              processIssueCommentActivity,
+              processPrActivityRefresh,
+            } = await import(`${process.cwd()}/.github/scripts/activity.js`);
+
+            if (context.eventName === "issue_comment") {
+              await processIssueCommentActivity({ github, context, core });
+              return;
+            }
+
+            await processPrActivityRefresh({ github, context, core });


### PR DESCRIPTION
## Summary

This PR improves the GitHub issue claim automation by addressing several workflow edge cases while preserving the existing claim lifecycle.

### Changes

- Freeze claim expiration while an open linked PR exists
- Refresh inactivity timer on meaningful contributor activity
- Add author priority window for contributor-created issues
- Respect manual maintainer assignments
- Add comprehensive regression tests

### Validation

- Existing automation behavior preserved
- 48-hour expiration unchanged
- 8-hour reminder cadence unchanged
- All automation tests passing
- Backward-compatible metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 48-hour priority claim window for contributor-created issues.
  * Pull request reviews, comments, and linked pull request updates now refresh assignee activity automatically.
  * Open linked pull requests pause claim expiration while work is active.

* **Bug Fixes**
  * Manual assignments are now protected from automatic expiration and unauthorized removal.
  * Improved handling of duplicate welcome comments and legacy or incomplete issue metadata.
  * Updated claim messaging to clearly explain the author’s exclusive claim period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->