### PR TITLE
perf: batch process expired poll cleanup

### DIFF
--- a/server/jobs/pollExpirationJob.js
+++ b/server/jobs/pollExpirationJob.js
@@ -1,47 +1,69 @@
 import cron from "node-cron";
 import Poll from "../models/pollModel.js";
 
-const startPollExpirationJob = (io) => {
+/**
+ * Processes expired polls in configurable batches to prevent high memory usage.
+ * @param {object} io - Socket.io server instance
+ * @param {number} batchSize - Maximum number of polls to query per batch (default: 100)
+ * @returns {Promise<number>} Total number of expired polls processed
+ */
+export const processExpiredPollsBatch = async (io, batchSize = 100) => {
+  const now = new Date();
+  let totalProcessed = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const expiredPolls = await Poll.find({
+      isClosed: false,
+      expiresAt: { $lte: now },
+    }).limit(batchSize);
+
+    if (!expiredPolls || expiredPolls.length === 0) {
+      hasMore = false;
+      break;
+    }
+
+    for (const poll of expiredPolls) {
+      poll.isClosed = true;
+      const closedPoll = await poll.save();
+      await closedPoll.populate("createdBy", "name email profilePicture");
+      if (!poll.isAnonymous) {
+        await closedPoll.populate("options.votes", "name email profilePicture");
+      }
+
+      // Format for response if anonymous
+      let pollResponse = closedPoll;
+      if (poll.isAnonymous) {
+        const pollObj = closedPoll.toObject
+          ? closedPoll.toObject()
+          : closedPoll;
+        pollObj.options = pollObj.options.map((option) => ({
+          ...option,
+          voteCount: option.votes ? option.votes.length : 0,
+          votes: [],
+        }));
+        pollResponse = pollObj;
+      }
+
+      if (io) {
+        io.to(poll.meeting.toString()).emit("poll:closed", pollResponse);
+      }
+      totalProcessed++;
+    }
+
+    if (expiredPolls.length < batchSize) {
+      hasMore = false;
+    }
+  }
+
+  return totalProcessed;
+};
+
+const startPollExpirationJob = (io, batchSize = 100) => {
   // Run every 5 minutes
   cron.schedule("*/5 * * * *", async () => {
     try {
-      // Find all polls that are not closed and have expired
-      const expiredPolls = await Poll.find({
-        isClosed: false,
-        expiresAt: { $lte: new Date() },
-      });
-
-      if (expiredPolls.length === 0) return;
-
-      for (const poll of expiredPolls) {
-        poll.isClosed = true;
-        const closedPoll = await poll.save();
-        await closedPoll.populate("createdBy", "name email profilePicture");
-        if (!poll.isAnonymous) {
-          await closedPoll.populate(
-            "options.votes",
-            "name email profilePicture",
-          );
-        }
-
-        // Format for response if anonymous
-        let pollResponse = closedPoll;
-        if (poll.isAnonymous) {
-          const pollObj = closedPoll.toObject
-            ? closedPoll.toObject()
-            : closedPoll;
-          pollObj.options = pollObj.options.map((option) => ({
-            ...option,
-            voteCount: option.votes.length,
-            votes: [],
-          }));
-          pollResponse = pollObj;
-        }
-
-        if (io) {
-          io.to(poll.meeting.toString()).emit("poll:closed", pollResponse);
-        }
-      }
+      await processExpiredPollsBatch(io, batchSize);
     } catch (error) {
       console.error("Error in poll expiration cron job:", error);
     }

--- a/server/tests/pollExpirationBatch.test.js
+++ b/server/tests/pollExpirationBatch.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+import Poll from "../models/pollModel.js";
+import { processExpiredPollsBatch } from "../jobs/pollExpirationJob.js";
+
+describe("Batch Process Expired Poll Cleanup (#829)", () => {
+  const dummyMeetingId = new mongoose.Types.ObjectId();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("processes expired polls in batches", async () => {
+    const mockIo = {
+      to: vi.fn().mockReturnThis(),
+      emit: vi.fn(),
+    };
+
+    const createMockPoll = (id) => ({
+      _id: id,
+      meeting: dummyMeetingId,
+      isClosed: false,
+      expiresAt: new Date(Date.now() - 10000),
+      isAnonymous: false,
+      save: vi.fn().mockImplementation(function () {
+        return Promise.resolve(this);
+      }),
+      populate: vi.fn().mockImplementation(function () {
+        return Promise.resolve(this);
+      }),
+      toObject: vi.fn().mockImplementation(function () {
+        return this;
+      }),
+    });
+
+    const batch1 = [createMockPoll("poll_1"), createMockPoll("poll_2")];
+    const batch2 = [createMockPoll("poll_3")];
+
+    let callCount = 0;
+    vi.spyOn(Poll, "find").mockImplementation(() => {
+      callCount++;
+      const results = callCount === 1 ? batch1 : callCount === 2 ? batch2 : [];
+      return {
+        limit: vi.fn().mockResolvedValue(results),
+      };
+    });
+
+    const totalProcessed = await processExpiredPollsBatch(mockIo, 2);
+
+    expect(totalProcessed).toBe(3);
+    expect(Poll.find).toHaveBeenCalledTimes(2);
+    expect(mockIo.to).toHaveBeenCalledWith(dummyMeetingId.toString());
+    expect(mockIo.emit).toHaveBeenCalledWith("poll:closed", expect.anything());
+  });
+
+  it("handles anonymous polls correctly during batch cleanup", async () => {
+    const mockIo = {
+      to: vi.fn().mockReturnThis(),
+      emit: vi.fn(),
+    };
+
+    const mockPoll = {
+      _id: "anon_poll_1",
+      meeting: dummyMeetingId,
+      isClosed: false,
+      expiresAt: new Date(Date.now() - 10000),
+      isAnonymous: true,
+      options: [
+        { text: "Option A", votes: ["user1", "user2"] },
+        { text: "Option B", votes: ["user3"] },
+      ],
+      save: vi.fn().mockImplementation(function () {
+        return Promise.resolve(this);
+      }),
+      populate: vi.fn().mockImplementation(function () {
+        return Promise.resolve(this);
+      }),
+      toObject: vi.fn().mockImplementation(function () {
+        return {
+          _id: this._id,
+          meeting: this.meeting,
+          isClosed: this.isClosed,
+          isAnonymous: this.isAnonymous,
+          options: this.options,
+        };
+      }),
+    };
+
+    vi.spyOn(Poll, "find").mockImplementation(() => ({
+      limit: vi.fn().mockResolvedValue([mockPoll]),
+    }));
+
+    const totalProcessed = await processExpiredPollsBatch(mockIo, 10);
+
+    expect(totalProcessed).toBe(1);
+    expect(mockPoll.save).toHaveBeenCalled();
+    expect(mockIo.emit).toHaveBeenCalledWith(
+      "poll:closed",
+      expect.objectContaining({
+        options: [
+          { text: "Option A", votes: [], voteCount: 2 },
+          { text: "Option B", votes: [], voteCount: 1 },
+        ],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# ⚡ Batch Process Expired Poll Cleanup

Fixes #829

## 📌 Overview
The poll expiration cron job (`server/jobs/pollExpirationJob.js`) previously executed a single un-paginated query `Poll.find({ isClosed: false, expiresAt: { $lte: new Date() } })` fetching all expired polls into memory at once. As dataset sizes grow, this increases memory consumption and execution time.

## 🛠️ Changes Made
- Created `processExpiredPollsBatch(io, batchSize = 100)` in [pollExpirationJob.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/jobs/pollExpirationJob.js) to query and process expired polls in configurable batches (`limit(batchSize)`).
- Loop through available expired poll batches until no remaining expired polls exist for the run.
- Preserved existing poll closing logic: updating `isClosed = true`, populating `createdBy` and `options.votes`, stripping voter identity for anonymous polls, and emitting `poll:closed` via Socket.IO.
- Added unit test suite in `server/tests/pollExpirationBatch.test.js` to verify batch processing and anonymous poll formatting.

## 🧪 Acceptance Criteria Verification
- [x] **Expired polls are processed in batches:** Verified batch querying with batch limits.
- [x] **Memory usage is reduced:** Avoids loading large arrays of expired poll documents into Node process memory simultaneously.
- [x] **Existing expiration logic remains correct:** Verified Socket.IO emissions and anonymous voter stripping behave identically.

## 🔬 Testing
- Ran unit tests for batch poll cleanup:
  ```bash
  npm test tests/pollExpirationBatch.test.js
