### PR TITLE
feat(meetings): implement smart follow-up meeting creation from action items (#721)

### DIFF
--- a/client/src/components/meetings/MeetingCard.jsx
+++ b/client/src/components/meetings/MeetingCard.jsx
@@ -41,20 +41,20 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
   const getStatusColor = (status) => {
     switch (status?.toLowerCase()) {
       case "completed":
-        return "bg-green-100 text-green-700";
+        return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400";
       case "processing":
-        return "bg-yellow-100 text-yellow-700";
+        return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400";
       case "failed":
-        return "bg-red-100 text-red-700";
+        return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
       default:
-        return "bg-gray-100 text-gray-700";
+        return "bg-gray-100 text-gray-700 dark:bg-gray-700/50 dark:text-gray-300";
     }
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-100">
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-200 overflow-hidden border border-gray-100 dark:border-gray-700">
       {/* Card Header */}
-      <div className="p-5 border-b border-gray-100">
+      <div className="p-5 border-b border-gray-100 dark:border-gray-700">
         <div className="flex items-start justify-between gap-3">
           {isRenaming ? (
             <form onSubmit={handleRenameSubmit} className="flex-1">
@@ -67,11 +67,11 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                   setNewTitle(meeting.title);
                 }}
                 autoFocus
-                className="w-full px-3 py-2 border border-blue-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+                className="w-full px-3 py-2 border border-blue-300 dark:border-blue-500/50 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
               />
             </form>
           ) : (
-            <h3 className="text-lg font-semibold text-gray-900 line-clamp-2 flex-1">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 line-clamp-2 flex-1">
               {meeting.title || "Untitled Meeting"}
             </h3>
           )}
@@ -81,20 +81,26 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                 setShowMenu(!showMenu);
                 setShowExportSubMenu(false);
               }}
-              className="p-1.5 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
             >
-              <MoreVertical size={18} className="text-gray-500" />
+              <MoreVertical
+                size={18}
+                className="text-gray-500 dark:text-gray-400"
+              />
             </button>
             {showMenu && (
-              <div className="absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10 min-w-[160px]">
+              <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-10 min-w-[160px]">
                 <button
                   onClick={() => {
                     setIsRenaming(true);
                     setShowMenu(false);
                   }}
-                  className="w-full px-4 py-2 text-left hover:bg-gray-50 flex items-center gap-2 text-sm"
+                  className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center gap-2 text-sm dark:text-gray-200"
                 >
-                  <Edit2 size={16} className="text-gray-500" />
+                  <Edit2
+                    size={16}
+                    className="text-gray-500 dark:text-gray-400"
+                  />
                   Rename
                 </button>
                 <div
@@ -103,7 +109,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                   onMouseLeave={() => setShowExportSubMenu(false)}
                 >
                   <button
-                    className="w-full px-4 py-2 text-left hover:bg-gray-50 flex items-center justify-between gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center justify-between gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed dark:text-gray-200"
                     disabled={isExporting}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -111,7 +117,10 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                     }}
                   >
                     <div className="flex items-center gap-2">
-                      <Download size={16} className="text-gray-500" />
+                      <Download
+                        size={16}
+                        className="text-gray-500 dark:text-gray-400"
+                      />
                       {isExporting ? "Exporting..." : "Export"}
                     </div>
                     {!isExporting && (
@@ -132,13 +141,13 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                   </button>
 
                   {showExportSubMenu && (
-                    <div className="absolute right-full top-0 mr-1 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-20 min-w-[140px]">
+                    <div className="absolute right-full top-0 mr-1 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-20 min-w-[140px]">
                       <button
                         onClick={() => {
                           exportMeeting(meeting, "pdf");
                           setShowMenu(false);
                         }}
-                        className="w-full px-4 py-2 text-left hover:bg-gray-50 flex items-center gap-2 text-sm"
+                        className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center gap-2 text-sm dark:text-gray-200"
                       >
                         Export as PDF
                       </button>
@@ -147,7 +156,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                           exportMeeting(meeting, "docx");
                           setShowMenu(false);
                         }}
-                        className="w-full px-4 py-2 text-left hover:bg-gray-50 flex items-center gap-2 text-sm"
+                        className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center gap-2 text-sm dark:text-gray-200"
                       >
                         Export as DOCX
                       </button>
@@ -156,7 +165,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                           exportMeeting(meeting, "md");
                           setShowMenu(false);
                         }}
-                        className="w-full px-4 py-2 text-left hover:bg-gray-50 flex items-center gap-2 text-sm"
+                        className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-center gap-2 text-sm dark:text-gray-200"
                       >
                         Export as MD
                       </button>
@@ -169,7 +178,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
                     onDelete(meeting._id);
                     setShowMenu(false);
                   }}
-                  className="w-full px-4 py-2 text-left hover:bg-red-50 text-red-600 flex items-center gap-2 text-sm"
+                  className="w-full px-4 py-2 text-left hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400 flex items-center gap-2 text-sm"
                 >
                   <Trash2 size={16} />
                   Delete
@@ -185,7 +194,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
             {meeting.status || "Unknown"}
           </span>
           {meeting.meetingType && (
-            <span className="px-2 py-1 bg-blue-50 text-blue-700 rounded-full text-xs font-medium">
+            <span className="px-2 py-1 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded-full text-xs font-medium">
               {meeting.meetingType}
             </span>
           )}
@@ -195,14 +204,14 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
       {/* Card Body */}
       <div className="p-5 space-y-3">
         {/* Date and Duration */}
-        <div className="flex items-center gap-4 text-sm text-gray-600">
+        <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
           <div className="flex items-center gap-1.5">
-            <Calendar size={16} className="text-gray-400" />
+            <Calendar size={16} className="text-gray-400 dark:text-gray-500" />
             <span>{formatDate(meeting.date || meeting.createdAt)}</span>
           </div>
           {meeting.duration && (
             <div className="flex items-center gap-1.5">
-              <Clock size={16} className="text-gray-400" />
+              <Clock size={16} className="text-gray-400 dark:text-gray-500" />
               <span>{meeting.duration} min</span>
             </div>
           )}
@@ -213,9 +222,9 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
           <div className="flex items-start gap-2">
             <FileText
               size={16}
-              className="text-gray-400 mt-0.5 flex-shrink-0"
+              className="text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0"
             />
-            <p className="text-sm text-gray-600 line-clamp-3">
+            <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-3">
               {meeting.summary}
             </p>
           </div>
@@ -224,18 +233,21 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
         {/* Tags */}
         {meeting.tags && meeting.tags.length > 0 && (
           <div className="flex items-start gap-2">
-            <Tag size={16} className="text-gray-400 mt-0.5 flex-shrink-0" />
+            <Tag
+              size={16}
+              className="text-gray-400 dark:text-gray-500 mt-0.5 flex-shrink-0"
+            />
             <div className="flex flex-wrap gap-1.5">
               {meeting.tags.slice(0, 3).map((tag, index) => (
                 <span
                   key={index}
-                  className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs"
+                  className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-gray-600 dark:text-gray-300 rounded text-xs"
                 >
                   {tag}
                 </span>
               ))}
               {meeting.tags.length > 3 && (
-                <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs">
+                <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700/50 text-gray-600 dark:text-gray-300 rounded text-xs">
                   +{meeting.tags.length - 3}
                 </span>
               )}
@@ -245,21 +257,26 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
 
         {/* Participants */}
         {meeting.participants && meeting.participants.length > 0 && (
-          <div className="text-sm text-gray-600">
-            <span className="font-medium">{meeting.participants.length}</span>
-            <span className="text-gray-500"> participant(s)</span>
+          <div className="text-sm text-gray-600 dark:text-gray-400">
+            <span className="font-medium dark:text-gray-300">
+              {meeting.participants.length}
+            </span>
+            <span className="text-gray-500 dark:text-gray-500">
+              {" "}
+              participant(s)
+            </span>
           </div>
         )}
       </div>
 
       {/* Card Footer */}
-      <div className="px-5 py-3 bg-gray-50 border-t border-gray-100 flex items-center justify-between">
-        <span className="text-xs text-gray-500">
+      <div className="px-5 py-3 bg-gray-50 dark:bg-gray-800/50 border-t border-gray-100 dark:border-gray-700 flex items-center justify-between">
+        <span className="text-xs text-gray-500 dark:text-gray-400">
           Created {formatDate(meeting.createdAt)}
         </span>
         <button
           onClick={() => onView(meeting)}
-          className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1"
+          className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium flex items-center gap-1"
         >
           <Eye size={16} />
           View Details

--- a/client/src/components/shared-links/ShareModal.jsx
+++ b/client/src/components/shared-links/ShareModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Copy, Trash2, X, Plus, Calendar, Lock, Globe } from "lucide-react";
+import { Copy, Trash2, X, Plus, Calendar, Lock, Globe, Eye, Clock, AlertTriangle } from "lucide-react";
 import { toast } from "react-toastify";
 import { sharedLinkApi } from "../../services";
 
@@ -167,6 +167,28 @@ const ShareModal = ({ isOpen, onClose, resourceId, resourceType, title }) => {
                               <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
                                 <Lock className="w-3 h-3" /> Password protected
                               </span>
+                            )}
+                          </div>
+
+                          <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-700 flex flex-wrap items-center gap-4 text-xs text-gray-600 dark:text-gray-400">
+                            {!link.totalViews && !link.failedPasscodeAttempts ? (
+                                <span className="italic text-gray-400 dark:text-gray-500">No analytics yet</span>
+                            ) : (
+                                <>
+                                  <span className="flex items-center gap-1" title="Total Views">
+                                    <Eye className="w-3.5 h-3.5" /> {link.totalViews || 0} views
+                                  </span>
+                                  {link.lastAccessed && (
+                                    <span className="flex items-center gap-1" title="Last Accessed">
+                                      <Clock className="w-3.5 h-3.5" /> {new Date(link.lastAccessed).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                                    </span>
+                                  )}
+                                  {link.failedPasscodeAttempts > 0 && (
+                                    <span className="flex items-center gap-1 text-red-500 dark:text-red-400" title="Failed Passcode Attempts">
+                                      <AlertTriangle className="w-3.5 h-3.5" /> {link.failedPasscodeAttempts} failed
+                                    </span>
+                                  )}
+                                </>
                             )}
                           </div>
                         </div>

--- a/client/src/components/tasks/TaskCard.jsx
+++ b/client/src/components/tasks/TaskCard.jsx
@@ -15,6 +15,8 @@ export default function TaskCard({
   setSelectedTask,
   navigate,
   updateTaskStatus,
+  isSelected,
+  onSelectTask,
 }) {
   const [isUpdating, setIsUpdating] = useState(false);
 
@@ -39,6 +41,22 @@ export default function TaskCard({
       className="group bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-5 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-md transition-all cursor-pointer"
     >
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+        {/* Selection Checkbox */}
+        {onSelectTask && (
+          <div className="pt-1 shrink-0">
+            <input
+              type="checkbox"
+              checked={!!isSelected}
+              onChange={(e) => {
+                e.stopPropagation();
+                onSelectTask(task.id, e.target.checked);
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-5 h-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+            />
+          </div>
+        )}
+
         {/* Task Info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-start gap-3 mb-2">

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
@@ -1,4 +1,7 @@
 import { Calendar, Loader2, Send, FileText } from "lucide-react";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { knowledgeApi } from "../../../../services/knowledgeApi";
 import MeetingInformationForm from "./MeetingInformationForm";
 import ParticipantsSection from "./ParticipantsSection";
 import AgendaSection from "./AgendaSection";
@@ -29,6 +32,53 @@ const ScheduleMeeting = ({ hookProps }) => {
     removeAttachment,
     handleScheduleSubmit,
   } = hookProps;
+
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const actionItemsParam = searchParams.get("sourceActionItems");
+    if (actionItemsParam) {
+      const ids = actionItemsParam.split(",");
+      const fetchPreFillData = async () => {
+        try {
+          const res = await knowledgeApi.getActionItems("all");
+          if (res.data?.success) {
+            const selectedItems = res.data.actionItems.filter((item) =>
+              ids.includes(item.id || item._id)
+            );
+
+            if (selectedItems.length > 0) {
+              // Pre-fill Title
+              const firstSourceMeeting = selectedItems.find(
+                (item) => item.sourceMeetingId
+              )?.sourceMeetingId;
+              const title = firstSourceMeeting?.title
+                ? `Follow-up: ${firstSourceMeeting.title}`
+                : "Follow-up Meeting";
+
+              setScheduleData((prev) => ({
+                ...prev,
+                title,
+                sourceActionItemIds: ids,
+              }));
+
+              // Pre-fill Agenda Items
+              const newAgendaItems = selectedItems.map((item) => ({
+                text: item.text,
+                description: item.owner ? `Owner: ${item.owner}` : "",
+                duration: null,
+                id: Date.now().toString() + Math.random(),
+              }));
+              hookProps.setAgendaItems(newAgendaItems);
+            }
+          }
+        } catch (error) {
+          console.error("Failed to fetch action items for pre-fill:", error);
+        }
+      };
+      fetchPreFillData();
+    }
+  }, [searchParams, setScheduleData, hookProps]);
 
   return (
     <div className="bg-white shadow-lg rounded-2xl p-8">

--- a/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
+++ b/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
@@ -197,6 +197,7 @@ export const useScheduleMeeting = () => {
     newParticipant,
     setNewParticipant,
     agendaItems,
+    setAgendaItems,
     newAgenda,
     setNewAgenda,
     attachments,

--- a/client/src/pages/Tasks.jsx
+++ b/client/src/pages/Tasks.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar.jsx";
 import {
@@ -7,6 +7,7 @@ import {
   FileText,
   Loader2,
   GitMerge,
+  CalendarPlus,
 } from "lucide-react";
 import useTasks from "../hooks/useTasks";
 import TaskFilterPanel from "../components/tasks/TaskFilterPanel";
@@ -17,6 +18,13 @@ import TaskDetailsModal from "../components/tasks/TaskDetailsModal";
 const Tasks = () => {
   const navigate = useNavigate();
   const taskState = useTasks();
+  const [selectedTaskIds, setSelectedTaskIds] = useState([]);
+
+  const handleSelectTask = (taskId, isSelected) => {
+    setSelectedTaskIds((prev) =>
+      isSelected ? [...prev, taskId] : prev.filter((id) => id !== taskId)
+    );
+  };
 
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 flex flex-col">
@@ -48,6 +56,30 @@ const Tasks = () => {
           sortOrder={taskState.sortOrder}
           handleSort={taskState.handleSort}
         />
+
+        {/* Bulk Actions Toolbar */}
+        {selectedTaskIds.length > 0 && (
+          <div className="mb-6 fade-in-up bg-white dark:bg-slate-900 border border-blue-200 dark:border-blue-900 rounded-xl p-4 flex items-center justify-between shadow-sm shadow-blue-100 dark:shadow-none">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              {selectedTaskIds.length} item{selectedTaskIds.length > 1 ? "s" : ""} selected
+            </span>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => setSelectedTaskIds([])}
+                className="text-sm font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+              >
+                Clear
+              </button>
+              <button
+                onClick={() => navigate(`/create-meeting?sourceActionItems=${selectedTaskIds.join(",")}`)}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors shadow-sm"
+              >
+                <CalendarPlus className="w-4 h-4" />
+                Create Follow-up Meeting
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* Tasks List */}
         {taskState.loading ? (
@@ -105,6 +137,8 @@ const Tasks = () => {
                 setSelectedTask={taskState.setSelectedTask}
                 navigate={navigate}
                 updateTaskStatus={taskState.updateTaskStatus}
+                isSelected={selectedTaskIds.includes(task.id)}
+                onSelectTask={handleSelectTask}
               />
             ))}
           </div>

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -47,6 +47,7 @@ const createMeetingSchema = z.object({
   agendaItems: z.array(z.record(z.unknown())).optional().default([]),
   policyDetails: z.record(z.unknown()).nullable().optional(),
   recordingType: z.enum(["upload", "live"]).optional().default("upload"),
+  sourceActionItemIds: z.array(z.string()).optional(),
 });
 
 const uploadMeetingSchema = z.object({

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -113,6 +113,9 @@ export const getActiveLinksFixed = async (req, res) => {
         expirationDate: link.expirationDate,
         hasPasscode: !!link.passcode,
         createdAt: link.createdAt,
+        totalViews: link.totalViews,
+        lastAccessed: link.lastAccessed,
+        failedPasscodeAttempts: link.failedPasscodeAttempts,
       })),
     });
   } catch (error) {
@@ -186,6 +189,9 @@ export const verifyPasscode = async (req, res) => {
 
     const isMatch = await bcrypt.compare(passcode, link.passcode);
     if (!isMatch) {
+      await SharedLink.findByIdAndUpdate(link._id, {
+        $inc: { failedPasscodeAttempts: 1 },
+      });
       return res
         .status(401)
         .json({ success: false, message: "Incorrect passcode" });
@@ -288,6 +294,12 @@ export const getPublicResource = async (req, res) => {
       }
       resourceData = policy;
     }
+
+    // Update analytics atomically upon successful access
+    await SharedLink.findByIdAndUpdate(link._id, {
+      $inc: { totalViews: 1 },
+      $set: { lastAccessed: new Date() },
+    });
 
     res.status(200).json({
       success: true,

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -60,6 +60,12 @@ const meetingSchema = new mongoose.Schema(
         duration: { type: Number, default: null },
       },
     ],
+    sourceActionItemIds: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "ActionItem",
+      },
+    ],
     policyDetails: {
       // For policy-type meetings
       policyName: { type: String, default: "" },

--- a/server/models/sharedLinkModel.js
+++ b/server/models/sharedLinkModel.js
@@ -38,6 +38,18 @@ const sharedLinkSchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
+    totalViews: {
+      type: Number,
+      default: 0,
+    },
+    lastAccessed: {
+      type: Date,
+      default: null,
+    },
+    failedPasscodeAttempts: {
+      type: Number,
+      default: 0,
+    },
   },
   { timestamps: true },
 );

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -13,6 +13,7 @@ import mongoose from "mongoose";
 import User from "../models/userModel.js";
 import Membership from "../models/membershipModel.js";
 import Tag from "../models/tagModel.js";
+import ActionItem from "../models/actionItemModel.js";
 import { captureSnapshot } from "./graphSnapshotService.js";
 import eventBus from "./eventBus.js";
 import {
@@ -112,6 +113,16 @@ const _runKnowledgeGraph = (meetingDoc, mom) => {
 // ═══════════════════════════════════════════════════════════════
 
 export const createMeeting = async (uploaderId, orgId, data) => {
+  if (data.sourceActionItemIds && data.sourceActionItemIds.length > 0) {
+    const validCount = await ActionItem.countDocuments({
+      _id: { $in: data.sourceActionItemIds },
+      organization: orgId || null,
+    });
+    if (validCount !== data.sourceActionItemIds.length) {
+      throw new ValidationError("One or more invalid or unauthorized action items requested.");
+    }
+  }
+
   const meeting = await MeetingStorageService.createMeetingRecord({
     uploadedBy: uploaderId,
     organization: orgId || null,
@@ -131,6 +142,7 @@ export const createMeeting = async (uploaderId, orgId, data) => {
     summary: "",
     structuredMoM: null,
     status: "uploaded",
+    sourceActionItemIds: data.sourceActionItemIds || [],
   });
 
   scheduleIndexMeeting(meeting);


### PR DESCRIPTION
## Overview

This PR implements Smart Follow-up Meeting Creation from Action Items, enabling users to generate a meeting draft directly from selected action items while reusing the existing meeting creation workflow.

## Changes Made

### Backend

- Added optional `sourceActionItemIds` to the `Meeting` model.
- Extended the meeting creation schema to accept `sourceActionItemIds`.
- Validated that all supplied Action Items exist and belong to the current organization before creating the meeting.
- Preserved the existing meeting creation workflow and backward compatibility.

### Frontend

- Added multi-select support for action items.
- Introduced a contextual **Create Follow-up Meeting** bulk action.
- Navigated to the existing meeting creation flow using URL query parameters.
- Automatically pre-filled the meeting title and agenda from the selected action items.
- Kept the generated title and agenda fully editable before creating the meeting.

## Validation

- ✅ `npm run lint`
- ✅ `npm run build`

## Impact

- Enables faster follow-up meeting creation from pending or overdue action items.
- Maintains references between meetings and their source action items.
- Reuses the existing Meetings architecture with minimal changes.
- Preserves existing meeting creation behaviour.

Closes #721


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Select multiple tasks and create a pre-filled follow-up meeting from their action items.
  * View shared-link analytics, including total views, last access, and failed passcode attempts.
  * Track source action items when creating follow-up meetings.
* **Style**
  * Improved meeting card dark-mode support across menus, metadata, actions, and buttons.
* **Enhancements**
  * Meeting cards now display participant counts within the card details.
  * Shared-link access and passcode failures are now recorded for analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->