### PR TITLE
fix: remove sensitive authentication data from server logs

### DIFF
--- a/server/middleware/userAuth.js
+++ b/server/middleware/userAuth.js
@@ -46,3 +46,5 @@ console.log("Decoded JWT user id:", decoded?.id);
 };
 
 export default userAuth;
+
+

--- a/server/middleware/userAuth.js
+++ b/server/middleware/userAuth.js
@@ -3,12 +3,11 @@ import userModel from "../models/userModel.js";
 
 const userAuth = async (req, res, next) => {
   try {
-    console.log("=================================");
+console.log("=================================");
     console.log("Origin:", req.headers.origin);
-    console.log("Cookies:", req.cookies);
-    console.log("Authorization:", req.headers.authorization);
+    console.log("Cookies present:", req.cookies?.token ? "YES" : "NO");
+    console.log("Authorization header present:", req.headers.authorization ? "YES" : "NO");
     console.log("=================================");
-
     const token =
       req.cookies?.token || req.header("Authorization")?.replace("Bearer ", "");
 
@@ -23,8 +22,7 @@ const userAuth = async (req, res, next) => {
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    console.log("Decoded JWT:", decoded);
-
+console.log("Decoded JWT user id:", decoded?.id);
     const user = await userModel.findById(decoded.id).select("-password");
 
     if (!user) {


### PR DESCRIPTION
## Summary
Fixes #612 by removing sensitive authentication data from application logs in the auth middleware.

## Changes
- `server/middleware/userAuth.js`
  - Stopped logging raw `req.cookies` and the raw `Authorization` header; now only logs whether each is present.
  - Stopped logging the full decoded JWT payload; now logs only the user id from the token.

## Why
Logging cookies, authorization headers, and full JWT payloads exposes credentials in application logs, increasing the risk of credential leakage if logs are ever exposed or compromised.

## Acceptance Criteria
- [x] Cookies are not logged.
- [x] Authorization headers are removed/redacted from logs.
- [x] Debug logging remains useful (existence/presence checks) without exposing credentials.

Closes #612 
@imuniqueshiv 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved authentication diagnostics with safer debug logging for token presence and decoded user identification.
  * Authentication behavior and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->