### PR TITLE
fix(router): replace catch-all redirect with dedicated 404 page (closes #630)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,7 +7,7 @@ import "react-toastify/dist/ReactToastify.css";
 import PublicRoutes from "./routes/PublicRoutes.jsx";
 import ProtectedRoutes from "./routes/ProtectedRoutes.jsx";
 
-import Home from "./pages/Home.jsx"; // 👈 Fallback page
+import NotFound from "./pages/NotFound.jsx";
 
 import Navbar from "./components/Navbar";
 import ScrollNavigator from "./components/ScrollNavigator";
@@ -48,8 +48,8 @@ const App = () => {
           <Routes>
             {PublicRoutes}
             {ProtectedRoutes}
-            {/* ✅ Fallback route — send unknown routes to Home */}
-            <Route path="*" element={<Home />} />
+            {/* ✅ Fallback route — send unknown routes to NotFound */}
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
 

--- a/client/src/__tests__/App.test.jsx
+++ b/client/src/__tests__/App.test.jsx
@@ -46,6 +46,9 @@ vi.mock("../components/ErrorBoundary.jsx", () => ({
 vi.mock("../pages/Home.jsx", () => ({
   default: () => <div data-testid="home-page" />,
 }));
+vi.mock("../pages/NotFound.jsx", () => ({
+  default: () => <div data-testid="not-found-page" />,
+}));
 vi.mock("../pages/Login.jsx", () => ({
   default: () => <div data-testid="login-page" />,
 }));
@@ -90,13 +93,13 @@ describe("App Routing", () => {
     expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
   });
 
-  it("renders Home page as fallback on unknown paths", () => {
+  it("renders NotFound page as fallback on unknown paths", () => {
     render(
       <MemoryRouter initialEntries={["/unknown-path-that-does-not-exist"]}>
         <App />
       </MemoryRouter>,
     );
-    // Since fallback route maps to <Home />
-    expect(screen.getByTestId("home-page")).toBeInTheDocument();
+    // Since fallback route maps to <NotFound />
+    expect(screen.getByTestId("not-found-page")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const NotFound = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[70vh] px-4 text-center">
+      <h1 className="text-6xl font-bold text-gray-900 dark:text-white mb-4">
+        404
+      </h1>
+      <h2 className="text-3xl font-semibold text-gray-800 dark:text-gray-200 mb-6">
+        Page Not Found
+      </h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-8 max-w-md">
+        Oops! The page you are looking for does not exist. It might have been
+        moved or deleted.
+      </p>
+      <Link
+        to="/"
+        className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+      >
+        Back to Home
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Summary

This PR replaces the catch-all redirect with a dedicated 404 page for unknown routes.

### Changes

- Added a reusable `NotFound` page.
- Updated the wildcard (`*`) route to render the 404 page.
- Updated routing tests to verify the new behaviour.

### Behaviour

- ✅ Unknown routes display a dedicated 404 page.
- ✅ Existing valid routes remain unchanged.
- ✅ Deep links continue to function correctly.

## Validation

- ✅ `npm run lint`
- ✅ `npm run build`
- ✅ `npm run test`

Closes #630.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 Not Found page for unknown URLs.
  * Included a link allowing visitors to return to the home page.

* **Bug Fixes**
  * Unknown routes no longer display the landing page and now show the appropriate Not Found view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->