### PR TITLE
Add shareable meeting invite links with secure join.

### DIFF
--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -2,12 +2,18 @@ import React, { useState, useEffect } from "react";
 import { format } from "date-fns";
 import { useNavigate } from "react-router-dom";
 import CalendarSyncBadge from "../CalendarSyncBadge.jsx";
-import { Share2, Presentation, Bookmark, MessageSquare } from "lucide-react";
+import {
+  Share2,
+  Presentation,
+  Bookmark,
+  MessageSquare,
+  Link2,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import { toggleBookmarkAPI, getBookmarkStatusAPI } from "../../api/bookmarkApi";
 import { askAssistantAbout } from "../../utils/askAssistant.js";
 
-const MeetingHeader = ({ meeting, onShare, onPresent }) => {
+const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
   const navigate = useNavigate();
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isLoadingBookmark, setIsLoadingBookmark] = useState(false);
@@ -171,6 +177,12 @@ const MeetingHeader = ({ meeting, onShare, onPresent }) => {
             className="flex items-center gap-2 px-3 py-1.5 bg-violet-50 text-violet-700 hover:bg-violet-100 dark:bg-violet-900/30 dark:text-violet-300 dark:hover:bg-violet-900/50 rounded-lg text-sm font-medium transition-colors"
           >
             <MessageSquare className="w-4 h-4" /> Ask Assistant
+          </button>
+          <button
+            onClick={onShareInvite}
+            className="flex items-center gap-2 px-3 py-1.5 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/30 dark:text-emerald-300 dark:hover:bg-emerald-900/50 rounded-lg text-sm font-medium transition-colors"
+          >
+            <Link2 className="w-4 h-4" /> Share Invite
           </button>
           <button
             onClick={onShare}

--- a/client/src/components/meetings/MeetingInviteModal.jsx
+++ b/client/src/components/meetings/MeetingInviteModal.jsx
@@ -1,0 +1,296 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+import {
+  Copy,
+  Link2,
+  Loader2,
+  RefreshCw,
+  ToggleLeft,
+  ToggleRight,
+  X,
+} from "lucide-react";
+import { toast } from "react-toastify";
+import { meetingApi } from "../../services";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const MeetingInviteModal = ({ isOpen, onClose, meetingId, title }) => {
+  const [invite, setInvite] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [expiresAt, setExpiresAt] = useState("");
+  const titleId = useId();
+  const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const previouslyFocusedRef = useRef(null);
+
+  const inviteUrl = invite?.code
+    ? `${window.location.origin}/meeting-invite/${invite.code}`
+    : "";
+
+  const loadInvite = useCallback(async () => {
+    if (!meetingId) return;
+    setLoading(true);
+    try {
+      const res = await meetingApi.getInvite(meetingId);
+      const next = res.data?.invite;
+      setInvite(next || null);
+      setExpiresAt(
+        next?.expiresAt
+          ? new Date(next.expiresAt).toISOString().slice(0, 16)
+          : "",
+      );
+    } catch (err) {
+      console.error(err);
+      toast.error(
+        err.response?.data?.message || "Could not load meeting invite.",
+      );
+      setInvite(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [meetingId]);
+
+  useEffect(() => {
+    if (isOpen) loadInvite();
+  }, [isOpen, loadInvite]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedRef.current = document.activeElement;
+    const frame = window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = [
+        ...dialogRef.current.querySelectorAll(FOCUSABLE_SELECTOR),
+      ];
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("keydown", onKeyDown);
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [isOpen, onClose]);
+
+  const copyLink = async () => {
+    if (!inviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      toast.success("Invite link copied.");
+    } catch {
+      toast.error("Could not copy invite link.");
+    }
+  };
+
+  const regenerate = async () => {
+    setBusy(true);
+    try {
+      const res = await meetingApi.regenerateInvite(meetingId);
+      setInvite(res.data?.invite || null);
+      toast.success("Invite link regenerated. Old links no longer work.");
+    } catch (err) {
+      toast.error(
+        err.response?.data?.message || "Could not regenerate invite link.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleEnabled = async () => {
+    if (!invite) return;
+    setBusy(true);
+    try {
+      const res = await meetingApi.updateInvite(meetingId, {
+        enabled: !invite.enabled,
+      });
+      setInvite(res.data?.invite || null);
+      toast.success(
+        res.data?.invite?.enabled
+          ? "Invite link enabled."
+          : "Invite link disabled.",
+      );
+    } catch (err) {
+      toast.error(
+        err.response?.data?.message || "Could not update invite link.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveExpiration = async () => {
+    setBusy(true);
+    try {
+      const res = await meetingApi.updateInvite(meetingId, {
+        expiresAt: expiresAt ? new Date(expiresAt).toISOString() : null,
+      });
+      setInvite(res.data?.invite || null);
+      toast.success("Invite expiration updated.");
+    } catch (err) {
+      toast.error(
+        err.response?.data?.message || "Could not update expiration.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-lg rounded-2xl bg-white shadow-xl dark:bg-slate-900"
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+          <div>
+            <h2
+              id={titleId}
+              className="text-lg font-semibold text-slate-900 dark:text-slate-100"
+            >
+              Share Invite
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 truncate">
+              {title || "Meeting"}
+            </p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-2 text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+            aria-label="Close invite dialog"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Preparing invite link...
+            </div>
+          ) : (
+            <>
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/50">
+                <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <Link2 className="h-3.5 w-3.5" />
+                  Invite link
+                </div>
+                <p className="break-all font-mono text-sm text-slate-800 dark:text-slate-200">
+                  {inviteUrl || "Unavailable"}
+                </p>
+                <p className="mt-2 text-xs text-slate-500">
+                  Code:{" "}
+                  <span className="font-semibold text-slate-700 dark:text-slate-300">
+                    {invite?.code || "—"}
+                  </span>
+                  {" · "}
+                  {invite?.enabled ? "Enabled" : "Disabled"}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={copyLink}
+                  disabled={!inviteUrl || busy}
+                  className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  <Copy className="h-4 w-4" />
+                  Copy link
+                </button>
+                <button
+                  type="button"
+                  onClick={regenerate}
+                  disabled={busy}
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 disabled:opacity-50"
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Regenerate
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleEnabled}
+                  disabled={busy || !invite}
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 disabled:opacity-50"
+                >
+                  {invite?.enabled ? (
+                    <ToggleRight className="h-4 w-4 text-emerald-600" />
+                  ) : (
+                    <ToggleLeft className="h-4 w-4 text-slate-400" />
+                  )}
+                  {invite?.enabled ? "Disable" : "Enable"}
+                </button>
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  htmlFor="meeting-invite-expires"
+                  className="block text-xs font-semibold uppercase tracking-wide text-slate-500"
+                >
+                  Expiration (optional)
+                </label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <input
+                    id="meeting-invite-expires"
+                    type="datetime-local"
+                    value={expiresAt}
+                    onChange={(e) => setExpiresAt(e.target.value)}
+                    className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+                  />
+                  <button
+                    type="button"
+                    onClick={saveExpiration}
+                    disabled={busy}
+                    className="rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 disabled:opacity-50"
+                  >
+                    Save
+                  </button>
+                </div>
+                <p className="text-xs text-slate-500">
+                  Clear the date and save to remove expiration.
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingInviteModal;

--- a/client/src/pages/AcceptInvite.jsx
+++ b/client/src/pages/AcceptInvite.jsx
@@ -51,7 +51,12 @@ const AcceptInvite = () => {
       toast.info(
         "Please log in or create an account to accept the invitation.",
       );
-      navigate("/login", { state: { redirect: `/invite/${token}` } });
+      navigate("/login", {
+        state: {
+          from: { pathname: `/invite/${token}` },
+          redirect: `/invite/${token}`,
+        },
+      });
       return;
     }
 

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -32,15 +32,26 @@ const Login = () => {
     }
   }, [location.search]);
 
-  // Already signed in — leave the login page
+  // Already signed in — leave the login page (preserve invite/return URL)
   useEffect(() => {
     if (!loading && isLoggedin && userData) {
+      const from = location.state?.from;
+      const redirect = location.state?.redirect;
+      const target =
+        (from?.pathname ? `${from.pathname}${from.search || ""}` : null) ||
+        redirect;
+
+      if (target) {
+        navigate(target, { replace: true });
+        return;
+      }
+
       navigate(
         userData.hasCompletedOnboarding ? "/dashboard" : "/organizations",
         { replace: true },
       );
     }
-  }, [loading, isLoggedin, userData, navigate]);
+  }, [loading, isLoggedin, userData, navigate, location.state]);
 
   const finishAuth = async (welcomeName) => {
     const user = await initializeAuth();
@@ -51,9 +62,14 @@ const Login = () => {
 
     toast.success(`Welcome, ${welcomeName || user.name}!`);
 
-    const from = location.state?.from?.pathname;
-    if (from) {
-      navigate(from, { replace: true });
+    const from = location.state?.from;
+    const redirect = location.state?.redirect;
+    const target =
+      (from?.pathname ? `${from.pathname}${from.search || ""}` : null) ||
+      redirect;
+
+    if (target) {
+      navigate(target, { replace: true });
       return;
     }
 

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -10,6 +10,7 @@ import MeetingParticipants from "../components/meeting-details/MeetingParticipan
 import MeetingMetadata from "../components/meeting-details/MeetingMetadata";
 import MeetingActions from "../components/meeting-details/MeetingActions";
 import ShareModal from "../components/shared-links/ShareModal";
+import MeetingInviteModal from "../components/meetings/MeetingInviteModal";
 import MeetingFollowUpBanner from "../components/meeting-details/MeetingFollowUpBanner";
 import PresentMode from "../components/meeting-details/PresentMode";
 import CommentSection from "../components/meeting-details/CommentSection";
@@ -30,6 +31,7 @@ const MeetingDetails = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [inviteModalOpen, setInviteModalOpen] = useState(false);
   const [isPresentModeOpen, setIsPresentModeOpen] = useState(false);
 
   useEffect(() => {
@@ -172,6 +174,7 @@ const MeetingDetails = () => {
         <MeetingHeader
           meeting={meeting}
           onShare={() => setShareModalOpen(true)}
+          onShareInvite={() => setInviteModalOpen(true)}
           onPresent={() => setIsPresentModeOpen(true)}
         />
 
@@ -212,6 +215,13 @@ const MeetingDetails = () => {
         onClose={() => setShareModalOpen(false)}
         resourceId={meeting._id}
         resourceType="Meeting"
+        title={meeting.title}
+      />
+
+      <MeetingInviteModal
+        isOpen={inviteModalOpen}
+        onClose={() => setInviteModalOpen(false)}
+        meetingId={meeting._id}
         title={meeting.title}
       />
 

--- a/client/src/pages/MeetingInviteJoin.jsx
+++ b/client/src/pages/MeetingInviteJoin.jsx
@@ -1,0 +1,152 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  Calendar,
+  CheckCircle2,
+  Loader2,
+  LogIn,
+  Video,
+} from "lucide-react";
+import { toast } from "react-toastify";
+import AppContent from "../context/AppContent.js";
+import { meetingApi } from "../services";
+import Navbar from "../components/Navbar.jsx";
+
+const MeetingInviteJoin = () => {
+  const { code } = useParams();
+  const navigate = useNavigate();
+  const { isLoggedin, loading: authLoading } = useContext(AppContent);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [result, setResult] = useState(null);
+
+  const invitePath = `/meeting-invite/${code || ""}`;
+
+  const resolve = useCallback(async () => {
+    if (!code) {
+      setError("Missing invite code.");
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await meetingApi.resolveInvite(code);
+      const data = res.data || {};
+      setResult(data);
+
+      if (data.action === "live" && data.path) {
+        toast.success("Invite validated. Joining live meeting...");
+        navigate(data.path, { replace: true });
+        return;
+      }
+
+      if (data.action === "details" && data.path) {
+        toast.success(data.reason || "Opening meeting details...");
+        navigate(data.path, { replace: true });
+        return;
+      }
+
+      if (data.action === "blocked") {
+        setError(data.reason || "This invite cannot be used right now.");
+      }
+    } catch (err) {
+      setError(
+        err.response?.data?.message ||
+          "Invalid, expired, or unauthorized meeting invite.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [code, navigate]);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!isLoggedin) {
+      setLoading(false);
+      return;
+    }
+
+    resolve();
+  }, [authLoading, isLoggedin, resolve]);
+
+  const goLogin = () => {
+    navigate("/login", {
+      state: {
+        from: { pathname: invitePath },
+        redirect: invitePath,
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 pt-20 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <Navbar />
+
+      <div className="mx-auto mt-12 max-w-md p-6">
+        <div className="space-y-6 rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-xl dark:border-slate-800 dark:bg-slate-900">
+          {authLoading || loading ? (
+            <div className="py-12">
+              <Loader2 className="mx-auto mb-3 h-8 w-8 animate-spin text-indigo-600" />
+              <p className="text-sm text-slate-500">
+                Validating meeting invite...
+              </p>
+            </div>
+          ) : !isLoggedin ? (
+            <div className="space-y-4 py-4">
+              <Video className="mx-auto h-12 w-12 text-indigo-600" />
+              <h1 className="text-xl font-bold">Join meeting</h1>
+              <p className="text-sm text-slate-500">
+                Sign in to continue with this invite link. We will bring you
+                back here after authentication.
+              </p>
+              <button
+                type="button"
+                onClick={goLogin}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 py-2.5 text-sm font-medium text-white hover:bg-indigo-700"
+              >
+                <LogIn className="h-4 w-4" />
+                Continue to login
+              </button>
+            </div>
+          ) : error ? (
+            <div className="space-y-4 py-4">
+              <AlertCircle className="mx-auto h-12 w-12 text-red-500" />
+              <h1 className="text-xl font-bold">Invite unavailable</h1>
+              <p className="text-sm text-slate-500">{error}</p>
+              <button
+                type="button"
+                onClick={() => navigate("/meetings")}
+                className="w-full rounded-xl bg-slate-200 py-2.5 text-sm font-medium dark:bg-slate-800"
+              >
+                Go to meetings
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4 py-4">
+              <CheckCircle2 className="mx-auto h-12 w-12 text-emerald-500" />
+              <h1 className="text-xl font-bold">
+                {result?.meeting?.title || "Meeting invite"}
+              </h1>
+              <p className="text-sm text-slate-500">
+                Invite validated. Redirecting you to the meeting...
+              </p>
+              {result?.meeting?.date && (
+                <p className="inline-flex items-center gap-2 text-xs text-slate-500">
+                  <Calendar className="h-3.5 w-3.5" />
+                  {new Date(result.meeting.date).toLocaleString()}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MeetingInviteJoin;

--- a/client/src/routes/PublicRoutes.jsx
+++ b/client/src/routes/PublicRoutes.jsx
@@ -19,6 +19,7 @@ import Careers from "../pages/Careers.jsx";
 import PublicSharedView from "../pages/PublicSharedView.jsx";
 import DeveloperDocs from "../pages/DeveloperDocs.jsx";
 import AcceptInvite from "../pages/AcceptInvite.jsx";
+import MeetingInviteJoin from "../pages/MeetingInviteJoin.jsx";
 
 const PublicRoutes = (
   <React.Fragment>
@@ -27,6 +28,7 @@ const PublicRoutes = (
     <Route path="/email-verify" element={<EmailVerify />} />
     <Route path="/reset-password" element={<ResetPassword />} />
     <Route path="/invite/:token" element={<AcceptInvite />} />
+    <Route path="/meeting-invite/:code" element={<MeetingInviteJoin />} />
     <Route path="/privacy" element={<Privacy />} />
     <Route path="/terms" element={<Terms />} />
     <Route path="/security" element={<Security />} />

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -40,4 +40,11 @@ export const meetingApi = {
     apiClient.put(`/api/meetings/timer/${meetingId}/agenda/${itemId}/skip`),
   getAgendaPacingReport: (meetingId) =>
     apiClient.get(`/api/meetings/timer/${meetingId}/pacing`),
+
+  getInvite: (meetingId) => apiClient.get(`/api/meetings/${meetingId}/invite`),
+  regenerateInvite: (meetingId) =>
+    apiClient.post(`/api/meetings/${meetingId}/invite/regenerate`),
+  updateInvite: (meetingId, data) =>
+    apiClient.patch(`/api/meetings/${meetingId}/invite`, data),
+  resolveInvite: (code) => apiClient.get(`/api/meetings/invite/${code}`),
 };

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -17,6 +17,7 @@ import path from "path";
 import { z } from "zod";
 import Meeting from "../models/meetingModel.js"; // eslint-disable-line no-unused-vars
 import * as MeetingService from "../services/MeetingService.js";
+import * as MeetingInviteService from "../services/MeetingInviteService.js";
 import { ValidationError, UnauthorizedError } from "../utils/errors.js";
 import AuditService from "../services/AuditService.js";
 import { sendSuccess } from "../utils/responseHandler.js";
@@ -571,6 +572,66 @@ export const notifyLiveMeeting = async (req, res, next) => {
     );
 
     return sendSuccess(res, { count }, "Participants notified");
+  } catch (err) {
+    next(err);
+  }
+};
+
+/* ─────────────────────────────────────────────────────────────
+   Meeting invite links (Issue #920)
+   ───────────────────────────────────────────────────────────── */
+
+export const getMeetingInvite = async (req, res, next) => {
+  try {
+    if (!req.user?._id) throw new UnauthorizedError("Login required");
+    const invite = await MeetingInviteService.getOrCreateInvite(
+      req.params.id,
+      req.user,
+    );
+    return sendSuccess(res, { invite }, "Meeting invite ready.");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const regenerateMeetingInvite = async (req, res, next) => {
+  try {
+    if (!req.user?._id) throw new UnauthorizedError("Login required");
+    const invite = await MeetingInviteService.regenerateInvite(
+      req.params.id,
+      req.user,
+    );
+    return sendSuccess(res, { invite }, "Meeting invite regenerated.");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateMeetingInvite = async (req, res, next) => {
+  try {
+    if (!req.user?._id) throw new UnauthorizedError("Login required");
+    const invite = await MeetingInviteService.updateInvite(
+      req.params.id,
+      req.user,
+      {
+        enabled: req.body?.enabled,
+        expiresAt: req.body?.expiresAt,
+      },
+    );
+    return sendSuccess(res, { invite }, "Meeting invite updated.");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const resolveMeetingInvite = async (req, res, next) => {
+  try {
+    if (!req.user?._id) throw new UnauthorizedError("Login required");
+    const result = await MeetingInviteService.resolveInvite(
+      req.params.code,
+      req.user,
+    );
+    return sendSuccess(res, result, "Meeting invite validated.");
   } catch (err) {
     next(err);
   }

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -160,6 +160,21 @@ const meetingSchema = new mongoose.Schema(
       type: Number,
       default: null,
     },
+
+    // Shareable meeting invite link (Issue #920)
+    inviteCode: {
+      type: String,
+      default: null,
+      trim: true,
+    },
+    inviteEnabled: {
+      type: Boolean,
+      default: true,
+    },
+    inviteExpiresAt: {
+      type: Date,
+      default: null,
+    },
   },
   { timestamps: true },
 );
@@ -169,6 +184,14 @@ meetingSchema.index({ organization: 1, createdAt: -1 });
 meetingSchema.index({ uploadedBy: 1, createdAt: -1 });
 meetingSchema.index({ status: 1 });
 meetingSchema.index({ title: "text", summary: "text" });
+meetingSchema.index(
+  { inviteCode: 1 },
+  {
+    unique: true,
+    sparse: true,
+    partialFilterExpression: { inviteCode: { $type: "string" } },
+  },
+);
 
 const Meeting = mongoose.model("Meeting", meetingSchema);
 export default Meeting;

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -28,6 +28,10 @@ import {
   archiveMeeting,
   restoreMeeting,
   notifyLiveMeeting, // NEW: Notify participants of a live meeting
+  getMeetingInvite,
+  regenerateMeetingInvite,
+  updateMeetingInvite,
+  resolveMeetingInvite,
 } from "../controllers/meetingController.js";
 import {
   resendDigest,
@@ -156,6 +160,34 @@ router.get(
   requireOrgMembership,
   requirePermission("meetings", "view"),
   getAllMeetings,
+);
+
+// ✅ Resolve shareable meeting invite (must be before /:id)
+router.get("/invite/:code", userAuth, resolveMeetingInvite);
+
+// ✅ Meeting invite management (Issue #920)
+router.get(
+  "/:id/invite",
+  userAuth,
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  getMeetingInvite,
+);
+router.post(
+  "/:id/invite/regenerate",
+  userAuth,
+  writeLimiter,
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  regenerateMeetingInvite,
+);
+router.patch(
+  "/:id/invite",
+  userAuth,
+  writeLimiter,
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  updateMeetingInvite,
 );
 
 // ✅ Get Single Meeting Details (for Meeting Details Page)

--- a/server/services/MeetingInviteService.js
+++ b/server/services/MeetingInviteService.js
@@ -1,0 +1,268 @@
+import crypto from "crypto";
+import mongoose from "mongoose";
+import Meeting from "../models/meetingModel.js";
+import Membership from "../models/membershipModel.js";
+import {
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+} from "../utils/errors.js";
+
+const INVITE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const INVITE_CODE_LENGTH = 10;
+
+const isValidObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+export const generateInviteCode = () => {
+  const bytes = crypto.randomBytes(INVITE_CODE_LENGTH);
+  let code = "";
+  for (let i = 0; i < INVITE_CODE_LENGTH; i += 1) {
+    code += INVITE_ALPHABET[bytes[i] % INVITE_ALPHABET.length];
+  }
+  return code;
+};
+
+const allocateUniqueInviteCode = async () => {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const code = generateInviteCode();
+    const existing = await Meeting.findOne({ inviteCode: code })
+      .select("_id")
+      .lean();
+    if (!existing) return code;
+  }
+  throw new ValidationError("Could not allocate a unique invite code.");
+};
+
+const invitePayload = (meeting) => ({
+  code: meeting.inviteCode || null,
+  enabled: meeting.inviteEnabled !== false,
+  expiresAt: meeting.inviteExpiresAt || null,
+  path: meeting.inviteCode ? `/meeting-invite/${meeting.inviteCode}` : null,
+});
+
+const assertMeetingManageAccess = async (meeting, user) => {
+  const isOwner =
+    meeting.uploadedBy?.toString() === user._id?.toString() ||
+    meeting.uploadedBy?.toString() === user.id?.toString();
+  if (isOwner) return;
+
+  if (!meeting.organization) {
+    throw new ForbiddenError("Only the meeting organizer can manage invites.");
+  }
+
+  const membership = await Membership.findOne({
+    user: user._id,
+    organization: meeting.organization,
+    status: "active",
+    role: { $in: ["owner", "admin"] },
+  })
+    .select("_id")
+    .lean();
+
+  if (!membership) {
+    throw new ForbiddenError(
+      "Only the organizer or an organization admin can manage invites.",
+    );
+  }
+};
+
+const assertCanJoinMeeting = async (meeting, user) => {
+  const userId = user._id?.toString() || user.id?.toString();
+  if (meeting.uploadedBy?.toString() === userId) return;
+
+  if (meeting.organization) {
+    const membership = await Membership.findOne({
+      user: user._id,
+      organization: meeting.organization,
+      status: "active",
+    })
+      .select("_id")
+      .lean();
+
+    if (!membership) {
+      throw new ForbiddenError(
+        "You must be a member of this organization to join the meeting.",
+      );
+    }
+    return;
+  }
+
+  // Personal meetings: invite code is the access secret for authenticated users.
+};
+
+const resolveJoinTarget = (meeting) => {
+  if (meeting.archived) {
+    return {
+      action: "blocked",
+      reason: "This meeting has been cancelled or archived.",
+    };
+  }
+
+  if (meeting.status === "failed") {
+    return {
+      action: "blocked",
+      reason: "This meeting is unavailable.",
+    };
+  }
+
+  if (meeting.status === "completed") {
+    return {
+      action: "details",
+      reason: "This meeting has already ended. Opening meeting details.",
+      meetingId: meeting._id.toString(),
+      path: `/meeting/${meeting._id}`,
+    };
+  }
+
+  const now = Date.now();
+  const meetingStart = meeting.date ? new Date(meeting.date).getTime() : null;
+  const durationMs = (meeting.duration || 60) * 60 * 1000;
+  const meetingEnd = meetingStart != null ? meetingStart + durationMs : null;
+
+  const isLiveType = meeting.recordingType === "live";
+  const hasStarted =
+    meetingStart == null || meetingStart <= now + 15 * 60 * 1000;
+  const hasEnded = meetingEnd != null && now > meetingEnd;
+
+  if (hasEnded && meeting.status === "completed") {
+    return {
+      action: "details",
+      reason: "This meeting has already ended.",
+      meetingId: meeting._id.toString(),
+      path: `/meeting/${meeting._id}`,
+    };
+  }
+
+  if (isLiveType && hasStarted && !hasEnded) {
+    return {
+      action: "live",
+      meetingId: meeting._id.toString(),
+      path: `/meeting-room/${meeting._id}`,
+    };
+  }
+
+  return {
+    action: "details",
+    meetingId: meeting._id.toString(),
+    path: `/meeting/${meeting._id}`,
+  };
+};
+
+export const getOrCreateInvite = async (meetingId, user) => {
+  if (!isValidObjectId(meetingId)) {
+    throw new ValidationError("Invalid meeting id.");
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) throw new NotFoundError("Meeting not found.");
+
+  await assertMeetingManageAccess(meeting, user);
+
+  if (!meeting.inviteCode) {
+    meeting.inviteCode = await allocateUniqueInviteCode();
+    meeting.inviteEnabled = true;
+    await meeting.save();
+  }
+
+  return invitePayload(meeting);
+};
+
+export const regenerateInvite = async (meetingId, user) => {
+  if (!isValidObjectId(meetingId)) {
+    throw new ValidationError("Invalid meeting id.");
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) throw new NotFoundError("Meeting not found.");
+
+  await assertMeetingManageAccess(meeting, user);
+
+  meeting.inviteCode = await allocateUniqueInviteCode();
+  meeting.inviteEnabled = true;
+  await meeting.save();
+
+  return invitePayload(meeting);
+};
+
+export const updateInvite = async (meetingId, user, updates = {}) => {
+  if (!isValidObjectId(meetingId)) {
+    throw new ValidationError("Invalid meeting id.");
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) throw new NotFoundError("Meeting not found.");
+
+  await assertMeetingManageAccess(meeting, user);
+
+  if (!meeting.inviteCode) {
+    meeting.inviteCode = await allocateUniqueInviteCode();
+  }
+
+  if (typeof updates.enabled === "boolean") {
+    meeting.inviteEnabled = updates.enabled;
+  }
+
+  if (updates.expiresAt !== undefined) {
+    if (updates.expiresAt === null || updates.expiresAt === "") {
+      meeting.inviteExpiresAt = null;
+    } else {
+      const expires = new Date(updates.expiresAt);
+      if (Number.isNaN(expires.getTime())) {
+        throw new ValidationError("Invalid invite expiration date.");
+      }
+      meeting.inviteExpiresAt = expires;
+    }
+  }
+
+  await meeting.save();
+  return invitePayload(meeting);
+};
+
+export const resolveInvite = async (code, user) => {
+  const inviteCode = typeof code === "string" ? code.trim().toUpperCase() : "";
+  if (!inviteCode || inviteCode.length < 6) {
+    throw new ValidationError("Invalid invite code.");
+  }
+
+  const meeting = await Meeting.findOne({ inviteCode }).populate(
+    "organization",
+    "name slug",
+  );
+  if (!meeting) {
+    throw new NotFoundError("Invalid or unknown meeting invite link.");
+  }
+
+  if (meeting.inviteEnabled === false) {
+    throw new ForbiddenError("This meeting invite link has been disabled.");
+  }
+
+  if (
+    meeting.inviteExpiresAt &&
+    new Date(meeting.inviteExpiresAt).getTime() < Date.now()
+  ) {
+    throw new ForbiddenError("This meeting invite link has expired.");
+  }
+
+  await assertCanJoinMeeting(meeting, user);
+
+  const target = resolveJoinTarget(meeting);
+
+  return {
+    meeting: {
+      id: meeting._id.toString(),
+      title: meeting.title,
+      date: meeting.date,
+      time: meeting.time,
+      status: meeting.status,
+      recordingType: meeting.recordingType,
+      organization: meeting.organization
+        ? {
+            id: meeting.organization._id?.toString(),
+            name: meeting.organization.name,
+            slug: meeting.organization.slug,
+          }
+        : null,
+    },
+    ...target,
+  };
+};


### PR DESCRIPTION
## Summary
- Add unique meeting invite codes with copy, regenerate, disable/enable, and optional expiry
- Add `/meeting-invite/:code` join flow that redirects through login and validates org access
- Route validated invites to the live room or meeting details based on meeting state
Closes #920
## Test plan
- [ ] Open a meeting → Share Invite → copy link
- [ ] Open the link logged out → login → return to invite and join
- [ ] Regenerate code and confirm the old link fails
- [ ] Disable invite and confirm join is blocked
- [ ] Set expiry in the past and confirm join is blocked
- [ ] Live meeting opens `/meeting-room/:id`; scheduled opens `/meeting/:id`
- [ ] Non-org member cannot join an org meeting invite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shareable meeting invites with controls to copy, regenerate, enable, disable, and set expiration dates.
  * Added public invite links that validate access and direct participants to the appropriate meeting experience.
  * Added invite management to meeting details.
* **Bug Fixes**
  * Preserved invite destinations through login and authentication redirects.
  * Prevented access to disabled, expired, archived, or unavailable meeting invites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->