### PR TITLE
Add accessible label to the Live Chat send button.

### DIFF
--- a/client/src/components/contact/LiveChatWidget.jsx
+++ b/client/src/components/contact/LiveChatWidget.jsx
@@ -78,9 +78,10 @@ export default function LiveChatWidget({
         />
         <button
           type="submit"
+          aria-label="Send message"
           className="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl transition shrink-0"
         >
-          <Send className="w-3.5 h-3.5" />
+          <Send className="w-3.5 h-3.5" aria-hidden="true" />
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Add `aria-label="Send message"` to the Live Chat icon-only send button
- Mark the Send icon as decorative with `aria-hidden`
Closes #851
## Test plan
- [ ] Open Contact page Live Chat
- [ ] Confirm send still works
- [ ] Confirm screen reader / accessibility tree announces “Send message”
