### PR TITLE
Dark mode support for meeting section

### DIFF
--- a/client/src/components/tasks.jsx
+++ b/client/src/components/tasks.jsx
@@ -707,14 +707,14 @@ const Tasks = () => {
                   </div>
 
                   {/* Related Meeting */}
-                  <div className="p-4 bg-blue-50 rounded-xl border border-blue-100">
+                  <div className="p-4 bg-blue-50 dark:bg-blue-950/40 rounded-xl border border-blue-100 dark:border-blue-900/50">
                     <div className="flex items-center justify-between">
                       <div>
-                        <div className="flex items-center gap-2 text-sm text-blue-600 mb-1">
+                        <div className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 mb-1">
                           <FileText className="w-4 h-4" />
                           Related Meeting
                         </div>
-                        <p className="font-medium text-slate-900">
+                        <p className="font-medium text-slate-900 dark:text-white">
                           {selectedTask.meetingTitle}
                         </p>
                       </div>
@@ -723,7 +723,7 @@ const Tasks = () => {
                           setSelectedTask(null);
                           navigate(`/meeting/${selectedTask.meetingId}`);
                         }}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 hover:bg-blue-100 rounded-lg transition-colors"
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-lg transition-colors"
                       >
                         View Meeting
                         <ExternalLink className="w-3.5 h-3.5" />

--- a/client/src/components/tasks/TaskDetailsModal.jsx
+++ b/client/src/components/tasks/TaskDetailsModal.jsx
@@ -34,7 +34,7 @@ export default function TaskDetailsModal({
             onClick={() => setSelectedTask(null)}
             className="p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors"
           >
-            <X className="w-5 h-5 text-slate-600" />
+            <X className="w-5 h-5 text-slate-600 dark:text-slate-400" />
           </button>
         </div>
 
@@ -127,14 +127,14 @@ export default function TaskDetailsModal({
             </div>
 
             {/* Related Meeting */}
-            <div className="p-4 bg-blue-50 rounded-xl border border-blue-100">
+            <div className="p-4 bg-blue-50 dark:bg-blue-950/40 rounded-xl border border-blue-100 dark:border-blue-900/50">
               <div className="flex items-center justify-between">
                 <div>
-                  <div className="flex items-center gap-2 text-sm text-blue-600 mb-1">
+                  <div className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 mb-1">
                     <FileText className="w-4 h-4" />
                     Related Meeting
                   </div>
-                  <p className="font-medium text-slate-900">
+                  <p className="font-medium text-slate-900 dark:text-white">
                     {selectedTask.meetingTitle}
                   </p>
                 </div>
@@ -143,7 +143,7 @@ export default function TaskDetailsModal({
                     setSelectedTask(null);
                     navigate(`/meeting/${selectedTask.meetingId}`);
                   }}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 hover:bg-blue-100 rounded-lg transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-lg transition-colors"
                 >
                   View Meeting
                   <ExternalLink className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Description
 Added dark mode support to the **Related Meeting** section inside the Task Details modal.
- Applied dark background (`dark:bg-blue-950/40`) and border (`dark:border-blue-900/50`) to the container card.
- Updated text styling (`dark:text-blue-400` and `dark:text-white`) to ensure high contrast and readability in
  dark theme.
- Added dark mode hover and text styles (`dark:text-blue-400 dark:hover:bg-blue-900/50`) for the "View Meeting"
  action button.
- Added dark mode icon styling (`dark:text-slate-400`) to the modal close button.

## Type of Change

- [ ] New Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #843 

## Testing

Describe the testing performed.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark-mode styling in task details, including the Related Meeting card, labels, close icon, and View Meeting button.
  * Enhanced button hover states, contrast, and visual transitions for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->