### PR TITLE
fix(poll): prevent voting on expired polls before background cleanup

### DIFF
--- a/server/controllers/pollController.js
+++ b/server/controllers/pollController.js
@@ -148,6 +148,12 @@ export const castVote = async (req, res) => {
       return res.status(400).json({ message: "Poll is closed" });
     }
 
+    if (poll.expiresAt && new Date(poll.expiresAt) <= new Date()) {
+      poll.isClosed = true;
+      await poll.save();
+      return res.status(400).json({ message: "Poll has expired" });
+    }
+
     if (poll.organization.toString() !== req.user.organization.toString()) {
       return res
         .status(403)


### PR DESCRIPTION
📝 Summary
Add immediate expiresAt validation in castVote() so expired polls reject votes at submission time instead of relying solely on the 5-minute cron job.

🔗 Related Issue
Fixes #828

✨ Changes Made
- Added expiresAt check in castVote() after the isClosed check — if poll.expiresAt exists and is in the past, return 400 "Poll has expired" and mark the poll as isClosed = true immediately
- Existing 5-minute cron job (pollExpirationJob.js) is untouched and continues to clean up polls that expire between vote submissions

🧪 Testing
- Tests pass
- Linters run successfully
- Tested locally
- Screenshots attached (if applicable)
Testing Details:
Manual test scenarios verified:
- Expired poll (expiresAt in past) → vote returns 400 "Poll has expired"
- Active poll (expiresAt in future or null) → vote proceeds normally
- Closed poll (isClosed: true) → vote returns 400 "Poll is closed" (unchanged behavior)
- 
✅ Checklist
- My code follows the project's coding style and conventions.
- I have performed a self-review of my code.
- All tests pass successfully.
- Linters run without errors or warnings.
- I have updated the documentation where necessary.
- I have added or updated tests where applicable.
- I have linked the related issue.
- No unnecessary files, debug code, or commented-out code are included.
- My changes do not introduce new warnings or breaking changes.
- This pull request is ready for review.
- 
📎 Additional Notes
- Only 1 file changed (server/controllers/pollController.js) — minimal, focused change
- The expiresAt check mirrors the same logic used in the cron job (expiresAt: { $lte: new Date() })
- Setting isClosed = true during rejection keeps the poll model consistent even before the cron job runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented voting on polls after their expiration time.
  * Expired polls are automatically marked as closed and display an expiration message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->