### PR TITLE
fix: correct AI Search result navigation to use /meeting/:id route

### DIFF
--- a/client/src/pages/AiSearch.jsx
+++ b/client/src/pages/AiSearch.jsx
@@ -25,7 +25,7 @@ const ResultModal = ({ result, onClose }) => {
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-2xl"
-          ></button>
+          />
         </div>
 
         <div className="space-y-4">
@@ -63,9 +63,7 @@ const ResultModal = ({ result, onClose }) => {
               </p>
             </div>
             <div>
-              <span className="text-gray-500">
-                {t("aiSearch.similarityScore")}
-              </span>
+              <span className="text-gray-500">{t("aiSearch.similarityScore")}</span>
               <p className="font-medium text-gray-800">
                 {result.similarityScore || "N/A"}
               </p>
@@ -147,13 +145,9 @@ const AiSearch = () => {
         let sortedResults = data.results || [];
 
         if (filters.sortBy === "date-desc") {
-          sortedResults.sort(
-            (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
-          );
+          sortedResults.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
         } else if (filters.sortBy === "date-asc") {
-          sortedResults.sort(
-            (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
-          );
+          sortedResults.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
         }
 
         setResults(sortedResults);
@@ -186,12 +180,14 @@ const AiSearch = () => {
     setSelectedResult(result);
   };
 
-const handleOpenMeeting = (result) => {
+  const handleOpenMeeting = (result) => {
     window.open(`/meeting/${result.meetingId}`, "_blank");
   };
-const handleOpenMeetingById = (meetingId) => {
+
+  const handleOpenMeetingById = (meetingId) => {
     if (meetingId) window.open(`/meeting/${meetingId}`, "_blank");
   };
+
   const handleCopySummary = async (result) => {
     const textToCopy = result.summary || result.transcript || "";
     if (textToCopy) {
@@ -219,20 +215,9 @@ const handleOpenMeetingById = (meetingId) => {
         />
 
         {/* Search Input */}
-        <SearchBar
-          query={query}
-          setQuery={setQuery}
-          onSearch={handleSearch}
-          loading={loading}
-          onClear={handleClear}
-        />
+        <SearchBar query={query} setQuery={setQuery} onSearch={handleSearch} loading={loading} onClear={handleClear} />
 
-        <HybridSearchToggle
-          mode={searchMode}
-          setMode={setSearchMode}
-          weights={hybridWeights}
-          setWeights={setHybridWeights}
-        />
+        <HybridSearchToggle mode={searchMode} setMode={setSearchMode} weights={hybridWeights} setWeights={setHybridWeights} />
 
         {/* Error Message */}
         {error && (
@@ -255,20 +240,12 @@ const handleOpenMeetingById = (meetingId) => {
           {!loading && results.length > 0 && (
             <>
               {searchMode === "standard" && (
-                <SearchFilters
-                  filters={filters}
-                  setFilters={setFilters}
-                  resultCount={results.length}
-                />
+                <SearchFilters filters={filters} setFilters={setFilters} resultCount={results.length} />
               )}
               <div className="space-y-5">
                 {searchMode === "hybrid"
                   ? results.map((result, index) => (
-                      <HybridResultCard
-                        key={result.key || index}
-                        result={result}
-                        onOpenMeeting={handleOpenMeetingById}
-                      />
+                      <HybridResultCard key={result.key || index} result={result} onOpenMeeting={handleOpenMeetingById} />
                     ))
                   : results.map((result, index) => (
                       <SearchResultCard
@@ -283,19 +260,12 @@ const handleOpenMeetingById = (meetingId) => {
             </>
           )}
 
-          {!loading && results.length === 0 && (
-            <SearchEmptyState hasSearched={hasSearched} />
-          )}
+          {!loading && results.length === 0 && <SearchEmptyState hasSearched={hasSearched} />}
         </div>
       </div>
 
       {/* Result Modal */}
-      {selectedResult && (
-        <ResultModal
-          result={selectedResult}
-          onClose={() => setSelectedResult(null)}
-        />
-      )}
+      {selectedResult && <ResultModal result={selectedResult} onClose={() => setSelectedResult(null)} />}
     </div>
   );
 };

--- a/client/src/pages/AiSearch.jsx
+++ b/client/src/pages/AiSearch.jsx
@@ -186,14 +186,12 @@ const AiSearch = () => {
     setSelectedResult(result);
   };
 
-  const handleOpenMeeting = (result) => {
-    window.open(`/meetings/${result.meetingId}`, "_blank");
+const handleOpenMeeting = (result) => {
+    window.open(`/meeting/${result.meetingId}`, "_blank");
   };
-
-  const handleOpenMeetingById = (meetingId) => {
-    if (meetingId) window.open(`/meetings/${meetingId}`, "_blank");
+const handleOpenMeetingById = (meetingId) => {
+    if (meetingId) window.open(`/meeting/${meetingId}`, "_blank");
   };
-
   const handleCopySummary = async (result) => {
     const textToCopy = result.summary || result.transcript || "";
     if (textToCopy) {


### PR DESCRIPTION
## Summary
Fixes #624 by correcting the meeting detail URLs used in AI Search so results navigate to a valid route instead of a broken one.

## Root Cause
client/src/pages/AiSearch.jsx opens meeting details using `/meetings/${id}` (plural), but the application only defines the route `/meeting/:id` (singular) in client/src/routes/ProtectedRoutes.jsx. This mismatch caused every AI Search result click to open a broken page.

## Changes
- `client/src/pages/AiSearch.jsx`
  - `handleOpenMeeting`: changed the opened URL from `/meetings/${result.meetingId}` to `/meeting/${result.meetingId}`.
  - `handleOpenMeetingById`: changed the opened URL from `/meetings/${meetingId}` to `/meeting/${meetingId}`.
- `client/src/routes/ProtectedRoutes.jsx` — no changes needed; the route was already correctly defined as `/meeting/:id`.

## Acceptance Criteria
- [x] AI Search navigates to the correct meeting route.
- [x] Meeting details open successfully.
- [x] Existing search functionality remains unchanged (only the destination URL was corrected).

@imuniqueshiv 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected meeting links so selected results open the appropriate meeting pages.
  * Fixed date sorting for ascending and descending search results.

* **UI Improvements**
  * Streamlined search controls, filters, result cards, empty states, and result dialogs.
  * Improved similarity-score display and dialog close-button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->