### PR TITLE
feat(meetings): create follow-up drafts from action items

### DIFF
--- a/client/src/components/tasks/FollowUpSelectionBar.jsx
+++ b/client/src/components/tasks/FollowUpSelectionBar.jsx
@@ -1,0 +1,42 @@
+import { CalendarPlus, X } from "lucide-react";
+
+/**
+ * Sticky bulk action bar when action items are selected for a follow-up meeting.
+ */
+export default function FollowUpSelectionBar({
+  selectedCount,
+  onClear,
+  onCreateFollowUp,
+  canCreateMeeting,
+}) {
+  if (selectedCount <= 0) return null;
+
+  return (
+    <div className="sticky top-24 z-20 mb-4 rounded-xl border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-4 py-3 shadow-sm flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div className="text-sm text-blue-900 dark:text-blue-100">
+        <span className="font-semibold">{selectedCount}</span> action item
+        {selectedCount === 1 ? "" : "s"} selected for follow-up
+      </div>
+      <div className="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800"
+        >
+          <X className="w-4 h-4" />
+          Clear
+        </button>
+        {canCreateMeeting && (
+          <button
+            type="button"
+            onClick={onCreateFollowUp}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-sm font-semibold rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+          >
+            <CalendarPlus className="w-4 h-4" />
+            Create Follow-up Meeting
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/tasks/TaskCard.jsx
+++ b/client/src/components/tasks/TaskCard.jsx
@@ -20,6 +20,10 @@ export default function TaskCard({
   navigate,
   updateTaskStatus,
   toggleTaskReminder,
+  selectable = false,
+  selected = false,
+  onToggleSelect,
+  selectionDisabled = false,
 }) {
   const [isUpdating, setIsUpdating] = useState(false);
   const [isTogglingReminder, setIsTogglingReminder] = useState(false);
@@ -64,12 +68,31 @@ export default function TaskCard({
     <div
       onClick={() => setSelectedTask(task)}
       className={`group bg-white dark:bg-slate-900 border rounded-xl p-5 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-md transition-all cursor-pointer ${
-        isOverdue
-          ? "border-red-300 dark:border-red-900/60 bg-red-50/20 dark:bg-red-950/10"
-          : "border-slate-200 dark:border-slate-700"
+        selected
+          ? "border-blue-400 dark:border-blue-600 ring-1 ring-blue-200 dark:ring-blue-900"
+          : isOverdue
+            ? "border-red-300 dark:border-red-900/60 bg-red-50/20 dark:bg-red-950/10"
+            : "border-slate-200 dark:border-slate-700"
       }`}
     >
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
+        {selectable && (
+          <div className="pt-1 shrink-0">
+            <input
+              type="checkbox"
+              checked={selected}
+              disabled={selectionDisabled && !selected}
+              aria-label={`Select action item: ${task.title}`}
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                e.stopPropagation();
+                onToggleSelect?.(task.id, e.target.checked);
+              }}
+              className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            />
+          </div>
+        )}
+
         {/* Task Info */}
         <div className="flex-1 min-w-0">
           <div className="flex items-start gap-3 mb-2 flex-wrap">

--- a/client/src/pages/CreateMeeting.jsx
+++ b/client/src/pages/CreateMeeting.jsx
@@ -12,7 +12,14 @@ import { useSessionCards } from "./CreateMeeting/hooks/useSessionCards";
 const CreateMeeting = () => {
   const [activeSection, setActiveSection] = useState(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get("templateId") ? "schedule" : "live";
+    if (
+      urlParams.get("templateId") ||
+      urlParams.get("fromActionItems") === "1" ||
+      window.history.state?.followUpDraft
+    ) {
+      return "schedule";
+    }
+    return "live";
   });
 
   const scheduleMeetingHooks = useScheduleMeeting();

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
@@ -28,6 +28,8 @@ const ScheduleMeeting = ({ hookProps }) => {
     handleAttachmentUpload,
     removeAttachment,
     handleScheduleSubmit,
+    isFollowUpDraft,
+    sourceActionItemIds,
   } = hookProps;
 
   return (
@@ -42,6 +44,18 @@ const ScheduleMeeting = ({ hookProps }) => {
           </p>
         </div>
       </div>
+
+      {isFollowUpDraft && (
+        <div className="mb-6 rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-900">
+          <p className="font-semibold mb-1">Follow-up meeting draft</p>
+          <p>
+            Title and agenda were pre-filled from{" "}
+            {sourceActionItemIds?.length || agendaItems.length} selected action
+            item(s). Review the agenda preview below, adjust as needed, then
+            schedule.
+          </p>
+        </div>
+      )}
 
       <form onSubmit={handleScheduleSubmit}>
         <MeetingInformationForm
@@ -77,6 +91,27 @@ const ScheduleMeeting = ({ hookProps }) => {
                 </option>
               ))}
             </select>
+          </div>
+        )}
+
+        {isFollowUpDraft && agendaItems.length > 0 && (
+          <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+            <p className="text-sm font-semibold text-slate-800 mb-2">
+              Agenda preview ({agendaItems.length} items)
+            </p>
+            <ol className="list-decimal list-inside space-y-1 text-sm text-slate-700">
+              {agendaItems.map((item) => (
+                <li key={item.id || item.text}>
+                  <span className="font-medium">{item.text}</span>
+                  {item.description ? (
+                    <span className="text-slate-500">
+                      {" "}
+                      — {item.description}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
           </div>
         )}
 

--- a/client/src/utils/__tests__/followUpMeetingDraft.test.js
+++ b/client/src/utils/__tests__/followUpMeetingDraft.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFollowUpMeetingDraft,
+  isFollowUpEligible,
+} from "../followUpMeetingDraft";
+
+describe("followUpMeetingDraft (#721)", () => {
+  const tasks = [
+    {
+      id: "a1",
+      title: "Ship docs",
+      owner: "Alex",
+      dueDate: "2026-08-01T00:00:00.000Z",
+      meetingTitle: "Sprint Review",
+      status: "open",
+    },
+    {
+      id: "a2",
+      title: "Fix login",
+      owner: "Unassigned",
+      meetingTitle: "Sprint Review",
+      status: "in-progress",
+    },
+    {
+      id: "a3",
+      title: "Done item",
+      status: "resolved",
+      meetingTitle: "Sprint Review",
+    },
+  ];
+
+  it("marks only open/in-progress items as eligible", () => {
+    expect(isFollowUpEligible(tasks[0])).toBe(true);
+    expect(isFollowUpEligible(tasks[1])).toBe(true);
+    expect(isFollowUpEligible(tasks[2])).toBe(false);
+  });
+
+  it("builds a prefilled title, agenda, and source ids from eligible items", () => {
+    const draft = buildFollowUpMeetingDraft(tasks);
+
+    expect(draft.title).toBe("Follow-up: Sprint Review");
+    expect(draft.sourceActionItemIds).toEqual(["a1", "a2"]);
+    expect(draft.agendaItems).toHaveLength(2);
+    expect(draft.agendaItems[0].text).toBe("Ship docs");
+    expect(draft.agendaItems[0].description).toContain("Owner: Alex");
+    expect(draft.agendaItems[0].description).toContain("From: Sprint Review");
+    expect(draft.description).toMatch(/2 selected action item/);
+  });
+
+  it("uses a multi-meeting title when sources differ", () => {
+    const draft = buildFollowUpMeetingDraft([
+      { ...tasks[0], meetingTitle: "Alpha" },
+      { ...tasks[1], meetingTitle: "Beta" },
+    ]);
+    expect(draft.title).toBe("Follow-up: 2 meetings");
+  });
+});

--- a/client/src/utils/followUpMeetingDraft.js
+++ b/client/src/utils/followUpMeetingDraft.js
@@ -1,0 +1,57 @@
+/**
+ * Helpers for creating a follow-up meeting draft from Tasks / action items (#721).
+ */
+
+export const FOLLOW_UP_ELIGIBLE_STATUSES = ["open", "in-progress"];
+
+export const isFollowUpEligible = (task) =>
+  Boolean(task) && FOLLOW_UP_ELIGIBLE_STATUSES.includes(task.status);
+
+/**
+ * Build a schedule-meeting draft from selected action items.
+ * Reuses the existing CreateMeeting form fields (title, description, agendaItems).
+ *
+ * @param {Array<{ id: string, title: string, owner?: string, dueDate?: string|Date, meetingTitle?: string, status: string }>} tasks
+ * @returns {{ title: string, description: string, agendaItems: Array, sourceActionItemIds: string[] }}
+ */
+export const buildFollowUpMeetingDraft = (tasks = []) => {
+  const eligible = tasks.filter(isFollowUpEligible);
+
+  const meetingTitles = [
+    ...new Set(eligible.map((t) => t.meetingTitle).filter(Boolean)),
+  ];
+
+  let title;
+  if (meetingTitles.length === 1) {
+    title = `Follow-up: ${meetingTitles[0]}`;
+  } else if (meetingTitles.length > 1) {
+    title = `Follow-up: ${meetingTitles.length} meetings`;
+  } else {
+    const n = eligible.length;
+    title = `Follow-up: ${n} action item${n === 1 ? "" : "s"}`;
+  }
+
+  const agendaItems = eligible.map((task) => {
+    const details = [
+      task.owner && task.owner !== "Unassigned" ? `Owner: ${task.owner}` : null,
+      task.dueDate
+        ? `Due: ${new Date(task.dueDate).toLocaleDateString()}`
+        : null,
+      task.meetingTitle ? `From: ${task.meetingTitle}` : null,
+    ].filter(Boolean);
+
+    return {
+      text: task.title,
+      description: details.join(" · "),
+      id: `source-${task.id}`,
+      sourceActionItemId: task.id,
+    };
+  });
+
+  return {
+    title,
+    description: `Follow-up meeting generated from ${eligible.length} selected action item(s). Review the agenda below before scheduling.`,
+    agendaItems,
+    sourceActionItemIds: eligible.map((task) => task.id),
+  };
+};

--- a/server/tests/sourceActionItemLinks.test.js
+++ b/server/tests/sourceActionItemLinks.test.js
@@ -1,0 +1,79 @@
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import { ValidationError, ForbiddenError } from "../utils/errors.js";
+
+jest.unstable_mockModule("../models/actionItemModel.js", () => ({
+  default: {
+    find: jest.fn(),
+  },
+}));
+
+const { default: ActionItem } = await import("../models/actionItemModel.js");
+const { resolveSourceActionItemIds } =
+  await import("../utils/sourceActionItemLinks.js");
+
+describe("resolveSourceActionItemIds (#721)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns empty array when no ids are provided", async () => {
+    await expect(resolveSourceActionItemIds("org-1", [])).resolves.toEqual([]);
+    await expect(resolveSourceActionItemIds("org-1")).resolves.toEqual([]);
+    expect(ActionItem.find).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid ObjectIds", async () => {
+    await expect(
+      resolveSourceActionItemIds("org-1", ["not-an-id"]),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects when an action item is missing", async () => {
+    const id = new mongoose.Types.ObjectId().toString();
+    ActionItem.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([]),
+    });
+
+    await expect(
+      resolveSourceActionItemIds("org-1", [id]),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("rejects cross-organization action items", async () => {
+    const id = new mongoose.Types.ObjectId().toString();
+    const orgA = new mongoose.Types.ObjectId();
+    const orgB = new mongoose.Types.ObjectId();
+
+    ActionItem.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        {
+          _id: id,
+          sourceMeetingId: { organization: orgB },
+        },
+      ]),
+    });
+
+    await expect(resolveSourceActionItemIds(orgA, [id])).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+  });
+
+  it("accepts action items that belong to the organization", async () => {
+    const id = new mongoose.Types.ObjectId().toString();
+    const orgId = new mongoose.Types.ObjectId();
+
+    ActionItem.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        {
+          _id: id,
+          sourceMeetingId: { organization: orgId },
+        },
+      ]),
+    });
+
+    await expect(resolveSourceActionItemIds(orgId, [id, id])).resolves.toEqual([
+      id,
+    ]);
+  });
+});

--- a/server/utils/sourceActionItemLinks.js
+++ b/server/utils/sourceActionItemLinks.js
@@ -1,0 +1,61 @@
+import mongoose from "mongoose";
+import ActionItem from "../models/actionItemModel.js";
+import { ValidationError, ForbiddenError } from "./errors.js";
+
+const MAX_SOURCE_ACTION_ITEMS = 50;
+
+/**
+ * Validate optional source action-item IDs for follow-up meeting creation (#721).
+ * Ensures every ID exists and belongs to the caller's organization (when set).
+ *
+ * @param {string|null} orgId
+ * @param {string[]} rawIds
+ * @returns {Promise<string[]>}
+ */
+export const resolveSourceActionItemIds = async (orgId, rawIds = []) => {
+  if (!Array.isArray(rawIds) || rawIds.length === 0) {
+    return [];
+  }
+
+  const uniqueIds = [
+    ...new Set(
+      rawIds.map((id) => (id == null ? "" : String(id).trim())).filter(Boolean),
+    ),
+  ];
+
+  if (uniqueIds.length > MAX_SOURCE_ACTION_ITEMS) {
+    throw new ValidationError(
+      `At most ${MAX_SOURCE_ACTION_ITEMS} source action items can be linked`,
+    );
+  }
+
+  const invalidId = uniqueIds.find(
+    (id) => !mongoose.Types.ObjectId.isValid(id),
+  );
+  if (invalidId) {
+    throw new ValidationError(`Invalid source action item id: ${invalidId}`);
+  }
+
+  const items = await ActionItem.find({ _id: { $in: uniqueIds } }).populate(
+    "sourceMeetingId",
+    "organization",
+  );
+
+  if (items.length !== uniqueIds.length) {
+    throw new ValidationError("One or more source action items were not found");
+  }
+
+  if (orgId) {
+    const orgIdStr = orgId.toString();
+    for (const item of items) {
+      const meetingOrg = item.sourceMeetingId?.organization;
+      if (meetingOrg && meetingOrg.toString() !== orgIdStr) {
+        throw new ForbiddenError(
+          "Source action items must belong to your organization",
+        );
+      }
+    }
+  }
+
+  return uniqueIds;
+};


### PR DESCRIPTION
## Description

Implements follow-up meeting draft creation from selected action items by extending the existing meeting creation workflow.

### Changes

- Added support for selecting multiple eligible action items.
- Introduced a "Create Follow-up Meeting" workflow from the Tasks page.
- Automatically generates a pre-filled meeting title and draft agenda.
- Preserves references to the originating action items.
- Added shared utilities for follow-up meeting draft generation and source action item linking.
- Added regression tests covering draft generation and source action item linking.
- Reused the existing meeting creation flow without affecting current functionality.

## Related Issue

Closes #721

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

Validated locally:

- ✅ Prettier
- ✅ ESLint
- ✅ Client related tests
- ✅ Follow-up meeting draft tests
- ✅ Source action item link tests
- ✅ Client PR validation
- ✅ Server PR validation
- ✅ Production client build

## Checklist

- [x] Code follows project conventions
- [x] Existing meeting creation workflow preserved
- [x] Regression tests added
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk selection controls for action items, including selection counts, clearing selections, and creating follow-up meetings when permitted.
  * Added visual selection states and checkboxes to task cards.
  * Follow-up meetings now open with prefilled titles and agenda items, including task details and source meeting information.
  * Added validation to ensure linked action items are valid and accessible.

* **Tests**
  * Added coverage for follow-up meeting drafts and action-item validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->