### PR TITLE
Show planned vs actual overrun indicators in the agenda timer

### DIFF
--- a/client/src/components/meeting-details/AgendaTimer.jsx
+++ b/client/src/components/meeting-details/AgendaTimer.jsx
@@ -1,8 +1,14 @@
 import React, { useState, useEffect, useContext, useRef } from "react";
 import AppContent from "../../context/AppContent";
 import { io } from "socket.io-client";
+import { toast } from "react-toastify";
 import { meetingApi } from "../../services";
-import { Play, Square, SkipForward } from "lucide-react";
+import { Play, Square, SkipForward, AlertTriangle } from "lucide-react";
+import {
+  formatClock,
+  getItemTiming,
+  summarizeAgendaTiming,
+} from "../../utils/agendaTiming";
 
 const AgendaTimer = ({ meeting }) => {
   const { backendUrl, userData } = useContext(AppContent);
@@ -11,6 +17,7 @@ const AgendaTimer = ({ meeting }) => {
   const [elapsedMs, setElapsedMs] = useState(0);
   const socketRef = useRef(null);
   const timerRef = useRef(null);
+  const overrunNotifiedRef = useRef(new Set());
 
   const isOrganizerOrAdmin = meeting.uploadedBy === userData?._id;
 
@@ -39,6 +46,18 @@ const AgendaTimer = ({ meeting }) => {
 
     return () => clearInterval(timerRef.current);
   }, [activeItem]);
+
+  // Warn once per item as soon as it runs past its planned duration.
+  useEffect(() => {
+    if (!activeItem) return;
+    const { isOverrun } = getItemTiming(activeItem, elapsedMs);
+    if (!isOverrun || overrunNotifiedRef.current.has(activeItem._id)) return;
+
+    overrunNotifiedRef.current.add(activeItem._id);
+    toast.warning(
+      `"${activeItem.text}" has passed its planned ${activeItem.duration} min`,
+    );
+  }, [activeItem, elapsedMs]);
 
   useEffect(() => {
     socketRef.current = io(backendUrl, {
@@ -115,101 +134,180 @@ const AgendaTimer = ({ meeting }) => {
     }
   };
 
-  const formatTime = (ms) => {
-    const totalSeconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-  };
-
   if (!agendaItems || agendaItems.length === 0) return null;
+
+  const summary = summarizeAgendaTiming(agendaItems, elapsedMs);
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-        Live Agenda
-      </h3>
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Live Agenda
+        </h3>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 dark:text-gray-400">
+            Planned{" "}
+            <span className="font-mono text-gray-700 dark:text-gray-300">
+              {formatClock(summary.plannedMs)}
+            </span>{" "}
+            · Actual{" "}
+            <span className="font-mono text-gray-700 dark:text-gray-300">
+              {formatClock(summary.actualMs)}
+            </span>
+          </span>
+          {summary.isOverrun && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
+              <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+              {formatClock(summary.overrunMs)} over
+            </span>
+          )}
+        </div>
+      </div>
       <div className="space-y-4">
         {agendaItems.map((item) => {
           const isActive = item.status === "active";
           const isCompleted = item.status === "completed";
           const isSkipped = item.status === "skipped";
 
+          const {
+            plannedMs,
+            actualMs,
+            hasPlan,
+            isOverrun,
+            isNearLimit,
+            overrunMs,
+            remainingMs,
+            progressPercent,
+          } = getItemTiming(item, elapsedMs);
+
           let borderClass = "border-gray-200 dark:border-gray-700";
-          if (isActive)
+          if (isActive && isOverrun)
+            borderClass = "border-red-500 bg-red-50 dark:bg-red-900/20";
+          else if (isActive && isNearLimit)
+            borderClass = "border-amber-500 bg-amber-50 dark:bg-amber-900/20";
+          else if (isActive)
             borderClass = "border-blue-500 bg-blue-50 dark:bg-blue-900/20";
+          else if (isCompleted && isOverrun)
+            borderClass = "border-amber-500 bg-amber-50 dark:bg-amber-900/20";
           else if (isCompleted)
             borderClass = "border-green-500 bg-green-50 dark:bg-green-900/20";
           else if (isSkipped)
             borderClass =
               "border-gray-300 bg-gray-50 dark:bg-gray-800/50 opacity-60";
 
+          let barClass = "bg-gray-400 dark:bg-gray-500";
+          if (isOverrun) barClass = "bg-red-500";
+          else if (isNearLimit) barClass = "bg-amber-500";
+          else if (isActive) barClass = "bg-blue-500";
+          else if (isCompleted) barClass = "bg-green-500";
+
+          let timeClass = "text-gray-700 dark:text-gray-300";
+          if (isOverrun) timeClass = "text-red-600 dark:text-red-400";
+          else if (isNearLimit)
+            timeClass = "text-amber-600 dark:text-amber-400";
+
           return (
             <div
               key={item._id}
-              className={`p-4 rounded-lg border flex justify-between items-center transition-colors ${borderClass}`}
+              className={`p-4 rounded-lg border transition-colors ${borderClass}`}
             >
-              <div>
-                <h4 className="font-medium text-gray-900 dark:text-gray-100 flex items-center gap-2">
-                  {item.text}
-                  {isActive && (
-                    <span className="flex h-3 w-3 relative">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
-                      <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
-                    </span>
-                  )}
-                </h4>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Planned: {item.duration || 0} min
-                </p>
-              </div>
-
-              <div className="flex items-center gap-4">
-                <div className="text-lg font-mono font-semibold text-gray-700 dark:text-gray-300">
-                  {isActive
-                    ? formatTime(elapsedMs)
-                    : formatTime(item.actualDuration || 0)}
+              <div className="flex justify-between items-center gap-4">
+                <div className="min-w-0">
+                  <h4 className="font-medium text-gray-900 dark:text-gray-100 flex flex-wrap items-center gap-2">
+                    {item.text}
+                    {isActive && (
+                      <span className="flex h-3 w-3 relative">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                        <span className="relative inline-flex rounded-full h-3 w-3 bg-blue-500"></span>
+                      </span>
+                    )}
+                    {isOverrun && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                        <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                        Over by {formatClock(overrunMs)}
+                      </span>
+                    )}
+                    {isActive && isNearLimit && (
+                      <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                        {formatClock(remainingMs)} left
+                      </span>
+                    )}
+                  </h4>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                    Planned: {item.duration || 0} min
+                  </p>
                 </div>
 
-                {isOrganizerOrAdmin && !isCompleted && !isSkipped && (
-                  <div className="flex gap-2">
-                    {!isActive ? (
-                      <button
-                        onClick={() => handleStart(item._id)}
-                        className="p-2 bg-blue-100 text-blue-600 rounded-full hover:bg-blue-200 transition"
-                        title="Start Item"
-                      >
-                        <Play size={18} />
-                      </button>
-                    ) : (
-                      <button
-                        onClick={() => handleStop(item._id)}
-                        className="p-2 bg-red-100 text-red-600 rounded-full hover:bg-red-200 transition"
-                        title="Stop Item"
-                      >
-                        <Square size={18} />
-                      </button>
-                    )}
-                    <button
-                      onClick={() => handleSkip(item._id)}
-                      className="p-2 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition"
-                      title="Skip Item"
+                <div className="flex items-center gap-4">
+                  <div className="text-right">
+                    <div
+                      className={`text-lg font-mono font-semibold ${timeClass}`}
                     >
-                      <SkipForward size={18} />
-                    </button>
+                      {formatClock(actualMs)}
+                    </div>
+                    {hasPlan && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        of {formatClock(plannedMs)} planned
+                      </div>
+                    )}
                   </div>
-                )}
-                {isCompleted && (
-                  <span className="text-sm font-medium text-green-600 bg-green-100 px-2 py-1 rounded">
-                    Done
-                  </span>
-                )}
-                {isSkipped && (
-                  <span className="text-sm font-medium text-gray-600 bg-gray-200 px-2 py-1 rounded">
-                    Skipped
-                  </span>
-                )}
+
+                  {isOrganizerOrAdmin && !isCompleted && !isSkipped && (
+                    <div className="flex gap-2">
+                      {!isActive ? (
+                        <button
+                          onClick={() => handleStart(item._id)}
+                          className="p-2 bg-blue-100 text-blue-600 rounded-full hover:bg-blue-200 transition"
+                          title="Start Item"
+                        >
+                          <Play size={18} />
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => handleStop(item._id)}
+                          className="p-2 bg-red-100 text-red-600 rounded-full hover:bg-red-200 transition"
+                          title="Stop Item"
+                        >
+                          <Square size={18} />
+                        </button>
+                      )}
+                      <button
+                        onClick={() => handleSkip(item._id)}
+                        className="p-2 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition"
+                        title="Skip Item"
+                      >
+                        <SkipForward size={18} />
+                      </button>
+                    </div>
+                  )}
+                  {isCompleted && (
+                    <span className="text-sm font-medium text-green-600 bg-green-100 px-2 py-1 rounded">
+                      Done
+                    </span>
+                  )}
+                  {isSkipped && (
+                    <span className="text-sm font-medium text-gray-600 bg-gray-200 px-2 py-1 rounded">
+                      Skipped
+                    </span>
+                  )}
+                </div>
               </div>
+
+              {hasPlan && !isSkipped && (
+                <div
+                  className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={progressPercent}
+                  aria-label={`${item.text} progress against planned time`}
+                >
+                  <div
+                    className={`h-full rounded-full transition-all duration-500 ${barClass}`}
+                    style={{ width: `${progressPercent}%` }}
+                  />
+                </div>
+              )}
             </div>
           );
         })}

--- a/client/src/utils/__tests__/agendaTiming.test.js
+++ b/client/src/utils/__tests__/agendaTiming.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatClock,
+  getItemTiming,
+  summarizeAgendaTiming,
+} from "../agendaTiming.js";
+
+const MINUTE = 60 * 1000;
+
+describe("formatClock", () => {
+  it("formats milliseconds as mm:ss", () => {
+    expect(formatClock(0)).toBe("00:00");
+    expect(formatClock(65 * 1000)).toBe("01:05");
+    expect(formatClock(75 * MINUTE)).toBe("75:00");
+  });
+
+  it("treats missing or negative values as zero", () => {
+    expect(formatClock(undefined)).toBe("00:00");
+    expect(formatClock(-5000)).toBe("00:00");
+  });
+});
+
+describe("getItemTiming", () => {
+  it("uses the live elapsed time for the active item", () => {
+    const timing = getItemTiming(
+      { status: "active", duration: 5, actualDuration: 0 },
+      3 * MINUTE,
+    );
+
+    expect(timing.actualMs).toBe(3 * MINUTE);
+    expect(timing.remainingMs).toBe(2 * MINUTE);
+    expect(timing.progressPercent).toBe(60);
+    expect(timing.isOverrun).toBe(false);
+    expect(timing.isNearLimit).toBe(false);
+  });
+
+  it("uses the recorded duration for items that are not active", () => {
+    const timing = getItemTiming(
+      { status: "completed", duration: 5, actualDuration: 4 * MINUTE },
+      99 * MINUTE,
+    );
+
+    expect(timing.actualMs).toBe(4 * MINUTE);
+    expect(timing.progressPercent).toBe(80);
+  });
+
+  it("flags an item as nearing its limit at 80% of planned time", () => {
+    const timing = getItemTiming(
+      { status: "active", duration: 10 },
+      8 * MINUTE,
+    );
+
+    expect(timing.isNearLimit).toBe(true);
+    expect(timing.isOverrun).toBe(false);
+  });
+
+  it("reports the overrun amount and caps progress at 100%", () => {
+    const timing = getItemTiming({ status: "active", duration: 5 }, 8 * MINUTE);
+
+    expect(timing.isOverrun).toBe(true);
+    expect(timing.isNearLimit).toBe(false);
+    expect(timing.overrunMs).toBe(3 * MINUTE);
+    expect(timing.remainingMs).toBe(0);
+    expect(timing.progressPercent).toBe(100);
+  });
+
+  it("never reports an overrun for items without a planned duration", () => {
+    const timing = getItemTiming({ status: "active" }, 20 * MINUTE);
+
+    expect(timing.hasPlan).toBe(false);
+    expect(timing.isOverrun).toBe(false);
+    expect(timing.progressPercent).toBe(0);
+  });
+});
+
+describe("summarizeAgendaTiming", () => {
+  it("totals planned and actual time across the agenda", () => {
+    const items = [
+      { status: "completed", duration: 5, actualDuration: 7 * MINUTE },
+      { status: "active", duration: 10 },
+      { status: "pending", duration: 5 },
+    ];
+
+    const summary = summarizeAgendaTiming(items, 4 * MINUTE);
+
+    expect(summary.plannedMs).toBe(20 * MINUTE);
+    expect(summary.actualMs).toBe(11 * MINUTE);
+    expect(summary.itemsOverrun).toBe(1);
+    expect(summary.isOverrun).toBe(false);
+  });
+
+  it("reports how far the whole agenda has run over", () => {
+    const items = [
+      { status: "completed", duration: 5, actualDuration: 9 * MINUTE },
+      { status: "completed", duration: 5, actualDuration: 6 * MINUTE },
+    ];
+
+    const summary = summarizeAgendaTiming(items);
+
+    expect(summary.isOverrun).toBe(true);
+    expect(summary.overrunMs).toBe(5 * MINUTE);
+    expect(summary.itemsOverrun).toBe(2);
+  });
+
+  it("handles an empty agenda", () => {
+    expect(summarizeAgendaTiming([])).toEqual({
+      plannedMs: 0,
+      actualMs: 0,
+      itemsOverrun: 0,
+      isOverrun: false,
+      overrunMs: 0,
+    });
+  });
+});

--- a/client/src/utils/agendaTiming.js
+++ b/client/src/utils/agendaTiming.js
@@ -1,0 +1,80 @@
+// Timing maths shared by the live agenda timer so the pacing rules stay in one
+// place and can be unit tested without rendering the socket-backed component.
+
+// Amber warning starts once an item has used this share of its planned time.
+export const WARNING_THRESHOLD = 0.8;
+
+/**
+ * Formats a duration in milliseconds as mm:ss (hours roll into minutes).
+ */
+export const formatClock = (ms) => {
+  const totalSeconds = Math.max(0, Math.floor((ms || 0) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+};
+
+/**
+ * Compares an agenda item's planned duration against the time it has actually
+ * used. `liveElapsedMs` is the ticking value for the currently active item.
+ *
+ * @returns {{
+ *   plannedMs: number,
+ *   actualMs: number,
+ *   hasPlan: boolean,
+ *   isOverrun: boolean,
+ *   isNearLimit: boolean,
+ *   overrunMs: number,
+ *   remainingMs: number,
+ *   progressPercent: number,
+ * }}
+ */
+export const getItemTiming = (item, liveElapsedMs = 0) => {
+  const plannedMs = Math.max(0, (item?.duration || 0) * 60 * 1000);
+  const actualMs =
+    item?.status === "active"
+      ? Math.max(0, liveElapsedMs)
+      : Math.max(0, item?.actualDuration || 0);
+
+  const hasPlan = plannedMs > 0;
+  const isOverrun = hasPlan && actualMs > plannedMs;
+  const ratio = hasPlan ? actualMs / plannedMs : 0;
+
+  return {
+    plannedMs,
+    actualMs,
+    hasPlan,
+    isOverrun,
+    isNearLimit: hasPlan && !isOverrun && ratio >= WARNING_THRESHOLD,
+    overrunMs: isOverrun ? actualMs - plannedMs : 0,
+    remainingMs: hasPlan ? Math.max(0, plannedMs - actualMs) : 0,
+    progressPercent: hasPlan ? Math.min(100, Math.round(ratio * 100)) : 0,
+  };
+};
+
+/**
+ * Totals planned and actual time across every agenda item so the header can
+ * show whether the meeting as a whole is running late.
+ */
+export const summarizeAgendaTiming = (items = [], liveElapsedMs = 0) => {
+  const totals = items.reduce(
+    (acc, item) => {
+      const { plannedMs, actualMs } = getItemTiming(item, liveElapsedMs);
+      acc.plannedMs += plannedMs;
+      acc.actualMs += actualMs;
+      return acc;
+    },
+    { plannedMs: 0, actualMs: 0 },
+  );
+
+  const itemsOverrun = items.filter(
+    (item) => getItemTiming(item, liveElapsedMs).isOverrun,
+  ).length;
+
+  return {
+    ...totals,
+    itemsOverrun,
+    isOverrun: totals.plannedMs > 0 && totals.actualMs > totals.plannedMs,
+    overrunMs: Math.max(0, totals.actualMs - totals.plannedMs),
+  };
+};


### PR DESCRIPTION
## Description

The live agenda timer showed elapsed time and planned time as two unrelated numbers, so there was nothing to tell a presenter that an item had run past its allocation. This adds a planned-vs-actual comparison to each item and to the agenda as a whole.

Each agenda item now shows:

- A progress bar that fills as the item consumes its planned time: blue while on track, amber once 80% is used, red once the plan is exceeded.
- An "Over by mm:ss" badge when the item runs long, and a "mm:ss left" badge on the active item as it approaches its limit.
- A colour-coded elapsed clock with "of mm:ss planned" beneath it, and a card border that shifts from blue to amber to red.

The panel header gains agenda-wide planned vs actual totals with an overrun pill, and a single toast fires per item the moment it crosses its planned duration. All indicators recompute on the existing one-second tick, so they update live.

The pacing calculations live in a new `client/src/utils/agendaTiming.js` helper (`getItemTiming`, `summarizeAgendaTiming`) rather than inside the socket-backed component, which keeps them pure and unit-testable. Everything derives from the `duration` and `actualDuration` fields the timer already receives, so there are no API, model, or socket payload changes.

As the issue requests, this is presentation only: timer synchronisation, socket handling, and permission checks are untouched, and the Start / Stop / Skip controls behave exactly as before. Colours use the `dark:` variants already established in the component, so contrast holds in both themes.

### Files changed

- `client/src/utils/agendaTiming.js` (new) — pacing helpers.
- `client/src/utils/__tests__/agendaTiming.test.js` (new) — unit tests for those helpers.
- `client/src/components/meeting-details/AgendaTimer.jsx` — renders the indicators.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #918

## Testing

- 10 new unit tests in `client/src/utils/__tests__/agendaTiming.test.js` covering live vs recorded elapsed time, the 80% warning boundary, overrun amounts, progress capped at 100%, items with no planned duration, and agenda-wide totals. All pass.
- `npm run format:check:changed` passes.
- `npm run validate:pr` in `client/` (lint, format, build) passes with no new warnings.
- Verified in the browser with an agenda item running under, near, and over its planned time, in both light and dark mode.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed agenda timing indicators showing planned versus actual duration.
  * Added per-item progress, remaining time, exceeded time, and near-limit warnings.
  * Added overrun notifications for agenda items.
  * Added whole-agenda timing summaries, including total overruns and unplanned items.

* **Tests**
  * Added coverage for agenda timing, progress states, warnings, overruns, and empty agendas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->