### PR TITLE
feat(summaries): optimize meeting loading with server pagination

### DIFF
--- a/client/src/pages/Summaries.jsx
+++ b/client/src/pages/Summaries.jsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Navbar from "../components/Navbar.jsx";
+import Pagination from "../components/meetings/Pagination.jsx";
 import { meetingApi } from "../services";
-import AppContent from "../context/AppContent";
 import useExport from "../hooks/useExport.js";
 import { toast } from "react-toastify";
 import {
@@ -22,18 +22,30 @@ import {
 
 /**
  * Summaries.jsx
- * ✅ Displays all stored meeting summaries
- * ✅ Supports both text and voice search
- * ✅ "View" button and modal fully functional
+ * Displays meeting summaries with server-side pagination, search, and sorting.
+ * Supports text and voice search; pin/star remain local page preferences.
  */
+
+const PAGE_SIZE = 9;
+const SEARCH_DEBOUNCE_MS = 300;
 
 const Summaries = () => {
   const { t } = useTranslation();
   const [summaries, setSummaries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pagination, setPagination] = useState({
+    total: 0,
+    page: 1,
+    limit: PAGE_SIZE,
+    totalPages: 0,
+  });
   const [listening, setListening] = useState(false);
   const recognitionRef = useRef(null);
+  const pageCacheRef = useRef(new Map());
+  const requestIdRef = useRef(0);
 
   const [openMenuId, setOpenMenuId] = useState(null);
   const [viewModal, setViewModal] = useState(null);
@@ -41,6 +53,29 @@ const Summaries = () => {
   const [starredIds, setStarredIds] = useState([]);
   const [openExportMenuId, setOpenExportMenuId] = useState(null);
   const { exportMeeting, isExporting } = useExport();
+
+  const getCacheKey = useCallback(
+    (page, searchTerm) =>
+      `${page}|${PAGE_SIZE}|createdAt|desc|${searchTerm.trim().toLowerCase()}`,
+    [],
+  );
+
+  const invalidatePageCache = useCallback(() => {
+    pageCacheRef.current.clear();
+  }, []);
+
+  // Debounce search input → server query (reset page only when term changes)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const next = search.trim();
+      setDebouncedSearch((prev) => {
+        if (prev === next) return prev;
+        setCurrentPage(1);
+        return next;
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [search]);
 
   // Handle Escape key to close modal
   useEffect(() => {
@@ -53,7 +88,7 @@ const Summaries = () => {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // 🎙️ Setup browser-based voice recognition
+  // Setup browser-based voice recognition
   useEffect(() => {
     if ("webkitSpeechRecognition" in window || "SpeechRecognition" in window) {
       const SpeechRecognition =
@@ -99,37 +134,79 @@ const Summaries = () => {
     }
   };
 
-  // 🧠 Fetch all meeting summaries
-  useEffect(() => {
-    const fetchSummaries = async () => {
+  const fetchSummaries = useCallback(
+    async (page, searchTerm, { force = false } = {}) => {
+      const cacheKey = getCacheKey(page, searchTerm);
+      if (!force && pageCacheRef.current.has(cacheKey)) {
+        const cached = pageCacheRef.current.get(cacheKey);
+        setSummaries(cached.meetings);
+        setPagination(cached.pagination);
+        setLoading(false);
+        return;
+      }
+
+      const requestId = ++requestIdRef.current;
+      setLoading(true);
+
       try {
-        const res = await meetingApi.getAllMeetings();
+        const res = await meetingApi.getAllMeetings({
+          page,
+          limit: PAGE_SIZE,
+          search: searchTerm || undefined,
+          sortBy: "createdAt",
+          sortOrder: "desc",
+        });
+
+        if (requestId !== requestIdRef.current) return;
 
         if (res.data?.success) {
-          setSummaries(res.data.meetings || []);
+          const meetings = res.data.meetings || [];
+          const nextPagination = res.data.pagination || {
+            total: meetings.length,
+            page,
+            limit: PAGE_SIZE,
+            totalPages: 1,
+          };
+          pageCacheRef.current.set(cacheKey, {
+            meetings,
+            pagination: nextPagination,
+          });
+          setSummaries(meetings);
+          setPagination(nextPagination);
         } else {
           toast.error(res.data?.message || t("summaries.loadFailed"));
         }
       } catch (error) {
+        if (requestId !== requestIdRef.current) return;
         console.error("Error fetching summaries:", error);
         toast.error(t("summaries.loadFailed"));
       } finally {
-        setLoading(false);
+        if (requestId === requestIdRef.current) {
+          setLoading(false);
+        }
       }
-    };
-
-    fetchSummaries();
-  }, [t]);
-
-  // 🔍 Filter meetings by title or summary
-  const filteredSummaries = summaries.filter(
-    (m) =>
-      m.title?.toLowerCase().includes(search.toLowerCase()) ||
-      m.summary?.toLowerCase().includes(search.toLowerCase()),
+    },
+    [getCacheKey, t],
   );
 
-  // 📌 Sort meetings (Pinned > Starred > Default)
-  const sortedSummaries = [...filteredSummaries].sort((a, b) => {
+  useEffect(() => {
+    fetchSummaries(currentPage, debouncedSearch);
+  }, [currentPage, debouncedSearch, fetchSummaries]);
+
+  const handleSearchSubmit = () => {
+    const nextSearch = search.trim();
+    setDebouncedSearch(nextSearch);
+    setCurrentPage(1);
+    fetchSummaries(1, nextSearch, { force: true });
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  // Pin/star reorder only within the current page (local preference)
+  const sortedSummaries = [...summaries].sort((a, b) => {
     const aPinned = pinnedIds.includes(a._id);
     const bPinned = pinnedIds.includes(b._id);
     const aStarred = starredIds.includes(a._id);
@@ -142,7 +219,6 @@ const Summaries = () => {
     return 0;
   });
 
-  // ❌ Delete meeting
   const handleDelete = async (id) => {
     if (!window.confirm("Are you sure you want to delete this meeting?"))
       return;
@@ -151,10 +227,22 @@ const Summaries = () => {
       const res = await meetingApi.deleteMeeting(id);
 
       if (res.data?.success) {
-        setSummaries((prev) => prev.filter((s) => s._id !== id));
+        invalidatePageCache();
         setPinnedIds((prev) => prev.filter((pid) => pid !== id));
         setStarredIds((prev) => prev.filter((sid) => sid !== id));
         toast.success("Meeting deleted successfully");
+
+        const remainingOnPage = summaries.filter((s) => s._id !== id).length;
+        const nextPage =
+          remainingOnPage === 0 && currentPage > 1
+            ? currentPage - 1
+            : currentPage;
+
+        if (nextPage !== currentPage) {
+          setCurrentPage(nextPage);
+        } else {
+          await fetchSummaries(nextPage, debouncedSearch, { force: true });
+        }
       } else {
         toast.error(res.data?.message || "Failed to delete meeting");
       }
@@ -187,6 +275,8 @@ const Summaries = () => {
     exportMeeting(meeting, format);
   };
 
+  const emptyMessage = t("summaries.noSummaries");
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <Navbar />
@@ -205,7 +295,7 @@ const Summaries = () => {
             {t("dashboard.aiSummarizationDesc")}
           </p>
 
-          {/* 🔍 Search Bar with Voice + Text */}
+          {/* Search Bar with Voice + Text */}
           <div className="flex items-center justify-center mb-10">
             <div className="flex items-center w-full sm:w-[30rem] bg-white dark:bg-gray-800 shadow-sm border border-gray-200 dark:border-gray-700 rounded-full overflow-hidden hover:ring-2 hover:ring-blue-300 transition">
               <input
@@ -213,9 +303,11 @@ const Summaries = () => {
                 placeholder={t("summaries.searchPlaceholder")}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSearchSubmit();
+                }}
                 className="flex-grow px-4 py-2 text-sm text-gray-700 focus:outline-none bg-transparent dark:text-gray-200"
               />
-              {/* 🎤 Voice Search Button */}
               <button
                 onClick={handleVoiceSearch}
                 className={`px-3 py-2 border-l border-gray-200 transition flex items-center justify-center ${
@@ -228,10 +320,9 @@ const Summaries = () => {
                 {listening ? <MicOff size={18} /> : <Mic size={18} />}
               </button>
 
-              {/* Search Button */}
               <button
                 className="bg-blue-600 text-white px-4 py-2 rounded-r-full hover:bg-blue-700 transition flex items-center gap-2"
-                onClick={() => toast.info("Search updated")}
+                onClick={handleSearchSubmit}
               >
                 <Search size={16} /> {t("common.search")}
               </button>
@@ -245,173 +336,180 @@ const Summaries = () => {
               {t("summaries.loading")}
             </div>
           ) : sortedSummaries.length > 0 ? (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center">
-              {sortedSummaries.map((summary) => (
-                <div
-                  key={summary._id}
-                  className="bg-white dark:bg-gray-800 w-full max-w-sm rounded-2xl shadow-md hover:shadow-lg border border-gray-100 dark:border-gray-700 transition-all duration-300 p-6 text-left hover:-translate-y-1 relative"
-                >
-                  {/* Top indicators */}
-                  <div className="absolute top-3 left-3 flex gap-2">
-                    {pinnedIds.includes(summary._id) && (
-                      <span className="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full flex items-center gap-1">
-                        <Pin size={12} /> {t("summaries.pin")}
-                      </span>
-                    )}
-                    {starredIds.includes(summary._id) && (
-                      <span className="text-yellow-500">
-                        <Star size={16} fill="currentColor" />
-                      </span>
-                    )}
-                  </div>
+            <>
+              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center">
+                {sortedSummaries.map((summary) => (
+                  <div
+                    key={summary._id}
+                    data-testid="summary-card"
+                    className="bg-white dark:bg-gray-800 w-full max-w-sm rounded-2xl shadow-md hover:shadow-lg border border-gray-100 dark:border-gray-700 transition-all duration-300 p-6 text-left hover:-translate-y-1 relative"
+                  >
+                    {/* Top indicators */}
+                    <div className="absolute top-3 left-3 flex gap-2">
+                      {pinnedIds.includes(summary._id) && (
+                        <span className="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded-full flex items-center gap-1">
+                          <Pin size={12} /> {t("summaries.pin")}
+                        </span>
+                      )}
+                      {starredIds.includes(summary._id) && (
+                        <span className="text-yellow-500">
+                          <Star size={16} fill="currentColor" />
+                        </span>
+                      )}
+                    </div>
 
-                  {/* Three Dots Menu */}
-                  <div className="absolute top-3 right-3">
-                    <button
-                      onClick={() =>
-                        setOpenMenuId(
-                          openMenuId === summary._id ? null : summary._id,
-                        )
-                      }
-                      className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition"
-                    >
-                      <MoreVertical
-                        size={20}
-                        className="text-gray-600 dark:text-gray-400"
-                      />
-                    </button>
-
-                    {openMenuId === summary._id && (
-                      <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 z-10">
-                        <button
-                          onClick={() => setViewModal(summary)}
-                          className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
-                        >
-                          <FileText size={16} /> {t("summaries.view")}
-                        </button>
-                        <button
-                          onClick={() => handleCopy(summary)}
-                          className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
-                        >
-                          <Copy size={16} /> {t("summaries.copy")}
-                        </button>
-                        <button
-                          onClick={() => toggleStar(summary._id)}
-                          className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
-                        >
-                          <Star size={16} />{" "}
-                          {starredIds.includes(summary._id)
-                            ? t("summaries.unstar")
-                            : t("summaries.star")}
-                        </button>
-                        <button
-                          onClick={() => togglePin(summary._id)}
-                          className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
-                        >
-                          <Pin size={16} />{" "}
-                          {pinnedIds.includes(summary._id)
-                            ? t("summaries.unpin")
-                            : t("summaries.pin")}
-                        </button>
-                        <button
-                          onClick={() => handleDelete(summary._id)}
-                          className="w-full text-left px-4 py-2 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2 text-sm text-red-600 dark:text-red-400 rounded-b-lg"
-                        >
-                          <Trash2 size={16} /> {t("summaries.delete")}
-                        </button>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="flex items-center gap-3 mb-3 mt-8">
-                    <FileText className="w-6 h-6 text-indigo-600" />
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
-                      {summary.title || t("aiSearch.untitledMeeting")}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-gray-500 mb-3">
-                    {summary.createdAt
-                      ? new Date(summary.createdAt).toLocaleString()
-                      : t("aiSearch.unknown")}
-                  </p>
-                  <p className="text-gray-700 dark:text-gray-300 text-sm line-clamp-5 whitespace-pre-wrap">
-                    {summary.summary ||
-                      (summary.transcript
-                        ? `${summary.transcript.slice(0, 200)}...`
-                        : t("aiSearch.noSummary"))}
-                  </p>
-
-                  <div className="flex gap-3 mt-4">
-                    <button
-                      onClick={() => setViewModal(summary)}
-                      className="text-sm px-4 py-1.5 rounded-md border border-gray-300 text-gray-700 dark:text-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    >
-                      {t("summaries.view")}
-                    </button>
-
-                    <div
-                      className="relative ml-auto"
-                      onMouseEnter={() => setOpenExportMenuId(summary._id)}
-                      onMouseLeave={() => setOpenExportMenuId(null)}
-                    >
+                    {/* Three Dots Menu */}
+                    <div className="absolute top-3 right-3">
                       <button
                         onClick={() =>
-                          setOpenExportMenuId(
-                            openExportMenuId === summary._id
-                              ? null
-                              : summary._id,
+                          setOpenMenuId(
+                            openMenuId === summary._id ? null : summary._id,
                           )
                         }
-                        disabled={isExporting}
-                        className="text-sm px-4 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition"
                       >
-                        <Download size={16} />{" "}
-                        {isExporting && openExportMenuId === summary._id
-                          ? "Exporting..."
-                          : t("summaries.export")}
+                        <MoreVertical
+                          size={20}
+                          className="text-gray-600 dark:text-gray-400"
+                        />
                       </button>
 
-                      {openExportMenuId === summary._id && (
-                        <div className="absolute right-0 bottom-full mb-2 bg-white dark:bg-gray-700 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 py-1 z-20 min-w-[140px]">
+                      {openMenuId === summary._id && (
+                        <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 z-10">
                           <button
-                            onClick={() => {
-                              handleExport(summary, "pdf");
-                              setOpenExportMenuId(null);
-                            }}
-                            className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            onClick={() => setViewModal(summary)}
+                            className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
                           >
-                            Export as PDF
+                            <FileText size={16} /> {t("summaries.view")}
                           </button>
                           <button
-                            onClick={() => {
-                              handleExport(summary, "docx");
-                              setOpenExportMenuId(null);
-                            }}
-                            className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            onClick={() => handleCopy(summary)}
+                            className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
                           >
-                            Export as DOCX
+                            <Copy size={16} /> {t("summaries.copy")}
                           </button>
                           <button
-                            onClick={() => {
-                              handleExport(summary, "md");
-                              setOpenExportMenuId(null);
-                            }}
-                            className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            onClick={() => toggleStar(summary._id)}
+                            className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
                           >
-                            Export as MD
+                            <Star size={16} />{" "}
+                            {starredIds.includes(summary._id)
+                              ? t("summaries.unstar")
+                              : t("summaries.star")}
+                          </button>
+                          <button
+                            onClick={() => togglePin(summary._id)}
+                            className="w-full text-left px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                          >
+                            <Pin size={16} />{" "}
+                            {pinnedIds.includes(summary._id)
+                              ? t("summaries.unpin")
+                              : t("summaries.pin")}
+                          </button>
+                          <button
+                            onClick={() => handleDelete(summary._id)}
+                            className="w-full text-left px-4 py-2 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2 text-sm text-red-600 dark:text-red-400 rounded-b-lg"
+                          >
+                            <Trash2 size={16} /> {t("summaries.delete")}
                           </button>
                         </div>
                       )}
                     </div>
+
+                    <div className="flex items-center gap-3 mb-3 mt-8">
+                      <FileText className="w-6 h-6 text-indigo-600" />
+                      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate">
+                        {summary.title || t("aiSearch.untitledMeeting")}
+                      </h3>
+                    </div>
+                    <p className="text-sm text-gray-500 mb-3">
+                      {summary.createdAt
+                        ? new Date(summary.createdAt).toLocaleString()
+                        : t("aiSearch.unknown")}
+                    </p>
+                    <p className="text-gray-700 dark:text-gray-300 text-sm line-clamp-5 whitespace-pre-wrap">
+                      {summary.summary ||
+                        (summary.transcript
+                          ? `${summary.transcript.slice(0, 200)}...`
+                          : t("aiSearch.noSummary"))}
+                    </p>
+
+                    <div className="flex gap-3 mt-4">
+                      <button
+                        onClick={() => setViewModal(summary)}
+                        className="text-sm px-4 py-1.5 rounded-md border border-gray-300 text-gray-700 dark:text-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+                      >
+                        {t("summaries.view")}
+                      </button>
+
+                      <div
+                        className="relative ml-auto"
+                        onMouseEnter={() => setOpenExportMenuId(summary._id)}
+                        onMouseLeave={() => setOpenExportMenuId(null)}
+                      >
+                        <button
+                          onClick={() =>
+                            setOpenExportMenuId(
+                              openExportMenuId === summary._id
+                                ? null
+                                : summary._id,
+                            )
+                          }
+                          disabled={isExporting}
+                          className="text-sm px-4 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <Download size={16} />{" "}
+                          {isExporting && openExportMenuId === summary._id
+                            ? "Exporting..."
+                            : t("summaries.export")}
+                        </button>
+
+                        {openExportMenuId === summary._id && (
+                          <div className="absolute right-0 bottom-full mb-2 bg-white dark:bg-gray-700 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 py-1 z-20 min-w-[140px]">
+                            <button
+                              onClick={() => {
+                                handleExport(summary, "pdf");
+                                setOpenExportMenuId(null);
+                              }}
+                              className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            >
+                              Export as PDF
+                            </button>
+                            <button
+                              onClick={() => {
+                                handleExport(summary, "docx");
+                                setOpenExportMenuId(null);
+                              }}
+                              className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            >
+                              Export as DOCX
+                            </button>
+                            <button
+                              onClick={() => {
+                                handleExport(summary, "md");
+                                setOpenExportMenuId(null);
+                              }}
+                              className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-600 flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200"
+                            >
+                              Export as MD
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+
+              <Pagination
+                currentPage={pagination.page || currentPage}
+                totalPages={pagination.totalPages || 0}
+                onPageChange={handlePageChange}
+              />
+            </>
           ) : (
             <div className="bg-white dark:bg-gray-800 p-10 rounded-2xl shadow-md border border-gray-100 dark:border-gray-700">
-              <p className="text-gray-500 dark:text-gray-400">
-                {t("summaries.noSummaries")}
-              </p>
+              <p className="text-gray-500 dark:text-gray-400">{emptyMessage}</p>
             </div>
           )}
         </div>

--- a/client/src/pages/__tests__/Summaries.test.jsx
+++ b/client/src/pages/__tests__/Summaries.test.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import Summaries from "../Summaries";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key, fallback) => fallback || key,
+  }),
+}));
+
+vi.mock("../../hooks/useExport.js", () => ({
+  default: () => ({
+    exportMeeting: vi.fn(),
+    isExporting: false,
+  }),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const getAllMeetings = vi.fn();
+const deleteMeeting = vi.fn();
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getAllMeetings: (...args) => getAllMeetings(...args),
+    deleteMeeting: (...args) => deleteMeeting(...args),
+  },
+}));
+
+const meetingPage = (page, total = 20) => ({
+  data: {
+    success: true,
+    meetings: Array.from({ length: 9 }, (_, i) => ({
+      _id: `m-${page}-${i}`,
+      title: `Meeting ${page}-${i}`,
+      summary: `Summary for page ${page} item ${i}`,
+      createdAt: new Date("2024-01-15T10:00:00Z").toISOString(),
+    })),
+    pagination: {
+      total,
+      page,
+      limit: 9,
+      totalPages: Math.ceil(total / 9),
+    },
+  },
+});
+
+describe("Summaries page server-side loading (#909)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllMeetings.mockImplementation(({ page = 1 } = {}) =>
+      Promise.resolve(meetingPage(page)),
+    );
+  });
+
+  it("loads the first page from the API with pagination params", async () => {
+    render(
+      <MemoryRouter>
+        <Summaries />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(getAllMeetings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: 1,
+          limit: 9,
+          sortBy: "createdAt",
+          sortOrder: "desc",
+        }),
+      );
+    });
+
+    expect(await screen.findAllByTestId("summary-card")).toHaveLength(9);
+    expect(screen.getByText("Meeting 1-0")).toBeInTheDocument();
+  });
+
+  it("requests the next page from the server when pagination is used", async () => {
+    render(
+      <MemoryRouter>
+        <Summaries />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Meeting 1-0");
+
+    const page2 = await screen.findByRole("button", { name: "2" });
+    fireEvent.click(page2);
+
+    await waitFor(() => {
+      expect(getAllMeetings).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, limit: 9 }),
+      );
+    });
+
+    expect(await screen.findByText("Meeting 2-0")).toBeInTheDocument();
+  });
+
+  it("sends search to the backend instead of filtering only in memory", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    render(
+      <MemoryRouter>
+        <Summaries />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getAllMeetings).toHaveBeenCalled());
+
+    const input = screen.getByPlaceholderText("summaries.searchPlaceholder");
+    fireEvent.change(input, { target: { value: "quarterly" } });
+
+    await vi.advanceTimersByTimeAsync(350);
+
+    await waitFor(() => {
+      expect(getAllMeetings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: 1,
+          search: "quarterly",
+          sortBy: "createdAt",
+          sortOrder: "desc",
+        }),
+      );
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("reuses cached page results without an extra network request", async () => {
+    render(
+      <MemoryRouter>
+        <Summaries />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Meeting 1-0");
+
+    fireEvent.click(await screen.findByRole("button", { name: "2" }));
+    await screen.findByText("Meeting 2-0");
+
+    getAllMeetings.mockClear();
+
+    fireEvent.click(await screen.findByRole("button", { name: "1" }));
+    expect(await screen.findByText("Meeting 1-0")).toBeInTheDocument();
+
+    expect(getAllMeetings).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/validation/run-server-related-tests.mjs
+++ b/scripts/validation/run-server-related-tests.mjs
@@ -20,6 +20,7 @@ const VITEST_TEST_FILES = new Set([
   "server/tests/transcriptController.test.js",
   "server/tests/meetingDigestService.test.js",
   "server/tests/imageUrl.test.js",
+  "server/tests/MeetingService.test.js",
 ]);
 const JEST_RELATED_IGNORE = [
   "tests/integration.test.js",
@@ -42,14 +43,25 @@ const vitestOwnedSources = new Set([
   "server/controllers/organizationController.js",
   "server/controllers/knowledgeController.js",
   "server/controllers/transcriptController.js",
+  "server/controllers/meetingController.js",
   "server/services/meetingDigestService.js",
+  "server/services/MeetingService.js",
+  "server/services/MeetingStorageService.js",
   "server/utils/imageUrl.js",
 ]);
+const VITEST_SOURCE_TEST_MAP = {
+  "server/controllers/meetingController.js":
+    "server/tests/MeetingService.test.js",
+  "server/services/MeetingService.js": "server/tests/MeetingService.test.js",
+  "server/services/MeetingStorageService.js":
+    "server/tests/MeetingService.test.js",
+};
 const vitestTests = [
   ...directTests.filter((file) => VITEST_TEST_FILES.has(file)),
   ...sourceFiles
     .filter((file) => vitestOwnedSources.has(file))
     .map((file) => {
+      if (VITEST_SOURCE_TEST_MAP[file]) return VITEST_SOURCE_TEST_MAP[file];
       const base = file.split("/").pop().replace(/\.js$/, "");
       return `server/tests/${base}.test.js`;
     })

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -119,6 +119,13 @@ const getAllMeetingsQuerySchema = z.object({
     }),
   search: z.string().optional(),
   meetingType: z.string().optional(),
+  sortBy: z
+    .enum(["createdAt", "title", "date"])
+    .optional()
+    .default("createdAt"),
+  sortOrder: z.enum(["asc", "desc"]).optional().default("desc"),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
   includeArchived: z
     .string()
     .optional()

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --ci tests/integration.test.js",
     "test:related:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand --passWithNoTests --findRelatedTests",
     "test:related:vitest": "vitest related",
-    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js",
+    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/MeetingService.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js",
     "test:related": "node ../scripts/validation/run-server-related-tests.mjs",
     "validate": "node ../scripts/validation/validate-server-changed.mjs",
     "validate:changed": "node ../scripts/validation/validate-server-changed.mjs",

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -425,6 +425,11 @@ export const generateMeetingMoM = async (
   };
 };
 
+const MEETING_LIST_SORT_FIELDS = new Set(["createdAt", "title", "date"]);
+
+const escapeRegex = (value) =>
+  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 export const getAllMeetings = async (userId, orgId, queryParams = {}) => {
   const {
     page = 1,
@@ -432,29 +437,60 @@ export const getAllMeetings = async (userId, orgId, queryParams = {}) => {
     startDate,
     endDate,
     includeArchived,
+    search,
+    meetingType,
+    sortBy = "createdAt",
+    sortOrder = "desc",
   } = queryParams;
 
-  const queryOptions = [{ uploadedBy: userId }];
-  if (orgId) {
-    queryOptions.push({ organization: orgId });
-  }
+  const filters = [];
 
-  const query = { $or: queryOptions };
+  const ownershipOptions = [{ uploadedBy: userId }];
+  if (orgId) {
+    ownershipOptions.push({ organization: orgId });
+  }
+  filters.push({ $or: ownershipOptions });
 
   if (!includeArchived) {
-    query.archived = { $ne: true };
+    filters.push({ archived: { $ne: true } });
   }
 
   if (startDate || endDate) {
-    query.date = {};
-    if (startDate) query.date.$gte = new Date(startDate);
-    if (endDate) query.date.$lte = new Date(endDate);
+    const dateFilter = {};
+    if (startDate) dateFilter.$gte = new Date(startDate);
+    if (endDate) dateFilter.$lte = new Date(endDate);
+    filters.push({ date: dateFilter });
   }
 
-  const skip = (parseInt(page) - 1) * parseInt(limit);
+  if (meetingType) {
+    filters.push({ meetingType });
+  }
+
+  const searchTerm = typeof search === "string" ? search.trim() : "";
+  if (searchTerm) {
+    const escaped = escapeRegex(searchTerm);
+    filters.push({
+      $or: [
+        { title: { $regex: escaped, $options: "i" } },
+        { summary: { $regex: escaped, $options: "i" } },
+      ],
+    });
+  }
+
+  const query = filters.length === 1 ? filters[0] : { $and: filters };
+
+  const resolvedSortBy = MEETING_LIST_SORT_FIELDS.has(sortBy)
+    ? sortBy
+    : "createdAt";
+  const sortDirection = sortOrder === "asc" ? 1 : -1;
+  const sort = { [resolvedSortBy]: sortDirection };
+
+  const pageNum = parseInt(page, 10);
+  const limitNum = parseInt(limit, 10);
+  const skip = (pageNum - 1) * limitNum;
 
   const [meetings, total] = await Promise.all([
-    MeetingStorageService.getMeetingsQuery(query, skip, parseInt(limit)),
+    MeetingStorageService.getMeetingsQuery(query, skip, limitNum, sort),
     MeetingStorageService.countMeetingsQuery(query),
   ]);
 
@@ -462,9 +498,9 @@ export const getAllMeetings = async (userId, orgId, queryParams = {}) => {
     meetings,
     pagination: {
       total,
-      page: parseInt(page),
-      limit: parseInt(limit),
-      totalPages: Math.ceil(total / parseInt(limit)),
+      page: pageNum,
+      limit: limitNum,
+      totalPages: Math.ceil(total / limitNum) || 0,
     },
   };
 };

--- a/server/services/MeetingStorageService.js
+++ b/server/services/MeetingStorageService.js
@@ -12,9 +12,14 @@ export const findMeetingByQuery = async (query) => {
   return await Meeting.findOne(query);
 };
 
-export const getMeetingsQuery = async (query, skip, limit) => {
+export const getMeetingsQuery = async (
+  query,
+  skip,
+  limit,
+  sort = { createdAt: -1 },
+) => {
   return await Meeting.find(query)
-    .sort({ createdAt: -1 })
+    .sort(sort)
     .skip(skip)
     .limit(limit)
     .select(

--- a/server/tests/MeetingService.test.js
+++ b/server/tests/MeetingService.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/userModel.js", () => ({ default: {} }));
+vi.mock("../models/membershipModel.js", () => ({ default: {} }));
+vi.mock("../models/tagModel.js", () => ({ default: {} }));
+vi.mock("../services/graphSnapshotService.js", () => ({
+  captureSnapshot: vi.fn(),
+}));
+vi.mock("../services/eventBus.js", () => ({
+  default: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock("../services/MeetingStorageService.js", () => ({
+  createMeetingRecord: vi.fn(),
+  findMeetingById: vi.fn(),
+  findMeetingByQuery: vi.fn(),
+  getMeetingsQuery: vi.fn(),
+  countMeetingsQuery: vi.fn(),
+  deleteMeetingById: vi.fn(),
+  searchMeetingsRecords: vi.fn(),
+}));
+
+import * as MeetingStorageService from "../services/MeetingStorageService.js";
+import { getAllMeetings } from "../services/MeetingService.js";
+
+describe("getAllMeetings pagination, search, and sorting (#909)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    MeetingStorageService.getMeetingsQuery.mockResolvedValue([]);
+    MeetingStorageService.countMeetingsQuery.mockResolvedValue(0);
+  });
+
+  it("paginates with skip/limit and default createdAt desc sort", async () => {
+    MeetingStorageService.getMeetingsQuery.mockResolvedValue([
+      { _id: "m1", title: "One" },
+    ]);
+    MeetingStorageService.countMeetingsQuery.mockResolvedValue(25);
+
+    const result = await getAllMeetings("user-1", "org-1", {
+      page: 2,
+      limit: 10,
+    });
+
+    expect(MeetingStorageService.getMeetingsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $and: expect.any(Array),
+      }),
+      10,
+      10,
+      { createdAt: -1 },
+    );
+    expect(result.pagination).toEqual({
+      total: 25,
+      page: 2,
+      limit: 10,
+      totalPages: 3,
+    });
+    expect(result.meetings).toHaveLength(1);
+  });
+
+  it("applies case-insensitive title/summary search on the server", async () => {
+    await getAllMeetings("user-1", "org-1", {
+      page: 1,
+      limit: 9,
+      search: "budget*",
+    });
+
+    const [query] = MeetingStorageService.getMeetingsQuery.mock.calls[0];
+    expect(query).toEqual(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          {
+            $or: [
+              { title: { $regex: "budget\\*", $options: "i" } },
+              { summary: { $regex: "budget\\*", $options: "i" } },
+            ],
+          },
+        ]),
+      }),
+    );
+    expect(MeetingStorageService.countMeetingsQuery).toHaveBeenCalledWith(
+      query,
+    );
+  });
+
+  it("filters by meetingType when provided", async () => {
+    await getAllMeetings("user-1", null, {
+      meetingType: "standup",
+      page: 1,
+      limit: 10,
+    });
+
+    const [query] = MeetingStorageService.getMeetingsQuery.mock.calls[0];
+    expect(query.$and).toEqual(
+      expect.arrayContaining([{ meetingType: "standup" }]),
+    );
+  });
+
+  it("supports title ascending sort", async () => {
+    await getAllMeetings("user-1", "org-1", {
+      sortBy: "title",
+      sortOrder: "asc",
+      page: 1,
+      limit: 5,
+    });
+
+    expect(MeetingStorageService.getMeetingsQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      0,
+      5,
+      { title: 1 },
+    );
+  });
+
+  it("falls back to createdAt desc for unknown sort fields", async () => {
+    await getAllMeetings("user-1", "org-1", {
+      sortBy: "not-a-field",
+      sortOrder: "desc",
+    });
+
+    expect(MeetingStorageService.getMeetingsQuery).toHaveBeenCalledWith(
+      expect.any(Object),
+      0,
+      10,
+      { createdAt: -1 },
+    );
+  });
+});


### PR DESCRIPTION
## Description

Optimizes the Summaries page by replacing client-side loading, filtering, and sorting of all meetings with efficient server-side pagination, search, and sorting.

### Changes

- Refactored the Summaries page to request meetings page-by-page using the existing API.
- Added debounced server-side search and backend-driven sorting.
- Reused the existing pagination component for navigation.
- Added an in-memory page cache to avoid unnecessary refetches when revisiting pages.
- Extended the existing meetings endpoint to support search, sorting, and additional filters while maintaining backward compatibility.
- Added regression tests covering client pagination/search behavior and backend pagination/filtering/sorting.

## Related Issue

Closes #909

## Type of Change

- [x] Performance improvement
- [x] Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Testing

Validated locally:

- ✅ Prettier
- ✅ ESLint
- ✅ Client Summaries tests (4/4 passing)
- ✅ Server MeetingService tests (5/5 passing)
- ✅ Client related tests
- ✅ Server related tests
- ✅ Client PR validation
- ✅ Server PR validation
- ✅ Production client build

## Checklist

- [x] Code follows project conventions
- [x] Existing summary functionality preserved
- [x] Server-side pagination, search, and sorting implemented
- [x] Regression tests added
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Summaries page now uses server-side pagination with debounced search
  * Search submits via Enter key or Search button
  * Sorting and meeting-type filtering now available
  * Page caching prevents redundant requests when navigating

* **Tests**
  * Added comprehensive tests for pagination and search functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->