### PR TITLE
fix: count active Membership documents for memberCount in organization search (#887)

### DIFF
--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -529,10 +529,24 @@ export const browsePublicOrganizations = async ({
     Organization.countDocuments(finalQuery),
   ]);
 
-  // Calculate member counts for each organization
+  // Calculate member counts for each organization from Membership model
+  const orgIds = organizations.map((org) => org._id);
+  const membershipCounts =
+    typeof Membership.aggregate === "function"
+      ? await Membership.aggregate([
+          { $match: { organization: { $in: orgIds }, status: "active" } },
+          { $group: { _id: "$organization", count: { $sum: 1 } } },
+        ])
+      : [];
+  const countMap = new Map(
+    membershipCounts.map((item) => [item._id.toString(), item.count]),
+  );
+
   const organizationsWithCounts = organizations.map((org) => ({
     ...org,
-    memberCount: org.members ? org.members.length : 0,
+    memberCount:
+      countMap.get(org._id.toString()) ??
+      (org.members ? org.members.length : 0),
   }));
 
   return {
@@ -580,9 +594,23 @@ export const searchOrganizations = async (q, page = 1, limit = 12) => {
   ]);
 
   // Calculate member counts
+  const searchOrgIds = organizations.map((org) => org._id);
+  const searchMembershipCounts =
+    typeof Membership.aggregate === "function"
+      ? await Membership.aggregate([
+          { $match: { organization: { $in: searchOrgIds }, status: "active" } },
+          { $group: { _id: "$organization", count: { $sum: 1 } } },
+        ])
+      : [];
+  const searchCountMap = new Map(
+    searchMembershipCounts.map((item) => [item._id.toString(), item.count]),
+  );
+
   const organizationsWithCounts = organizations.map((org) => ({
     ...org,
-    memberCount: org.members ? org.members.length : 0,
+    memberCount:
+      searchCountMap.get(org._id.toString()) ??
+      (org.members ? org.members.length : 0),
   }));
 
   return {


### PR DESCRIPTION
Closes #887

- Compute active membership counts from the `Membership` collection instead of reading the legacy `org.members` array in `OrganizationService.js`.