### PR TITLE
Simplify authenticated navbar by removing AI Search and AI Assistant …

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -21,7 +21,6 @@ import {
   Calendar,
   CalendarDays,
   Building2,
-  Search,
   Bell,
   User,
   Settings,
@@ -36,7 +35,6 @@ import {
   Plus,
   Compass,
   Check,
-  MessageSquare,
 } from "lucide-react";
 
 const NAV_LINK_KEYS = [
@@ -265,6 +263,7 @@ const Navbar = () => {
       if (e.key === "Escape") {
         setMenuOpen(false);
         setNotificationsOpen(false);
+        setOrgDropdownOpen(false);
         setMobileOpen(false);
       }
     };
@@ -328,9 +327,6 @@ const Navbar = () => {
         currentPath === "/join-organization"
       );
     }
-    if (tabPath === "/ai-search") {
-      return currentPath === "/ai-search";
-    }
     return currentPath === tabPath;
   };
 
@@ -358,17 +354,6 @@ const Navbar = () => {
       href: "/organizations",
       icon: Building2,
       permission: { resource: "organizations", action: "view" },
-    },
-    {
-      label: t("navbar.aiSearch"),
-      href: "/ai-search",
-      icon: Search,
-      permission: { resource: "ai_search", action: "search" },
-    },
-    {
-      label: "AI Assistant",
-      href: "/assistant",
-      icon: MessageSquare,
     },
   ].filter(
     (link) =>
@@ -464,7 +449,7 @@ const Navbar = () => {
           {userData ? (
             /* Logged In Desktop App Nav */
             <nav
-              className="hidden md:flex items-center gap-1.5 bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700 p-1 rounded-2xl"
+              className="hidden md:flex items-center gap-1 lg:gap-1.5 bg-gray-50 dark:bg-gray-800/50 border border-gray-100 dark:border-gray-700 p-1 rounded-2xl"
               aria-label="Application navigation"
             >
               {primaryLinks.map((link) => {
@@ -472,8 +457,10 @@ const Navbar = () => {
                 return (
                   <button
                     key={link.href}
+                    type="button"
                     onClick={() => navigate(link.href)}
-                    className={`flex items-center px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer ${
+                    aria-current={active ? "page" : undefined}
+                    className={`flex items-center px-3 lg:px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900 cursor-pointer ${
                       active
                         ? "bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-xs border border-gray-100/50 dark:border-gray-600/50"
                         : "text-gray-600 dark:text-gray-300 border border-transparent hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100/60 dark:hover:bg-gray-700/60"
@@ -503,7 +490,7 @@ const Navbar = () => {
           )}
 
           {/* Right Side Controls */}
-          <div className="flex items-center gap-1 sm:gap-3 shrink-0">
+          <div className="flex items-center gap-1.5 sm:gap-2.5 lg:gap-3 shrink-0">
             {/* Language Switcher */}
             <LanguageSwitcher />
 
@@ -1048,11 +1035,13 @@ const Navbar = () => {
                 return (
                   <button
                     key={link.href}
+                    type="button"
                     onClick={() => {
                       setMobileOpen(false);
                       navigate(link.href);
                     }}
-                    className={`w-full flex items-center gap-3 px-4 py-3 text-sm font-semibold rounded-xl transition-all cursor-pointer ${
+                    aria-current={active ? "page" : undefined}
+                    className={`w-full flex items-center gap-3 px-4 py-3 text-sm font-semibold rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer ${
                       active
                         ? "bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400"
                         : "text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100"


### PR DESCRIPTION
## Summary
- Remove AI Search and AI Assistant from the primary authenticated navbar
- Tighten spacing/focus styles and improve Escape / `aria-current` behavior
- Keep theme, language, notifications, org switcher, and user menu intact
Closes #726
## Test plan
- [ ] Desktop: primary nav shows Dashboard, Meetings, Tasks, Organizations only
- [ ] Mobile drawer: no AI Search / AI Assistant entries
- [ ] Theme toggle, language switcher, notifications, org switcher, user menu still work
- [ ] Keyboard: Tab focus rings + Escape closes dropdowns/menus
- [ ] Existing routes (including `/ai-search` if opened elsewhere) still load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the AI Search and AI Assistant links from the navigation.
  * Pressing Escape now closes the organization menu.
  * Improved navigation button accessibility with active-state indicators and visible keyboard focus styling.
  * Updated navigation controls to behave consistently across desktop and mobile layouts.
  * Refined spacing for right-side navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->