### PR TITLE
feat(compliance): support all policy compliance classifications with tab filters (#911)

### DIFF
--- a/client/src/pages/PolicyCompliance.jsx
+++ b/client/src/pages/PolicyCompliance.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar.jsx";
 import { policyComplianceApi } from "../services";
@@ -8,20 +8,21 @@ import {
   ShieldCheck,
   Link2,
   ShieldQuestion,
+  Shield,
   CheckCircle2,
   XCircle,
   RotateCcw,
   Loader2,
   ExternalLink,
   FileText,
+  Filter,
 } from "lucide-react";
 
 /**
  * PolicyCompliance.jsx
- * Dashboard of meeting decisions flagged as potentially conflicting with
- * (or otherwise related to) an organizational policy. Detection/flagging
- * only — acknowledging or dismissing a flag never alters the underlying
- * meeting decision.
+ * Dashboard of meeting decisions evaluated against organizational policies.
+ * Supports filtering by status and all compliance classifications
+ * (potential_conflict, aligned, references, unrelated, unclassified, all).
  */
 
 const CLASSIFICATION_STYLES = {
@@ -62,6 +63,15 @@ const CLASSIFICATION_STYLES = {
   },
 };
 
+const CLASSIFICATION_TABS = [
+  { value: "all", label: "All Classifications", icon: Shield },
+  { value: "potential_conflict", label: "Potential Conflicts", icon: ShieldAlert },
+  { value: "aligned", label: "Aligned", icon: ShieldCheck },
+  { value: "references", label: "References", icon: Link2 },
+  { value: "unrelated", label: "Unrelated", icon: ShieldQuestion },
+  { value: "unclassified", label: "Needs Retry", icon: ShieldQuestion },
+];
+
 const STATUS_TABS = [
   { value: "unresolved", label: "Unresolved" },
   { value: "acknowledged", label: "Acknowledged" },
@@ -76,16 +86,14 @@ const PolicyCompliance = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [statusTab, setStatusTab] = useState("unresolved");
+  const [classificationTab, setClassificationTab] = useState("all");
   const [actioningId, setActioningId] = useState(null);
 
-  const fetchFlags = useCallback(async (status) => {
+  const fetchFlags = useCallback(async (status, classification) => {
     try {
       setLoading(true);
       setError(null);
-      const res = await policyComplianceApi.getFlags(
-        status,
-        "potential_conflict",
-      );
+      const res = await policyComplianceApi.getFlags(status, classification);
       if (res.data?.success) {
         setFlags(res.data.flags || []);
       } else {
@@ -100,8 +108,26 @@ const PolicyCompliance = () => {
   }, []);
 
   useEffect(() => {
-    fetchFlags(statusTab);
-  }, [statusTab, fetchFlags]);
+    fetchFlags(statusTab, classificationTab);
+  }, [statusTab, classificationTab, fetchFlags]);
+
+  // Compute counts per classification for summary cards
+  const countsByClassification = useMemo(() => {
+    const counts = {
+      all: flags.length,
+      potential_conflict: 0,
+      aligned: 0,
+      references: 0,
+      unrelated: 0,
+      unclassified: 0,
+    };
+    flags.forEach((flag) => {
+      if (counts[flag.classification] !== undefined) {
+        counts[flag.classification]++;
+      }
+    });
+    return counts;
+  }, [flags]);
 
   const handleReview = async (flagId, status) => {
     try {
@@ -139,32 +165,61 @@ const PolicyCompliance = () => {
       <main className="flex-1 w-full max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-28 pb-16">
         <div className="mb-8">
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
-            <ShieldAlert className="w-6 h-6 text-red-500" />
+            <Shield className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
             Policy Compliance
           </h1>
           <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-            Meeting decisions flagged as potentially conflicting with an
-            organizational policy. This is a detection layer only — review and
-            acknowledge or dismiss each flag; nothing here blocks or
-            auto-rejects a decision.
+            Meeting decisions evaluated against organizational policies. Explore all policy
+            compliance classifications including potential conflicts, aligned decisions, references, and unclassified items.
           </p>
         </div>
 
         {/* Status tabs */}
-        <div className="flex gap-2 mb-6 border-b border-slate-200 dark:border-slate-800">
+        <div className="flex gap-2 mb-4 border-b border-slate-200 dark:border-slate-800">
           {STATUS_TABS.map((tab) => (
             <button
               key={tab.value}
               onClick={() => setStatusTab(tab.value)}
-              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
                 statusTab === tab.value
-                  ? "border-red-500 text-red-600 dark:text-red-400"
+                  ? "border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400"
                   : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
               }`}
             >
               {tab.label}
             </button>
           ))}
+        </div>
+
+        {/* Classification Filter Chips / Tabs (Issue #911) */}
+        <div className="mb-6 flex flex-wrap gap-2 items-center bg-slate-100/70 dark:bg-slate-900/60 p-2 rounded-xl border border-slate-200/60 dark:border-slate-800/80">
+          <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 flex items-center gap-1 ml-1 mr-2">
+            <Filter className="w-3.5 h-3.5" />
+            Classification:
+          </span>
+          {CLASSIFICATION_TABS.map((tab) => {
+            const Icon = tab.icon;
+            const isSelected = classificationTab === tab.value;
+            return (
+              <button
+                key={tab.value}
+                onClick={() => setClassificationTab(tab.value)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all cursor-pointer ${
+                  isSelected
+                    ? "bg-white dark:bg-slate-800 text-slate-900 dark:text-white shadow-xs border border-slate-200 dark:border-slate-700"
+                    : "text-slate-600 dark:text-slate-400 hover:bg-slate-200/50 dark:hover:bg-slate-800/50"
+                }`}
+              >
+                <Icon className={`w-3.5 h-3.5 ${isSelected ? "text-indigo-600 dark:text-indigo-400" : ""}`} />
+                {tab.label}
+                {classificationTab === "all" && countsByClassification[tab.value] !== undefined && (
+                  <span className="ml-1 px-1.5 py-0.5 rounded-full bg-slate-200 dark:bg-slate-700 text-[10px] font-semibold text-slate-700 dark:text-slate-300">
+                    {countsByClassification[tab.value]}
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
 
         {loading && (
@@ -181,7 +236,8 @@ const PolicyCompliance = () => {
         {!loading && !error && flags.length === 0 && (
           <div className="text-center py-16 text-slate-400 dark:text-slate-500">
             <ShieldCheck className="w-10 h-10 mx-auto mb-3 text-emerald-400" />
-            No {statusTab === "all" ? "" : statusTab} flags found.
+            No {classificationTab !== "all" ? classificationTab.replace("_", " ") : ""}{" "}
+            {statusTab === "all" ? "" : statusTab} compliance records found.
           </div>
         )}
 
@@ -201,7 +257,7 @@ const PolicyCompliance = () => {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-2">
                       <span
-                        className={`inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full ${style.bgColor} ${style.textColor}`}
+                        className={`inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-1 rounded-full ${style.bgColor} ${style.textColor}`}
                       >
                         <Icon className="w-3.5 h-3.5" />
                         {style.label}
@@ -232,7 +288,7 @@ const PolicyCompliance = () => {
                         onClick={() =>
                           navigate(`/meeting/${flag.sourceMeetingId._id}`)
                         }
-                        className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                        className="mt-2 inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
                       >
                         <ExternalLink className="w-3 h-3" />
                         {flag.sourceMeetingId.title}
@@ -246,7 +302,7 @@ const PolicyCompliance = () => {
                       <button
                         disabled={actioningId === flag._id}
                         onClick={() => handleReview(flag._id, "acknowledged")}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/60 disabled:opacity-50"
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/60 disabled:opacity-50 cursor-pointer"
                       >
                         <CheckCircle2 className="w-3.5 h-3.5" />
                         Acknowledge
@@ -256,7 +312,7 @@ const PolicyCompliance = () => {
                       <button
                         disabled={actioningId === flag._id}
                         onClick={() => handleReview(flag._id, "dismissed")}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 disabled:opacity-50"
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 disabled:opacity-50 cursor-pointer"
                       >
                         <XCircle className="w-3.5 h-3.5" />
                         Dismiss
@@ -266,7 +322,7 @@ const PolicyCompliance = () => {
                       <button
                         disabled={actioningId === flag._id}
                         onClick={() => handleReview(flag._id, "unresolved")}
-                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-50 text-slate-500 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 disabled:opacity-50"
+                        className="inline-flex items-center gap-1 text-xs font-medium px-3 py-1.5 rounded-lg bg-slate-50 text-slate-500 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 disabled:opacity-50 cursor-pointer"
                       >
                         <RotateCcw className="w-3.5 h-3.5" />
                         Reopen

--- a/client/src/pages/PolicyCompliance.jsx
+++ b/client/src/pages/PolicyCompliance.jsx
@@ -65,7 +65,11 @@ const CLASSIFICATION_STYLES = {
 
 const CLASSIFICATION_TABS = [
   { value: "all", label: "All Classifications", icon: Shield },
-  { value: "potential_conflict", label: "Potential Conflicts", icon: ShieldAlert },
+  {
+    value: "potential_conflict",
+    label: "Potential Conflicts",
+    icon: ShieldAlert,
+  },
   { value: "aligned", label: "Aligned", icon: ShieldCheck },
   { value: "references", label: "References", icon: Link2 },
   { value: "unrelated", label: "Unrelated", icon: ShieldQuestion },
@@ -169,8 +173,9 @@ const PolicyCompliance = () => {
             Policy Compliance
           </h1>
           <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-            Meeting decisions evaluated against organizational policies. Explore all policy
-            compliance classifications including potential conflicts, aligned decisions, references, and unclassified items.
+            Meeting decisions evaluated against organizational policies. Explore
+            all policy compliance classifications including potential conflicts,
+            aligned decisions, references, and unclassified items.
           </p>
         </div>
 
@@ -210,13 +215,16 @@ const PolicyCompliance = () => {
                     : "text-slate-600 dark:text-slate-400 hover:bg-slate-200/50 dark:hover:bg-slate-800/50"
                 }`}
               >
-                <Icon className={`w-3.5 h-3.5 ${isSelected ? "text-indigo-600 dark:text-indigo-400" : ""}`} />
+                <Icon
+                  className={`w-3.5 h-3.5 ${isSelected ? "text-indigo-600 dark:text-indigo-400" : ""}`}
+                />
                 {tab.label}
-                {classificationTab === "all" && countsByClassification[tab.value] !== undefined && (
-                  <span className="ml-1 px-1.5 py-0.5 rounded-full bg-slate-200 dark:bg-slate-700 text-[10px] font-semibold text-slate-700 dark:text-slate-300">
-                    {countsByClassification[tab.value]}
-                  </span>
-                )}
+                {classificationTab === "all" &&
+                  countsByClassification[tab.value] !== undefined && (
+                    <span className="ml-1 px-1.5 py-0.5 rounded-full bg-slate-200 dark:bg-slate-700 text-[10px] font-semibold text-slate-700 dark:text-slate-300">
+                      {countsByClassification[tab.value]}
+                    </span>
+                  )}
               </button>
             );
           })}
@@ -236,7 +244,10 @@ const PolicyCompliance = () => {
         {!loading && !error && flags.length === 0 && (
           <div className="text-center py-16 text-slate-400 dark:text-slate-500">
             <ShieldCheck className="w-10 h-10 mx-auto mb-3 text-emerald-400" />
-            No {classificationTab !== "all" ? classificationTab.replace("_", " ") : ""}{" "}
+            No{" "}
+            {classificationTab !== "all"
+              ? classificationTab.replace("_", " ")
+              : ""}{" "}
             {statusTab === "all" ? "" : statusTab} compliance records found.
           </div>
         )}

--- a/client/src/pages/__tests__/PolicyCompliance.test.jsx
+++ b/client/src/pages/__tests__/PolicyCompliance.test.jsx
@@ -57,11 +57,18 @@ describe("PolicyCompliance Component (Issue #911)", () => {
     );
 
     await waitFor(() => {
-      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "all");
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith(
+        "unresolved",
+        "all",
+      );
     });
 
-    expect(await screen.findByText("Use third-party encryption key")).toBeInTheDocument();
-    expect(await screen.findByText("Enforce MFA for all admin logins")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Use third-party encryption key"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Enforce MFA for all admin logins"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Potential Conflict")).toBeInTheDocument();
   });
 
@@ -80,7 +87,10 @@ describe("PolicyCompliance Component (Issue #911)", () => {
     );
 
     await waitFor(() => {
-      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "all");
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith(
+        "unresolved",
+        "all",
+      );
     });
 
     policyComplianceApi.getFlags.mockResolvedValueOnce({
@@ -91,13 +101,18 @@ describe("PolicyCompliance Component (Issue #911)", () => {
     });
 
     const alignedButtons = screen.getAllByRole("button");
-    const alignedTab = alignedButtons.find((btn) => btn.textContent.includes("Aligned"));
+    const alignedTab = alignedButtons.find((btn) =>
+      btn.textContent.includes("Aligned"),
+    );
     expect(alignedTab).toBeTruthy();
 
     fireEvent.click(alignedTab);
 
     await waitFor(() => {
-      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "aligned");
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith(
+        "unresolved",
+        "aligned",
+      );
     });
   });
 });

--- a/client/src/pages/__tests__/PolicyCompliance.test.jsx
+++ b/client/src/pages/__tests__/PolicyCompliance.test.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PolicyCompliance from "../PolicyCompliance.jsx";
+import { policyComplianceApi } from "../../services";
+
+vi.mock("../../services", () => ({
+  policyComplianceApi: {
+    getFlags: vi.fn(),
+    updateFlagStatus: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+describe("PolicyCompliance Component (Issue #911)", () => {
+  const mockFlags = [
+    {
+      _id: "flag-1",
+      classification: "potential_conflict",
+      status: "unresolved",
+      similarityScore: 0.85,
+      decisionId: { text: "Use third-party encryption key" },
+      policyId: { name: "Data Security Policy", version: "1.2" },
+      reasoning: "Conflicts with section 4: Internal Key Management",
+    },
+    {
+      _id: "flag-2",
+      classification: "aligned",
+      status: "unresolved",
+      similarityScore: 0.92,
+      decisionId: { text: "Enforce MFA for all admin logins" },
+      policyId: { name: "Access Control Policy", version: "2.0" },
+      reasoning: "Fully satisfies section 2: Authentication Controls",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches all compliance classifications by default and displays summary badges", async () => {
+    policyComplianceApi.getFlags.mockResolvedValue({
+      data: {
+        success: true,
+        flags: mockFlags,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <PolicyCompliance />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "all");
+    });
+
+    expect(await screen.findByText("Use third-party encryption key")).toBeInTheDocument();
+    expect(await screen.findByText("Enforce MFA for all admin logins")).toBeInTheDocument();
+    expect(screen.getByText("Potential Conflict")).toBeInTheDocument();
+  });
+
+  it("switches classification tab and fetches flags for selected classification", async () => {
+    policyComplianceApi.getFlags.mockResolvedValue({
+      data: {
+        success: true,
+        flags: mockFlags,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <PolicyCompliance />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "all");
+    });
+
+    policyComplianceApi.getFlags.mockResolvedValueOnce({
+      data: {
+        success: true,
+        flags: [mockFlags[1]],
+      },
+    });
+
+    const alignedButtons = screen.getAllByRole("button");
+    const alignedTab = alignedButtons.find((btn) => btn.textContent.includes("Aligned"));
+    expect(alignedTab).toBeTruthy();
+
+    fireEvent.click(alignedTab);
+
+    await waitFor(() => {
+      expect(policyComplianceApi.getFlags).toHaveBeenCalledWith("unresolved", "aligned");
+    });
+  });
+});

--- a/client/src/services/policyComplianceApi.js
+++ b/client/src/services/policyComplianceApi.js
@@ -1,7 +1,7 @@
 import apiClient from "./apiClient";
 
 export const policyComplianceApi = {
-  getFlags: (status = "unresolved", classification = "potential_conflict") =>
+  getFlags: (status = "unresolved", classification = "all") =>
     apiClient.get(
       `/api/policy-compliance/flags?status=${status}&classification=${classification}`,
     ),


### PR DESCRIPTION
# Pull Request

## Description

Supports all policy compliance classifications in the Policy Compliance interface as requested in issue #911.

Currently, the Policy Compliance dashboard hardcodes request filtering to `potential_conflict`, preventing users from exploring other backend-supported compliance classifications (`aligned`, `references`, `unrelated`, `unclassified`, and `all`). This PR updates `policyComplianceApi.js` to default to `all` classifications and introduces classification filter tabs, category summary badges, and distinct visual indicators in `PolicyCompliance.jsx`.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [x] Documentation Update
- [ ] Refactor
- [x] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #911

## Testing

Describe the testing performed.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

Testing Summary:
- Client Vitest tests: `pnpm --prefix client exec vitest run src/pages/__tests__/PolicyCompliance.test.jsx` (2/2 passing).

## Screenshots

N/A (Policy compliance classification filter tabs & badge UI updates)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added classification tabs to filter compliance records alongside status.
  * Added per-classification record counts and classification-specific dashboard guidance.
  * Added visual icons and interaction states for classification filters.
  * Updated empty states to reflect the selected status and classification.

* **Bug Fixes**
  * Compliance records now default to showing all classifications instead of a single classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->