### PR TITLE
fix: add getUserId helper to calendarController for user ID robustness (#942)

### DIFF
--- a/server/controllers/calendarController.js
+++ b/server/controllers/calendarController.js
@@ -10,12 +10,18 @@ import {
 } from "../services/calendarService.js";
 import { triggerManualSync } from "../jobs/calendarSyncJob.js";
 
+const getUserId = (req) => {
+  const id = req.user?._id || req.user?.id;
+  if (!id) throw new Error("Unauthorized: User ID missing");
+  return id;
+};
+
 /**
  * Get calendar connection status for a user
  */
 export const getConnectionStatus = async (req, res) => {
   try {
-    const userId = req.user.id || req.user._id;
+    const userId = getUserId(req);
     const connections = await CalendarConnection.find({ user: userId });
 
     const status = {


### PR DESCRIPTION
Closes #942

- Defined `getUserId` helper in `server/controllers/calendarController.js` safely checking both `req.user._id` and `req.user.id` across calendarEndpoints.