### PR TITLE
fix(a11y): add accessible labels to attachment panel actions

### DIFF
--- a/client/src/components/meeting-details/AttachmentPanel.jsx
+++ b/client/src/components/meeting-details/AttachmentPanel.jsx
@@ -4,7 +4,6 @@ import { toast } from "react-toastify";
 import {
   Paperclip,
   Upload,
-  X,
   File,
   Download,
   Trash2,
@@ -226,6 +225,7 @@ const AttachmentPanel = ({ meetingId }) => {
                   onClick={() => handleDownload(file)}
                   className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors"
                   title="Download"
+                  aria-label="Download attachment"
                 >
                   <Download className="w-4 h-4" />
                 </button>
@@ -233,6 +233,7 @@ const AttachmentPanel = ({ meetingId }) => {
                   onClick={() => handleDelete(file._id)}
                   className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                   title="Delete"
+                  aria-label="Delete attachment"
                 >
                   <Trash2 className="w-4 h-4" />
                 </button>

--- a/client/src/components/meeting-details/__tests__/AttachmentPanel.test.jsx
+++ b/client/src/components/meeting-details/__tests__/AttachmentPanel.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AttachmentPanel from "../AttachmentPanel";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services", () => ({
+  attachmentApi: {
+    getAttachments: vi.fn(),
+    uploadAttachment: vi.fn(),
+    downloadAttachment: vi.fn(),
+    deleteAttachment: vi.fn(),
+  },
+}));
+
+import { attachmentApi } from "../../../services";
+
+describe("AttachmentPanel accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes accessible names for icon-only attachment actions", async () => {
+    attachmentApi.getAttachments.mockResolvedValue({
+      data: {
+        success: true,
+        attachments: [
+          {
+            _id: "att-1",
+            fileName: "agenda.pdf",
+            mimeType: "application/pdf",
+            fileSize: 1024,
+            uploadedBy: { name: "Alice" },
+            createdAt: "2024-01-15T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    render(<AttachmentPanel meetingId="meeting-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("agenda.pdf")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Download attachment" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete attachment" }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Improves the accessibility of the Attachment Panel by adding accessible names to icon-only action buttons.

### Changes made

- Added descriptive `aria-label` attributes to icon-only action buttons:
  - Download attachment
  - Delete attachment
- Added focused accessibility tests to verify the buttons are discoverable by their accessible names.
- Removed an unused `X` import.
- Preserved all existing functionality and visual behavior.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #793

## Testing

Executed the project's validation pipeline successfully.

- Prettier (changed files)
- ESLint (changed files)
- `npm run test:related --prefix client`
- `npm run validate:pr --prefix client`
- `npm run validate:pr --prefix server`
- Production build

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (accessibility improvement only)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader support by adding accessible names to attachment download and delete actions.

* **Tests**
  * Added coverage verifying that attachment action buttons are correctly identified by assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->