### PR TITLE
fix: remove duplicate token schema index in invitationModel (#885)

### DIFF
--- a/server/models/invitationModel.js
+++ b/server/models/invitationModel.js
@@ -58,7 +58,6 @@ const invitationSchema = new mongoose.Schema(
 );
 
 // Indexes for performance and uniqueness
-invitationSchema.index({ token: 1 }, { unique: true });
 invitationSchema.index({ email: 1, organization: 1, status: 1 });
 invitationSchema.index({ organization: 1, status: 1 });
 invitationSchema.index({ invitedBy: 1 });


### PR DESCRIPTION
Closes #885

- Removed redundant `invitationSchema.index({ token: 1 }, { unique: true });` in `server/models/invitationModel.js` to resolve Mongoose initialization warnings.