### PR TITLE
fix(ci): preserve Jest ESM support in related backend tests

### DIFF
--- a/scripts/validation/run-server-related-tests.mjs
+++ b/scripts/validation/run-server-related-tests.mjs
@@ -3,8 +3,13 @@ import {
   logStep,
   quoteFiles,
   repoRoot,
+  run,
   runNpx,
 } from "./changed-files.mjs";
+
+const JEST =
+  "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit";
+const serverCwd = `${repoRoot}/server`;
 
 const TEST_FILE_REGEX = /(\.test\.|\.spec\.|__tests__)/;
 const VITEST_TEST_FILES = new Set([
@@ -44,12 +49,12 @@ if (serverFiles.length === 0) {
 }
 
 if (jestTests.length > 0) {
-  runNpx(
-    `jest --runInBand --passWithNoTests ${quoteFiles(
+  run(
+    `${JEST} --runInBand --passWithNoTests ${quoteFiles(
       jestTests.map((file) => file.slice("server/".length)),
     )}`,
     {
-      cwd: `${repoRoot}/server`,
+      cwd: serverCwd,
     },
   );
 }
@@ -60,17 +65,17 @@ if (sourceFiles.length > 0) {
     (pattern) => `--testPathIgnorePatterns="${pattern}"`,
   ).join(" ");
 
-  runNpx(
-    `jest --runInBand --findRelatedTests --passWithNoTests ${ignoreArgs} ${quoteFiles(
+  run(
+    `${JEST} --runInBand --findRelatedTests --passWithNoTests ${ignoreArgs} ${quoteFiles(
       scopedSources,
     )}`,
     {
-      cwd: `${repoRoot}/server`,
+      cwd: serverCwd,
     },
   );
 
   runNpx(`vitest related --passWithNoTests ${quoteFiles(scopedSources)}`, {
-    cwd: `${repoRoot}/server`,
+    cwd: serverCwd,
   });
 }
 
@@ -80,7 +85,7 @@ if (vitestTests.length > 0) {
       vitestTests.map((file) => file.slice("server/".length)),
     )}`,
     {
-    cwd: `${repoRoot}/server`,
+      cwd: serverCwd,
     },
   );
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a regression introduced by the contributor-first validation architecture.

### Issue

Backend Validation failed during `test:related` execution with:

```text
SyntaxError: Cannot use import statement outside a module
```

The issue occurred because `test:related` invoked Jest using a different execution path than `test:ci`, causing ESM modules (such as `server/tests/setup.js`) to be loaded incorrectly.

### Changes

- Updated the related Jest execution to use the same ESM-compatible invocation as `test:ci`.
- Preserved the existing contributor-first validation architecture.
- Kept related-test execution fast without reverting to the full backend test suite.

### Result

- ✅ Backend Validation now correctly supports ESM modules.
- ✅ Related Jest tests execute successfully.
- ✅ Contributor validation remains fast.
- ✅ No workflow architecture or CI behavior was changed beyond fixing the regression.

---

## Type of Change

- [x] Bug Fix

---

## Related Issue

Closes #

---

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Verified

- Backend `test:related` executes successfully.
- Jest loads ESM test setup correctly.
- Contributor validation remains scoped to related tests.
- Existing CI architecture remains unchanged.

---

## Screenshots

N/A

---

## Checklist

- [x] Code follows project conventions
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review