### PR TITLE
perf: optimize decision graph loading with server side pagination

### DIFF
--- a/client/src/services/decisionGraphApi.js
+++ b/client/src/services/decisionGraphApi.js
@@ -1,7 +1,7 @@
 import apiClient from "./apiClient";
 
-export const getDecisionGraph = async () => {
-  const response = await apiClient.get("/api/decision-graph");
+export const getDecisionGraph = async (params = {}) => {
+  const response = await apiClient.get("/api/decision-graph", { params });
   return response.data;
 };
 

--- a/server/controllers/decisionGraphController.js
+++ b/server/controllers/decisionGraphController.js
@@ -8,21 +8,44 @@ import Decision from "../models/decisionModel.js";
 export const getDecisionGraph = async (req, res) => {
   try {
     const orgId = req.user.organization;
+    const { search, status } = req.query || {};
 
-    // Fetch all non-expired decisions for this org
-    const decisions = await Decision.find({
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+    const skip = (page - 1) * limit;
+
+    const filter = {
       organization: orgId,
       lifecycleState: { $ne: "expired" },
-    })
+    };
+
+    if (
+      status &&
+      ["open", "in-progress", "resolved", "superseded"].includes(status)
+    ) {
+      filter.status = status;
+    }
+
+    if (search && typeof search === "string") {
+      filter.text = { $regex: search, $options: "i" };
+    }
+
+    const total = await Decision.countDocuments(filter);
+
+    // Fetch paginated decisions for this org
+    const decisions = await Decision.find(filter)
       .select(
         "text owner status importanceScore relatesTo supersededByMemory sourceMeetingId createdAt updatedAt lifecycleState",
       )
+      .sort({ importanceScore: -1, createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
       .lean();
 
     const nodes = [];
     const edges = [];
 
-    // To ensure edges only point to existing nodes in the graph
+    // To ensure edges only point to existing nodes in the graph window
     const validNodeIds = new Set(decisions.map((d) => d._id.toString()));
 
     decisions.forEach((decision) => {
@@ -67,7 +90,20 @@ export const getDecisionGraph = async (req, res) => {
       }
     });
 
-    res.status(200).json({ nodes, edges });
+    const totalPages = Math.ceil(total / limit) || 1;
+    const hasMore = page < totalPages;
+
+    res.status(200).json({
+      nodes,
+      edges,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages,
+        hasMore,
+      },
+    });
   } catch (error) {
     console.error("Error fetching decision graph:", error);
     res.status(500).json({ message: "Server error fetching decision graph" });

--- a/server/tests/decisionGraphOptimized.test.js
+++ b/server/tests/decisionGraphOptimized.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getDecisionGraph } from "../controllers/decisionGraphController.js";
+import Decision from "../models/decisionModel.js";
+
+vi.mock("../models/decisionModel.js", () => ({
+  default: {
+    find: vi.fn(),
+    countDocuments: vi.fn(),
+  },
+}));
+
+describe("Decision Graph Optimization (#834)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns paginated decision graph nodes and edges", async () => {
+    const req = {
+      user: { organization: "org123" },
+      query: { page: "1", limit: "10" },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    Decision.countDocuments.mockResolvedValue(25);
+
+    const mockDecisions = [
+      {
+        _id: "d1",
+        text: "Decision 1",
+        owner: "user1",
+        status: "resolved",
+        importanceScore: 85,
+        relatesTo: [{ target: "d2", confidence: 90 }],
+        lifecycleState: "active",
+      },
+      {
+        _id: "d2",
+        text: "Decision 2",
+        owner: "user2",
+        status: "open",
+        importanceScore: 70,
+        lifecycleState: "active",
+      },
+    ];
+
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      sort: vi.fn().mockReturnThis(),
+      skip: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue(mockDecisions),
+    };
+
+    Decision.find.mockReturnValue(chain);
+
+    await getDecisionGraph(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodes: expect.any(Array),
+        edges: expect.any(Array),
+        pagination: {
+          total: 25,
+          page: 1,
+          limit: 10,
+          totalPages: 3,
+          hasMore: true,
+        },
+      }),
+    );
+
+    const callArgs = res.json.mock.calls[0][0];
+    expect(callArgs.nodes).toHaveLength(2);
+    expect(callArgs.edges).toHaveLength(1);
+    expect(callArgs.edges[0]).toEqual({
+      source: "d1",
+      target: "d2",
+      type: "relatesTo",
+      confidence: 90,
+    });
+  });
+});


### PR DESCRIPTION
# ⚡ Optimize Decision Graph Loading for Large Organizations

Closes #834

## 📌 Overview

This PR optimizes decision graph loading endpoints for large organizations by introducing server-side pagination, search filtering, and node bounding. It reduces peak payload size and prevents memory degradation in high-volume environments while preserving existing graph structure and functionality.

## 🚀 Key Changes

- **Server-Side Pagination & Bounding:**
  - Updated `getDecisionGraph` in `server/controllers/decisionGraphController.js` to accept `page`, `limit` (default 50, max 200), `status`, and `search` query parameters.
  - Slices decision nodes using `.skip()` and `.limit()` on MongoDB queries sorted by `importanceScore` and `createdAt`.
  - Filters return edges to ensure edges only connect valid node IDs within the active paginated graph window.
  - Added standard pagination metadata (`total`, `page`, `limit`, `totalPages`, `hasMore`) to the JSON response.

- **API Service Layer:**
  - Updated `getDecisionGraph` in `client/src/services/decisionGraphApi.js` to pass optional `params` objects to the GET request.

- **Testing:**
  - Added test suite `server/tests/decisionGraphOptimized.test.js` verifying node pagination, edge filtering, and metadata calculations.

## ✅ Acceptance Criteria Checklist

- [x] Large organization decision graphs load efficiently using pagination.
- [x] Graph node and edge integrity is preserved within paginated view windows.
- [x] Response payload size is significantly reduced.
- [x] Unit test suite passes (`tests/decisionGraphOptimized.test.js`).

## 🧪 Manual Testing Instructions

1. Query `GET /api/decision-graph?page=1&limit=10`.
2. Verify the response contains `nodes` (max 10), `edges` connecting those nodes, and a `pagination` metadata object.
3. Test query filtering with `GET /api/decision-graph?search=migration&status=resolved`.
