### PR TITLE
fix: capture raw request body before JSON parsing for Slack signature verification

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -23,6 +23,14 @@ export function configureExpress(app) {
   // MIDDLEWARES
   app.use(cors(corsOptions));
 
+  // ==========================================
+  // 1a. SLACK WEBHOOK ROUTE (raw body required for signature verification)
+  //     Must be mounted BEFORE the global JSON/urlencoded parsers below,
+  //     so slackWebhookParser is the first thing to read the request
+  //     stream and can capture req.rawBody exactly as Slack sent it.
+  // ==========================================
+  app.use("/api/slack", slackWebhookParser, slackRoutes);
+
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ extended: true, limit: "50mb" }));
 
@@ -30,7 +38,6 @@ export function configureExpress(app) {
   // 1. BYPASSED ROUTES (No CSRF Protection)
   //    External services authenticate via their own mechanisms.
   // ==========================================
-  app.use("/api/slack", slackWebhookParser, slackRoutes);
   app.use("/api/webhooks", webhookRoutes);
   app.use("/api/public/shared", publicSharedRoutes);
 

--- a/server/tests/slack.test.js
+++ b/server/tests/slack.test.js
@@ -143,6 +143,66 @@ describe("verifySlackSignature (unit)", () => {
   });
 });
 
+// Regression: raw body must be captured BEFORE any JSON parsing
+//
+// This guards against the bug in #614, where a global express.json()
+// parser ran before slackWebhookParser was mounted. That consumed the
+// request stream first, so req.rawBody no longer matched the exact bytes
+// Slack signed — silently breaking signature verification.
+//
+// This test builds a minimal app using the SAME middleware order as
+// server/config/express.js (slackWebhookParser mounted before the global
+// JSON parser) and confirms req.rawBody exactly matches what was sent,
+// and that a signature computed over it verifies successfully.
+
+describe("Raw body capture ordering (regression for #614)", () => {
+  it("captures req.rawBody before the global JSON parser can touch it", async () => {
+    const express = (await import("express")).default;
+    const { slackWebhookParser } = await import(
+      "../middleware/slackWebhookParser.js"
+    );
+
+    const testApp = express();
+
+    // Same order as configureExpress(): Slack route + its raw-body
+    // capturing parser mounted BEFORE the global JSON parser.
+    testApp.post(
+      "/api/slack/events",
+      slackWebhookParser,
+      (req, res) => {
+        res.json({ rawBody: req.rawBody ? req.rawBody.toString("utf8") : null });
+      },
+    );
+    testApp.use(express.json({ limit: "50mb" }));
+
+    const payload = { type: "event_callback", team_id: "TREGRESSION" };
+    const rawPayloadString = JSON.stringify(payload);
+
+    const res = await request(testApp)
+      .post("/api/slack/events")
+      .set("Content-Type", "application/json")
+      .send(rawPayloadString);
+
+    expect(res.status).toBe(200);
+    // The captured rawBody must be byte-for-byte identical to what was sent
+    expect(res.body.rawBody).toBe(rawPayloadString);
+
+    // And a signature computed over that captured rawBody must verify
+    const { signature, timestamp } = generateSlackSignature(
+      res.body.rawBody,
+    );
+    const mockReq = {
+      headers: {
+        "x-slack-signature": signature,
+        "x-slack-request-timestamp": timestamp,
+      },
+      rawBody: Buffer.from(res.body.rawBody),
+    };
+    const result = verifySlackSignature(mockReq);
+    expect(result.valid).toBe(true);
+  });
+});
+
 // Integration tests — /api/slack/events
 // NOTE: In NODE_ENV=test, slackSignatureMiddleware is bypassed.
 


### PR DESCRIPTION
## Summary
Fixes #614 by ensuring the raw request body is captured before any JSON parsing occurs, so Slack webhook signature verification works reliably.

## Root Cause
In `server/config/express.js`, the global `express.json()` / `express.urlencoded()` middleware was applied BEFORE the `/api/slack` route (and its `slackWebhookParser`) was mounted. This meant the request stream was already consumed by the time `slackWebhookParser` tried to capture `req.rawBody`, so the raw bytes no longer matched what Slack originally signed.

## Changes
- `server/config/express.js`
  - Moved the `/api/slack` route mount (with `slackWebhookParser`) to run BEFORE the global `express.json()` / `express.urlencoded()` middleware, so the raw body is captured first.
  - `/api/webhooks` and `/api/public/shared` remain mounted after the global body parsers, since they don't need raw-body capture.
- `server/middleware/slackWebhookParser.js` — no change needed, already captures `req.rawBody` correctly.
- `server/services/slackService.js` — no change needed, already verifies using `req.rawBody` correctly.
- `server/tests/slack.test.js`
  - Added a regression test verifying that the raw body captured by Express matches the exact bytes used to compute a valid Slack signature.

## Acceptance Criteria
- [x] Raw request body captured before JSON parsing.
- [x] Slack signatures verify correctly.
- [x] Existing Slack integrations continue working.
- [x] Regression test added for webhook verification.

Closes #614 
@imuniqueshiv 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.