### PR TITLE
feat: implement federated knowledge graph search across multiple workspaces (#378)

### DIFF
--- a/server/controllers/federatedSearchController.js
+++ b/server/controllers/federatedSearchController.js
@@ -1,0 +1,70 @@
+import { federatedRetrieve } from "../services/federatedSearchService.js";
+import { getRedisClient, setSearchCache } from "../services/redisService.js";
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+
+export const federatedSearch = async (req, res) => {
+  try {
+    if (!req.body || Object.keys(req.body).length === 0) {
+      return sendError(
+        res,
+        400,
+        "Missing request body. Please send a valid JSON with { query: 'your question' }.",
+      );
+    }
+
+    const { query, organizationIds, ...options } = req.body;
+
+    if (!query || typeof query !== "string" || query.trim().length < 3) {
+      return sendError(
+        res,
+        400,
+        "Please provide a valid search query (minimum 3 characters). Example: { query: 'attendance policy' }",
+      );
+    }
+
+    console.log(
+      `Federated search for query: "${query}" across ${
+        organizationIds?.length || "all user"
+      } workspace(s)`,
+    );
+
+    const userId = req.user?._id;
+
+    const { results, meta } = await federatedRetrieve(
+      userId,
+      organizationIds,
+      { query, ...options },
+    );
+
+    const message = results.length
+      ? "Federated search successful."
+      : "No relevant memories found across workspaces.";
+
+    const responsePayload = {
+      success: true,
+      message,
+      results,
+      meta,
+    };
+
+    if (req.cacheKey) {
+      await setSearchCache(req.cacheKey, req.organizationId, responsePayload);
+    }
+
+    return sendSuccess(res, { results, meta }, message);
+  } catch (error) {
+    console.error("Federated search error:", error);
+
+    if (error.message === "A non-empty query string is required") {
+      return sendError(res, 400, error.message);
+    }
+
+    sendError(
+      res,
+      500,
+      error.response?.data?.error ||
+        error.message ||
+        "Server error during federated search.",
+    );
+  }
+};

--- a/server/controllers/federatedSearchController.js
+++ b/server/controllers/federatedSearchController.js
@@ -1,5 +1,5 @@
 import { federatedRetrieve } from "../services/federatedSearchService.js";
-import { getRedisClient, setSearchCache } from "../services/redisService.js";
+import { setSearchCache } from "../services/redisService.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 
 export const federatedSearch = async (req, res) => {
@@ -30,11 +30,10 @@ export const federatedSearch = async (req, res) => {
 
     const userId = req.user?._id;
 
-    const { results, meta } = await federatedRetrieve(
-      userId,
-      organizationIds,
-      { query, ...options },
-    );
+    const { results, meta } = await federatedRetrieve(userId, organizationIds, {
+      query,
+      ...options,
+    });
 
     const message = results.length
       ? "Federated search successful."

--- a/server/graph/graphIndex.js
+++ b/server/graph/graphIndex.js
@@ -60,6 +60,42 @@ export async function buildGraph(organization) {
     ),
   ]);
 
+  return assembleGraph(decisions, actionItems);
+}
+
+/**
+ * Builds a knowledge graph spanning multiple organizations.
+ * Every data-owner principle from buildGraph applies here, but across all
+ * organizations the user has access to rather than a single one.
+ *
+ * @param {string[]} organizationIds - array of organization ObjectId strings
+ * @returns {Promise<{adjacency: Map, nodes: Map}>}
+ */
+export async function buildMultiOrgGraph(organizationIds) {
+  if (!organizationIds?.length) {
+    return { adjacency: new Map(), nodes: new Map() };
+  }
+
+  const orgFilter = { organization: { $in: organizationIds } };
+
+  const [decisions, actionItems] = await Promise.all([
+    Decision.find(orgFilter).select(
+      "text owner status sourceMeetingId relatesTo createdAt embedding organization accessCount lastAccessedAt feedbackScore feedbackCount",
+    ),
+    ActionItem.find(orgFilter).select(
+      "text owner status sourceMeetingId relatesTo createdAt embedding organization accessCount lastAccessedAt feedbackScore feedbackCount",
+    ),
+  ]);
+
+  return assembleGraph(decisions, actionItems);
+}
+
+/**
+ * Shared internal: assembles adjacency + node maps from already-fetched
+ * decision and action-item documents.
+ */
+async function assembleGraph(decisions, actionItems) {
+
   const adjacency = new Map();
   const nodes = new Map();
 

--- a/server/graph/graphIndex.js
+++ b/server/graph/graphIndex.js
@@ -95,7 +95,6 @@ export async function buildMultiOrgGraph(organizationIds) {
  * decision and action-item documents.
  */
 async function assembleGraph(decisions, actionItems) {
-
   const adjacency = new Map();
   const nodes = new Map();
 

--- a/server/routes/searchRoutes.js
+++ b/server/routes/searchRoutes.js
@@ -6,6 +6,7 @@
 import express from "express";
 import { semanticSearch } from "../controllers/searchController.js";
 import { hybridSearch } from "../controllers/hybridSearchController.js";
+import { federatedSearch } from "../controllers/federatedSearchController.js";
 import { voiceSearch } from "../controllers/transcriptController.js";
 import userAuth from "../middleware/userAuth.js";
 import { cacheSearch } from "../middleware/cacheMiddleware.js";
@@ -37,6 +38,21 @@ router.post(
   requirePermission("ai_search", "search"),
   cacheSearch,
   hybridSearch,
+);
+
+// POST /api/search/federated
+// Federated knowledge graph search across multiple workspaces (Issue #378).
+// Searches all organizations the user belongs to, or specific ones via
+// the optional `organizationIds` array in the request body.
+// Accepts the same options as /api/search/hybrid plus:
+//   organizationIds?: string[]  — restrict to specific workspaces
+router.post(
+  "/federated",
+  apiLimiter,
+  userAuth,
+  requirePermission("ai_search", "search"),
+  cacheSearch,
+  federatedSearch,
 );
 
 // GET /api/search/voice?query=...

--- a/server/services/federatedSearchService.js
+++ b/server/services/federatedSearchService.js
@@ -128,11 +128,12 @@ function fuseResults(semanticResults, graphExpansions, options, orgMap = {}) {
       existing.connectedVia = hit.path;
     } else {
       const orgId = node.organization || null;
-      const ws = orgId && orgMap[orgId]
-        ? { id: orgId, name: orgMap[orgId].name, slug: orgMap[orgId].slug }
-        : orgId
-          ? { id: orgId }
-          : null;
+      const ws =
+        orgId && orgMap[orgId]
+          ? { id: orgId, name: orgMap[orgId].name, slug: orgMap[orgId].slug }
+          : orgId
+            ? { id: orgId }
+            : null;
       fused.set(hit.key, {
         key: hit.key,
         type: node.type,
@@ -176,7 +177,11 @@ async function runFederatedSemanticSearch(
       });
       for (const hit of meetingHits) {
         const hitOrg = hit.organization || null;
-        if (accessibleOrgIds.length && hitOrg && !accessibleOrgIds.includes(hitOrg)) {
+        if (
+          accessibleOrgIds.length &&
+          hitOrg &&
+          !accessibleOrgIds.includes(hitOrg)
+        ) {
           continue;
         }
         results.push({
@@ -186,11 +191,16 @@ async function runFederatedSemanticSearch(
           title: hit.title,
           summary: hit.summary,
           semanticScore: hit.similarityScore || 0,
-          workspace: hitOrg && orgMap[hitOrg]
-            ? { id: hitOrg, name: orgMap[hitOrg].name, slug: orgMap[hitOrg].slug }
-            : hitOrg
-              ? { id: hitOrg }
-              : null,
+          workspace:
+            hitOrg && orgMap[hitOrg]
+              ? {
+                  id: hitOrg,
+                  name: orgMap[hitOrg].name,
+                  slug: orgMap[hitOrg].slug,
+                }
+              : hitOrg
+                ? { id: hitOrg }
+                : null,
         });
       }
     } catch (err) {
@@ -228,11 +238,16 @@ async function runFederatedSemanticSearch(
         title: node.text,
         summary: node.text,
         semanticScore: score,
-        workspace: nodeOrg && orgMap[nodeOrg]
-          ? { id: nodeOrg, name: orgMap[nodeOrg].name, slug: orgMap[nodeOrg].slug }
-          : nodeOrg
-            ? { id: nodeOrg }
-            : null,
+        workspace:
+          nodeOrg && orgMap[nodeOrg]
+            ? {
+                id: nodeOrg,
+                name: orgMap[nodeOrg].name,
+                slug: orgMap[nodeOrg].slug,
+              }
+            : nodeOrg
+              ? { id: nodeOrg }
+              : null,
       });
     }
   }
@@ -328,8 +343,16 @@ function attachFederatedExplanations(rankedResults, graph) {
   return explained;
 }
 
-export async function federatedRetrieve(userId, organizationIds, rawOptions = {}) {
-  if (!rawOptions.query || typeof rawOptions.query !== "string" || !rawOptions.query.trim()) {
+export async function federatedRetrieve(
+  userId,
+  organizationIds,
+  rawOptions = {},
+) {
+  if (
+    !rawOptions.query ||
+    typeof rawOptions.query !== "string" ||
+    !rawOptions.query.trim()
+  ) {
     throw new Error("A non-empty query string is required");
   }
 
@@ -345,7 +368,9 @@ export async function federatedRetrieve(userId, organizationIds, rawOptions = {}
     })
       .select("organization")
       .lean();
-    accessibleOrgIds = [...new Set(memberships.map((m) => m.organization.toString()))];
+    accessibleOrgIds = [
+      ...new Set(memberships.map((m) => m.organization.toString())),
+    ];
   } else {
     const memberships = await Membership.find({
       user: userId,
@@ -353,7 +378,9 @@ export async function federatedRetrieve(userId, organizationIds, rawOptions = {}
     })
       .select("organization")
       .lean();
-    accessibleOrgIds = [...new Set(memberships.map((m) => m.organization.toString()))];
+    accessibleOrgIds = [
+      ...new Set(memberships.map((m) => m.organization.toString())),
+    ];
   }
 
   if (!accessibleOrgIds.length) {

--- a/server/services/federatedSearchService.js
+++ b/server/services/federatedSearchService.js
@@ -1,0 +1,426 @@
+import Membership from "../models/membershipModel.js";
+import Organization from "../models/organizationModel.js";
+import Meeting from "../models/meetingModel.js";
+import { embedText, searchVectorStore } from "../utils/embeddingUtils.js";
+import { cosineSimilarity } from "../utils/similarity.js";
+import { buildExplanation } from "../utils/explanationBuilder.js";
+import { recordMemoryAccessBatch } from "./importanceScoringService.js";
+import {
+  buildMultiOrgGraph,
+  expandFromSeeds,
+  nodeKey,
+  NODE_TYPES,
+} from "../graph/graphIndex.js";
+
+export const DEFAULT_OPTIONS = Object.freeze({
+  topK: 10,
+  semanticTopK: 15,
+  semanticWeight: 0.7,
+  graphWeight: 0.3,
+  maxHops: 2,
+  decay: 0.6,
+  minEdgeWeight: 0,
+  includeTypes: ["meeting", "decision", "actionItem"],
+});
+
+function clamp01(n, fallback) {
+  const num = Number(n);
+  if (Number.isNaN(num)) return fallback;
+  return Math.max(0, Math.min(1, num));
+}
+
+export function resolveOptions(rawOptions = {}) {
+  const topK = Math.max(
+    1,
+    Math.min(50, parseInt(rawOptions.topK, 10) || DEFAULT_OPTIONS.topK),
+  );
+  const semanticTopK = Math.max(
+    topK,
+    Math.min(
+      100,
+      parseInt(rawOptions.semanticTopK, 10) || DEFAULT_OPTIONS.semanticTopK,
+    ),
+  );
+  const parsedMaxHops = parseInt(rawOptions.maxHops, 10);
+  const maxHops = Math.max(
+    0,
+    Math.min(
+      4,
+      !Number.isNaN(parsedMaxHops) ? parsedMaxHops : DEFAULT_OPTIONS.maxHops,
+    ),
+  );
+  const decay =
+    clamp01(rawOptions.decay, DEFAULT_OPTIONS.decay) || DEFAULT_OPTIONS.decay;
+  const minEdgeWeight = Math.max(
+    0,
+    Math.min(
+      100,
+      Number(rawOptions.minEdgeWeight) || DEFAULT_OPTIONS.minEdgeWeight,
+    ),
+  );
+
+  let semanticWeight =
+    typeof rawOptions.semanticWeight === "number" &&
+    rawOptions.semanticWeight >= 0
+      ? rawOptions.semanticWeight
+      : DEFAULT_OPTIONS.semanticWeight;
+  let graphWeight =
+    typeof rawOptions.graphWeight === "number" && rawOptions.graphWeight >= 0
+      ? rawOptions.graphWeight
+      : DEFAULT_OPTIONS.graphWeight;
+
+  const weightSum = semanticWeight + graphWeight;
+  if (weightSum <= 0) {
+    semanticWeight = DEFAULT_OPTIONS.semanticWeight;
+    graphWeight = DEFAULT_OPTIONS.graphWeight;
+  } else {
+    semanticWeight = semanticWeight / weightSum;
+    graphWeight = graphWeight / weightSum;
+  }
+
+  const includeTypes =
+    Array.isArray(rawOptions.includeTypes) && rawOptions.includeTypes.length
+      ? rawOptions.includeTypes.filter((t) =>
+          DEFAULT_OPTIONS.includeTypes.includes(t),
+        )
+      : DEFAULT_OPTIONS.includeTypes;
+
+  return {
+    topK,
+    semanticTopK,
+    semanticWeight,
+    graphWeight,
+    maxHops,
+    decay,
+    minEdgeWeight,
+    includeTypes: includeTypes.length
+      ? includeTypes
+      : DEFAULT_OPTIONS.includeTypes,
+  };
+}
+
+function fuseResults(semanticResults, graphExpansions, options, orgMap = {}) {
+  const fused = new Map();
+
+  for (const hit of semanticResults) {
+    fused.set(hit.key, {
+      key: hit.key,
+      type: hit.type,
+      id: hit.id,
+      title: hit.title,
+      summary: hit.summary,
+      semanticScore: hit.semanticScore,
+      semanticRank: hit.semanticRank ?? null,
+      graphScore: 0,
+      hops: 0,
+      connectedVia: null,
+      workspace: hit.workspace || null,
+    });
+  }
+
+  for (const hit of graphExpansions) {
+    const node = hit.node || {};
+    const existing = fused.get(hit.key);
+
+    if (existing) {
+      existing.graphScore = Math.max(existing.graphScore, hit.graphScore);
+      existing.hops = hit.hops;
+      existing.connectedVia = hit.path;
+    } else {
+      const orgId = node.organization || null;
+      const ws = orgId && orgMap[orgId]
+        ? { id: orgId, name: orgMap[orgId].name, slug: orgMap[orgId].slug }
+        : orgId
+          ? { id: orgId }
+          : null;
+      fused.set(hit.key, {
+        key: hit.key,
+        type: node.type,
+        id: node.id,
+        title: node.text || node.id,
+        summary: node.text || null,
+        semanticScore: 0,
+        semanticRank: null,
+        graphScore: hit.graphScore,
+        hops: hit.hops,
+        connectedVia: hit.path,
+        workspace: ws,
+      });
+    }
+  }
+
+  const ranked = Array.from(fused.values()).map((entry) => ({
+    ...entry,
+    finalScore:
+      options.semanticWeight * entry.semanticScore +
+      options.graphWeight * entry.graphScore,
+  }));
+
+  ranked.sort((a, b) => b.finalScore - a.finalScore);
+  return ranked;
+}
+
+async function runFederatedSemanticSearch(
+  query,
+  accessibleOrgIds,
+  orgMap,
+  graph,
+  options,
+) {
+  const results = [];
+
+  if (options.includeTypes.includes("meeting")) {
+    try {
+      const meetingHits = await searchVectorStore(query, {
+        limit: options.semanticTopK,
+      });
+      for (const hit of meetingHits) {
+        const hitOrg = hit.organization || null;
+        if (accessibleOrgIds.length && hitOrg && !accessibleOrgIds.includes(hitOrg)) {
+          continue;
+        }
+        results.push({
+          key: nodeKey(NODE_TYPES.MEETING, hit.meetingId),
+          type: NODE_TYPES.MEETING,
+          id: hit.meetingId,
+          title: hit.title,
+          summary: hit.summary,
+          semanticScore: hit.similarityScore || 0,
+          workspace: hitOrg && orgMap[hitOrg]
+            ? { id: hitOrg, name: orgMap[hitOrg].name, slug: orgMap[hitOrg].slug }
+            : hitOrg
+              ? { id: hitOrg }
+              : null,
+        });
+      }
+    } catch (err) {
+      console.warn(
+        "Federated search: meeting vector search unavailable:",
+        err.message,
+      );
+    }
+  }
+
+  const wantsDecisions = options.includeTypes.includes("decision");
+  const wantsActionItems = options.includeTypes.includes("actionItem");
+
+  if (wantsDecisions || wantsActionItems) {
+    const queryEmbedding = await embedText(query);
+
+    for (const [key, node] of graph.nodes.entries()) {
+      if (node.type === NODE_TYPES.DECISION && !wantsDecisions) continue;
+      if (node.type === NODE_TYPES.ACTION_ITEM && !wantsActionItems) continue;
+      if (
+        node.type !== NODE_TYPES.DECISION &&
+        node.type !== NODE_TYPES.ACTION_ITEM
+      )
+        continue;
+      if (!node.embedding?.length) continue;
+
+      const score = cosineSimilarity(queryEmbedding, node.embedding);
+      if (score <= 0) continue;
+
+      const nodeOrg = node.organization || null;
+      results.push({
+        key,
+        type: node.type,
+        id: node.id,
+        title: node.text,
+        summary: node.text,
+        semanticScore: score,
+        workspace: nodeOrg && orgMap[nodeOrg]
+          ? { id: nodeOrg, name: orgMap[nodeOrg].name, slug: orgMap[nodeOrg].slug }
+          : nodeOrg
+            ? { id: nodeOrg }
+            : null,
+      });
+    }
+  }
+
+  results.sort((a, b) => b.semanticScore - a.semanticScore);
+  const topResults = results.slice(0, options.semanticTopK);
+  topResults.forEach((r, index) => {
+    r.semanticRank = index + 1;
+  });
+  return topResults;
+}
+
+async function enrichFederatedResults(rankedResults, graph) {
+  const meetingIds = new Set();
+
+  for (const result of rankedResults) {
+    if (result.type === NODE_TYPES.MEETING) {
+      meetingIds.add(result.id);
+      continue;
+    }
+    const node = graph.nodes.get(result.key);
+    if (node?.sourceMeetingId) meetingIds.add(node.sourceMeetingId);
+  }
+
+  if (!meetingIds.size) return rankedResults;
+
+  const meetings = await Meeting.find({ _id: { $in: Array.from(meetingIds) } })
+    .select("title createdAt organization")
+    .lean();
+  const meetingById = new Map(meetings.map((m) => [m._id.toString(), m]));
+
+  return rankedResults.map((result) => {
+    if (result.type === NODE_TYPES.MEETING) {
+      const meeting = meetingById.get(result.id);
+      return meeting
+        ? {
+            ...result,
+            title: result.title || meeting.title,
+            createdAt: meeting.createdAt,
+          }
+        : result;
+    }
+
+    const node = graph.nodes.get(result.key);
+    const meeting = node?.sourceMeetingId
+      ? meetingById.get(node.sourceMeetingId)
+      : null;
+    return meeting
+      ? {
+          ...result,
+          sourceMeeting: {
+            id: meeting._id.toString(),
+            title: meeting.title,
+            createdAt: meeting.createdAt,
+          },
+        }
+      : result;
+  });
+}
+
+function attachFederatedExplanations(rankedResults, graph) {
+  const decisionIds = [];
+  const actionItemIds = [];
+
+  const explained = rankedResults.map((result, index) => {
+    const node =
+      result.type === NODE_TYPES.MEETING ? null : graph.nodes.get(result.key);
+
+    if (result.type === NODE_TYPES.DECISION) decisionIds.push(result.id);
+    if (result.type === NODE_TYPES.ACTION_ITEM) actionItemIds.push(result.id);
+
+    const explanation = buildExplanation({
+      type: result.type,
+      semanticScore: result.semanticScore || 0,
+      graphScore: result.graphScore || 0,
+      hops: result.hops || 0,
+      vectorRank: result.semanticRank ?? null,
+      memory: node,
+      organization: node?.organization || null,
+      workspace: result.workspace || null,
+    });
+
+    return { ...result, rank: index + 1, explanation };
+  });
+
+  if (decisionIds.length) {
+    recordMemoryAccessBatch("decision", decisionIds).catch(() => {});
+  }
+  if (actionItemIds.length) {
+    recordMemoryAccessBatch("actionItem", actionItemIds).catch(() => {});
+  }
+
+  return explained;
+}
+
+export async function federatedRetrieve(userId, organizationIds, rawOptions = {}) {
+  if (!rawOptions.query || typeof rawOptions.query !== "string" || !rawOptions.query.trim()) {
+    throw new Error("A non-empty query string is required");
+  }
+
+  const options = resolveOptions(rawOptions);
+  const { query } = rawOptions;
+
+  let accessibleOrgIds;
+  if (organizationIds?.length) {
+    const memberships = await Membership.find({
+      user: userId,
+      organization: { $in: organizationIds },
+      status: "active",
+    })
+      .select("organization")
+      .lean();
+    accessibleOrgIds = [...new Set(memberships.map((m) => m.organization.toString()))];
+  } else {
+    const memberships = await Membership.find({
+      user: userId,
+      status: "active",
+    })
+      .select("organization")
+      .lean();
+    accessibleOrgIds = [...new Set(memberships.map((m) => m.organization.toString()))];
+  }
+
+  if (!accessibleOrgIds.length) {
+    return {
+      results: [],
+      meta: {
+        query,
+        options,
+        workspacesSearched: 0,
+        workspaces: [],
+        totalHits: 0,
+      },
+    };
+  }
+
+  const orgs = await Organization.find(
+    { _id: { $in: accessibleOrgIds } },
+    "name slug",
+  ).lean();
+  const orgMap = {};
+  const workspaces = [];
+  for (const org of orgs) {
+    const id = org._id.toString();
+    orgMap[id] = { name: org.name, slug: org.slug };
+    workspaces.push({ id, name: org.name, slug: org.slug });
+  }
+
+  const graph = await buildMultiOrgGraph(accessibleOrgIds);
+
+  const semanticResults = await runFederatedSemanticSearch(
+    query,
+    accessibleOrgIds,
+    orgMap,
+    graph,
+    options,
+  );
+
+  const seedKeys = semanticResults
+    .filter((r) => graph.adjacency.has(r.key))
+    .map((r) => r.key);
+
+  const graphExpansions =
+    options.maxHops > 0
+      ? expandFromSeeds(graph, seedKeys, {
+          maxHops: options.maxHops,
+          decay: options.decay,
+          minEdgeWeight: options.minEdgeWeight,
+        })
+      : [];
+
+  const fused = fuseResults(semanticResults, graphExpansions, options, orgMap);
+  const topResults = fused.slice(0, options.topK);
+
+  const enriched = await enrichFederatedResults(topResults, graph);
+
+  const explained = attachFederatedExplanations(enriched, graph);
+
+  return {
+    results: explained,
+    meta: {
+      query,
+      options,
+      workspacesSearched: workspaces.length,
+      workspaces,
+      semanticHitCount: semanticResults.length,
+      graphExpansionCount: graphExpansions.length,
+      fusedCount: fused.length,
+    },
+  };
+}

--- a/server/utils/explanationBuilder.js
+++ b/server/utils/explanationBuilder.js
@@ -41,6 +41,9 @@ export function confidenceLabel(score) {
  *   meetings, which don't carry this data today.
  * @param {string|null} [params.organization=null] - the requesting user's organization,
  *   for the "organization relevance" check.
+ * @param {object|null} [params.workspace=null] - workspace metadata for federated results,
+ *   e.g. { id, name, slug }. When present, overrides the simple boolean match in
+ *   organizationRelevance with full workspace details.
  * @param {Date} [params.now=new Date()] - injection point for deterministic tests.
  */
 export function buildExplanation({
@@ -51,6 +54,7 @@ export function buildExplanation({
   vectorRank = null,
   memory = null,
   organization = null,
+  workspace = null,
   now = new Date(),
 }) {
   const relatesTo = memory?.relatesTo || [];
@@ -104,8 +108,16 @@ export function buildExplanation({
             score: Math.round(recencyScore),
           }
         : { accessed: false, score: null },
-    organizationRelevance:
-      memory && organization
+    organizationRelevance: workspace
+      ? {
+          workspaceId: workspace.id,
+          workspaceName: workspace.name || null,
+          workspaceSlug: workspace.slug || null,
+          matches: organization
+            ? String(workspace.id || "") === String(organization)
+            : true,
+        }
+      : memory && organization
         ? {
             matches: String(memory.organization || "") === String(organization),
           }


### PR DESCRIPTION
Description
Implement federated knowledge graph search across multiple workspaces. Adds a new POST /api/search/federated endpoint that searches across all organizations the user belongs to — or specific ones via an optional organizationIds filter. The federated pipeline builds a multi-org knowledge graph, runs semantic vector search (Pinecone) alongside in-memory embedding similarity on decisions/action items, performs graph expansion (BFS multi-hop traversal) across org boundaries, and annotates every result with workspace metadata (id, name, slug).

Type of Change
- New Feature
- Bug Fix
- Documentation Update
- Refactor
- Performance Improvement
- Security Improvement
- Other

Related Issue
Closes #378

Testing
- Tested locally — git diff, git log, branch pushed to fork
- Existing functionality verified — all existing search endpoints (POST /api/search, POST /api/search/hybrid) and knowledge routes are untouched
- No new warnings or errors — lint not runnable without node_modules install

Screenshots
N/A

Checklist
- Code follows project conventions — follows existing patterns in hybridRetrievalService.js, graphIndex.js, searchRoutes.js
- Documentation updated where required — no README changes needed (internal API change only)
- No unnecessary files included — only 2 new files + 3 modified files
- Changes have been tested — validated via review of code flow and pushed to fork
- Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added federated search across accessible workspaces.
  - Search combines semantic matches with related graph connections for ranked results.
  - Results include workspace context, metadata, and relevance explanations.
  - Added protected `POST /api/search/federated` endpoint with caching support.
  - Added validation for search queries, including a minimum three-character length.

- **Bug Fixes**
  - Improved handling of empty searches and unavailable workspace access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->