### PR TITLE
test: add HTTP status coverage for API interceptor

### DIFF
--- a/client/src/services/__tests__/apiClient.test.js
+++ b/client/src/services/__tests__/apiClient.test.js
@@ -360,6 +360,10 @@ describe("apiClient interceptors", () => {
 
         await expect(apiClient.get("/test")).rejects.toMatchObject({
           message: "Server unavailable. Please try again later.",
+          response: {
+            status,
+            data: { message: "Server unavailable. Please try again later." },
+          },
         });
       }
     });
@@ -452,5 +456,90 @@ describe("apiClient interceptors", () => {
         });
       }
     });
+  });
+
+  describe("additional HTTP status codes (#420)", () => {
+    const SERVER_UNAVAILABLE = "Server unavailable. Please try again later.";
+    let originalAdapter;
+
+    beforeEach(() => {
+      originalAdapter = captureAdapter(apiClient);
+    });
+
+    afterEach(() => {
+      restoreAdapter(apiClient, originalAdapter);
+    });
+
+    // Codes that fall through to the interceptor default branch:
+    // prefer backend message when present, otherwise use DEFAULT_MESSAGE.
+    const defaultBranchStatuses = [
+      { status: 400, label: "400 Bad Request" },
+      { status: 408, label: "408 Request Timeout" },
+      { status: 409, label: "409 Conflict" },
+      { status: 422, label: "422 Unprocessable Entity" },
+      { status: 429, label: "429 Too Many Requests" },
+    ];
+
+    it.each(defaultBranchStatuses)(
+      "maps $label without a backend message to the default fallback",
+      async ({ status }) => {
+        mockErrorResponse(apiClient, { status, data: {} });
+
+        await expect(apiClient.get("/test")).rejects.toMatchObject({
+          message: DEFAULT_MESSAGE,
+          response: {
+            status,
+            data: { message: DEFAULT_MESSAGE },
+          },
+        });
+      },
+    );
+
+    it.each(defaultBranchStatuses)(
+      "preserves custom backend messages for $label",
+      async ({ status, label }) => {
+        const backendMessage = `Backend detail for ${label}`;
+        mockErrorResponse(apiClient, {
+          status,
+          data: { message: backendMessage, code: `E_${status}` },
+        });
+
+        await expect(apiClient.get("/test")).rejects.toMatchObject({
+          message: backendMessage,
+          response: {
+            status,
+            data: {
+              message: backendMessage,
+              code: `E_${status}`,
+            },
+          },
+        });
+      },
+    );
+
+    // 502/503/504 are already covered in #422 for the message mapping.
+    // These assertions confirm fixed messaging and response attachment when
+    // a backend message is also present (implementation intentionally ignores it).
+    it.each([
+      { status: 502, label: "502 Bad Gateway" },
+      { status: 503, label: "503 Service Unavailable" },
+      { status: 504, label: "504 Gateway Timeout" },
+    ])(
+      "keeps fixed server-unavailable messaging for $label even with a backend message",
+      async ({ status }) => {
+        mockErrorResponse(apiClient, {
+          status,
+          data: { message: "Upstream provider timed out" },
+        });
+
+        await expect(apiClient.get("/test")).rejects.toMatchObject({
+          message: SERVER_UNAVAILABLE,
+          response: {
+            status,
+            data: { message: SERVER_UNAVAILABLE },
+          },
+        });
+      },
+    );
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Adds comprehensive test coverage for additional HTTP status codes handled by the API response interceptor.

### Changes made

- Added dedicated tests for additional HTTP status codes:
  - 400 Bad Request
  - 408 Request Timeout
  - 409 Conflict
  - 422 Unprocessable Entity
  - 429 Too Many Requests
  - 502 Bad Gateway
  - 503 Service Unavailable
  - 504 Gateway Timeout
- Verified expected friendly error messages for each status code.
- Verified backend messages are preserved where appropriate.
- Verified response objects remain attached to rejected errors when applicable.
- Expanded test coverage without modifying production behavior.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #420

## Testing

Executed the project's validation pipeline successfully.

- Prettier (changed files)
- ESLint (changed files)
- API interceptor test suite (43/43)
- Related tests
- `npm run validate:changed`
- `npm run validate:pr --prefix client`
- `npm run validate:pr --prefix server`
- Production build

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (test coverage improvements only)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review