### PR TITLE
fix: await async isSafeWebhookUrl refinement in updateWebhookSchema (#941)

### DIFF
--- a/server/controllers/webhookController.js
+++ b/server/controllers/webhookController.js
@@ -134,7 +134,7 @@ const updateWebhookSchema = z.object({
     .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
       message: "Target URL must start with http:// or https://.",
     })
-    .refine((url) => isSafeWebhookUrl(url), {
+    .refine(async (url) => await isSafeWebhookUrl(url), {
       message:
         "Target URL must be a public, safe address. Local/private addresses are not permitted.",
     })


### PR DESCRIPTION
Closes #941

- Updated `updateWebhookSchema` in `server/controllers/webhookController.js` to await `isSafeWebhookUrl` asynchronously inside Zod `.refine()`, preventing SSRF IP validation bypass.