### PR TITLE
fix(rbac): synchronize client permissions with server

### DIFF
--- a/client/src/components/RoleGate.jsx
+++ b/client/src/components/RoleGate.jsx
@@ -1,46 +1,6 @@
 import React, { useContext } from "react";
 import AppContent from "../context/AppContent";
-
-/**
- * Role & Permission Hierarchy for frontend gates
- */
-const ROLE_HIERARCHY = {
-  owner: 5,
-  admin: 4,
-  moderator: 3,
-  member: 2,
-  viewer: 1,
-  guest: 0,
-};
-
-const PERMISSIONS = {
-  meetings: {
-    view: ["owner", "admin", "moderator", "member", "viewer"],
-    create: ["owner", "admin", "moderator", "member"],
-    edit: ["owner", "admin", "moderator", "member"],
-    delete: ["owner", "admin"],
-  },
-  policies: {
-    view: ["owner", "admin", "moderator", "member", "viewer"],
-    create: ["owner", "admin", "moderator", "member"],
-    edit: ["owner", "admin", "moderator", "member"],
-    delete: ["owner", "admin"],
-    approve: ["owner", "admin"],
-  },
-  team_members: {
-    view: ["owner", "admin", "moderator", "member", "viewer"],
-    invite: ["owner", "admin"],
-    remove: ["owner", "admin"],
-    change_role: ["owner", "admin"],
-  },
-  audit_logs: {
-    view: ["owner", "admin"],
-  },
-  admin_panel: {
-    view: ["owner", "admin"],
-    manage: ["owner", "admin"],
-  },
-};
+import { ROLE_HIERARCHY, hasPermission } from "../utils/rbacPermissions.js";
 
 /**
  * RoleGate Component
@@ -77,13 +37,9 @@ const RoleGate = ({
     }
   }
 
-  // Check resource permission
+  // Check resource permission (shared map — mirrors backend)
   if (resource && action) {
-    const allowedForAction = PERMISSIONS[resource]?.[action] || [
-      "owner",
-      "admin",
-    ];
-    if (!allowedForAction.includes(userRole)) {
+    if (!hasPermission(userRole, resource, action)) {
       return fallback;
     }
   }

--- a/client/src/utils/__tests__/rbacPermissions.test.js
+++ b/client/src/utils/__tests__/rbacPermissions.test.js
@@ -1,9 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import {
+  PERMISSIONS,
+  ROLE_HIERARCHY,
   hasPermission,
   hasHigherOrEqualRole,
   isValidRole,
 } from "../rbacPermissions";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Parse ROLE_HIERARCHY / PERMISSIONS object literals from the server mirror
+ * without executing server code (keeps the client test self-contained).
+ */
+const loadServerPermissionExports = () => {
+  const serverPath = resolve(
+    __dirname,
+    "../../../../server/utils/rbacPermissions.js",
+  );
+  const source = readFileSync(serverPath, "utf8");
+
+  const hierarchyMatch = source.match(
+    /export const ROLE_HIERARCHY = (\{[\s\S]*?\n\});/,
+  );
+  const permissionsMatch = source.match(
+    /export const PERMISSIONS = (\{[\s\S]*?\n\});/,
+  );
+
+  if (!hierarchyMatch || !permissionsMatch) {
+    throw new Error("Unable to parse server rbacPermissions.js exports");
+  }
+
+  // Object literals only — no functions — so Function() is safe here.
+  const ROLE_HIERARCHY_SERVER = new Function(`return (${hierarchyMatch[1]})`)();
+  const PERMISSIONS_SERVER = new Function(`return (${permissionsMatch[1]})`)();
+
+  return {
+    ROLE_HIERARCHY: ROLE_HIERARCHY_SERVER,
+    PERMISSIONS: PERMISSIONS_SERVER,
+  };
+};
 
 describe("RBAC Permissions Utils", () => {
   describe("hasPermission", () => {
@@ -30,6 +69,7 @@ describe("RBAC Permissions Utils", () => {
       expect(hasHigherOrEqualRole("admin", "member")).toBe(true);
       expect(hasHigherOrEqualRole("guest", "moderator")).toBe(false);
       expect(hasHigherOrEqualRole("member", "member")).toBe(true);
+      expect(hasHigherOrEqualRole("viewer", "guest")).toBe(true);
     });
   });
 
@@ -37,11 +77,49 @@ describe("RBAC Permissions Utils", () => {
     it("returns true for valid roles", () => {
       expect(isValidRole("owner")).toBe(true);
       expect(isValidRole("member")).toBe(true);
+      expect(isValidRole("viewer")).toBe(true);
     });
 
     it("returns false for invalid roles", () => {
       expect(isValidRole("superadmin")).toBe(false);
       expect(isValidRole("")).toBe(false);
+    });
+  });
+
+  describe("client/server synchronization (#627)", () => {
+    const server = loadServerPermissionExports();
+
+    it("mirrors backend ROLE_HIERARCHY including viewer", () => {
+      expect(ROLE_HIERARCHY).toEqual(server.ROLE_HIERARCHY);
+    });
+
+    it("mirrors backend PERMISSIONS map exactly", () => {
+      expect(PERMISSIONS).toEqual(server.PERMISSIONS);
+    });
+
+    it("exposes previously missing backend permission actions", () => {
+      expect(hasPermission("member", "settings", "self_view")).toBe(true);
+      expect(hasPermission("guest", "settings", "self_edit")).toBe(true);
+      expect(hasPermission("moderator", "knowledge", "consolidate")).toBe(true);
+      expect(hasPermission("moderator", "knowledge", "resolve_conflicts")).toBe(
+        true,
+      );
+      expect(hasPermission("moderator", "knowledge", "manage_lifecycle")).toBe(
+        true,
+      );
+      expect(hasPermission("member", "notifications", "self_manage")).toBe(
+        true,
+      );
+      expect(hasPermission("admin", "audit_logs", "view")).toBe(true);
+      expect(hasPermission("member", "audit_logs", "view")).toBe(false);
+    });
+
+    it("allows viewer search/view but blocks meeting mutation", () => {
+      expect(hasPermission("viewer", "meetings", "view")).toBe(true);
+      expect(hasPermission("viewer", "ai_search", "search")).toBe(true);
+      expect(hasPermission("viewer", "meetings", "create")).toBe(false);
+      expect(hasPermission("member", "meetings", "create")).toBe(true);
+      expect(hasPermission("moderator", "team_members", "invite")).toBe(false);
     });
   });
 });

--- a/client/src/utils/rbacPermissions.js
+++ b/client/src/utils/rbacPermissions.js
@@ -7,71 +7,74 @@ export const ROLE_HIERARCHY = {
   admin: 4,
   moderator: 3,
   member: 2,
-  guest: 1,
+  viewer: 1,
+  guest: 0,
 };
 
 // Resource permissions
 export const PERMISSIONS = {
   // Meeting permissions
   meetings: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    create: ["owner", "admin", "moderator"],
-    edit: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    create: ["owner", "admin", "moderator", "member"],
+    edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin"],
     export: ["owner", "admin", "moderator", "member"],
     transcribe: ["owner", "admin", "moderator", "member"],
   },
   // Policy permissions
   policies: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    create: ["owner", "admin", "moderator"],
-    edit: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    create: ["owner", "admin", "moderator", "member"],
+    edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin"],
     approve: ["owner", "admin"],
   },
   // Task permissions
   tasks: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    create: ["owner", "admin", "moderator"],
-    edit: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    create: ["owner", "admin", "moderator", "member"],
+    edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin", "moderator"],
     assign: ["owner", "admin", "moderator"],
   },
   // Calendar permissions
   calendar: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    create: ["owner", "admin", "moderator"],
-    edit: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    create: ["owner", "admin", "moderator", "member"],
+    edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin", "moderator"],
   },
   // AI Search permissions
   ai_search: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    search: ["owner", "admin", "moderator", "member"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    search: ["owner", "admin", "moderator", "member", "viewer"],
   },
   // Team Members permissions
   team_members: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
-    invite: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    invite: ["owner", "admin"],
     remove: ["owner", "admin"],
     change_role: ["owner", "admin"],
   },
   // Organization permissions
   organizations: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
     create: ["owner", "admin"],
     edit: ["owner", "admin"],
     delete: ["owner"],
-    leave: ["owner", "admin", "moderator", "member", "guest"],
+    leave: ["owner", "admin", "moderator", "member", "viewer", "guest"],
   },
   // Settings permissions
   settings: {
-    view: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member"],
     edit: ["owner", "admin"],
+    self_view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+    self_edit: ["owner", "admin", "moderator", "member", "viewer", "guest"],
   },
   // Reports permissions
   reports: {
-    view: ["owner", "admin", "moderator"],
+    view: ["owner", "admin", "moderator", "member"],
     export: ["owner", "admin", "moderator"],
   },
   // Admin Panel permissions
@@ -81,15 +84,23 @@ export const PERMISSIONS = {
   },
   // Knowledge Base permissions
   knowledge: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
     create: ["owner", "admin", "moderator", "member"],
     edit: ["owner", "admin", "moderator", "member"],
     delete: ["owner", "admin", "moderator"],
+    consolidate: ["owner", "admin", "moderator"],
+    resolve_conflicts: ["owner", "admin", "moderator"],
+    manage_lifecycle: ["owner", "admin", "moderator"],
   },
   // Notifications permissions
   notifications: {
-    view: ["owner", "admin", "moderator", "member", "guest"],
+    view: ["owner", "admin", "moderator", "member", "viewer", "guest"],
     manage: ["owner", "admin"],
+    self_manage: ["owner", "admin", "moderator", "member", "viewer", "guest"],
+  },
+  // Audit Logs permissions
+  audit_logs: {
+    view: ["owner", "admin"],
   },
 };
 
@@ -149,7 +160,7 @@ export const hasAllPermissions = (role, resource, actions) => {
  * @returns {boolean}
  */
 export const hasHigherOrEqualRole = (role1, role2) => {
-  return ROLE_HIERARCHY[role1] >= ROLE_HIERARCHY[role2];
+  return (ROLE_HIERARCHY[role1] || 0) >= (ROLE_HIERARCHY[role2] || 0);
 };
 
 /**


### PR DESCRIPTION
## Description

Synchronizes the client-side RBAC permission definitions with the backend to eliminate authorization inconsistencies between the UI and server.

### Changes

- Synchronized the client RBAC permission map with the backend definitions.
- Added missing permissions from the server to the client.
- Updated the client role hierarchy to match the backend.
- Aligned role assignments for existing permissions.
- Refactored `RoleGate` to use the shared RBAC permission utilities instead of maintaining a separate permission map.
- Added regression tests to ensure client permission definitions remain synchronized with the backend.

## Related Issue

Closes #627

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Testing

Validated locally:

- ✅ Prettier
- ✅ ESLint (`lint:changed`)
- ✅ Related client tests
- ✅ Client RBAC regression tests (10 passing)
- ✅ Client PR validation
- ✅ Server PR validation
- ✅ Production client build

## Checklist

- [x] Code follows project conventions
- [x] Existing RBAC behavior preserved
- [x] Client permission definitions synchronized with backend
- [x] Regression tests added
- [x] Ready for review