### PR TITLE
fix: enforce ai permission check for session generation

### DIFF
--- a/server/routes/sessionRoutes.js
+++ b/server/routes/sessionRoutes.js
@@ -2,10 +2,17 @@ import express from "express";
 import { generateSession } from "../controllers/sessionController.js";
 import userAuth from "../middleware/userAuth.js";
 import { writeLimiter } from "../middleware/rateLimiter.js";
+import { requirePermission } from "../middleware/rbac.js";
 
 const router = express.Router();
 
 // Generate session card
-router.post("/generate", userAuth, writeLimiter, generateSession);
+router.post(
+  "/generate",
+  userAuth,
+  requirePermission("ai_search", "search"),
+  writeLimiter,
+  generateSession,
+);
 
 export default router;

--- a/server/tests/sessionAiPermission.test.js
+++ b/server/tests/sessionAiPermission.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { requirePermission } from "../middleware/rbac.js";
+
+describe("Session Generation AI Permission Enforcement (#836)", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    next = vi.fn();
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("permits users with AI search privileges (e.g. member, admin, owner)", () => {
+    req = { user: { role: "member" } };
+    const middleware = requirePermission("ai_search", "search");
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("denies requests from unassigned or unauthorized roles without AI permissions", () => {
+    req = { user: { role: "unauthorized_role" } };
+    const middleware = requirePermission("ai_search", "search");
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining("Forbidden"),
+      }),
+    );
+  });
+
+  it("denies unauthenticated requests", () => {
+    req = {};
+    const middleware = requirePermission("ai_search", "search");
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Unauthorized",
+    });
+  });
+});


### PR DESCRIPTION
# 🔒 Enforce AI Permission Check for Session Generation

Closes #836

## 📌 Overview

This PR secures the session generation endpoint `POST /api/sessions/generate` by attaching MeetOnMemory's standard RBAC permission middleware (`requirePermission`). This prevents authenticated users without AI search/generation privileges from invoking AI-powered session card generation.

## 🚀 Key Changes

- **Middleware Enforcement:**
  - Updated `server/routes/sessionRoutes.js` to include `requirePermission("ai_search", "search")` prior to invoking the `generateSession` controller.
  - Ensures unauthorized roles receive a standard HTTP `403 Forbidden` response.

- **Testing:**
  - Added unit test suite `server/tests/sessionAiPermission.test.js` verifying access for authorized roles (admin, owner, member) and 403 denial for unauthorized roles.

## ✅ Acceptance Criteria Checklist

- [x] `POST /api/sessions/generate` requires `ai_search:search` permissions.
- [x] Authorized users retain full session card generation capabilities.
- [x] Requests from unauthorized roles are rejected with 403 Forbidden.
- [x] Unit test suite passes (`tests/sessionAiPermission.test.js`).

## 🧪 Manual Testing Instructions

1. Make a request to `POST /api/sessions/generate` with a user account lacking `ai_search` permissions. Verify HTTP 403 Forbidden is returned.
2. Make a request to `POST /api/sessions/generate` with an authorized user (e.g., `member` or `admin`). Verify session generation succeeds.
