### PR TITLE
fix: improve meeting delete and rename modal accessibility and dark mode support

### DIFF
--- a/client/src/components/meeting-details/MeetingActions.jsx
+++ b/client/src/components/meeting-details/MeetingActions.jsx
@@ -59,6 +59,27 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
     setShowDeleteModal(true);
   };
 
+  // Accessibility & Escape key handler (#838)
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        if (showDeleteModal) setShowDeleteModal(false);
+        if (showRenameModal) setShowRenameModal(false);
+      }
+    };
+
+    if (showDeleteModal || showRenameModal) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showDeleteModal, showRenameModal]);
+
+  const handleBackdropClick = (e, closeModal) => {
+    if (e.target === e.currentTarget) {
+      closeModal();
+    }
+  };
+
   const confirmDelete = () => {
     onDelete(meeting._id);
     setShowDeleteModal(false);
@@ -431,25 +452,38 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
 
       {/* Delete Confirmation Modal */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        <div
+          onClick={(e) =>
+            handleBackdropClick(e, () => setShowDeleteModal(false))
+          }
+          className="fixed inset-0 bg-black/60 backdrop-blur-xs flex items-center justify-center z-50 p-4"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-modal-title"
+            className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 max-w-md w-full shadow-2xl space-y-4"
+          >
+            <h3
+              id="delete-modal-title"
+              className="text-lg font-bold text-slate-900 dark:text-white"
+            >
               Delete Meeting
             </h3>
-            <p className="text-gray-600 mb-6">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Are you sure you want to delete this meeting? This action cannot
               be undone.
             </p>
-            <div className="flex gap-3 justify-end">
+            <div className="flex gap-3 justify-end pt-2">
               <button
                 onClick={() => setShowDeleteModal(false)}
-                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors text-sm font-medium"
+                className="px-4 py-2 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-xl transition-colors text-xs font-semibold cursor-pointer"
               >
                 Cancel
               </button>
               <button
                 onClick={confirmDelete}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors text-sm font-medium"
+                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-xl transition-colors text-xs font-semibold cursor-pointer shadow-xs"
               >
                 Delete
               </button>
@@ -460,29 +494,47 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
 
       {/* Rename Modal */}
       {showRenameModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        <div
+          onClick={(e) =>
+            handleBackdropClick(e, () => setShowRenameModal(false))
+          }
+          className="fixed inset-0 bg-black/60 backdrop-blur-xs flex items-center justify-center z-50 p-4"
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="rename-modal-title"
+            className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 max-w-md w-full shadow-2xl space-y-4"
+          >
+            <h3
+              id="rename-modal-title"
+              className="text-lg font-bold text-slate-900 dark:text-white"
+            >
               Rename Meeting
             </h3>
             <input
               type="text"
               value={newTitle}
               onChange={(e) => setNewTitle(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mb-4"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  confirmRename();
+                }
+              }}
+              className="w-full px-3.5 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white text-xs focus:ring-2 focus:ring-blue-500 focus:outline-none"
               placeholder="Enter new title"
               autoFocus
             />
-            <div className="flex gap-3 justify-end">
+            <div className="flex gap-3 justify-end pt-2">
               <button
                 onClick={() => setShowRenameModal(false)}
-                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors text-sm font-medium"
+                className="px-4 py-2 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-xl transition-colors text-xs font-semibold cursor-pointer"
               >
                 Cancel
               </button>
               <button
                 onClick={confirmRename}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors text-sm font-medium"
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl transition-colors text-xs font-semibold cursor-pointer shadow-xs"
               >
                 Save
               </button>

--- a/client/src/components/meeting-details/__tests__/MeetingActionsModals.test.jsx
+++ b/client/src/components/meeting-details/__tests__/MeetingActionsModals.test.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import MeetingActions from "../MeetingActions";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../../../hooks/useExport.js", () => ({
+  default: () => ({ exportMeeting: vi.fn(), isExporting: false }),
+}));
+
+describe("Meeting Delete & Rename Modals - Accessibility & Dark Mode (#838)", () => {
+  const mockMeeting = {
+    _id: "m123",
+    title: "Project Sync",
+    transcript: "Hello world",
+  };
+
+  const mockOnDelete = vi.fn();
+  const mockOnRename = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders Delete Modal with proper dialog role and ARIA labels", () => {
+    render(
+      <MemoryRouter>
+        <MeetingActions
+          meeting={mockMeeting}
+          onDelete={mockOnDelete}
+          onRename={mockOnRename}
+        />
+      </MemoryRouter>,
+    );
+
+    // Open Delete Modal
+    const deleteBtn = screen.getByText("Delete Meeting");
+    fireEvent.click(deleteBtn);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "delete-modal-title");
+  });
+
+  it("closes Delete Modal on Escape key press and backdrop click", () => {
+    render(
+      <MemoryRouter>
+        <MeetingActions
+          meeting={mockMeeting}
+          onDelete={mockOnDelete}
+          onRename={mockOnRename}
+        />
+      </MemoryRouter>,
+    );
+
+    // Open Delete Modal
+    fireEvent.click(screen.getByText("Delete Meeting"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Escape Key press
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Re-open and click backdrop
+    fireEvent.click(screen.getByText("Delete Meeting"));
+    const backdrop = screen.getByRole("dialog").parentElement;
+    fireEvent.click(backdrop);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders Rename Modal with proper ARIA attributes and submits on Enter key", () => {
+    render(
+      <MemoryRouter>
+        <MeetingActions
+          meeting={mockMeeting}
+          onDelete={mockOnDelete}
+          onRename={mockOnRename}
+        />
+      </MemoryRouter>,
+    );
+
+    // Open Rename Modal
+    fireEvent.click(screen.getByText("Rename Meeting"));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-labelledby", "rename-modal-title");
+
+    const input = screen.getByPlaceholderText("Enter new title");
+    fireEvent.change(input, { target: { value: "Updated Sync Title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockOnRename).toHaveBeenCalledWith("m123", "Updated Sync Title");
+  });
+});


### PR DESCRIPTION
# 🌙 Improve Meeting Delete & Rename Modal Accessibility and Dark Mode Support

Closes #838

## 📌 Overview

This PR improves WAI-ARIA accessibility compliance, keyboard shortcuts, backdrop dismissals, and dark mode theme support for the Meeting Delete and Meeting Rename modals in `MeetingActions.jsx`.

## 🚀 Key Changes

- **Accessibility (WAI-ARIA):**
  - Added `role="dialog"` and `aria-modal="true"` to modal containers.
  - Added `aria-labelledby="delete-modal-title"` and `aria-labelledby="rename-modal-title"` linking dialogs to their respective title headings.
  - Added `Escape` key event listener (`useEffect`) to dismiss open Delete or Rename modals instantly.

- **Backdrop Dismissal:**
  - Added `onClick` handlers on modal background overlays allowing users to close modals by clicking outside the dialog content box.

- **Dark Mode Support:**
  - Upgraded modal containers, text headings, inputs, and buttons with Tailwind CSS dark mode classes (`dark:bg-slate-900`, `dark:text-white`, `dark:border-slate-800`, `dark:bg-slate-800`).

- **Testing:**
  - Added Vitest/React Testing Library test suite in `client/src/components/meeting-details/__tests__/MeetingActionsModals.test.jsx` verifying ARIA attributes, Escape key dismissals, backdrop clicks, and rename submissions.

## ✅ Acceptance Criteria Checklist

- [x] Pressing `Escape` closes the Delete or Rename modal.
- [x] Clicking the backdrop overlay dismisses the active modal.
- [x] Modals support full dark mode styling (`dark:bg-slate-900`).
- [x] WAI-ARIA dialog attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) are present.
- [x] Delete and rename workflows function without regression.
- [x] Component test suite passes (`MeetingActionsModals.test.jsx`).

## 🧪 Manual Testing Instructions

1. Open a meeting details page and click **Delete Meeting** or **Rename Meeting**.
2. Press the `Escape` key and verify the modal closes.
3. Click the dark backdrop outside the modal card and verify it dismisses.
4. Toggle dark mode in the application UI and verify modal borders, text, inputs, and buttons adapt appropriately.
