### PR TITLE
Add AI Assistant context pinning for meetings, policies, and knowledge.

### DIFF
--- a/client/src/components/SourceCitation.jsx
+++ b/client/src/components/SourceCitation.jsx
@@ -4,7 +4,12 @@ import { Link } from "react-router-dom";
 const SourceCitation = ({ source, index }) => {
   const { refType, refId, title } = source;
 
-  const linkUrl = refType === "meeting" ? `/meetings/${refId}` : `/policies`; // or another policy route if specific policy view exists
+  const linkUrl =
+    refType === "meeting"
+      ? `/meeting/${refId}`
+      : refType === "knowledge"
+        ? `/knowledge/${refId}`
+        : `/policies`;
 
   return (
     <Link

--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { format } from "date-fns";
+import { useNavigate } from "react-router-dom";
 import CalendarSyncBadge from "../CalendarSyncBadge.jsx";
-import { Share2, Presentation, Bookmark } from "lucide-react";
+import { Share2, Presentation, Bookmark, MessageSquare } from "lucide-react";
 import { toast } from "react-toastify";
 import { toggleBookmarkAPI, getBookmarkStatusAPI } from "../../api/bookmarkApi";
+import { askAssistantAbout } from "../../utils/askAssistant.js";
 
 const MeetingHeader = ({ meeting, onShare, onPresent }) => {
+  const navigate = useNavigate();
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isLoadingBookmark, setIsLoadingBookmark] = useState(false);
 
@@ -155,6 +158,19 @@ const MeetingHeader = ({ meeting, onShare, onPresent }) => {
             className="flex items-center gap-2 px-3 py-1.5 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50 rounded-lg text-sm font-medium transition-colors"
           >
             <Presentation className="w-4 h-4" /> Present
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              askAssistantAbout(navigate, {
+                type: "meeting",
+                refId: meeting._id,
+                title: meeting.title || "Untitled Meeting",
+              })
+            }
+            className="flex items-center gap-2 px-3 py-1.5 bg-violet-50 text-violet-700 hover:bg-violet-100 dark:bg-violet-900/30 dark:text-violet-300 dark:hover:bg-violet-900/50 rounded-lg text-sm font-medium transition-colors"
+          >
+            <MessageSquare className="w-4 h-4" /> Ask Assistant
           </button>
           <button
             onClick={onShare}

--- a/client/src/components/policies/PolicyDetailCard.jsx
+++ b/client/src/components/policies/PolicyDetailCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   FileText,
   UserCircle,
@@ -16,6 +17,7 @@ import {
 } from "lucide-react";
 import { StatusBadge, Pill, formatDate } from "./PolicyUtils";
 import ShareModal from "../shared-links/ShareModal";
+import { askAssistantAbout } from "../../utils/askAssistant.js";
 
 export const PolicyDetailModal = ({
   policy: p,
@@ -24,6 +26,7 @@ export const PolicyDetailModal = ({
   onReanalyze,
   onCompare,
 }) => {
+  const navigate = useNavigate();
   const [shareModalOpen, setShareModalOpen] = useState(false);
 
   const authorName = p?.uploadedBy?.name || "Unknown";
@@ -156,12 +159,25 @@ export const PolicyDetailModal = ({
         </div>
       )}
 
-      <div className="flex gap-2 pt-2 border-t border-gray-100 mt-2">
+      <div className="flex gap-2 pt-2 border-t border-gray-100 mt-2 flex-wrap">
         <button
           onClick={() => onDownload(p._id, p.name)}
           className="inline-flex items-center gap-2 bg-indigo-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-indigo-700 transition"
         >
           <Download className="w-4 h-4" /> Download
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            askAssistantAbout(navigate, {
+              type: "policy",
+              refId: p._id,
+              title: p.name || "Untitled Policy",
+            })
+          }
+          className="inline-flex items-center gap-2 bg-violet-50 text-violet-700 hover:bg-violet-100 px-4 py-2 rounded-lg text-sm font-medium transition"
+        >
+          <MessageSquare className="w-4 h-4" /> Ask Assistant
         </button>
         <button
           onClick={onClose}

--- a/client/src/pages/AiAssistant.jsx
+++ b/client/src/pages/AiAssistant.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { io } from "socket.io-client";
-import { Send, RefreshCw } from "lucide-react";
+import { Send, RefreshCw, Pin, X } from "lucide-react";
 import ChatSessionSidebar from "../components/ChatSessionSidebar";
 import SourceCitation from "../components/SourceCitation";
 import { getBackendUrl } from "../config/backendConfig.js";
+import { consumePendingAssistantPin } from "../utils/askAssistant.js";
 
 const API_URL = getBackendUrl();
 
@@ -16,10 +17,12 @@ const AiAssistant = () => {
   const [error, setError] = useState("");
   const [isSocketConnected, setIsSocketConnected] = useState(true);
   const [isRateLimited, setIsRateLimited] = useState(false);
+  const [pinnedContext, setPinnedContext] = useState(null);
 
   const socketRef = useRef(null);
   const messagesEndRef = useRef(null);
   const tokenRef = useRef(localStorage.getItem("token"));
+  const pendingPinHandled = useRef(false);
 
   useEffect(() => {
     fetchSessions();
@@ -119,6 +122,84 @@ const AiAssistant = () => {
     }
   };
 
+  const pinContextToSession = useCallback(async (sessionId, pin) => {
+    if (!sessionId || !pin?.type || !pin?.refId) return null;
+    const res = await fetch(
+      `${API_URL}/api/assistant/sessions/${sessionId}/pinned-context`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${tokenRef.current}`,
+        },
+        body: JSON.stringify({
+          type: pin.type,
+          refId: pin.refId,
+          title: pin.title,
+        }),
+      },
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(data.error || "Failed to pin context");
+    }
+    setPinnedContext(data.pinnedContext || null);
+    return data.pinnedContext;
+  }, []);
+
+  const handleUnpinContext = async () => {
+    if (!currentSessionId) {
+      setPinnedContext(null);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `${API_URL}/api/assistant/sessions/${currentSessionId}/pinned-context`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${tokenRef.current}` },
+        },
+      );
+      if (!res.ok) throw new Error("Failed to remove pinned context");
+      setPinnedContext(null);
+    } catch (err) {
+      console.error(err);
+      setError("Could not remove pinned context.");
+    }
+  };
+
+  const ensureSessionAndPin = useCallback(
+    async (pin) => {
+      let sessionId = currentSessionIdRef.current;
+      if (!sessionId) {
+        const res = await fetch(`${API_URL}/api/assistant/sessions`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${tokenRef.current}` },
+        });
+        if (!res.ok) throw new Error("Failed to create session");
+        const data = await res.json();
+        setSessions((prev) => [data, ...prev]);
+        sessionId = data._id;
+        setCurrentSessionId(sessionId);
+        setMessages([]);
+      }
+      await pinContextToSession(sessionId, pin);
+      setInputValue(`Tell me about: ${pin.title}`);
+    },
+    [pinContextToSession],
+  );
+
+  useEffect(() => {
+    if (pendingPinHandled.current) return;
+    const pending = consumePendingAssistantPin();
+    if (!pending) return;
+    pendingPinHandled.current = true;
+    ensureSessionAndPin(pending).catch((err) => {
+      console.error(err);
+      setError(err.message || "Could not pin this resource.");
+    });
+  }, [ensureSessionAndPin]);
+
   const handleSelectSession = async (id) => {
     setCurrentSessionId(id);
     setError("");
@@ -130,6 +211,7 @@ const AiAssistant = () => {
       if (!res.ok) throw new Error("Failed to load session");
       const data = await res.json();
       setMessages(data.messages || []);
+      setPinnedContext(data.pinnedContext || null);
     } catch (err) {
       console.error(err);
       setError("Could not load the selected conversation.");
@@ -147,6 +229,7 @@ const AiAssistant = () => {
       setSessions([data, ...sessions]);
       setCurrentSessionId(data._id);
       setMessages([]);
+      setPinnedContext(null);
       setError("");
       setIsRateLimited(false);
     } catch (err) {
@@ -165,6 +248,7 @@ const AiAssistant = () => {
       if (currentSessionId === id) {
         setCurrentSessionId(null);
         setMessages([]);
+        setPinnedContext(null);
       }
     } catch (err) {
       console.error(err);
@@ -248,6 +332,30 @@ const AiAssistant = () => {
           </div>
         )}
 
+        {pinnedContext && (
+          <div className="px-4 sm:px-6 py-2.5 border-b border-indigo-100 bg-indigo-50/70 flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0 text-sm text-indigo-900">
+              <Pin className="w-4 h-4 shrink-0 text-indigo-600" />
+              <span className="font-medium shrink-0">Pinned context:</span>
+              <span className="truncate">
+                <span className="uppercase text-[10px] tracking-wide font-bold text-indigo-500 mr-1.5">
+                  {pinnedContext.type}
+                </span>
+                {pinnedContext.title}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={handleUnpinContext}
+              className="inline-flex items-center gap-1 shrink-0 rounded-lg px-2 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 transition"
+              aria-label="Remove pinned context"
+            >
+              <X className="w-3.5 h-3.5" />
+              Remove
+            </button>
+          </div>
+        )}
+
         <div className="flex-1 overflow-y-auto p-4 sm:p-6 custom-scrollbar">
           {!currentSessionId && messages.length === 0 ? (
             <div className="h-full flex flex-col items-center justify-center text-center max-w-lg mx-auto">
@@ -271,7 +379,8 @@ const AiAssistant = () => {
               </h2>
               <p className="text-gray-500 mb-8">
                 Ask questions about your organization's meetings, decisions, and
-                policies. I'll search your memory and provide cited answers.
+                policies. Pin a resource from Meeting, Policy, or Knowledge
+                pages to focus answers on that context.
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
                 {[
@@ -390,7 +499,11 @@ const AiAssistant = () => {
                 type="text"
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
-                placeholder="Ask about meetings, decisions, or policies..."
+                placeholder={
+                  pinnedContext
+                    ? `Ask about this ${pinnedContext.type}...`
+                    : "Ask about meetings, decisions, or policies..."
+                }
                 disabled={isStreaming || !isSocketConnected}
                 className="w-full pl-5 pr-14 py-3.5 bg-gray-50 border border-gray-300 rounded-2xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:opacity-60 transition-all shadow-sm"
               />

--- a/client/src/pages/KnowledgeTimeline.jsx
+++ b/client/src/pages/KnowledgeTimeline.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import AppContent from "../context/AppContent";
+import { useParams, useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar.jsx";
 import { knowledgeApi } from "../services";
+import { MessageSquare } from "lucide-react";
+import { askAssistantAbout } from "../utils/askAssistant.js";
 
 const KnowledgeTimeline = () => {
   const { decisionId } = useParams();
+  const navigate = useNavigate();
 
   const [lineage, setLineage] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -28,14 +30,37 @@ const KnowledgeTimeline = () => {
     fetchLineage();
   }, [decisionId]);
 
+  const latest = lineage[0];
+  const pinTitle = latest?.text
+    ? latest.text.slice(0, 80)
+    : "Knowledge decision";
+
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 pt-20">
       <Navbar />
 
       <div className="p-6 max-w-3xl mx-auto">
-        <h1 className="text-2xl font-bold mb-6 text-slate-900 dark:text-white">
-          Decision Timeline
-        </h1>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+            Decision Timeline
+          </h1>
+          {decisionId && (
+            <button
+              type="button"
+              onClick={() =>
+                askAssistantAbout(navigate, {
+                  type: "knowledge",
+                  refId: decisionId,
+                  title: pinTitle,
+                })
+              }
+              className="inline-flex items-center gap-2 self-start rounded-lg bg-violet-50 px-3 py-1.5 text-sm font-medium text-violet-700 transition hover:bg-violet-100 dark:bg-violet-900/30 dark:text-violet-300 dark:hover:bg-violet-900/50"
+            >
+              <MessageSquare className="w-4 h-4" />
+              Ask Assistant about this
+            </button>
+          )}
+        </div>
 
         {loading && (
           <p className="text-slate-500 dark:text-slate-400">Loading...</p>

--- a/client/src/utils/askAssistant.js
+++ b/client/src/utils/askAssistant.js
@@ -1,0 +1,35 @@
+const PENDING_PIN_KEY = "meetonmemory-pending-assistant-pin";
+
+/**
+ * Store a pending pin and navigate to the AI Assistant.
+ * AiAssistant will apply it to the active (or newly created) session.
+ */
+export function askAssistantAbout(navigate, { type, refId, title }) {
+  if (!type || !refId) return;
+  try {
+    sessionStorage.setItem(
+      PENDING_PIN_KEY,
+      JSON.stringify({
+        type,
+        refId: String(refId),
+        title: title || "Pinned resource",
+      }),
+    );
+  } catch {
+    // ignore storage errors
+  }
+  navigate("/assistant");
+}
+
+export function consumePendingAssistantPin() {
+  try {
+    const raw = sessionStorage.getItem(PENDING_PIN_KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(PENDING_PIN_KEY);
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export { PENDING_PIN_KEY };

--- a/server/models/ChatSession.js
+++ b/server/models/ChatSession.js
@@ -14,7 +14,7 @@ const messageSchema = new mongoose.Schema({
     {
       refType: {
         type: String,
-        enum: ["meeting", "policy"],
+        enum: ["meeting", "policy", "knowledge"],
         required: true,
       },
       refId: {
@@ -37,6 +37,26 @@ const messageSchema = new mongoose.Schema({
   },
 });
 
+const pinnedContextSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ["meeting", "policy", "knowledge"],
+      required: true,
+    },
+    refId: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+  },
+  { _id: false },
+);
+
 const chatSessionSchema = new mongoose.Schema({
   organizationId: {
     type: mongoose.Schema.Types.ObjectId,
@@ -53,6 +73,10 @@ const chatSessionSchema = new mongoose.Schema({
   title: {
     type: String,
     default: "New Chat",
+  },
+  pinnedContext: {
+    type: pinnedContextSchema,
+    default: null,
   },
   messages: [messageSchema],
   createdAt: {

--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -5,6 +5,8 @@ import {
   deleteSession,
   listSessions,
   processMessage,
+  setPinnedContext,
+  clearPinnedContext,
 } from "../services/ragAssistantService.js";
 import userAuth from "../middleware/userAuth.js";
 import rateLimit from "express-rate-limit";
@@ -63,6 +65,57 @@ router.delete("/sessions/:id", async (req, res) => {
   }
 });
 
+// Pin or replace pinned context for a session
+router.put("/sessions/:id/pinned-context", async (req, res) => {
+  try {
+    const { type, refId, title } = req.body || {};
+    if (!type || !refId) {
+      return res
+        .status(400)
+        .json({ error: "type and refId are required to pin context." });
+    }
+
+    const session = await setPinnedContext(
+      req.params.id,
+      req.user._id,
+      req.user.organization,
+      { type, refId, title },
+    );
+    res.json({
+      pinnedContext: session.pinnedContext,
+      sessionId: session._id,
+    });
+  } catch (error) {
+    console.error("Error pinning context:", error);
+    const status =
+      error.message?.includes("not found") ||
+      error.message?.includes("not accessible")
+        ? 403
+        : error.message?.includes("Invalid")
+          ? 400
+          : 500;
+    res.status(status).json({
+      error: error.message || "Failed to pin context",
+    });
+  }
+});
+
+// Remove pinned context
+router.delete("/sessions/:id/pinned-context", async (req, res) => {
+  try {
+    const session = await clearPinnedContext(req.params.id, req.user._id);
+    res.json({
+      pinnedContext: session.pinnedContext,
+      sessionId: session._id,
+    });
+  } catch (error) {
+    console.error("Error clearing pinned context:", error);
+    res.status(error.message === "Session not found" ? 404 : 500).json({
+      error: error.message || "Failed to clear pinned context",
+    });
+  }
+});
+
 // Send a message
 router.post("/sessions/:id/message", messageLimiter, async (req, res) => {
   try {
@@ -72,10 +125,8 @@ router.post("/sessions/:id/message", messageLimiter, async (req, res) => {
     }
 
     const sessionId = req.params.id;
-    // Get socket io instance to broadcast streaming events
     const io = req.app.get("io");
 
-    // Process message in the background and stream over socket
     processMessage(sessionId, req.user._id, content, io).catch((err) => {
       console.error("Error processing message:", err);
       io.emit("assistant_error", {

--- a/server/services/ragAssistantService.js
+++ b/server/services/ragAssistantService.js
@@ -1,10 +1,16 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import mongoose from "mongoose";
 import { embedText, initVectorStore } from "../utils/embeddingUtils.js";
 import ChatSession from "../models/ChatSession.js";
+import Meeting from "../models/meetingModel.js";
+import Policy from "../models/policyModel.js";
+import Decision from "../models/decisionModel.js";
+import ActionItem from "../models/actionItemModel.js";
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
 const POLICY_NAMESPACE = "policies";
+const PINNED_TYPES = new Set(["meeting", "policy", "knowledge"]);
 
 export const createSession = async (organizationId, userId) => {
   const session = new ChatSession({ organizationId, userId });
@@ -26,34 +32,225 @@ export const listSessions = async (userId) => {
   return await ChatSession.find({ userId }).sort({ updatedAt: -1 });
 };
 
-async function queryPinecone(organizationId, queryText, topK = 6) {
+/**
+ * Validate that the resource belongs to the user's organization and return a
+ * normalized pinnedContext payload.
+ */
+export const resolvePinnedResource = async (
+  organizationId,
+  type,
+  refId,
+  titleHint = "",
+) => {
+  if (!PINNED_TYPES.has(type)) {
+    throw new Error(
+      'Invalid pin type. Expected "meeting", "policy", or "knowledge".',
+    );
+  }
+  if (!mongoose.Types.ObjectId.isValid(refId)) {
+    throw new Error("Invalid resource id.");
+  }
+  if (!organizationId) {
+    throw new Error("Organization membership is required to pin context.");
+  }
+
+  const orgId = organizationId.toString();
+
+  if (type === "meeting") {
+    const meeting = await Meeting.findOne({
+      _id: refId,
+      organization: organizationId,
+    }).select("title organization");
+    if (!meeting) {
+      throw new Error(
+        "Meeting not found or not accessible in your organization.",
+      );
+    }
+    return {
+      type: "meeting",
+      refId: meeting._id,
+      title: titleHint || meeting.title || "Untitled Meeting",
+    };
+  }
+
+  if (type === "policy") {
+    const policy = await Policy.findOne({
+      _id: refId,
+      organization: organizationId,
+    }).select("name organization");
+    if (!policy) {
+      throw new Error(
+        "Policy not found or not accessible in your organization.",
+      );
+    }
+    return {
+      type: "policy",
+      refId: policy._id,
+      title: titleHint || policy.name || "Untitled Policy",
+    };
+  }
+
+  let knowledge = await Decision.findOne({
+    _id: refId,
+    organization: organizationId,
+  }).select("text organization sourceMeetingId");
+
+  if (!knowledge) {
+    knowledge = await ActionItem.findOne({
+      _id: refId,
+      organization: organizationId,
+    }).select("text organization sourceMeetingId");
+  }
+
+  if (!knowledge) {
+    throw new Error(
+      "Knowledge record not found or not accessible in your organization.",
+    );
+  }
+
+  const text = knowledge.text || "Knowledge record";
+  return {
+    type: "knowledge",
+    refId: knowledge._id,
+    title: titleHint || text.slice(0, 80),
+    text,
+    sourceMeetingId: knowledge.sourceMeetingId || null,
+  };
+};
+
+export const setPinnedContext = async (
+  sessionId,
+  userId,
+  organizationId,
+  { type, refId, title } = {},
+) => {
+  const session = await getSession(sessionId, userId);
+  if (session.organizationId.toString() !== organizationId?.toString()) {
+    throw new Error("Session does not belong to your organization.");
+  }
+
+  const resolved = await resolvePinnedResource(
+    organizationId,
+    type,
+    refId,
+    title,
+  );
+
+  session.pinnedContext = {
+    type: resolved.type,
+    refId: resolved.refId,
+    title: resolved.title,
+  };
+  await session.save();
+  return session;
+};
+
+export const clearPinnedContext = async (sessionId, userId) => {
+  const session = await getSession(sessionId, userId);
+  session.set("pinnedContext", undefined);
+  await session.save();
+  return session;
+};
+
+async function queryPinecone(
+  organizationId,
+  queryText,
+  topK = 6,
+  pinnedContext = null,
+) {
   const queryEmbedding = await embedText(queryText);
   const index = await initVectorStore();
+  const orgFilter = { organization: organizationId.toString() };
+  const pinType = pinnedContext?.type || null;
+  const pinId = pinnedContext?.refId?.toString?.() || null;
 
-  // 1. Query meetings (default namespace)
-  const meetingResults = await index.query({
-    vector: queryEmbedding,
-    topK,
-    includeMetadata: true,
-    filter: { organization: organizationId.toString() },
-  });
+  const meetingFilter =
+    pinType === "meeting" && pinId
+      ? { ...orgFilter, meetingId: { $eq: pinId } }
+      : pinType === "policy"
+        ? null
+        : orgFilter;
 
-  // 2. Query policies (policy namespace)
-  const policyResults = await index.namespace(POLICY_NAMESPACE).query({
-    vector: queryEmbedding,
-    topK,
-    includeMetadata: true,
-    filter: { organization: organizationId.toString() },
-  });
+  const policyFilter =
+    pinType === "policy" && pinId
+      ? { ...orgFilter, policyId: { $eq: pinId } }
+      : pinType === "meeting"
+        ? null
+        : orgFilter;
 
-  // Combine and sort by score
-  const combined = [
+  let meetingResults = { matches: [] };
+  let policyResults = { matches: [] };
+
+  if (meetingFilter) {
+    meetingResults = await index.query({
+      vector: queryEmbedding,
+      topK,
+      includeMetadata: true,
+      filter: meetingFilter,
+    });
+  }
+
+  if (policyFilter) {
+    policyResults = await index.namespace(POLICY_NAMESPACE).query({
+      vector: queryEmbedding,
+      topK,
+      includeMetadata: true,
+      filter: policyFilter,
+    });
+  }
+
+  let combined = [
     ...(meetingResults.matches || []).map((m) => ({
       ...m,
       refType: "meeting",
     })),
     ...(policyResults.matches || []).map((m) => ({ ...m, refType: "policy" })),
   ];
+
+  // If a strict pin filter returned nothing, fall back to org-wide retrieval
+  if (combined.length === 0 && pinType && pinType !== "knowledge") {
+    const [fallbackMeetings, fallbackPolicies] = await Promise.all([
+      index.query({
+        vector: queryEmbedding,
+        topK,
+        includeMetadata: true,
+        filter: orgFilter,
+      }),
+      index.namespace(POLICY_NAMESPACE).query({
+        vector: queryEmbedding,
+        topK,
+        includeMetadata: true,
+        filter: orgFilter,
+      }),
+    ]);
+    combined = [
+      ...(fallbackMeetings.matches || []).map((m) => ({
+        ...m,
+        refType: "meeting",
+      })),
+      ...(fallbackPolicies.matches || []).map((m) => ({
+        ...m,
+        refType: "policy",
+      })),
+    ];
+  }
+
+  // Knowledge pins: also prefer chunks from the source meeting when available
+  if (pinType === "knowledge" && pinnedContext?.sourceMeetingId) {
+    const meetingId = pinnedContext.sourceMeetingId.toString();
+    const preferred = await index.query({
+      vector: queryEmbedding,
+      topK,
+      includeMetadata: true,
+      filter: { ...orgFilter, meetingId: { $eq: meetingId } },
+    });
+    if (preferred.matches?.length) {
+      combined = [
+        ...preferred.matches.map((m) => ({ ...m, refType: "meeting" })),
+        ...combined,
+      ];
+    }
+  }
 
   combined.sort((a, b) => (b.score || 0) - (a.score || 0));
   return combined.slice(0, topK);
@@ -62,22 +259,61 @@ async function queryPinecone(organizationId, queryText, topK = 6) {
 export const processMessage = async (sessionId, userId, content, socket) => {
   const session = await getSession(sessionId, userId);
   const organizationId = session.organizationId;
+  const pinned = session.pinnedContext
+    ? {
+        type: session.pinnedContext.type,
+        refId: session.pinnedContext.refId,
+        title: session.pinnedContext.title,
+      }
+    : null;
+
+  // Enrich knowledge pins with text for the prompt
+  let pinnedKnowledgeText = "";
+  if (pinned?.type === "knowledge") {
+    try {
+      const resolved = await resolvePinnedResource(
+        organizationId,
+        "knowledge",
+        pinned.refId,
+        pinned.title,
+      );
+      pinnedKnowledgeText = resolved.text || "";
+      pinned.sourceMeetingId = resolved.sourceMeetingId;
+    } catch (err) {
+      console.warn("Pinned knowledge unavailable:", err.message);
+    }
+  }
 
   // Save user message
   session.messages.push({ role: "user", content, sources: [] });
   await session.save();
 
-  // Retrieve context
-  const rawHits = await queryPinecone(organizationId, content, 6);
+  // Retrieve context (prioritize pinned resource when set)
+  const rawHits = await queryPinecone(organizationId, content, 6, pinned);
 
   const sources = [];
   let contextText = "";
+
+  if (pinned) {
+    contextText += `\n\n[Pinned Context] Type: ${pinned.type}, Title: ${pinned.title}`;
+    if (pinnedKnowledgeText) {
+      contextText += `\nContent: ${pinnedKnowledgeText}`;
+      sources.push({
+        refType: "knowledge",
+        refId: pinned.refId,
+        title: pinned.title,
+        snippet: pinnedKnowledgeText.substring(0, 500),
+      });
+    } else {
+      contextText +=
+        "\nPrioritize information from this pinned resource when answering.";
+    }
+  }
 
   for (let i = 0; i < rawHits.length; i++) {
     const hit = rawHits[i];
     const meta = hit.metadata || {};
 
-    // De-dupe sources (optional, but good practice)
     let refId = "";
     let title = "";
     let snippet = "";
@@ -97,7 +333,7 @@ export const processMessage = async (sessionId, userId, content, socket) => {
         refType: hit.refType,
         refId,
         title,
-        snippet: snippet.substring(0, 500), // keep snippet brief for DB
+        snippet: snippet.substring(0, 500),
       });
     }
 
@@ -106,6 +342,7 @@ export const processMessage = async (sessionId, userId, content, socket) => {
 
   const systemPrompt = `You are an AI meeting assistant for an organization. 
 Answer the user's question STRICTLY based on the provided context below.
+If a pinned context is provided, prioritize it over other sources.
 If the context doesn't contain the answer, say "I couldn't find the answer in the retrieved meetings or policies."
 Cite your sources using [Source X] format.
 
@@ -113,7 +350,6 @@ Context:
 ${contextText}
 `;
 
-  // Gemini prompt
   const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
   const model = genAI.getGenerativeModel({
     model: GEMINI_MODEL,
@@ -140,7 +376,6 @@ ${contextText}
     }
   }
 
-  // Generate title if new chat
   if (session.title === "New Chat" && session.messages.length <= 1) {
     try {
       const titlePrompt = `Generate a short, 2-4 word title for a chat that started with this message: "${content}". Output only the title, no quotes.`;


### PR DESCRIPTION
## Summary
- Store optional pinned context on chat sessions and validate org access
- Prioritize pinned meetings/policies/knowledge in RAG retrieval
- Add Ask Assistant entry points and a removable context chip in the assistant UI
Closes #720
## Test plan
- [ ] From a meeting, click Ask Assistant and confirm the pin chip appears
- [ ] Ask a question and confirm answers prioritize that meeting
- [ ] Pin a policy and replace the previous context
- [ ] Pin a knowledge decision from the timeline page
- [ ] Remove the pin and confirm the assistant still works without context
- [ ] Attempt to pin a resource outside the org (should fail)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Ask Assistant” actions to meeting, policy, and decision timeline views.
  * Added pinned context support in Assistant sessions for meetings, policies, and knowledge entries.
  * Assistant responses can now prioritize the selected pinned resource.
  * Added controls to view and remove pinned context.
* **Bug Fixes**
  * Updated source links for meetings and knowledge entries to use the correct destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->