### PR TITLE
fix: enforce organization scope validation in policy download and re-analysis (#938)

### DIFF
--- a/server/controllers/policyController.js
+++ b/server/controllers/policyController.js
@@ -126,7 +126,9 @@ export const uploadPolicy = async (req, res, next) => {
    ───────────────────────────────────────────────────────────── */
 export const analyzePolicy = async (req, res, next) => {
   try {
-    const policy = await PolicyService.reanalyzePolicy(req.params.id);
+    const userId = getUserId(req);
+    const orgId = req.user?.organization || null;
+    const policy = await PolicyService.reanalyzePolicy(req.params.id, userId, orgId);
 
     return sendSuccess(
       res,
@@ -166,8 +168,10 @@ export const getPolicies = async (req, res, next) => {
    ───────────────────────────────────────────────────────────── */
 export const downloadPolicy = async (req, res, next) => {
   try {
+    const userId = getUserId(req);
+    const orgId = req.user?.organization || null;
     const { safeFilePath, fileName } =
-      await PolicyService.getPolicyDownloadPath(req.params.id);
+      await PolicyService.getPolicyDownloadPath(req.params.id, userId, orgId);
 
     res.setHeader(
       "Cache-Control",

--- a/server/controllers/policyController.js
+++ b/server/controllers/policyController.js
@@ -128,7 +128,11 @@ export const analyzePolicy = async (req, res, next) => {
   try {
     const userId = getUserId(req);
     const orgId = req.user?.organization || null;
-    const policy = await PolicyService.reanalyzePolicy(req.params.id, userId, orgId);
+    const policy = await PolicyService.reanalyzePolicy(
+      req.params.id,
+      userId,
+      orgId,
+    );
 
     return sendSuccess(
       res,

--- a/server/services/PolicyService.js
+++ b/server/services/PolicyService.js
@@ -23,8 +23,21 @@ import {
   removePolicyFromIndex,
   reevaluatePolicyDecisions,
 } from "./policyComplianceService.js";
-import { NotFoundError, ValidationError } from "../utils/errors.js";
+import { NotFoundError, ValidationError, ForbiddenError } from "../utils/errors.js";
 import { computeLineDiff } from "../utils/lineDiff.js";
+
+const _assertPolicyAccess = (policy, userId, orgId) => {
+  const isUploader =
+    policy.uploadedBy && userId && policy.uploadedBy.toString() === userId.toString();
+  const isInOrg =
+    policy.organization &&
+    orgId &&
+    policy.organization.toString() === orgId.toString();
+
+  if (!isUploader && !isInOrg) {
+    throw new ForbiddenError("Not authorized to access this policy.");
+  }
+};
 
 // ── pdf-parse (CJS module — requires dynamic require) ──────────
 const require = createRequire(import.meta.url);
@@ -300,9 +313,13 @@ export const uploadAndProcessPolicy = async (
  * @param {string} policyId - ObjectId of the policy to re-analyze
  * @returns {Promise<Policy>}
  */
-export const reanalyzePolicy = async (policyId) => {
+export const reanalyzePolicy = async (policyId, userId = null, orgId = null) => {
   const policy = await Policy.findById(policyId);
   if (!policy) throw new NotFoundError("Policy not found.");
+
+  if (userId || orgId) {
+    _assertPolicyAccess(policy, userId, orgId);
+  }
 
   const safeFileUrl = _validateUploadPath(policy.fileUrl);
 
@@ -375,9 +392,13 @@ export const getAllPolicies = async (userId, orgId) => {
  * @param {string} policyId
  * @returns {Promise<{safeFilePath: string, fileName: string}>}
  */
-export const getPolicyDownloadPath = async (policyId) => {
+export const getPolicyDownloadPath = async (policyId, userId = null, orgId = null) => {
   const policy = await Policy.findById(policyId);
   if (!policy) throw new NotFoundError("Policy not found.");
+
+  if (userId || orgId) {
+    _assertPolicyAccess(policy, userId, orgId);
+  }
 
   const safeFilePath = _validateUploadPath(policy.fileUrl);
 

--- a/server/services/PolicyService.js
+++ b/server/services/PolicyService.js
@@ -23,12 +23,18 @@ import {
   removePolicyFromIndex,
   reevaluatePolicyDecisions,
 } from "./policyComplianceService.js";
-import { NotFoundError, ValidationError, ForbiddenError } from "../utils/errors.js";
+import {
+  NotFoundError,
+  ValidationError,
+  ForbiddenError,
+} from "../utils/errors.js";
 import { computeLineDiff } from "../utils/lineDiff.js";
 
 const _assertPolicyAccess = (policy, userId, orgId) => {
   const isUploader =
-    policy.uploadedBy && userId && policy.uploadedBy.toString() === userId.toString();
+    policy.uploadedBy &&
+    userId &&
+    policy.uploadedBy.toString() === userId.toString();
   const isInOrg =
     policy.organization &&
     orgId &&
@@ -313,7 +319,11 @@ export const uploadAndProcessPolicy = async (
  * @param {string} policyId - ObjectId of the policy to re-analyze
  * @returns {Promise<Policy>}
  */
-export const reanalyzePolicy = async (policyId, userId = null, orgId = null) => {
+export const reanalyzePolicy = async (
+  policyId,
+  userId = null,
+  orgId = null,
+) => {
   const policy = await Policy.findById(policyId);
   if (!policy) throw new NotFoundError("Policy not found.");
 
@@ -392,7 +402,11 @@ export const getAllPolicies = async (userId, orgId) => {
  * @param {string} policyId
  * @returns {Promise<{safeFilePath: string, fileName: string}>}
  */
-export const getPolicyDownloadPath = async (policyId, userId = null, orgId = null) => {
+export const getPolicyDownloadPath = async (
+  policyId,
+  userId = null,
+  orgId = null,
+) => {
   const policy = await Policy.findById(policyId);
   if (!policy) throw new NotFoundError("Policy not found.");
 


### PR DESCRIPTION
# Pull Request

## Description

Enforce organization scope validation in policy download and re-analysis endpoints to prevent unauthorized cross-organization file access.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #938

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (Backend authorization fix)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review