### PR TITLE
fix(meeting): protect meeting room from anonymous access

### DIFF
--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -21,6 +21,7 @@ import Reports from "../pages/Reports.jsx";
 import AiSearch from "../pages/AiSearch.jsx";
 import AiAssistant from "../pages/AiAssistant.jsx";
 import MeetingDetails from "../pages/MeetingDetails.jsx";
+import MeetingRoom from "../pages/MeetingRoom.jsx";
 import TranscriptViewer from "../pages/TranscriptViewer.jsx";
 import TeamMembers from "../pages/TeamMembers.jsx";
 import Profile from "../pages/Profile.jsx";
@@ -180,6 +181,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="meetings" action="view">
           <MeetingDetails />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/meeting-room/:roomId"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <MeetingRoom />
         </ProtectedRoute>
       }
     />

--- a/client/src/routes/PublicRoutes.jsx
+++ b/client/src/routes/PublicRoutes.jsx
@@ -36,7 +36,6 @@ const PublicRoutes = (
       path="/organizations/:slug"
       element={<PublicOrganizationProfile />}
     />
-    <Route path="/meeting-room/:roomId" element={<MeetingRoom />} />
     <Route path="/shared/:hash" element={<PublicSharedView />} />
   </React.Fragment>
 );


### PR DESCRIPTION
## Description

This PR protects the meeting room routes from anonymous access.

Previously, `MeetingRoom` was rendered within `PublicRoutes.jsx`, allowing unauthenticated users to join meetings if they had the room ID. By moving this route to `ProtectedRoutes.jsx` and wrapping it with a `<ProtectedRoute>` component, we ensure that only authenticated organization members with the correct permissions can access the live meeting.

### Related Issue
Closes #620

### Component(s) Affected
- `client/src/routes/PublicRoutes.jsx`
- `client/src/routes/ProtectedRoutes.jsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting rooms are now available through a protected route and require meeting-view access.

* **Bug Fixes**
  * Removed public access to meeting rooms, ensuring they are only accessible through authorized navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->