### PR TITLE
Revalidate webhook destinations before every delivery.

### DIFF
--- a/server/controllers/webhookController.js
+++ b/server/controllers/webhookController.js
@@ -1,5 +1,4 @@
 import mongoose from "mongoose";
-import { URL } from "url";
 import { z } from "zod";
 import Webhook from "../models/Webhook.js";
 import WebhookDelivery from "../models/WebhookDelivery.js";
@@ -13,61 +12,7 @@ import {
   NotFoundError,
 } from "../utils/errors.js";
 import { sendSuccess } from "../utils/responseHandler.js";
-
-import dns from "dns/promises";
-import ipaddr from "ipaddr.js";
-
-const isSafeWebhookUrl = async (urlStr) => {
-  try {
-    const parsed = new URL(urlStr);
-    const hostname = parsed.hostname.toLowerCase();
-
-    // Block obvious localhosts immediately
-    if (hostname === "localhost" || hostname === "localhost.localdomain") {
-      return false;
-    }
-
-    // Resolve the hostname to an IP address
-    let resolvedIp;
-    try {
-      // dns.lookup checks /etc/hosts and DNS, returning the IP
-      const { address } = await dns.lookup(hostname);
-      resolvedIp = address;
-    } catch (_err) {
-      // If we can't resolve it, it's not a valid safe public URL
-      return false;
-    }
-
-    // Parse the resolved IP using ipaddr.js
-    let addr;
-    try {
-      addr = ipaddr.parse(resolvedIp);
-    } catch (_err) {
-      return false;
-    }
-
-    // Check if the address is in a private, loopback, link-local, or otherwise restricted range
-    const range = addr.range();
-
-    // ipaddr.js classifies public addresses as 'unicast'
-    // Private ranges are classified as 'private', 'loopback', 'linkLocal', etc.
-    if (range !== "unicast") {
-      return false;
-    }
-
-    // Explicitly block known IPv4 mapped IPv6 loopbacks just in case
-    if (addr.kind() === "ipv6" && addr.isIPv4MappedAddress()) {
-      const v4addr = addr.toIPv4Address();
-      if (v4addr.range() !== "unicast") {
-        return false;
-      }
-    }
-
-    return true;
-  } catch (_err) {
-    return false;
-  }
-};
+import { isSafeWebhookUrl } from "../utils/webhookUrlSafety.js";
 
 // Helper to verify user permissions (must be Owner or Admin of the target Organization)
 const hasAdminPermission = async (userId, organizationId) => {

--- a/server/services/webhookDispatcherService.js
+++ b/server/services/webhookDispatcherService.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import Webhook from "../models/Webhook.js";
 import WebhookDelivery from "../models/WebhookDelivery.js";
 import eventBus from "./eventBus.js";
+import { validateWebhookDestination } from "../utils/webhookUrlSafety.js";
 
 // Redis connection management
 let _producerConnection = null;
@@ -102,6 +103,69 @@ export const performDispatch = async (webhookId, payload, options = {}) => {
   const signature = generateSignature(payload, timestamp, webhook.secret);
   const startTime = Date.now();
 
+  // Re-validate destination immediately before delivery (DNS rebinding / TOCTOU).
+  const safety = await validateWebhookDestination(webhook.targetUrl);
+  if (!safety.ok) {
+    const executionTimeMs = Date.now() - startTime;
+    const errorMsg = `Unsafe webhook destination blocked: ${safety.reason}`;
+    const deliveryStatus = isFinalAttempt ? "dlq" : "failed";
+
+    console.warn(
+      `🚫 ${errorMsg} (webhook=${webhookId}, url=${webhook.targetUrl}, attempt=${attempt})`,
+    );
+
+    await WebhookDelivery.create({
+      webhookId: webhook._id,
+      organizationId: webhook.organizationId,
+      event: payload.event || "custom",
+      payload,
+      responseStatus: null,
+      responseHeaders: null,
+      responseBody: null,
+      executionTimeMs,
+      attempt,
+      status: deliveryStatus,
+      errorReason: errorMsg,
+    });
+
+    const updatedWebhook = await Webhook.findByIdAndUpdate(
+      webhookId,
+      { $inc: { consecutiveFailures: 1 } },
+      { new: true },
+    );
+
+    if (updatedWebhook) {
+      const newFailures = updatedWebhook.consecutiveFailures;
+      let newHealthStatus = updatedWebhook.healthStatus;
+      let newIsActive = updatedWebhook.isActive;
+
+      if (newFailures >= 15) {
+        newHealthStatus = "paused";
+        newIsActive = false;
+        console.warn(
+          `🚨 Webhook ${updatedWebhook._id} (${updatedWebhook.targetUrl}) reached 15 consecutive failures. Auto-pausing subscription.`,
+        );
+      } else if (newFailures >= 10) {
+        newHealthStatus = "degraded";
+        console.warn(
+          `⚠️ Webhook ${updatedWebhook._id} (${updatedWebhook.targetUrl}) health degraded (${newFailures} consecutive failures).`,
+        );
+      }
+
+      if (
+        newHealthStatus !== updatedWebhook.healthStatus ||
+        newIsActive !== updatedWebhook.isActive
+      ) {
+        await Webhook.findByIdAndUpdate(webhookId, {
+          healthStatus: newHealthStatus,
+          isActive: newIsActive,
+        });
+      }
+    }
+
+    throw new Error(`Webhook dispatch failed: ${errorMsg}`);
+  }
+
   try {
     console.log(
       `📡 Sending webhook event '${payload.event}' to ${webhook.targetUrl} (Attempt ${attempt})...`,
@@ -114,6 +178,12 @@ export const performDispatch = async (webhookId, payload, options = {}) => {
         "x-meetonmemory-request-timestamp": timestamp,
       },
       timeout: 10000, // 10 second timeout
+      // Do not follow redirects to a different (possibly private) host.
+      maxRedirects: 0,
+      // Pin the connection to the addresses we just validated.
+      lookup: (hostname, _options, callback) => {
+        callback(null, safety.pinnedAddress, safety.family);
+      },
     });
 
     const sanitizeHeaders = (headers) => {

--- a/server/tests/webhook.test.js
+++ b/server/tests/webhook.test.js
@@ -2,6 +2,7 @@ import request from "supertest";
 import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
 import axios from "axios";
+import dns from "dns/promises";
 import { jest } from "@jest/globals";
 import { app } from "../server.js";
 import User from "../models/userModel.js";
@@ -24,10 +25,16 @@ import * as dispatcher from "../services/webhookDispatcherService.js";
 // Mock axios post to avoid hitting real endpoints
 let axiosSpy;
 let queueSpy;
+let dnsLookupSpy;
+
+const publicDnsAnswer = [{ address: "93.184.216.34", family: 4 }];
+
 beforeAll(() => {
   axiosSpy = jest
     .spyOn(axios, "post")
     .mockResolvedValue({ status: 200, data: {} });
+
+  dnsLookupSpy = jest.spyOn(dns, "lookup").mockResolvedValue(publicDnsAnswer);
 
   if (dispatcher.webhookQueue) {
     queueSpy = jest
@@ -41,6 +48,7 @@ beforeAll(() => {
 
 afterAll(() => {
   axiosSpy.mockRestore();
+  dnsLookupSpy.mockRestore();
   if (queueSpy) queueSpy.mockRestore();
 });
 
@@ -252,12 +260,40 @@ describe("Webhook Endpoints & Dispatcher", () => {
       expect(
         callArgs[2].headers["x-meetonmemory-request-timestamp"],
       ).toBeDefined();
+      expect(callArgs[2].maxRedirects).toBe(0);
+      expect(typeof callArgs[2].lookup).toBe("function");
 
       // Verify WebhookDelivery log record created
       const logs = await WebhookDelivery.find({ webhookId: hook._id });
       expect(logs.length).toBe(1);
       expect(logs[0].status).toBe("success");
       expect(logs[0].event).toBe("meeting.created");
+    });
+
+    it("should block delivery when destination revalidates to a private IP", async () => {
+      const hook = await Webhook.create({
+        organizationId: organization._id,
+        targetUrl: "https://example.com/private-now",
+        events: ["meeting.created"],
+        secret: "secret",
+      });
+
+      axiosSpy.mockClear();
+      dnsLookupSpy.mockResolvedValueOnce([{ address: "10.0.0.5", family: 4 }]);
+
+      await expect(
+        dispatcher.performDispatch(hook._id, {
+          event: "meeting.created",
+          data: { title: "Should not deliver" },
+        }),
+      ).rejects.toThrow(/Unsafe webhook destination blocked/);
+
+      expect(axiosSpy).not.toHaveBeenCalled();
+
+      const logs = await WebhookDelivery.find({ webhookId: hook._id });
+      expect(logs.length).toBe(1);
+      expect(logs[0].status).toBe("failed");
+      expect(logs[0].errorReason).toMatch(/Unsafe webhook destination blocked/);
     });
   });
 

--- a/server/tests/webhookUrlSafety.test.js
+++ b/server/tests/webhookUrlSafety.test.js
@@ -1,0 +1,98 @@
+import { jest } from "@jest/globals";
+import dns from "dns/promises";
+
+const lookupSpy = jest.spyOn(dns, "lookup");
+const resolve4Spy = jest.spyOn(dns, "resolve4");
+const resolve6Spy = jest.spyOn(dns, "resolve6");
+
+const { validateWebhookDestination, isSafeWebhookUrl } =
+  await import("../utils/webhookUrlSafety.js");
+
+describe("webhookUrlSafety", () => {
+  afterEach(() => {
+    lookupSpy.mockReset();
+    resolve4Spy.mockReset();
+    resolve6Spy.mockReset();
+  });
+
+  afterAll(() => {
+    lookupSpy.mockRestore();
+    resolve4Spy.mockRestore();
+    resolve6Spy.mockRestore();
+  });
+
+  it("accepts a public hostname", async () => {
+    lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    const result = await validateWebhookDestination(
+      "https://example.com/hooks",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.pinnedAddress).toBe("93.184.216.34");
+    expect(result.family).toBe(4);
+    await expect(isSafeWebhookUrl("https://example.com/hooks")).resolves.toBe(
+      true,
+    );
+  });
+
+  it("rejects localhost hostnames without DNS", async () => {
+    const result = await validateWebhookDestination(
+      "http://localhost:3000/hook",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/not allowed/i);
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects private IPv4 destinations", async () => {
+    lookupSpy.mockResolvedValue([{ address: "10.0.0.8", family: 4 }]);
+
+    const result = await validateWebhookDestination(
+      "https://hooks.internal.example/webhook",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/private or local/i);
+  });
+
+  it("rejects loopback destinations", async () => {
+    lookupSpy.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    const result = await validateWebhookDestination("https://evil.test/hook");
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/private or local/i);
+  });
+
+  it("rejects when any resolved address is private", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "192.168.1.20", family: 4 },
+    ]);
+
+    const result = await validateWebhookDestination(
+      "https://mixed.example/hook",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/192\.168\.1\.20/);
+  });
+
+  it("rejects link-local / metadata style addresses", async () => {
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+    const result = await validateWebhookDestination(
+      "http://metadata.example/latest",
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects non-http protocols", async () => {
+    const result = await validateWebhookDestination("ftp://example.com/hook");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/http:\/\/ or https:\/\//i);
+  });
+});

--- a/server/utils/webhookUrlSafety.js
+++ b/server/utils/webhookUrlSafety.js
@@ -1,0 +1,156 @@
+import { URL } from "url";
+import dns from "dns/promises";
+import ipaddr from "ipaddr.js";
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "metadata.google.internal",
+]);
+
+const isBlockedHostname = (hostname) => {
+  const host = hostname.toLowerCase().replace(/\.$/, "");
+  if (BLOCKED_HOSTNAMES.has(host)) return true;
+  if (host.endsWith(".localhost") || host.endsWith(".local")) return true;
+  if (host.endsWith(".internal") || host.endsWith(".intranet")) return true;
+  return false;
+};
+
+const isPublicAddress = (address) => {
+  let addr;
+  try {
+    addr = ipaddr.parse(address);
+  } catch {
+    return false;
+  }
+
+  // Treat IPv4-mapped IPv6 as the embedded IPv4 address.
+  if (addr.kind() === "ipv6" && addr.isIPv4MappedAddress()) {
+    addr = addr.toIPv4Address();
+  }
+
+  // ipaddr.js marks public routable addresses as "unicast".
+  return addr.range() === "unicast";
+};
+
+const resolveAllAddresses = async (hostname) => {
+  // Prefer resolving every record so a single private answer cannot hide behind
+  // a public one (and so DNS changes are visible on every delivery).
+  const addresses = new Set();
+
+  try {
+    const results = await dns.lookup(hostname, { all: true, verbatim: true });
+    for (const entry of results) {
+      if (entry?.address) addresses.add(entry.address);
+    }
+  } catch {
+    // Fall through to family-specific resolvers below.
+  }
+
+  if (addresses.size === 0) {
+    const [v4, v6] = await Promise.allSettled([
+      dns.resolve4(hostname),
+      dns.resolve6(hostname),
+    ]);
+    if (v4.status === "fulfilled") {
+      for (const address of v4.value) addresses.add(address);
+    }
+    if (v6.status === "fulfilled") {
+      for (const address of v6.value) addresses.add(address);
+    }
+  }
+
+  return [...addresses];
+};
+
+/**
+ * Re-resolve and validate a webhook destination URL.
+ *
+ * Used both at configuration time and immediately before every delivery so
+ * DNS rebinding / infrastructure changes cannot silently point at private
+ * network targets.
+ *
+ * @param {string} urlStr
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   reason?: string,
+ *   addresses?: string[],
+ *   pinnedAddress?: string,
+ *   family?: 4 | 6,
+ *   parsedUrl?: URL,
+ * }>}
+ */
+export const validateWebhookDestination = async (urlStr) => {
+  let parsed;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    return { ok: false, reason: "Destination URL is not a valid URL." };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      reason: "Destination URL must use http:// or https://.",
+    };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) {
+    return { ok: false, reason: "Destination URL is missing a hostname." };
+  }
+
+  if (isBlockedHostname(hostname)) {
+    return {
+      ok: false,
+      reason: `Destination hostname '${hostname}' is not allowed.`,
+    };
+  }
+
+  let addresses;
+  try {
+    addresses = await resolveAllAddresses(hostname);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Destination DNS lookup failed: ${err.message}`,
+    };
+  }
+
+  if (!addresses.length) {
+    return {
+      ok: false,
+      reason: "Destination hostname could not be resolved.",
+    };
+  }
+
+  const privateHits = addresses.filter((address) => !isPublicAddress(address));
+  if (privateHits.length > 0) {
+    return {
+      ok: false,
+      reason: `Destination resolves to a private or local address (${privateHits.join(", ")}).`,
+      addresses,
+    };
+  }
+
+  const pinnedAddress = addresses[0];
+  const family = pinnedAddress.includes(":") ? 6 : 4;
+
+  return {
+    ok: true,
+    addresses,
+    pinnedAddress,
+    family,
+    parsedUrl: parsed,
+  };
+};
+
+/**
+ * Boolean helper for Zod refinements and simple call sites.
+ * @param {string} urlStr
+ * @returns {Promise<boolean>}
+ */
+export const isSafeWebhookUrl = async (urlStr) => {
+  const result = await validateWebhookDestination(urlStr);
+  return result.ok;
+};


### PR DESCRIPTION
## Summary
- Extract shared webhook destination safety checks (DNS resolve + private/loopback rejection)
- Revalidate the target URL immediately before each delivery attempt
- Log and record blocked deliveries; pin the validated IP and disable redirects
Closes #919
## Test plan
- [ ] Create a webhook with a public URL and confirm delivery still works
- [ ] Point a webhook hostname at a private IP (or mock DNS) and confirm delivery is blocked and logged
- [ ] Confirm create/update still reject localhost/private URLs
- [ ] `npm test --prefix server -- --testPathPatterns=webhookUrlSafety --forceExit`