### PR TITLE
fix(accessibility): improve webhook create/edit modal accessibility

### DIFF
--- a/client/src/components/WebhookModal.jsx
+++ b/client/src/components/WebhookModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { X, Globe, Lock, Shield, RefreshCw, Loader2 } from "lucide-react";
 import { toast } from "react-toastify";
 import { webhookApi } from "../services";
@@ -27,6 +27,7 @@ const WebhookModal = ({
   webhook = null,
   organizationId,
   onSuccess,
+  triggerRef,
 }) => {
   const isEdit = !!webhook;
 
@@ -38,6 +39,10 @@ const WebhookModal = ({
   const [secret, setSecret] = useState("");
   const [isActive, setIsActive] = useState(true);
   const [loading, setLoading] = useState(false);
+
+  const modalRef = useRef(null);
+  const backdropRef = useRef(null);
+  const previousActiveElementRef = useRef(null);
 
   useEffect(() => {
     if (webhook) {
@@ -52,6 +57,98 @@ const WebhookModal = ({
       setIsActive(true);
     }
   }, [webhook, isOpen]);
+
+  // Store previous active element when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      // If triggerRef is provided, use it; otherwise store current active element
+      if (triggerRef?.current) {
+        previousActiveElementRef.current = triggerRef.current;
+      } else {
+        previousActiveElementRef.current = document.activeElement;
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Handle Escape key
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+      return () => window.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, onClose]);
+
+  // Handle backdrop click
+  const handleBackdropClick = useCallback(
+    (e) => {
+      if (e.target === backdropRef.current) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // Focus trap implementation
+  const trapFocus = useCallback((e) => {
+    if (!modalRef.current) return;
+
+    const focusableElements = modalRef.current.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.key === "Tab") {
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement?.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement?.focus();
+        }
+      }
+    }
+  }, []);
+
+  // Set up focus trap when modal opens
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      const modal = modalRef.current;
+      const focusableElements = modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const firstElement = focusableElements[0];
+
+      // Focus first element after a small delay to ensure modal is rendered
+      setTimeout(() => {
+        firstElement?.focus();
+      }, 50);
+
+      modal.addEventListener("keydown", trapFocus);
+      return () => {
+        modal.removeEventListener("keydown", trapFocus);
+      };
+    }
+  }, [isOpen, trapFocus]);
+
+  // Restore focus to previous element when modal closes
+  useEffect(() => {
+    if (!isOpen && previousActiveElementRef.current) {
+      setTimeout(() => {
+        previousActiveElementRef.current?.focus();
+      }, 50);
+    }
+  }, [isOpen]);
 
   function generateRandomSecret() {
     const chars = "abcdef0123456789";
@@ -124,8 +221,20 @@ const WebhookModal = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur-xs p-4">
-      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden animate-in fade-in zoom-in-95 duration-150">
+    <div
+      ref={backdropRef}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur-xs p-4"
+    >
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="webhook-modal-title"
+        aria-describedby="webhook-modal-description"
+        onClick={(e) => e.stopPropagation()}
+        className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden animate-in fade-in zoom-in-95 duration-150"
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800">
           <div className="flex items-center gap-3">
@@ -133,10 +242,16 @@ const WebhookModal = ({
               <Globe className="w-5 h-5" />
             </div>
             <div>
-              <h3 className="font-semibold text-slate-900 dark:text-white text-lg">
+              <h3
+                id="webhook-modal-title"
+                className="font-semibold text-slate-900 dark:text-white text-lg"
+              >
                 {isEdit ? "Edit Webhook Subscription" : "Register Webhook"}
               </h3>
-              <p className="text-xs text-slate-500 dark:text-slate-400">
+              <p
+                id="webhook-modal-description"
+                className="text-xs text-slate-500 dark:text-slate-400"
+              >
                 Receive real-time event payloads to your HTTP endpoint
               </p>
             </div>

--- a/client/src/components/WebhooksManager.jsx
+++ b/client/src/components/WebhooksManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   Globe,
   Plus,
@@ -32,6 +32,10 @@ const WebhooksManager = ({ organizationId }) => {
 
   const [visibleSecrets, setVisibleSecrets] = useState({});
   const [copiedId, setCopiedId] = useState(null);
+
+  const addWebhookButtonRef = useRef(null);
+  const emptyStateButtonRef = useRef(null);
+  const editButtonRefs = useRef({});
 
   const fetchWebhooks = useCallback(async () => {
     if (!organizationId) return;
@@ -149,6 +153,7 @@ const WebhooksManager = ({ organizationId }) => {
         </div>
 
         <button
+          ref={addWebhookButtonRef}
           onClick={() => {
             setEditingWebhook(null);
             setShowModal(true);
@@ -178,6 +183,7 @@ const WebhooksManager = ({ organizationId }) => {
             are created, MoMs are generated, or policies change.
           </p>
           <button
+            ref={emptyStateButtonRef}
             onClick={() => {
               setEditingWebhook(null);
               setShowModal(true);
@@ -277,6 +283,9 @@ const WebhooksManager = ({ organizationId }) => {
                     </button>
 
                     <button
+                      ref={(el) => {
+                        if (el) editButtonRefs.current[hook._id] = el;
+                      }}
                       onClick={() => {
                         setEditingWebhook(hook);
                         setShowModal(true);
@@ -323,6 +332,13 @@ const WebhooksManager = ({ organizationId }) => {
         webhook={editingWebhook}
         organizationId={organizationId}
         onSuccess={fetchWebhooks}
+        triggerRef={
+          editingWebhook
+            ? editButtonRefs.current[editingWebhook._id]
+            : webhooks.length === 0
+              ? emptyStateButtonRef
+              : addWebhookButtonRef
+        }
       />
 
       <WebhookDeliveryLogsModal


### PR DESCRIPTION
## Description

This PR improves the accessibility and usability of the Webhook Create/Edit Modal by implementing standard modal dialog behavior and keyboard accessibility features.

### Changes Made

- Added Escape key handling to close the modal.
- Added backdrop click handling to close the modal.
- Implemented a focus trap to keep keyboard focus within the modal.
- Added initial focus management when the modal opens.
- Restored focus to the triggering element when the modal closes.
- Added proper dialog accessibility semantics:
  - `role="dialog"`
  - `aria-modal="true"`
  - `aria-labelledby`
  - `aria-describedby`
- Implemented keyboard navigation with Tab and Shift+Tab focus cycling.
- Ensured all interactive elements are keyboard accessible.
- Properly cleaned up event listeners to prevent memory leaks.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

- Closes #840

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Verified

- Escape key closes the modal.
- Clicking the backdrop closes the modal.
- Focus remains trapped inside the dialog.
- Initial focus is correctly set on open.
- Focus returns to the trigger after closing.
- Tab/Shift+Tab navigation works correctly.
- All controls are keyboard accessible.
- Existing Create/Edit functionality remains unchanged.

## Screenshots

N/A (Accessibility improvement)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required (not required)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved webhook modal keyboard accessibility.
  - Added Escape-key and backdrop-click closing.
  - Added focus trapping while the modal is open.
  - Restores focus to the button that opened the modal after closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->