### PR TITLE
Drive Present Mode from meeting agenda sections with timers.

### DIFF
--- a/client/src/components/meeting-details/PresentMode.jsx
+++ b/client/src/components/meeting-details/PresentMode.jsx
@@ -1,52 +1,91 @@
-import React, { useState, useEffect, useCallback } from "react";
-import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { X, ChevronLeft, ChevronRight, Clock, ListOrdered } from "lucide-react";
 import { format } from "date-fns";
+import useTheme from "../../context/useTheme.jsx";
+
+const formatCountdown = (totalSeconds) => {
+  const safe = Math.max(0, totalSeconds || 0);
+  const mins = Math.floor(safe / 60);
+  const secs = safe % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+};
 
 const PresentMode = ({ meeting, onClose }) => {
+  const { theme } = useTheme();
+  const isDark = theme !== "light";
+
+  const agendaItems = useMemo(
+    () =>
+      Array.isArray(meeting?.agendaItems)
+        ? meeting.agendaItems.filter((item) => item?.text?.trim())
+        : [],
+    [meeting?.agendaItems],
+  );
+  const hasAgenda = agendaItems.length > 0;
+
   const [currentSlide, setCurrentSlide] = useState(0);
+  const [currentSection, setCurrentSection] = useState(0);
+  const [secondsLeft, setSecondsLeft] = useState(null);
+  const [sectionEnded, setSectionEnded] = useState(false);
 
-  // Extract data
-  const summary = meeting.summary || meeting.structuredMoM || {};
-  const isStructured = typeof summary === "object";
+  const slides = useMemo(() => {
+    const summarySource = meeting.summary || meeting.structuredMoM;
+    const isStructured =
+      summarySource !== null &&
+      summarySource !== undefined &&
+      typeof summarySource === "object";
+    const summary = isStructured ? summarySource : {};
+    const next = [];
 
-  const slides = [];
-
-  // Slide 1: Title & Meta
-  slides.push({
-    type: "title",
-    title: meeting.title || "Untitled Meeting",
-    date: meeting.date ? format(new Date(meeting.date), "MMMM d, yyyy") : "N/A",
-    duration: meeting.duration ? `${meeting.duration} minutes` : "N/A",
-    attendees: isStructured && summary.attendees ? summary.attendees : [],
-  });
-
-  // Slide 2: Summary
-  const summaryText = isStructured ? summary.summary : summary;
-  if (summaryText && typeof summaryText === "string") {
-    slides.push({
-      type: "summary",
-      title: "Executive Summary",
-      content: summaryText,
+    next.push({
+      type: "title",
+      title: meeting.title || "Untitled Meeting",
+      date: meeting.date
+        ? format(new Date(meeting.date), "MMMM d, yyyy")
+        : "N/A",
+      duration: meeting.duration ? `${meeting.duration} minutes` : "N/A",
+      attendees: isStructured && summary.attendees ? summary.attendees : [],
     });
-  }
 
-  // Slide 3: Decisions
-  if (isStructured && summary.decisions && summary.decisions.length > 0) {
-    slides.push({
-      type: "decisions",
-      title: "Key Decisions",
-      items: summary.decisions,
-    });
-  }
+    const summaryText = isStructured ? summary.summary : summarySource;
+    if (summaryText && typeof summaryText === "string") {
+      next.push({
+        type: "summary",
+        title: "Executive Summary",
+        content: summaryText,
+      });
+    }
 
-  // Slide 4: Action Items
-  if (isStructured && summary.action_items && summary.action_items.length > 0) {
-    slides.push({
-      type: "actions",
-      title: "Action Items",
-      items: summary.action_items,
-    });
-  }
+    if (isStructured && summary.decisions?.length > 0) {
+      next.push({
+        type: "decisions",
+        title: "Key Decisions",
+        items: summary.decisions,
+      });
+    }
+
+    if (isStructured && summary.action_items?.length > 0) {
+      next.push({
+        type: "actions",
+        title: "Action Items",
+        items: summary.action_items,
+      });
+    }
+
+    return next;
+  }, [
+    meeting.title,
+    meeting.date,
+    meeting.duration,
+    meeting.summary,
+    meeting.structuredMoM,
+  ]);
+
+  const activeAgenda = hasAgenda ? agendaItems[currentSection] : null;
+  const agendaDuration =
+    typeof activeAgenda?.duration === "number" && activeAgenda.duration > 0
+      ? activeAgenda.duration
+      : null;
 
   const nextSlide = useCallback(() => {
     setCurrentSlide((prev) => Math.min(prev + 1, slides.length - 1));
@@ -56,17 +95,52 @@ const PresentMode = ({ meeting, onClose }) => {
     setCurrentSlide((prev) => Math.max(prev - 1, 0));
   }, []);
 
+  const nextSection = useCallback(() => {
+    setCurrentSection((prev) => Math.min(prev + 1, agendaItems.length - 1));
+  }, [agendaItems.length]);
+
+  const prevSection = useCallback(() => {
+    setCurrentSection((prev) => Math.max(prev - 1, 0));
+  }, []);
+
+  // Reset countdown whenever the agenda section changes
+  useEffect(() => {
+    if (!hasAgenda) return;
+    setSectionEnded(false);
+    if (agendaDuration) {
+      setSecondsLeft(Math.round(agendaDuration * 60));
+    } else {
+      setSecondsLeft(null);
+    }
+  }, [hasAgenda, currentSection, agendaDuration]);
+
+  useEffect(() => {
+    if (!hasAgenda || secondsLeft === null || sectionEnded) return;
+    if (secondsLeft <= 0) {
+      setSectionEnded(true);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setSecondsLeft((prev) => (prev === null ? null : prev - 1));
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [hasAgenda, secondsLeft, sectionEnded]);
+
   useEffect(() => {
     const handleKeyDown = (e) => {
-      if (e.key === "ArrowRight") nextSlide();
-      if (e.key === "ArrowLeft") prevSlide();
       if (e.key === "Escape") onClose();
+      if (hasAgenda) {
+        if (e.key === "ArrowRight") nextSection();
+        if (e.key === "ArrowLeft") prevSection();
+      } else {
+        if (e.key === "ArrowRight") nextSlide();
+        if (e.key === "ArrowLeft") prevSlide();
+      }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [nextSlide, prevSlide, onClose]);
+  }, [hasAgenda, nextSection, prevSection, nextSlide, prevSlide, onClose]);
 
-  // Request fullscreen on mount
   useEffect(() => {
     const elem = document.documentElement;
     if (elem.requestFullscreen) {
@@ -82,29 +156,61 @@ const PresentMode = ({ meeting, onClose }) => {
     };
   }, []);
 
+  const shellClass = isDark
+    ? "bg-gray-950 text-white"
+    : "bg-slate-50 text-slate-900";
+  const panelClass = isDark
+    ? "bg-white/10 hover:bg-white/20 text-white/70 hover:text-white"
+    : "bg-slate-900/5 hover:bg-slate-900/10 text-slate-600 hover:text-slate-900";
+  const footerClass = isDark
+    ? "border-white/10 bg-black/20"
+    : "border-slate-200 bg-white/80";
+  const mutedText = isDark ? "text-white/50" : "text-slate-500";
+  const cardClass = isDark
+    ? "bg-white/5 border-white/10 text-gray-200"
+    : "bg-white border-slate-200 text-slate-700 shadow-sm";
+
   const renderSlideContent = (slide) => {
     switch (slide.type) {
       case "title":
         return (
           <div className="flex flex-col items-center justify-center h-full text-center space-y-6">
-            <h1 className="text-5xl md:text-7xl font-bold text-white bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-indigo-500 leading-tight pb-2">
+            <h1
+              className={`text-5xl md:text-7xl font-bold leading-tight pb-2 bg-clip-text text-transparent bg-gradient-to-r ${
+                isDark
+                  ? "from-blue-400 to-indigo-500"
+                  : "from-blue-600 to-indigo-700"
+              }`}
+            >
               {slide.title}
             </h1>
-            <div className="text-xl md:text-2xl text-gray-300 flex items-center space-x-4">
+            <div
+              className={`text-xl md:text-2xl flex items-center space-x-4 ${
+                isDark ? "text-gray-300" : "text-slate-600"
+              }`}
+            >
               <span>{slide.date}</span>
               <span>&bull;</span>
               <span>{slide.duration}</span>
             </div>
             {slide.attendees.length > 0 && (
               <div className="mt-8 max-w-3xl">
-                <h3 className="text-lg text-gray-400 uppercase tracking-wider mb-4">
+                <h3
+                  className={`text-lg uppercase tracking-wider mb-4 ${
+                    isDark ? "text-gray-400" : "text-slate-500"
+                  }`}
+                >
                   Attendees
                 </h3>
                 <div className="flex flex-wrap justify-center gap-3">
                   {slide.attendees.map((attendee, idx) => (
                     <span
                       key={idx}
-                      className="px-4 py-2 bg-white/10 rounded-full text-white backdrop-blur-sm border border-white/20"
+                      className={`px-4 py-2 rounded-full backdrop-blur-sm border ${
+                        isDark
+                          ? "bg-white/10 text-white border-white/20"
+                          : "bg-white text-slate-700 border-slate-200"
+                      }`}
                     >
                       {attendee}
                     </span>
@@ -117,10 +223,16 @@ const PresentMode = ({ meeting, onClose }) => {
       case "summary":
         return (
           <div className="flex flex-col h-full justify-center max-w-5xl mx-auto w-full">
-            <h2 className="text-4xl md:text-5xl font-bold text-white mb-12 text-center">
+            <h2
+              className={`text-4xl md:text-5xl font-bold mb-12 text-center ${
+                isDark ? "text-white" : "text-slate-900"
+              }`}
+            >
               {slide.title}
             </h2>
-            <div className="text-2xl leading-relaxed text-gray-200 bg-white/5 p-10 rounded-3xl backdrop-blur-md border border-white/10 shadow-2xl max-h-[60vh] overflow-y-auto">
+            <div
+              className={`text-2xl leading-relaxed p-10 rounded-3xl backdrop-blur-md border shadow-2xl max-h-[60vh] overflow-y-auto ${cardClass}`}
+            >
               {slide.content}
             </div>
           </div>
@@ -128,19 +240,39 @@ const PresentMode = ({ meeting, onClose }) => {
       case "decisions":
         return (
           <div className="flex flex-col h-full justify-center max-w-5xl mx-auto w-full">
-            <h2 className="text-4xl md:text-5xl font-bold text-white mb-12 text-center">
+            <h2
+              className={`text-4xl md:text-5xl font-bold mb-12 text-center ${
+                isDark ? "text-white" : "text-slate-900"
+              }`}
+            >
               {slide.title}
             </h2>
             <div className="grid gap-6 max-h-[60vh] overflow-y-auto pr-4">
               {slide.items.map((decision, idx) => (
                 <div
                   key={idx}
-                  className="flex items-start gap-6 bg-gradient-to-r from-green-900/40 to-green-800/20 p-6 rounded-2xl border border-green-500/30 backdrop-blur-sm transform transition-all hover:scale-[1.02]"
+                  className={`flex items-start gap-6 p-6 rounded-2xl border backdrop-blur-sm ${
+                    isDark
+                      ? "bg-gradient-to-r from-green-900/40 to-green-800/20 border-green-500/30"
+                      : "bg-emerald-50 border-emerald-200"
+                  }`}
                 >
-                  <div className="flex-shrink-0 w-12 h-12 bg-green-500/20 text-green-400 rounded-full flex items-center justify-center text-xl font-bold border border-green-500/50">
+                  <div
+                    className={`flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold border ${
+                      isDark
+                        ? "bg-green-500/20 text-green-400 border-green-500/50"
+                        : "bg-emerald-100 text-emerald-700 border-emerald-300"
+                    }`}
+                  >
                     {idx + 1}
                   </div>
-                  <p className="text-2xl text-gray-200 mt-2">{decision}</p>
+                  <p
+                    className={`text-2xl mt-2 ${
+                      isDark ? "text-gray-200" : "text-slate-800"
+                    }`}
+                  >
+                    {decision}
+                  </p>
                 </div>
               ))}
             </div>
@@ -149,7 +281,11 @@ const PresentMode = ({ meeting, onClose }) => {
       case "actions":
         return (
           <div className="flex flex-col h-full justify-center max-w-5xl mx-auto w-full">
-            <h2 className="text-4xl md:text-5xl font-bold text-white mb-12 text-center">
+            <h2
+              className={`text-4xl md:text-5xl font-bold mb-12 text-center ${
+                isDark ? "text-white" : "text-slate-900"
+              }`}
+            >
               {slide.title}
             </h2>
             <div className="grid gap-6 max-h-[60vh] overflow-y-auto pr-4">
@@ -160,48 +296,46 @@ const PresentMode = ({ meeting, onClose }) => {
                 return (
                   <div
                     key={idx}
-                    className="flex flex-col gap-4 bg-gradient-to-r from-blue-900/40 to-blue-800/20 p-6 rounded-2xl border border-blue-500/30 backdrop-blur-sm transform transition-all hover:scale-[1.02]"
+                    className={`flex flex-col gap-4 p-6 rounded-2xl border backdrop-blur-sm ${
+                      isDark
+                        ? "bg-gradient-to-r from-blue-900/40 to-blue-800/20 border-blue-500/30"
+                        : "bg-blue-50 border-blue-200"
+                    }`}
                   >
                     <div className="flex items-start gap-6">
-                      <div className="flex-shrink-0 w-12 h-12 bg-blue-500/20 text-blue-400 rounded-full flex items-center justify-center text-xl font-bold border border-blue-500/50">
+                      <div
+                        className={`flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold border ${
+                          isDark
+                            ? "bg-blue-500/20 text-blue-400 border-blue-500/50"
+                            : "bg-blue-100 text-blue-700 border-blue-300"
+                        }`}
+                      >
                         {idx + 1}
                       </div>
                       <div className="flex-1">
-                        <p className="text-2xl text-gray-200 mt-2">{task}</p>
+                        <p
+                          className={`text-2xl mt-2 ${
+                            isDark ? "text-gray-200" : "text-slate-800"
+                          }`}
+                        >
+                          {task}
+                        </p>
                         <div className="flex gap-6 mt-4">
                           {owner && (
-                            <span className="flex items-center gap-2 text-blue-300 text-lg">
-                              <svg
-                                className="w-5 h-5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                                />
-                              </svg>
+                            <span
+                              className={`text-lg ${
+                                isDark ? "text-blue-300" : "text-blue-700"
+                              }`}
+                            >
                               {owner}
                             </span>
                           )}
                           {dueDate && (
-                            <span className="flex items-center gap-2 text-indigo-300 text-lg">
-                              <svg
-                                className="w-5 h-5"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth={2}
-                                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                                />
-                              </svg>
+                            <span
+                              className={`text-lg ${
+                                isDark ? "text-indigo-300" : "text-indigo-700"
+                              }`}
+                            >
                               {dueDate}
                             </span>
                           )}
@@ -219,18 +353,223 @@ const PresentMode = ({ meeting, onClose }) => {
     }
   };
 
+  if (hasAgenda) {
+    const timerUrgent =
+      secondsLeft !== null && secondsLeft <= 60 && !sectionEnded;
+
+    return (
+      <div
+        className={`fixed inset-0 z-50 overflow-hidden font-sans ${shellClass}`}
+      >
+        <div className="absolute inset-0 z-0 overflow-hidden pointer-events-none">
+          <div
+            className={`absolute top-[-20%] left-[-10%] w-[50%] h-[50%] rounded-full blur-[120px] ${
+              isDark ? "bg-blue-900/20" : "bg-blue-200/40"
+            }`}
+          />
+          <div
+            className={`absolute bottom-[-20%] right-[-10%] w-[50%] h-[50%] rounded-full blur-[120px] ${
+              isDark ? "bg-indigo-900/20" : "bg-indigo-200/40"
+            }`}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className={`absolute top-6 right-6 z-20 p-3 rounded-full backdrop-blur-md transition-all ${panelClass}`}
+          title="Close (Esc)"
+          aria-label="Close present mode"
+        >
+          <X className="w-6 h-6" />
+        </button>
+
+        <div className="relative z-10 w-full h-full flex flex-col">
+          <div className="px-8 md:px-16 pt-8 flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p
+                className={`text-xs uppercase tracking-[0.2em] font-semibold mb-2 ${mutedText}`}
+              >
+                Agenda · Section {currentSection + 1} of {agendaItems.length}
+              </p>
+              <h1
+                className={`text-3xl md:text-5xl font-bold truncate ${
+                  isDark ? "text-white" : "text-slate-900"
+                }`}
+              >
+                {meeting.title || "Untitled Meeting"}
+              </h1>
+            </div>
+
+            <div
+              className={`shrink-0 flex items-center gap-2 px-4 py-2 rounded-2xl border backdrop-blur-md ${
+                sectionEnded
+                  ? isDark
+                    ? "border-amber-400/40 bg-amber-500/10 text-amber-200"
+                    : "border-amber-300 bg-amber-50 text-amber-800"
+                  : timerUrgent
+                    ? isDark
+                      ? "border-rose-400/40 bg-rose-500/10 text-rose-200"
+                      : "border-rose-300 bg-rose-50 text-rose-700"
+                    : isDark
+                      ? "border-white/10 bg-white/5 text-white/80"
+                      : "border-slate-200 bg-white text-slate-700"
+              }`}
+              aria-live="polite"
+            >
+              <Clock className="w-4 h-4 opacity-80" />
+              <span className="font-mono text-lg tabular-nums">
+                {secondsLeft === null
+                  ? "Untimed"
+                  : formatCountdown(secondsLeft)}
+              </span>
+            </div>
+          </div>
+
+          {sectionEnded && (
+            <div
+              className={`mx-8 md:mx-16 mt-4 px-4 py-3 rounded-xl text-sm font-medium border ${
+                isDark
+                  ? "bg-amber-500/10 border-amber-400/30 text-amber-100"
+                  : "bg-amber-50 border-amber-200 text-amber-900"
+              }`}
+              role="status"
+            >
+              Section time is up — advance when you are ready.
+            </div>
+          )}
+
+          <div className="flex-1 flex items-center justify-center px-8 md:px-16 py-10">
+            <div
+              className={`w-full max-w-4xl rounded-3xl border p-8 md:p-12 backdrop-blur-md ${cardClass}`}
+            >
+              <div
+                className={`inline-flex items-center gap-2 text-sm font-semibold mb-6 ${
+                  isDark ? "text-blue-300" : "text-blue-700"
+                }`}
+              >
+                <ListOrdered className="w-4 h-4" />
+                Current section
+              </div>
+              <h2
+                className={`text-4xl md:text-5xl font-bold leading-tight ${
+                  isDark ? "text-white" : "text-slate-900"
+                }`}
+              >
+                {activeAgenda?.text}
+              </h2>
+              {activeAgenda?.description ? (
+                <p
+                  className={`mt-6 text-xl leading-relaxed ${
+                    isDark ? "text-gray-300" : "text-slate-600"
+                  }`}
+                >
+                  {activeAgenda.description}
+                </p>
+              ) : null}
+              {agendaDuration ? (
+                <p className={`mt-8 text-sm ${mutedText}`}>
+                  Planned for {agendaDuration} minute
+                  {agendaDuration === 1 ? "" : "s"}
+                </p>
+              ) : (
+                <p className={`mt-8 text-sm ${mutedText}`}>
+                  No duration set for this section
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div
+            className={`h-24 px-8 md:px-12 flex items-center justify-between border-t backdrop-blur-md ${footerClass}`}
+          >
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={prevSection}
+                disabled={currentSection === 0}
+                aria-label="Previous agenda section"
+                className={`p-3 rounded-full transition-all ${
+                  currentSection === 0
+                    ? isDark
+                      ? "text-white/20 cursor-not-allowed"
+                      : "text-slate-300 cursor-not-allowed"
+                    : isDark
+                      ? "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                      : "text-slate-800 hover:bg-slate-900/5 hover:scale-110 active:scale-95"
+                }`}
+              >
+                <ChevronLeft className="w-8 h-8" />
+              </button>
+              <button
+                type="button"
+                onClick={nextSection}
+                disabled={currentSection === agendaItems.length - 1}
+                aria-label="Next agenda section"
+                className={`p-3 rounded-full transition-all ${
+                  currentSection === agendaItems.length - 1
+                    ? isDark
+                      ? "text-white/20 cursor-not-allowed"
+                      : "text-slate-300 cursor-not-allowed"
+                    : isDark
+                      ? "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                      : "text-slate-800 hover:bg-slate-900/5 hover:scale-110 active:scale-95"
+                }`}
+              >
+                <ChevronRight className="w-8 h-8" />
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2">
+              {agendaItems.map((_, idx) => (
+                <button
+                  key={idx}
+                  type="button"
+                  onClick={() => setCurrentSection(idx)}
+                  className={`h-2 rounded-full transition-all duration-300 ${
+                    idx === currentSection
+                      ? "w-8 bg-blue-500"
+                      : isDark
+                        ? "w-2 bg-white/30 hover:bg-white/50"
+                        : "w-2 bg-slate-300 hover:bg-slate-400"
+                  }`}
+                  aria-label={`Go to agenda section ${idx + 1}`}
+                />
+              ))}
+            </div>
+
+            <div className={`font-medium ${mutedText}`}>
+              Section {currentSection + 1} of {agendaItems.length}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="fixed inset-0 z-50 bg-gray-950 text-white overflow-hidden font-sans">
-      {/* Background decoration */}
+    <div
+      className={`fixed inset-0 z-50 overflow-hidden font-sans ${shellClass}`}
+    >
       <div className="absolute inset-0 z-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-[-20%] left-[-10%] w-[50%] h-[50%] rounded-full bg-blue-900/20 blur-[120px]" />
-        <div className="absolute bottom-[-20%] right-[-10%] w-[50%] h-[50%] rounded-full bg-indigo-900/20 blur-[120px]" />
+        <div
+          className={`absolute top-[-20%] left-[-10%] w-[50%] h-[50%] rounded-full blur-[120px] ${
+            isDark ? "bg-blue-900/20" : "bg-blue-200/40"
+          }`}
+        />
+        <div
+          className={`absolute bottom-[-20%] right-[-10%] w-[50%] h-[50%] rounded-full blur-[120px] ${
+            isDark ? "bg-indigo-900/20" : "bg-indigo-200/40"
+          }`}
+        />
       </div>
 
       <button
+        type="button"
         onClick={onClose}
-        className="absolute top-6 right-6 z-20 p-3 bg-white/10 hover:bg-white/20 rounded-full backdrop-blur-md transition-all text-white/70 hover:text-white"
+        className={`absolute top-6 right-6 z-20 p-3 rounded-full backdrop-blur-md transition-all ${panelClass}`}
         title="Close (Esc)"
+        aria-label="Close present mode"
       >
         <X className="w-6 h-6" />
       </button>
@@ -253,27 +592,38 @@ const PresentMode = ({ meeting, onClose }) => {
           ))}
         </div>
 
-        {/* Controls and Progress */}
-        <div className="h-24 px-12 flex items-center justify-between border-t border-white/10 bg-black/20 backdrop-blur-md">
+        <div
+          className={`h-24 px-12 flex items-center justify-between border-t backdrop-blur-md ${footerClass}`}
+        >
           <div className="flex items-center gap-4">
             <button
+              type="button"
               onClick={prevSlide}
               disabled={currentSlide === 0}
               className={`p-3 rounded-full transition-all ${
                 currentSlide === 0
-                  ? "text-white/20 cursor-not-allowed"
-                  : "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                  ? isDark
+                    ? "text-white/20 cursor-not-allowed"
+                    : "text-slate-300 cursor-not-allowed"
+                  : isDark
+                    ? "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                    : "text-slate-800 hover:bg-slate-900/5 hover:scale-110 active:scale-95"
               }`}
             >
               <ChevronLeft className="w-8 h-8" />
             </button>
             <button
+              type="button"
               onClick={nextSlide}
               disabled={currentSlide === slides.length - 1}
               className={`p-3 rounded-full transition-all ${
                 currentSlide === slides.length - 1
-                  ? "text-white/20 cursor-not-allowed"
-                  : "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                  ? isDark
+                    ? "text-white/20 cursor-not-allowed"
+                    : "text-slate-300 cursor-not-allowed"
+                  : isDark
+                    ? "text-white hover:bg-white/10 hover:scale-110 active:scale-95"
+                    : "text-slate-800 hover:bg-slate-900/5 hover:scale-110 active:scale-95"
               }`}
             >
               <ChevronRight className="w-8 h-8" />
@@ -284,18 +634,21 @@ const PresentMode = ({ meeting, onClose }) => {
             {slides.map((_, idx) => (
               <button
                 key={idx}
+                type="button"
                 onClick={() => setCurrentSlide(idx)}
                 className={`h-2 rounded-full transition-all duration-300 ${
                   idx === currentSlide
                     ? "w-8 bg-blue-500"
-                    : "w-2 bg-white/30 hover:bg-white/50"
+                    : isDark
+                      ? "w-2 bg-white/30 hover:bg-white/50"
+                      : "w-2 bg-slate-300 hover:bg-slate-400"
                 }`}
                 aria-label={`Go to slide ${idx + 1}`}
               />
             ))}
           </div>
 
-          <div className="text-white/50 font-medium">
+          <div className={`font-medium ${mutedText}`}>
             Slide {currentSlide + 1} of {slides.length}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Use `meeting.agendaItems` in Present Mode when a template/agenda exists
- Add section title, countdown timer, Prev/Next navigation, and timer reset
- Keep the existing MoM slideshow as fallback for meetings without an agenda
Closes #725
## Test plan
- [ ] Create a meeting from a template with timed agenda blocks
- [ ] Open Present Mode and confirm sections + countdown
- [ ] Use Prev/Next (and arrow keys) and confirm the timer resets
- [ ] Let a section timer hit zero and confirm the end-of-section notice
- [ ] Open Present Mode on a meeting without agenda and confirm MoM slides still work
- [ ] Check light and dark theme