### PR TITLE
fix: enforce user and organization authorization in getMeetingById (#940)

### DIFF
--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -426,8 +426,13 @@ export const deleteMeeting = async (req, res, next) => {
    ───────────────────────────────────────────────────────────── */
 export const getMeetingById = async (req, res, next) => {
   try {
-    getUserId(req); // ensure authenticated
-    const meeting = await MeetingService.getMeetingById(req.params.id);
+    const userId = getUserId(req);
+    const orgId = req.user?.organization || null;
+    const meeting = await MeetingService.getMeetingById(
+      req.params.id,
+      userId,
+      orgId,
+    );
     return sendSuccess(res, { meeting });
   } catch (err) {
     next(err);

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -469,7 +469,11 @@ export const getAllMeetings = async (userId, orgId, queryParams = {}) => {
   };
 };
 
-export const getMeetingById = async (meetingId, userId = null, orgId = null) => {
+export const getMeetingById = async (
+  meetingId,
+  userId = null,
+  orgId = null,
+) => {
   if (!isValidObjectId(meetingId)) {
     throw new ValidationError("Invalid meeting ID");
   }

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -469,13 +469,31 @@ export const getAllMeetings = async (userId, orgId, queryParams = {}) => {
   };
 };
 
-export const getMeetingById = async (meetingId) => {
+export const getMeetingById = async (meetingId, userId = null, orgId = null) => {
   if (!isValidObjectId(meetingId)) {
     throw new ValidationError("Invalid meeting ID");
   }
 
   const meeting = await MeetingStorageService.findMeetingById(meetingId);
   if (!meeting) throw new NotFoundError("Meeting not found");
+
+  if (userId || orgId) {
+    const isUploader =
+      meeting.uploadedBy &&
+      userId &&
+      meeting.uploadedBy.toString() === userId.toString();
+    const isInOrg =
+      meeting.organization &&
+      orgId &&
+      meeting.organization.toString() === orgId.toString();
+
+    if (!isUploader && !isInOrg) {
+      throw new ForbiddenError(
+        "Forbidden: You do not have access to this meeting",
+      );
+    }
+  }
+
   return meeting;
 };
 


### PR DESCRIPTION
# Pull Request

## Description

Enforce uploader ownership or organization membership authorization checks in getMeetingById to prevent cross-organization meeting data exposure.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #940

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (Backend authorization fix)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review