### PR TITLE
Add backdrop dismiss and dark mode to calendar meeting modal.

### DIFF
--- a/client/src/components/calendar/MeetingDetailsModal.jsx
+++ b/client/src/components/calendar/MeetingDetailsModal.jsx
@@ -14,7 +14,6 @@ import { getStatusStyle, formatTimeSlot } from "./calendarUtils";
 const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
   const navigate = useNavigate();
 
-  // Handle outside click to close modal
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === "Escape") {
@@ -28,15 +27,18 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
   if (!selectedMeeting) return null;
 
   return (
-    <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-xs flex items-center justify-center p-4 z-50 animate-fade-in">
+    <div
+      className="fixed inset-0 bg-slate-900/40 dark:bg-black/60 backdrop-blur-xs flex items-center justify-center p-4 z-50 animate-fade-in"
+      onClick={() => setSelectedMeeting(null)}
+    >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-md bg-white border border-slate-200 rounded-2xl shadow-xl p-6 relative overflow-hidden"
+        className="w-full max-w-md bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-xl p-6 relative overflow-hidden"
       >
         {/* Close button */}
         <button
           onClick={() => setSelectedMeeting(null)}
-          className="absolute right-4 top-4 p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-50 rounded-lg cursor-pointer"
+          className="absolute right-4 top-4 p-1 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 rounded-lg cursor-pointer"
         >
           <X className="w-4 h-4" />
         </button>
@@ -48,17 +50,17 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
           >
             {selectedMeeting.status}
           </span>
-          <h3 className="text-xl font-bold text-slate-900 leading-tight">
+          <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100 leading-tight">
             {selectedMeeting.title}
           </h3>
         </div>
 
         {/* Detail rows */}
-        <div className="space-y-4 text-sm text-slate-600 border-t border-b border-slate-100 py-4 mb-5">
+        <div className="space-y-4 text-sm text-slate-600 dark:text-slate-300 border-t border-b border-slate-100 dark:border-slate-700 py-4 mb-5">
           <div className="flex items-start gap-3">
             <Clock className="w-4 h-4 text-slate-400 mt-0.5 shrink-0" />
             <div>
-              <div className="font-semibold text-slate-800">
+              <div className="font-semibold text-slate-800 dark:text-slate-100">
                 {new Date(selectedMeeting.date).toLocaleDateString("en-US", {
                   weekday: "long",
                   month: "long",
@@ -66,7 +68,7 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
                   year: "numeric",
                 })}
               </div>
-              <div className="text-xs text-slate-500 font-bold uppercase mt-0.5">
+              <div className="text-xs text-slate-500 dark:text-slate-400 font-bold uppercase mt-0.5">
                 {formatTimeSlot(selectedMeeting.time)} (
                 {selectedMeeting.duration || 60} mins)
               </div>
@@ -77,7 +79,7 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
             <div className="flex items-center gap-3">
               <Briefcase className="w-4 h-4 text-slate-400 shrink-0" />
               <div>
-                <span className="font-semibold text-slate-800">
+                <span className="font-semibold text-slate-800 dark:text-slate-100">
                   Organization:
                 </span>{" "}
                 {selectedMeeting.organization.name ||
@@ -89,7 +91,9 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
           <div className="flex items-center gap-3">
             <Layers className="w-4 h-4 text-slate-400 shrink-0" />
             <div>
-              <span className="font-semibold text-slate-800">Type:</span>{" "}
+              <span className="font-semibold text-slate-800 dark:text-slate-100">
+                Type:
+              </span>{" "}
               <span className="capitalize">
                 {selectedMeeting.meetingType || "Conference"}
               </span>
@@ -100,7 +104,9 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
             <div className="flex items-center gap-3">
               <MapPin className="w-4 h-4 text-slate-400 shrink-0" />
               <div>
-                <span className="font-semibold text-slate-800">Location:</span>{" "}
+                <span className="font-semibold text-slate-800 dark:text-slate-100">
+                  Location:
+                </span>{" "}
                 {selectedMeeting.location}
               </div>
             </div>
@@ -108,10 +114,10 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
 
           {selectedMeeting.description && (
             <div className="pt-2">
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-1">
+              <p className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
                 Description
               </p>
-              <p className="text-xs text-slate-500 leading-relaxed bg-slate-50 p-2.5 rounded-lg border border-slate-100">
+              <p className="text-xs text-slate-500 dark:text-slate-300 leading-relaxed bg-slate-50 dark:bg-slate-800 p-2.5 rounded-lg border border-slate-100 dark:border-slate-700">
                 {selectedMeeting.description}
               </p>
             </div>
@@ -138,7 +144,7 @@ const MeetingDetailsModal = ({ selectedMeeting, setSelectedMeeting }) => {
               setSelectedMeeting(null);
               navigate(`/meeting/${selectedMeeting._id}`);
             }}
-            className="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-bold text-slate-700 hover:text-slate-900 bg-white hover:bg-slate-50 border border-slate-200 rounded-xl transition-all shadow-xs cursor-pointer"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-xs font-bold text-slate-700 dark:text-slate-200 hover:text-slate-900 dark:hover:text-white bg-white dark:bg-slate-800 hover:bg-slate-50 dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-xl transition-all shadow-xs cursor-pointer"
           >
             <ExternalLink className="w-3.5 h-3.5" />
             View full details

--- a/client/src/components/calendar/calendarUtils.js
+++ b/client/src/components/calendar/calendarUtils.js
@@ -6,28 +6,32 @@ export const getStatusStyle = (status) => {
       return {
         bg: "bg-emerald-50 hover:bg-emerald-100/80 border-emerald-200 text-emerald-800",
         dot: "bg-emerald-500",
-        badge: "bg-emerald-50 text-emerald-700 border-emerald-100",
+        badge:
+          "bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800",
         icon: CheckCircle,
       };
     case "processing":
       return {
         bg: "bg-amber-50 hover:bg-amber-100/80 border-amber-200 text-amber-800 animate-pulse",
         dot: "bg-amber-500",
-        badge: "bg-amber-50 text-amber-700 border-amber-100",
+        badge:
+          "bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800",
         icon: Loader2,
       };
     case "failed":
       return {
         bg: "bg-rose-50 hover:bg-rose-100/80 border-rose-200 text-rose-800",
         dot: "bg-rose-500",
-        badge: "bg-rose-50 text-rose-700 border-rose-100",
+        badge:
+          "bg-rose-50 text-rose-700 border-rose-100 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-800",
         icon: AlertCircle,
       };
     default: // uploaded / upcoming
       return {
         bg: "bg-blue-50 hover:bg-blue-100/80 border-blue-200 text-blue-800",
         dot: "bg-blue-500",
-        badge: "bg-blue-50 text-blue-700 border-blue-100",
+        badge:
+          "bg-blue-50 text-blue-700 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-800",
         icon: HelpCircle,
       };
   }


### PR DESCRIPTION
## Summary
- Close the calendar meeting details modal on backdrop click
- Add dark mode styling for the modal and status badge
- Keep existing Escape key behavior
Closes #839
## Test plan
- [ ] Open a meeting from Calendar and click outside the modal to close
- [ ] Press Escape and confirm it still closes
- [ ] Toggle dark mode and confirm the modal looks correct
- [ ] Join Live Room / View full details still work