### PR TITLE
fix(org): create membership during organization creation

### DIFF
--- a/scripts/validation/run-server-related-tests.mjs
+++ b/scripts/validation/run-server-related-tests.mjs
@@ -36,8 +36,28 @@ const serverFiles = changedFiles.filter(
 
 const directTests = serverFiles.filter((file) => TEST_FILE_REGEX.test(file));
 const sourceFiles = serverFiles.filter((file) => !directTests.includes(file));
-const vitestTests = directTests.filter((file) => VITEST_TEST_FILES.has(file));
-const jestTests = directTests.filter((file) => !vitestTests.includes(file));
+const vitestOwnedSources = new Set([
+  "server/services/OrganizationService.js",
+  "server/services/InvitationService.js",
+  "server/controllers/organizationController.js",
+  "server/controllers/knowledgeController.js",
+  "server/controllers/transcriptController.js",
+  "server/services/meetingDigestService.js",
+  "server/utils/imageUrl.js",
+]);
+const vitestTests = [
+  ...directTests.filter((file) => VITEST_TEST_FILES.has(file)),
+  ...sourceFiles
+    .filter((file) => vitestOwnedSources.has(file))
+    .map((file) => {
+      const base = file.split("/").pop().replace(/\.js$/, "");
+      return `server/tests/${base}.test.js`;
+    })
+    .filter((file) => VITEST_TEST_FILES.has(file)),
+];
+const uniqueVitestTests = [...new Set(vitestTests)];
+const jestTests = directTests.filter((file) => !VITEST_TEST_FILES.has(file));
+const jestSources = sourceFiles.filter((file) => !vitestOwnedSources.has(file));
 
 logStep(
   "test:server:related",
@@ -60,16 +80,17 @@ if (jestTests.length > 0) {
   );
 }
 
-if (sourceFiles.length > 0) {
-  const scopedSources = sourceFiles.map((file) => file.slice("server/".length));
+if (jestSources.length > 0) {
+  const scopedSources = jestSources.map((file) => file.slice("server/".length));
   const ignoreArgs = JEST_RELATED_IGNORE.map(
-    (pattern) => `--testPathIgnorePatterns="${pattern}"`,
+    (pattern) => `--testPathIgnorePatterns=${pattern}`,
   ).join(" ");
 
+  // File paths must immediately follow --findRelatedTests (Jest 30+).
   run(
-    `${JEST} --runInBand --findRelatedTests --passWithNoTests ${ignoreArgs} ${quoteFiles(
+    `${JEST} --runInBand --passWithNoTests --findRelatedTests ${quoteFiles(
       scopedSources,
-    )}`,
+    )} ${ignoreArgs}`,
     {
       cwd: serverCwd,
     },
@@ -80,10 +101,10 @@ if (sourceFiles.length > 0) {
   });
 }
 
-if (vitestTests.length > 0) {
+if (uniqueVitestTests.length > 0) {
   runNpx(
     `vitest run --passWithNoTests ${quoteFiles(
-      vitestTests.map((file) => file.slice("server/".length)),
+      uniqueVitestTests.map((file) => file.slice("server/".length)),
     )}`,
     {
       cwd: serverCwd,

--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -210,6 +210,25 @@ export const createOrJoinOrganization = async (userId, orgName) => {
       members: [userId],
     });
 
+    // Create admin membership for the creator (RBAC); unique index prevents duplicates
+    try {
+      await Membership.create({
+        user: userId,
+        organization: organization._id,
+        role: "admin",
+        status: "active",
+      });
+    } catch (error) {
+      // Roll back the org if membership creation fails to avoid inconsistent state
+      await Organization.findByIdAndDelete(organization._id);
+      if (error.code === 11000) {
+        throw new ConflictError(
+          "You are already a member of this organization.",
+        );
+      }
+      throw error;
+    }
+
     await userModel.findByIdAndUpdate(userId, {
       role: "admin",
       organization: organization._id,

--- a/server/tests/OrganizationService.test.js
+++ b/server/tests/OrganizationService.test.js
@@ -72,6 +72,7 @@ describe("OrganizationService", () => {
         createdBy: "user1",
       };
       Organization.create.mockResolvedValue(mockOrg);
+      Membership.create.mockResolvedValue({});
 
       userModel.findByIdAndUpdate.mockResolvedValue(true);
       userModel.findById.mockReturnValue({
@@ -92,9 +93,62 @@ describe("OrganizationService", () => {
       expect(result.success).toBe(true);
       expect(result.message).toBe("Organization created successfully!");
       expect(Organization.create).toHaveBeenCalled();
+      expect(Membership.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: "user1",
+          organization: "org123",
+          role: "admin",
+          status: "active",
+        }),
+      );
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        "user1",
+        expect.objectContaining({
+          role: "admin",
+          organization: "org123",
+        }),
+      );
       expect(AuditService.logAction).toHaveBeenCalledWith(
         expect.objectContaining({ action: "ORGANIZATION_CREATED" }),
       );
+    });
+
+    it("should roll back the org if membership creation fails", async () => {
+      Organization.findOne.mockResolvedValue(null);
+      Organization.create.mockResolvedValue({
+        _id: "org123",
+        name: "Acme",
+        slug: "acme-abc123",
+      });
+      Organization.findByIdAndDelete.mockResolvedValue({});
+      Membership.create.mockRejectedValue(new Error("Membership write failed"));
+
+      await expect(
+        OrganizationService.createOrJoinOrganization("user1", "Acme"),
+      ).rejects.toThrow("Membership write failed");
+
+      expect(Organization.findByIdAndDelete).toHaveBeenCalledWith("org123");
+      expect(userModel.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(AuditService.logAction).not.toHaveBeenCalled();
+    });
+
+    it("should prevent duplicate membership when creating an organization", async () => {
+      Organization.findOne.mockResolvedValue(null);
+      Organization.create.mockResolvedValue({
+        _id: "org123",
+        name: "Acme",
+        slug: "acme-abc123",
+      });
+      Organization.findByIdAndDelete.mockResolvedValue({});
+      const duplicateError = new Error("E11000 duplicate key");
+      duplicateError.code = 11000;
+      Membership.create.mockRejectedValue(duplicateError);
+
+      await expect(
+        OrganizationService.createOrJoinOrganization("user1", "Acme"),
+      ).rejects.toThrow("You are already a member of this organization.");
+
+      expect(Organization.findByIdAndDelete).toHaveBeenCalledWith("org123");
     });
 
     it("should join existing org when it exists", async () => {


### PR DESCRIPTION
# Pull Request

## Description

Ensures a Membership record is created whenever a new organization is created through the `createOrJoinOrganization` flow.

### Changes made

- Created an active Membership record for the organization creator during organization creation.
- Assigned the creator the `admin` role to match the existing organization creation flow.
- Added rollback logic to delete the organization if Membership creation fails, preventing orphaned organizations.
- Handled duplicate Membership creation by throwing a `ConflictError`.
- Added and updated tests covering successful Membership creation, rollback behavior, and duplicate Membership handling.
- Updated the server related-test validation script to correctly route Vitest-owned modules and support Jest 30 `--findRelatedTests`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #623

## Testing

Successfully ran the project's validation pipeline.

- Prettier (changed files)
- ESLint (changed files)
- OrganizationService Vitest suite (28 tests)
- `npm run test:related --prefix server`
- `npm run validate:pr --prefix server`
- `npm run validate:pr --prefix client`
- Production build

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (backend functionality only)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New organizations now automatically create an active administrator membership for their creator.
  * Failed membership creation now rolls back the organization to prevent incomplete setup.
  * Duplicate membership errors now provide a clear conflict message.
* **Tests**
  * Expanded coverage for organization creation, membership assignment, rollback, duplicate handling, user updates, and audit logging.
  * Improved selection of related server tests across Vitest and Jest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->