### PR TITLE
fix: synchronize client RBAC permission map with backend definitions

### DIFF
--- a/client/src/utils/rbacPermissions.js
+++ b/client/src/utils/rbacPermissions.js
@@ -64,12 +64,13 @@ export const PERMISSIONS = {
     delete: ["owner"],
     leave: ["owner", "admin", "moderator", "member", "guest"],
   },
-  // Settings permissions
+// Settings permissions
   settings: {
     view: ["owner", "admin", "moderator"],
     edit: ["owner", "admin"],
-  },
-  // Reports permissions
+    self_view: ["owner", "admin", "moderator", "member", "guest"],
+    self_edit: ["owner", "admin", "moderator", "member", "guest"],
+  },  // Reports permissions
   reports: {
     view: ["owner", "admin", "moderator"],
     export: ["owner", "admin", "moderator"],
@@ -79,17 +80,25 @@ export const PERMISSIONS = {
     view: ["owner", "admin"],
     manage: ["owner", "admin"],
   },
-  // Knowledge Base permissions
+// Knowledge Base permissions
   knowledge: {
     view: ["owner", "admin", "moderator", "member", "guest"],
     create: ["owner", "admin", "moderator", "member"],
     edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin", "moderator"],
-  },
+    consolidate: ["owner", "admin", "moderator"],
+    resolve_conflicts: ["owner", "admin", "moderator"],
+    manage_lifecycle: ["owner", "admin", "moderator"],
+  },  
   // Notifications permissions
   notifications: {
     view: ["owner", "admin", "moderator", "member", "guest"],
     manage: ["owner", "admin"],
+    self_manage: ["owner", "admin", "moderator", "member", "guest"],
+  },
+  // Audit Logs permissions
+  audit_logs: {
+    view: ["owner", "admin"],
   },
 };
 


### PR DESCRIPTION
## Summary
Fixes #627 by syncing the frontend RBAC permission map (client/src/utils/rbacPermissions.js) with the backend definitions (server/utils/rbacPermissions.js), which already had several permissions the client was missing.

## Root Cause
The client and server each maintain their own copy of the PERMISSIONS map. Over time, new permissions were added on the backend without the corresponding entries being added to the frontend copy, causing the two to drift out of sync.

## Changes
- `client/src/utils/rbacPermissions.js`
  - Added `self_view` and `self_edit` to `settings` permissions.
  - Added `consolidate`, `resolve_conflicts`, and `manage_lifecycle` to `knowledge` permissions.
  - Added `self_manage` to `notifications` permissions.
  - Added the missing `audit_logs` resource (`view: ["owner", "admin"]`).
- `server/utils/rbacPermissions.js` — no changes needed; it was already correct.

## Acceptance Criteria
- [x] Client permissions match backend permissions.
- [x] UI authorization behaves consistently.
- [x] Existing RBAC functionality remains intact (only additions were made, nothing existing was changed or removed).

Closes #627 
@imuniqueshiv 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.