### PR TITLE
fix: prevent TypeError in updateSpeakers when req.user._id is undefined (#886)

### DIFF
--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -840,7 +840,7 @@ export const updateSpeakers = async (req, res) => {
     }
 
     const meeting = transcript.meeting;
-    const userId = req.user._id.toString();
+    const userId = (req.user._id || req.user.id)?.toString();
 
     const isOwner = meeting.uploadedBy?.toString() === userId;
     const isAdminInSameOrg =


### PR DESCRIPTION
Closes #886

- Safely extract user ID using `(req.user._id || req.user.id)?.toString()` in `updateSpeakers` to support Clerk and JWT auth payloads.