### PR TITLE
fix: validate target resource ownership in shared link creation (#939)

### DIFF
--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -39,7 +39,9 @@ export const createLink = async (req, res) => {
     const userOrgId = req.user.organization?.toString();
 
     const isUploader =
-      resource.uploadedBy && userId && resource.uploadedBy.toString() === userId;
+      resource.uploadedBy &&
+      userId &&
+      resource.uploadedBy.toString() === userId;
     const isInSameOrg =
       resource.organization &&
       userOrgId &&

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -25,7 +25,33 @@ export const createLink = async (req, res) => {
         .json({ success: false, message: "Invalid resource type" });
     }
 
-    // Optionally check if user has access to this resource, assuming they do because of auth middleware
+    // Check if user has access to this resource
+    const resourceModel = resourceType === "Meeting" ? Meeting : Policy;
+    const resource = await resourceModel.findById(resourceId);
+
+    if (!resource) {
+      return res
+        .status(404)
+        .json({ success: false, message: `${resourceType} not found` });
+    }
+
+    const userId = (req.user._id || req.user.id)?.toString();
+    const userOrgId = req.user.organization?.toString();
+
+    const isUploader =
+      resource.uploadedBy && userId && resource.uploadedBy.toString() === userId;
+    const isInSameOrg =
+      resource.organization &&
+      userOrgId &&
+      resource.organization.toString() === userOrgId;
+
+    if (!isUploader && !isInSameOrg) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to share this resource",
+      });
+    }
+
     let hashedPasscode = null;
     if (passcode) {
       const salt = await bcrypt.genSalt(10);


### PR DESCRIPTION
# Pull Request

## Description

Validate target resource (Meeting or Policy) existence and organization/uploader ownership in shared link creation to prevent unauthorized resource sharing.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #939

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (Backend authorization fix)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review