### PR TITLE
fix(queue): make background jobs durable across transient failures and deploys (#975)

### DIFF
--- a/docs/background-job-durability.md
+++ b/docs/background-job-durability.md
@@ -1,0 +1,135 @@
+# Background Job Durability
+
+How MeetOnMemory guarantees that queued background work survives transient
+failures and deploys. Added in response to [#975](https://github.com/imuniqueshiv/MeetOnMemory/issues/975).
+
+## The problem this replaced
+
+Every BullMQ queue used to be constructed as `new Queue(name, { connection })`
+with no `defaultJobOptions`. BullMQ's own default is `attempts: 1`, so **any**
+throw — a Redis blip, a Mongo failover, a Gemini `429` — permanently destroyed
+the job. Nothing retried it, nothing recorded that it had vanished, and the user
+was left with a spinner that never resolved.
+
+Separately, `SIGTERM` only called `server.close()`, which stops the HTTP listener
+and nothing else. In-flight jobs were killed mid-execution on every deploy and,
+with `attempts: 1`, were never re-delivered.
+
+## The model
+
+### One factory, one policy
+
+All queues are created through `getQueue(name)` in
+`server/services/queueService.js`, which applies the defaults resolved by
+`server/services/queueRegistry.js`. A new queue is one entry in
+`QUEUE_DEFINITIONS` and it cannot accidentally ship without a retry policy.
+
+Defaults (`BASE_JOB_OPTIONS`):
+
+| Option             | Value                 | Why                                                                                 |
+| ------------------ | --------------------- | ----------------------------------------------------------------------------------- |
+| `attempts`         | `3`                   | Matches what `webhookDispatcherService` and `MeetingService` already chose by hand. |
+| `backoff`          | exponential, `5000ms` | A retry storm against a rate-limited provider makes things worse, not better.       |
+| `removeOnComplete` | 100 jobs / 24h        | Enough history to debug; bounded so Redis can't grow without limit.                 |
+| `removeOnFail`     | 500 jobs / 7d         | Failures are what an operator needs to see, so they're kept longer.                 |
+
+Retention matters more than it looks: `processAudioJob` payloads carry transcript
+text, and unbounded retention leaks them into the same Redis instance that backs
+the rate limiter (`middleware/rateLimiter.js`) and the Socket.IO adapter
+(`config/socket.js`). An OOM there takes all three down at once.
+
+### Per-queue overrides
+
+`QUEUE_DEFINITIONS` records the deviations and why:
+
+- `ai-mom-generation` — `attempts: 5`, `delay: 15000`. The most user-visible job
+  and the most likely to hit a provider rate limit; a longer backoff gives a
+  quota window time to reset.
+- `memory-lifecycle-queue` — `attempts: 2`. The sweep is idempotent and re-runs
+  on a schedule anyway, so a long retry tail buys nothing.
+- `webhook-dispatches` — `attempts: 5`, `delay: 2000`. Unchanged from the values
+  that were previously inline at the call site.
+
+Per-call overrides still work and win over the queue's defaults:
+
+```js
+await conflictScanQueue.add("scan", { organization }, { jobId: "…" });
+```
+
+`resolveJobOptions` merges `backoff` field-by-field, so a caller can override
+only `delay` without losing `type`. Retention accepts BullMQ's boolean, number
+and object forms; the non-object forms replace rather than merge, so an existing
+`removeOnComplete: true` still means exactly that.
+
+### Shutdown ordering
+
+`queueRegistry` tracks every queue, worker and shared Redis connection so
+`shutdownQueues()` can close them in dependency order:
+
+1. **workers** — `worker.close()` stops fetching new jobs and waits for in-flight
+   ones to finish;
+2. **queues** — producers only, safe once no worker is running;
+3. **connections** — last, because a draining job is still issuing Redis commands.
+
+Closing connections first (the naive ordering) makes in-flight jobs fail with a
+connection error — precisely the data loss this exists to prevent.
+
+`server/utils/gracefulShutdown.js` wraps that in the wider sequence:
+
+```
+SIGTERM → HTTP listener → Socket.IO → BullMQ workers → MongoDB → Redis → exit(0)
+```
+
+Each step is individually try/caught, so a failure in one does not leak the
+connections the later steps would have closed. Every close is also individually
+timeout-bounded, and the whole sequence has a hard deadline — if anything hangs,
+the process force-exits rather than waiting for the platform to `SIGKILL` it.
+
+Shutdown is idempotent: a second signal returns the in-flight promise instead of
+starting a second teardown.
+
+## Configuration
+
+| Variable                        | Default    | Effect                                                           |
+| ------------------------------- | ---------- | ---------------------------------------------------------------- |
+| `SHUTDOWN_TIMEOUT_MS`           | `30000`    | Hard deadline for the whole shutdown sequence before force-exit. |
+| `QUEUE_WORKER_CLOSE_TIMEOUT_MS` | `15000`    | Grace period for a single worker to finish its in-flight job.    |
+| `QUEUE_CLOSE_TIMEOUT_MS`        | `5000`     | Budget for closing one queue or one Redis connection.            |
+| `LIFECYCLE_SWEEP_INTERVAL_MS`   | `86400000` | Memory-lifecycle sweep interval (pre-existing).                  |
+
+Set `SHUTDOWN_TIMEOUT_MS` **below** your platform's `SIGTERM`→`SIGKILL` grace
+period (Kubernetes' `terminationGracePeriodSeconds`, Render's shutdown window),
+so the app always wins the race and gets to drain on its own terms.
+
+## Adding a new queue
+
+1. Add an entry to `QUEUE_DEFINITIONS` in `queueRegistry.js`, overriding only
+   what genuinely differs from the base policy.
+2. Export a facade with `createQueueFacade("your-queue-name")`.
+3. Add an `initYourWorker` that calls `createWorker({ … })` — registration for
+   shutdown is automatic.
+4. Add it to `startWorkers` in `config/workers.js`.
+
+## Behaviour without Redis
+
+Unchanged: when `REDIS_URI` is unset, `add()` logs a warning and resolves to
+`null`, workers do not start, and the app boots normally. This keeps
+frontend-only development working, and it is why the test suite
+(`tests/setup.js` deletes `REDIS_URI`) can exercise the policy and shutdown logic
+without any infrastructure.
+
+## Observability
+
+Worker logs now distinguish a retry from a final failure:
+
+```
+↻ AI Worker: job 42 failed attempt 1/5, will retry — 429 Too Many Requests
+❌ AI Worker: job 42 permanently failed after 5/5 attempts — 429 Too Many Requests
+⚠️ AI Worker: job 43 stalled and will be re-queued.
+```
+
+Previously every attempt logged an identical line, so a job about to be retried
+was indistinguishable from one that had been abandoned.
+
+`getQueueStatus()` returns the live queue/worker names and whether a shutdown is
+in progress.

--- a/server/config/workers.js
+++ b/server/config/workers.js
@@ -9,32 +9,74 @@ import {
 } from "../services/queueService.js";
 import { initWebhookWorker } from "../services/webhookDispatcherService.js";
 
-export function startWorkers(app) {
+/**
+ * Boots every background service.
+ *
+ * Issue #975: `safeInit` was declared `async` but called without `await`, so its
+ * try/catch could never actually catch anything an initializer rejected with —
+ * the rejection escaped as an unhandled promise rejection instead of producing
+ * the intended log line. Nothing recorded which workers came up either, so a
+ * worker that silently failed to start was indistinguishable from one that was
+ * processing normally.
+ *
+ * Now every initializer is awaited and the outcome is summarised, so a failed
+ * worker is visible in the boot logs instead of being discovered later via jobs
+ * that never complete.
+ *
+ * Initialization is sequential on purpose: these share Redis connections and the
+ * log output is far easier to read when it isn't interleaved. The total cost is
+ * a handful of milliseconds at boot.
+ *
+ * @param {import("express").Express} app
+ * @returns {Promise<{started: string[], failed: {name: string, error: string}[]}>}
+ */
+export async function startWorkers(app) {
+  const started = [];
+  const failed = [];
+
   const safeInit = async (name, initFn) => {
     try {
       await initFn();
+      started.push(name);
     } catch (err) {
+      const error = err?.message || String(err);
+      failed.push({ name, error });
       console.error(
         `⚠️ Failed to initialize background service "${name}":`,
-        err.message || err,
+        error,
       );
     }
   };
 
-  safeInit("Redis", () => initRedis());
-  safeInit("AI Worker", () => initAIWorker(app));
-  safeInit("Data Export Worker", () => initDataExportWorker(app));
-  safeInit("Conflict Scan Worker", () => initConflictScanWorker(app));
-  safeInit("Webhook Worker", () => initWebhookWorker());
-  safeInit("Sentiment Worker", () => initSentimentWorker(app));
-  safeInit("Recalculate Importance Worker", () =>
+  await safeInit("Redis", () => initRedis());
+  await safeInit("AI Worker", () => initAIWorker(app));
+  await safeInit("Data Export Worker", () => initDataExportWorker(app));
+  await safeInit("Conflict Scan Worker", () => initConflictScanWorker(app));
+  await safeInit("Webhook Worker", () => initWebhookWorker());
+  await safeInit("Sentiment Worker", () => initSentimentWorker(app));
+  await safeInit("Recalculate Importance Worker", () =>
     initRecalculateImportanceWorker(app),
   );
-  safeInit("Memory Lifecycle Worker", () => initMemoryLifecycleWorker(app));
+  await safeInit("Memory Lifecycle Worker", () =>
+    initMemoryLifecycleWorker(app),
+  );
 
-  import("../utils/embeddingUtils.js")
-    .then(({ preWarmPinecone }) => {
-      safeInit("Pinecone DB", () => preWarmPinecone());
-    })
-    .catch(() => {});
+  // Pinecone pre-warm is best-effort and independent of the queue layer.
+  try {
+    const { preWarmPinecone } = await import("../utils/embeddingUtils.js");
+    await safeInit("Pinecone DB", () => preWarmPinecone());
+  } catch {
+    // Module unavailable (optional dependency) — not fatal.
+  }
+
+  if (failed.length === 0) {
+    console.log(`✅ Background services started (${started.length}).`);
+  } else {
+    console.warn(
+      `⚠️ Background services started with ${failed.length} failure(s): ` +
+        failed.map((f) => f.name).join(", "),
+    );
+  }
+
+  return { started, failed };
 }

--- a/server/server.js
+++ b/server/server.js
@@ -58,7 +58,11 @@ import {
   initAIWorker, // eslint-disable-line no-unused-vars
   initDataExportWorker, // eslint-disable-line no-unused-vars
   initConflictScanWorker, // eslint-disable-line no-unused-vars
+  shutdownQueues,
 } from "./services/queueService.js";
+import { createGracefulShutdown } from "./utils/gracefulShutdown.js";
+import mongoose from "mongoose";
+import { closeRedis } from "./services/redisService.js";
 import { initWebhookWorker } from "./services/webhookDispatcherService.js"; // eslint-disable-line no-unused-vars
 import { globalLimiter } from "./middleware/rateLimiter.js"; // eslint-disable-line no-unused-vars
 import errorHandler from "./middleware/errorHandler.js";
@@ -165,19 +169,25 @@ if (process.env.NODE_ENV !== "test") {
 // ERROR HANDLER
 app.use(errorHandler);
 
-// GRACEFUL SHUTDOWN
-process.on("SIGTERM", () => {
-  console.log("SIGTERM received. Shutting down gracefully...");
-  server.close(() => {
-    process.exit(0);
-  });
+// ─── GRACEFUL SHUTDOWN (Issue #975) ──────────────────────────────────────────
+// The previous handlers only called `server.close()`, which stops the HTTP
+// listener and nothing else. In-flight BullMQ jobs were killed mid-execution on
+// every deploy and — with the old `attempts: 1` default — were never
+// re-delivered. This controller drains workers *before* closing datastores, and
+// force-exits after a deadline so a stuck handle can't hang the process until
+// the platform SIGKILLs it.
+const gracefulShutdown = createGracefulShutdown({
+  server,
+  io,
+  closeQueues: () => shutdownQueues(),
+  closeDatabase: () => mongoose.connection.close(false),
+  closeRedis: () => closeRedis(),
 });
 
-process.on("SIGINT", () => {
-  console.log("SIGINT received. Shutting down gracefully...");
-  server.close(() => {
-    process.exit(0);
-  });
-});
+// Signal handlers are skipped under Jest: the test runner owns process
+// lifecycle, and registering an exit-on-SIGINT handler there would fight it.
+if (process.env.NODE_ENV !== "test") {
+  gracefulShutdown.registerSignalHandlers();
+}
 
-export { app, server };
+export { app, server, gracefulShutdown };

--- a/server/services/conflictScanTrigger.js
+++ b/server/services/conflictScanTrigger.js
@@ -23,14 +23,15 @@ eventBus.on("mom.generated", async (meeting) => {
     // One in-flight/queued scan per organization at a time — a burst of
     // meetings finishing MoM generation back-to-back shouldn't spawn a
     // pile of redundant scans of the same knowledge graph.
+    //
+    // Issue #975: the retention overrides that used to be spelled out here are
+    // now part of the queue's shared defaults (see queueRegistry.js), which
+    // also supply the `attempts`/`backoff` this call was missing — previously a
+    // single transient failure discarded the scan outright.
     await conflictScanQueue.add(
       "scan",
       { organization },
-      {
-        jobId: `conflict-scan-${organization || "global"}`,
-        removeOnComplete: true,
-        removeOnFail: 50,
-      },
+      { jobId: `conflict-scan-${organization || "global"}` },
     );
   } catch (err) {
     console.error("⚠️ Failed to enqueue conflict scan:", err.message);

--- a/server/services/queueRegistry.js
+++ b/server/services/queueRegistry.js
@@ -1,0 +1,399 @@
+// server/services/queueRegistry.js
+//
+// Issue #975 — Background jobs are silently lost.
+//
+// Before this module, every BullMQ queue in queueService.js was constructed as
+// `new Queue(name, { connection })` with no `defaultJobOptions`. BullMQ's own
+// default is `attempts: 1`, so *any* throw — a Redis blip, a Mongo failover, a
+// Gemini 429 — permanently destroyed the job. Nothing retried it and nothing
+// recorded that it had vanished.
+//
+// Two queues in this repo already did the right thing by hand
+// (webhookDispatcherService.js and MeetingService.js both pass `attempts` +
+// `backoff` at enqueue time), which established the intended behaviour. This
+// module makes that behaviour the default for *every* queue instead of
+// something each caller has to remember, and adds the two other things that
+// were missing: bounded retention so Redis memory can't grow without limit,
+// and a registry so workers can actually be drained on shutdown.
+//
+// Deliberately free of any Redis dependency: everything here is pure bookkeeping
+// over injected factories, so the option-resolution and shutdown-ordering logic
+// is unit-testable in an environment with no Redis (which is exactly how the
+// test suite runs — tests/setup.js deletes REDIS_URI).
+
+/**
+ * Options applied to every job on every queue unless a queue or an individual
+ * `add()` call overrides them.
+ *
+ * `attempts: 3` with exponential backoff mirrors what
+ * webhookDispatcherService.js and MeetingService.js already chose. The
+ * retention caps exist because BullMQ otherwise keeps every completed and
+ * failed job payload in Redis forever — and `processAudioJob` payloads carry
+ * transcript text, so that is an unbounded leak in the same Redis instance that
+ * backs the rate limiter and the Socket.IO adapter.
+ */
+export const BASE_JOB_OPTIONS = Object.freeze({
+  attempts: 3,
+  backoff: Object.freeze({ type: "exponential", delay: 5000 }),
+  // Keep a short window of completed jobs for debugging, then evict by count
+  // *and* by age so neither a burst nor a slow trickle can grow unbounded.
+  removeOnComplete: Object.freeze({ count: 100, age: 24 * 60 * 60 }),
+  // Failed jobs are kept longer — they are the ones an operator needs to see.
+  removeOnFail: Object.freeze({ count: 500, age: 7 * 24 * 60 * 60 }),
+});
+
+/**
+ * Per-queue overrides, keyed by BullMQ queue name.
+ *
+ * The rationale for each deviation from BASE_JOB_OPTIONS is recorded inline so
+ * a future reader can tell an intentional choice from an accidental one.
+ */
+export const QUEUE_DEFINITIONS = Object.freeze({
+  "ai-mom-generation": Object.freeze({
+    // MoM generation is the most user-visible job and the most likely to hit a
+    // transient provider error (the worker's own limiter comment acknowledges
+    // Gemini free-tier rate limits). Retry harder, and back off further so a
+    // quota window has time to reset.
+    jobOptions: { attempts: 5, backoff: { type: "exponential", delay: 15000 } },
+    workerOptions: { concurrency: 1 },
+  }),
+  "data-export-queue": Object.freeze({
+    // Exports write a file and email a link; a duplicate delivery is far less
+    // bad than a silently dropped export, so retries stay on.
+    jobOptions: { attempts: 3 },
+    workerOptions: { concurrency: 2 },
+  }),
+  "conflict-scan-queue": Object.freeze({
+    jobOptions: { attempts: 3 },
+    workerOptions: { concurrency: 2 },
+  }),
+  "sentiment-analysis-queue": Object.freeze({
+    jobOptions: { attempts: 3, backoff: { type: "exponential", delay: 10000 } },
+    workerOptions: { concurrency: 1 },
+  }),
+  "recalculate-importance-queue": Object.freeze({
+    jobOptions: { attempts: 3 },
+    workerOptions: { concurrency: 1 },
+  }),
+  "memory-lifecycle-queue": Object.freeze({
+    // The lifecycle sweep is idempotent and re-runs on a schedule anyway, so a
+    // long retry tail buys nothing; fail fast and let the next sweep pick it up.
+    jobOptions: { attempts: 2 },
+    workerOptions: { concurrency: 1 },
+  }),
+  "recap-delivery-queue": Object.freeze({
+    jobOptions: { attempts: 3 },
+    workerOptions: { concurrency: 2 },
+  }),
+  "webhook-dispatches": Object.freeze({
+    // These values already existed inline in webhookDispatcherService.js; they
+    // are recorded here so the webhook queue picks up the shared retention caps
+    // and joins the shutdown registry without changing its dispatch semantics.
+    jobOptions: { attempts: 5, backoff: { type: "exponential", delay: 2000 } },
+    workerOptions: { concurrency: 10 },
+  }),
+});
+
+/**
+ * Reads a positive integer from the environment, falling back when the value is
+ * absent, unparseable, or non-positive.
+ *
+ * @param {string} name
+ * @param {number} fallback
+ * @returns {number}
+ */
+export const readPositiveIntEnv = (name, fallback) => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+};
+
+/**
+ * Merges a retention setting (`removeOnComplete` / `removeOnFail`).
+ *
+ * BullMQ accepts three shapes for these: a boolean, a number (keep N), or an
+ * object (`{ count, age }`). Only the object form can be merged field-by-field;
+ * a boolean or number is a complete replacement and must be passed through
+ * untouched. Blindly spreading here would turn an existing caller's
+ * `removeOnComplete: true` into `{...base, ...true}` — i.e. silently back into
+ * the default object — which would quietly discard their intent.
+ *
+ * @param {...(boolean|number|object|undefined)} sources lowest precedence first
+ */
+const mergeRetention = (...sources) => {
+  let result;
+  for (const source of sources) {
+    if (source === undefined || source === null) continue;
+    if (typeof source !== "object") {
+      // Boolean/number: an outright replacement, not a partial override.
+      result = source;
+      continue;
+    }
+    result =
+      typeof result === "object" ? { ...result, ...source } : { ...source };
+  }
+  return result;
+};
+
+/**
+ * Merges BASE_JOB_OPTIONS with the queue's declared overrides and any
+ * caller-supplied overrides. Later sources win. Nested `backoff` and the
+ * retention settings are merged rather than replaced wholesale, so a queue can
+ * override only `delay` or only `count`.
+ *
+ * @param {string} queueName
+ * @param {object} [overrides]
+ * @returns {object} fully resolved defaultJobOptions
+ */
+export const resolveJobOptions = (queueName, overrides = {}) => {
+  const declared = QUEUE_DEFINITIONS[queueName]?.jobOptions ?? {};
+
+  return {
+    ...BASE_JOB_OPTIONS,
+    ...declared,
+    ...overrides,
+    backoff: {
+      ...BASE_JOB_OPTIONS.backoff,
+      ...(declared.backoff ?? {}),
+      ...(overrides.backoff ?? {}),
+    },
+    // Spread copies the frozen nested objects by reference; clone them so a
+    // caller mutating a returned options object can't corrupt the shared
+    // defaults for every other queue.
+    removeOnComplete: mergeRetention(
+      BASE_JOB_OPTIONS.removeOnComplete,
+      declared.removeOnComplete,
+      overrides.removeOnComplete,
+    ),
+    removeOnFail: mergeRetention(
+      BASE_JOB_OPTIONS.removeOnFail,
+      declared.removeOnFail,
+      overrides.removeOnFail,
+    ),
+  };
+};
+
+/**
+ * Resolves worker options for a queue, merging the declared defaults with
+ * caller overrides.
+ *
+ * @param {string} queueName
+ * @param {object} [overrides]
+ * @returns {object}
+ */
+export const resolveWorkerOptions = (queueName, overrides = {}) => ({
+  ...(QUEUE_DEFINITIONS[queueName]?.workerOptions ?? {}),
+  ...overrides,
+});
+
+/**
+ * Creates a registry that tracks every queue, worker and shared connection so
+ * they can be closed in the correct order on shutdown.
+ *
+ * Ordering matters and is the whole point of this thing:
+ *   1. workers  — stop accepting new jobs, let in-flight jobs finish
+ *   2. queues   — no producers left by this point
+ *   3. connections — only once nothing can still issue a Redis command
+ *
+ * Closing connections first (the naive ordering) makes in-flight jobs fail with
+ * a connection error, which is precisely the data loss this is meant to prevent.
+ *
+ * @param {object} [deps]
+ * @param {Console|object} [deps.logger]
+ */
+export const createQueueRegistry = ({ logger = console } = {}) => {
+  /** @type {Map<string, {name: string, queue: object}>} */
+  const queues = new Map();
+  /** @type {Map<string, {name: string, worker: object}>} */
+  const workers = new Map();
+  /** @type {Set<{name: string, connection: object}>} */
+  const connections = new Set();
+
+  let closing = false;
+  /** @type {Promise<object>|null} */
+  let closePromise = null;
+
+  /**
+   * Registers a queue. Re-registering the same name returns the existing entry
+   * so callers can stay lazy without risking duplicates.
+   */
+  const registerQueue = (name, queue) => {
+    if (queues.has(name)) return queues.get(name).queue;
+    queues.set(name, { name, queue });
+    return queue;
+  };
+
+  /**
+   * Registers a worker so it can be drained on shutdown. Registering a second
+   * worker for a name already present is a bug (it would double-process every
+   * job), so it is logged loudly rather than silently accepted.
+   */
+  const registerWorker = (name, worker) => {
+    if (workers.has(name)) {
+      logger.warn?.(
+        `⚠️ Worker for "${name}" is already registered — ignoring duplicate registration.`,
+      );
+      return workers.get(name).worker;
+    }
+    workers.set(name, { name, worker });
+    return worker;
+  };
+
+  const registerConnection = (name, connection) => {
+    if (!connection) return connection;
+    connections.add({ name, connection });
+    return connection;
+  };
+
+  const listQueues = () => [...queues.keys()];
+  const listWorkers = () => [...workers.keys()];
+  const isClosing = () => closing;
+
+  /**
+   * Runs `fn()` but never waits longer than `timeoutMs`.
+   *
+   * A close that hangs is the failure mode that turns a graceful shutdown into
+   * a SIGKILL, so every individual close gets its own budget. Resolves to a
+   * result descriptor instead of throwing, because one stuck worker must not
+   * prevent the remaining workers from being drained.
+   */
+  const closeWithTimeout = async (label, fn, timeoutMs) => {
+    let timer;
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(
+        () => resolve({ name: label, status: "timeout" }),
+        timeoutMs,
+      );
+      // Don't let the timer itself hold the event loop open.
+      timer.unref?.();
+    });
+
+    try {
+      const result = await Promise.race([
+        Promise.resolve()
+          .then(fn)
+          .then(() => ({ name: label, status: "closed" })),
+        timeout,
+      ]);
+      if (result.status === "timeout") {
+        logger.warn?.(`⚠️ Close timed out after ${timeoutMs}ms: ${label}`);
+      }
+      return result;
+    } catch (err) {
+      logger.error?.(`❌ Close failed for ${label}:`, err?.message || err);
+      return {
+        name: label,
+        status: "error",
+        error: err?.message || String(err),
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  /**
+   * Drains and closes everything, in dependency order.
+   *
+   * Idempotent: a second call (a second SIGTERM, or a signal arriving while an
+   * explicit shutdown is already running) returns the in-flight promise rather
+   * than starting a second teardown.
+   *
+   * @param {object} [options]
+   * @param {number} [options.workerTimeoutMs] grace period for in-flight jobs
+   * @param {number} [options.closeTimeoutMs]  budget for each queue/connection close
+   * @returns {Promise<{workers: object[], queues: object[], connections: object[]}>}
+   */
+  const closeAll = async ({
+    workerTimeoutMs = readPositiveIntEnv(
+      "QUEUE_WORKER_CLOSE_TIMEOUT_MS",
+      15000,
+    ),
+    closeTimeoutMs = readPositiveIntEnv("QUEUE_CLOSE_TIMEOUT_MS", 5000),
+  } = {}) => {
+    if (closing) return closePromise;
+    closing = true;
+
+    closePromise = (async () => {
+      // 1. Workers first. `worker.close()` stops fetching new jobs and waits for
+      //    in-flight ones, which is the entire reason this ordering exists.
+      const workerResults = await Promise.all(
+        [...workers.values()].map(({ name, worker }) =>
+          closeWithTimeout(
+            `worker:${name}`,
+            () => worker.close(),
+            workerTimeoutMs,
+          ),
+        ),
+      );
+
+      // 2. Queues — producers only; safe once workers are done.
+      const queueResults = await Promise.all(
+        [...queues.values()].map(({ name, queue }) =>
+          closeWithTimeout(
+            `queue:${name}`,
+            () => queue.close(),
+            closeTimeoutMs,
+          ),
+        ),
+      );
+
+      // 3. Shared Redis connections last. ioredis exposes `quit()` (graceful)
+      //    and `disconnect()` (immediate); prefer the former, fall back to the
+      //    latter so a client that only implements one still gets closed.
+      const connectionResults = await Promise.all(
+        [...connections].map(({ name, connection }) =>
+          closeWithTimeout(
+            `connection:${name}`,
+            () =>
+              typeof connection.quit === "function"
+                ? connection.quit()
+                : connection.disconnect?.(),
+            closeTimeoutMs,
+          ),
+        ),
+      );
+
+      queues.clear();
+      workers.clear();
+      connections.clear();
+
+      return {
+        workers: workerResults,
+        queues: queueResults,
+        connections: connectionResults,
+      };
+    })();
+
+    return closePromise;
+  };
+
+  /** Test-only: returns the registry to a pristine state. */
+  const reset = () => {
+    queues.clear();
+    workers.clear();
+    connections.clear();
+    closing = false;
+    closePromise = null;
+  };
+
+  return {
+    registerQueue,
+    registerWorker,
+    registerConnection,
+    listQueues,
+    listWorkers,
+    isClosing,
+    closeAll,
+    reset,
+  };
+};
+
+/**
+ * The process-wide registry. queueService.js and webhookDispatcherService.js
+ * both register into this so a single `closeAll()` drains everything.
+ */
+const queueRegistry = createQueueRegistry();
+
+export default queueRegistry;

--- a/server/services/queueService.js
+++ b/server/services/queueService.js
@@ -6,20 +6,43 @@ import conflictScanJob from "./conflictDetection/conflictScanJob.js";
 import sentimentAnalysisJob from "../jobs/sentimentAnalysisJob.js";
 import recalculateImportanceJob from "../jobs/recalculateImportanceJob.js";
 import memoryLifecycleJob from "../jobs/memoryLifecycleJob.js";
+import queueRegistry, {
+  readPositiveIntEnv,
+  resolveJobOptions,
+  resolveWorkerOptions,
+} from "./queueRegistry.js";
 
-// BullMQ requires maxRetriesPerRequest to be null
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #975 — Background jobs are silently lost.
+//
+// This file previously declared seven near-identical queue getters, seven
+// near-identical `add()` wrappers, and seven near-identical `initXWorker`
+// functions. None of them set `defaultJobOptions`, so every job ran with
+// BullMQ's default `attempts: 1` and was destroyed by the first transient
+// error; none of them retained a handle to the created Worker, so nothing could
+// be drained on shutdown.
+//
+// Both problems are now solved structurally rather than per-queue: queues and
+// workers are built by shared factories that apply the retry/backoff/retention
+// defaults from queueRegistry.js and register every handle for shutdown. Adding
+// an eighth queue is one table entry, and it cannot accidentally ship without
+// retries.
+//
+// The public API (`aiQueue.add(...)`, `initAIWorker(app)`, …) is unchanged so no
+// caller needed to be touched.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// BullMQ requires maxRetriesPerRequest to be null on worker connections.
 let _producerConnection = null;
 let _workerConnection = null;
-let _aiQueueInstance = null;
-let _dataExportQueueInstance = null;
-let _conflictScanQueueInstance = null;
-let _sentimentAnalysisQueueInstance = null;
-let _recalculateImportanceQueueInstance = null;
-let _memoryLifecycleQueueInstance = null;
-let _recapDeliveryQueueInstance = null;
+
+/** @type {Map<string, import("bullmq").Queue>} */
+const _queueInstances = new Map();
+
+const redisConfigured = () => Boolean(process.env.REDIS_URI);
 
 function getProducerConnection() {
-  if (!process.env.REDIS_URI) return null;
+  if (!redisConfigured()) return null;
   if (!_producerConnection) {
     _producerConnection = new Redis(process.env.REDIS_URI, {
       maxRetriesPerRequest: 3, // Fail fast for requests adding tasks to queue
@@ -28,12 +51,13 @@ function getProducerConnection() {
     _producerConnection.on("error", (err) => {
       console.error("⚠️ BullMQ Producer Redis Connection Error:", err.message);
     });
+    queueRegistry.registerConnection("bullmq-producer", _producerConnection);
   }
   return _producerConnection;
 }
 
 function getWorkerConnection() {
-  if (!process.env.REDIS_URI) return null;
+  if (!redisConfigured()) return null;
   if (!_workerConnection) {
     _workerConnection = new Redis(process.env.REDIS_URI, {
       maxRetriesPerRequest: null, // Unlimited retries for background workers
@@ -42,431 +66,254 @@ function getWorkerConnection() {
     _workerConnection.on("error", (err) => {
       console.error("⚠️ BullMQ Worker Redis Connection Error:", err.message);
     });
+    queueRegistry.registerConnection("bullmq-worker", _workerConnection);
   }
   return _workerConnection;
 }
 
-function getAiQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_aiQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _aiQueueInstance = new Queue("ai-mom-generation", { connection: conn });
-    }
-  }
-  return _aiQueueInstance;
+/**
+ * Lazily creates (and memoises) a queue with the shared durability defaults
+ * applied. Returns null when Redis is not configured — the historical
+ * behaviour, which lets the app boot for frontend-only development.
+ *
+ * @param {string} name BullMQ queue name
+ * @returns {import("bullmq").Queue|null}
+ */
+function getQueue(name) {
+  if (!redisConfigured()) return null;
+
+  const existing = _queueInstances.get(name);
+  if (existing) return existing;
+
+  const connection = getProducerConnection();
+  if (!connection) return null;
+
+  const queue = new Queue(name, {
+    connection,
+    // The fix for Problem 1 in #975: every job on every queue now gets
+    // attempts + exponential backoff + bounded retention by default.
+    defaultJobOptions: resolveJobOptions(name),
+  });
+
+  _queueInstances.set(name, queue);
+  queueRegistry.registerQueue(name, queue);
+  return queue;
 }
 
-function getDataExportQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_dataExportQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _dataExportQueueInstance = new Queue("data-export-queue", {
-        connection: conn,
-      });
-    }
-  }
-  return _dataExportQueueInstance;
-}
-
-function getConflictScanQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_conflictScanQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _conflictScanQueueInstance = new Queue("conflict-scan-queue", {
-        connection: conn,
-      });
-    }
-  }
-  return _conflictScanQueueInstance;
-}
-
-function getSentimentAnalysisQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_sentimentAnalysisQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _sentimentAnalysisQueueInstance = new Queue("sentiment-analysis-queue", {
-        connection: conn,
-      });
-    }
-  }
-  return _sentimentAnalysisQueueInstance;
-}
-
-function getRecalculateImportanceQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_recalculateImportanceQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _recalculateImportanceQueueInstance = new Queue(
-        "recalculate-importance-queue",
-        {
-          connection: conn,
-        },
+/**
+ * Builds the thin `{ add, isActive }` facade each queue is exported as.
+ *
+ * Preserves the previous contract exactly: `add()` resolves to null and warns
+ * when Redis is absent rather than throwing, so callers in request paths don't
+ * need to guard.
+ *
+ * @param {string} name
+ */
+const createQueueFacade = (name) => ({
+  /**
+   * @param {string} jobName
+   * @param {object} [data]
+   * @param {object} [opts] per-job overrides; merged over the queue defaults
+   */
+  add: async (jobName, data, opts) => {
+    const queue = getQueue(name);
+    if (!queue) {
+      console.warn(
+        `⚠️ Queue operation ignored: Redis is not configured (queue: ${name}).`,
       );
-    }
-  }
-  return _recalculateImportanceQueueInstance;
-}
-
-function getMemoryLifecycleQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_memoryLifecycleQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _memoryLifecycleQueueInstance = new Queue("memory-lifecycle-queue", {
-        connection: conn,
-      });
-    }
-  }
-  return _memoryLifecycleQueueInstance;
-}
-
-function getRecapDeliveryQueue() {
-  if (!process.env.REDIS_URI) return null;
-  if (!_recapDeliveryQueueInstance) {
-    const conn = getProducerConnection();
-    if (conn) {
-      _recapDeliveryQueueInstance = new Queue("recap-delivery-queue", {
-        connection: conn,
-      });
-    }
-  }
-  return _recapDeliveryQueueInstance;
-}
-
-// Wrapper to preserve syntax compatibility
-export const aiQueue = {
-  add: async (...args) => {
-    const q = getAiQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
       return null;
     }
-    return await q.add(...args);
+    // Explicitly resolve per-call options against the shared defaults. BullMQ
+    // would merge `defaultJobOptions` itself, but doing it here means an
+    // `opts` object that only sets e.g. `repeat` can't accidentally shadow the
+    // retry policy, and it keeps the merge behaviour unit-testable.
+    return await queue.add(jobName, data, resolveJobOptions(name, opts ?? {}));
   },
   get isActive() {
-    return getAiQueue() !== null;
+    return getQueue(name) !== null;
   },
-};
+  /** Exposed for diagnostics and tests. */
+  get name() {
+    return name;
+  },
+});
 
-export const dataExportQueue = {
-  add: async (...args) => {
-    const q = getDataExportQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getDataExportQueue() !== null;
-  },
-};
+export const aiQueue = createQueueFacade("ai-mom-generation");
+export const dataExportQueue = createQueueFacade("data-export-queue");
+export const conflictScanQueue = createQueueFacade("conflict-scan-queue");
+export const sentimentAnalysisQueue = createQueueFacade(
+  "sentiment-analysis-queue",
+);
+export const recalculateImportanceQueue = createQueueFacade(
+  "recalculate-importance-queue",
+);
+export const memoryLifecycleQueue = createQueueFacade("memory-lifecycle-queue");
+export const recapDeliveryQueue = createQueueFacade("recap-delivery-queue");
 
-export const conflictScanQueue = {
-  add: async (...args) => {
-    const q = getConflictScanQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getConflictScanQueue() !== null;
-  },
-};
-
-export const sentimentAnalysisQueue = {
-  add: async (...args) => {
-    const q = getSentimentAnalysisQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getSentimentAnalysisQueue() !== null;
-  },
-};
-
-export const recalculateImportanceQueue = {
-  add: async (...args) => {
-    const q = getRecalculateImportanceQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getRecalculateImportanceQueue() !== null;
-  },
-};
-
-export const memoryLifecycleQueue = {
-  add: async (...args) => {
-    const q = getMemoryLifecycleQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getMemoryLifecycleQueue() !== null;
-  },
-};
-
-export const recapDeliveryQueue = {
-  add: async (...args) => {
-    const q = getRecapDeliveryQueue();
-    if (!q) {
-      console.warn("⚠️ Queue operation ignored: Redis is not configured.");
-      return null;
-    }
-    return await q.add(...args);
-  },
-  get isActive() {
-    return getRecapDeliveryQueue() !== null;
-  },
-};
-
-export const initAIWorker = (app) => {
+/**
+ * Creates a worker, wires the standard lifecycle logging, and registers it with
+ * the shutdown registry.
+ *
+ * The `failed` handler is the one behavioural addition: it now distinguishes a
+ * retry from a final failure. Previously every attempt logged an identical
+ * "job failed" line, which made a job that was about to be retried
+ * indistinguishable from one that had been abandoned.
+ *
+ * @param {object} params
+ * @param {string} params.name  queue name
+ * @param {string} params.label human-readable name for logs
+ * @param {Function} params.processor async (job) => any
+ * @param {object} [params.workerOptions]
+ * @returns {import("bullmq").Worker|null}
+ */
+function createWorker({ name, label, processor, workerOptions = {} }) {
   const connection = getWorkerConnection();
   if (!connection) {
-    console.warn("⚠️ Redis not configured. AI Worker will not start.");
-    return;
+    console.warn(`⚠️ Redis not configured. ${label} will not start.`);
+    return null;
   }
 
-  const worker = new Worker(
-    "ai-mom-generation",
-    async (job) => await processAudioJob(job, app),
-    {
-      connection,
-      concurrency: 1, // Reduced to prevent concurrent API quota exhaustion
+  const worker = new Worker(name, processor, {
+    connection,
+    ...resolveWorkerOptions(name, workerOptions),
+  });
+
+  worker.on("completed", (job) => {
+    console.log(`✅ ${label}: job ${job.id} completed successfully`);
+  });
+
+  worker.on("failed", (job, err) => {
+    // `job` can be undefined when BullMQ fails before it can load the job.
+    const attemptsMade = job?.attemptsMade ?? 0;
+    const maxAttempts = job?.opts?.attempts ?? 1;
+    const willRetry = attemptsMade < maxAttempts;
+
+    if (willRetry) {
+      console.warn(
+        `↻ ${label}: job ${job?.id} failed attempt ${attemptsMade}/${maxAttempts}, will retry — ${err?.message}`,
+      );
+    } else {
+      console.error(
+        `❌ ${label}: job ${job?.id} permanently failed after ${attemptsMade}/${maxAttempts} attempts — ${err?.message}`,
+      );
+    }
+  });
+
+  worker.on("error", (err) => {
+    console.error(`❌ ${label} error:`, err?.message || err);
+  });
+
+  // Surfacing stalls matters here: a stalled job is exactly the case that used
+  // to disappear without a trace, because with attempts:1 BullMQ had nothing
+  // left to re-deliver.
+  worker.on("stalled", (jobId) => {
+    console.warn(`⚠️ ${label}: job ${jobId} stalled and will be re-queued.`);
+  });
+
+  queueRegistry.registerWorker(name, worker);
+  console.log(`✅ ${label} initialized and listening to ${name}`);
+  return worker;
+}
+
+export const initAIWorker = (app) =>
+  createWorker({
+    name: "ai-mom-generation",
+    label: "AI Worker",
+    processor: async (job) => await processAudioJob(job, app),
+    workerOptions: {
       limiter: {
         max: 5, // Process max 5 jobs
         duration: 60000, // per 60 seconds to match Gemini free tier limits
       },
     },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(`✅ Job ${job.id} completed successfully`);
   });
 
-  worker.on("failed", (job, err) => {
-    console.error(`❌ Job ${job.id} failed with error:`, err.message);
+export const initDataExportWorker = (app) =>
+  createWorker({
+    name: "data-export-queue",
+    label: "Data Export Worker",
+    processor: async (job) => await exportDataJob(job, app),
   });
 
-  worker.on("error", (err) => {
-    console.error("❌ AI Worker error:", err.message);
+export const initConflictScanWorker = (app) =>
+  createWorker({
+    name: "conflict-scan-queue",
+    label: "Conflict Scan Worker",
+    processor: async (job) => await conflictScanJob(job, app),
   });
 
-  console.log(
-    "✅ AI Worker initialized and listening to ai-mom-generation queue",
-  );
-};
-
-export const initDataExportWorker = (app) => {
-  const connection = getWorkerConnection();
-  if (!connection) {
-    console.warn("⚠️ Redis not configured. Data Export Worker will not start.");
-    return;
-  }
-
-  const worker = new Worker(
-    "data-export-queue",
-    async (job) => await exportDataJob(job, app),
-    { connection, concurrency: 2 },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(`✅ Data Export Job ${job.id} completed successfully`);
+export const initSentimentWorker = (app) =>
+  createWorker({
+    name: "sentiment-analysis-queue",
+    label: "Sentiment Analysis Worker",
+    processor: async (job) => await sentimentAnalysisJob(job, app),
   });
 
-  worker.on("failed", (job, err) => {
-    console.error(
-      `❌ Data Export Job ${job.id} failed with error:`,
-      err.message,
-    );
+export const initRecalculateImportanceWorker = (app) =>
+  createWorker({
+    name: "recalculate-importance-queue",
+    label: "Recalculate Importance Worker",
+    processor: async (job) => await recalculateImportanceJob(job, app),
   });
 
-  worker.on("error", (err) => {
-    console.error("❌ Data Export Worker error:", err.message);
+export const initMemoryLifecycleWorker = async (app) => {
+  const worker = createWorker({
+    name: "memory-lifecycle-queue",
+    label: "Memory Lifecycle Worker",
+    processor: async (job) => await memoryLifecycleJob(job, app),
   });
 
-  console.log(
-    "✅ Data Export Worker initialized and listening to data-export-queue",
-  );
-};
-
-export const initConflictScanWorker = (app) => {
-  const connection = getWorkerConnection();
-  if (!connection) {
-    console.warn(
-      "⚠️ Redis not configured. Conflict Scan Worker will not start.",
-    );
-    return;
-  }
-
-  const worker = new Worker(
-    "conflict-scan-queue",
-    async (job) => await conflictScanJob(job, app),
-    { connection, concurrency: 2 },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(`✅ Conflict Scan Job ${job.id} completed successfully`);
-  });
-
-  worker.on("failed", (job, err) => {
-    console.error(
-      `❌ Conflict Scan Job ${job.id} failed with error:`,
-      err.message,
-    );
-  });
-
-  worker.on("error", (err) => {
-    console.error("❌ Conflict Scan Worker error:", err.message);
-  });
-
-  console.log(
-    "✅ Conflict Scan Worker initialized and listening to conflict-scan-queue",
-  );
-};
-
-export const initSentimentWorker = (app) => {
-  const connection = getWorkerConnection();
-  if (!connection) {
-    console.warn("⚠️ Redis not configured. Sentiment Worker will not start.");
-    return;
-  }
-
-  const worker = new Worker(
-    "sentiment-analysis-queue",
-    async (job) => await sentimentAnalysisJob(job, app),
-    { connection, concurrency: 1 },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(`✅ Sentiment Analysis Job ${job.id} completed successfully`);
-  });
-
-  worker.on("failed", (job, err) => {
-    console.error(
-      `❌ Sentiment Analysis Job ${job.id} failed with error:`,
-      err.message,
-    );
-  });
-
-  worker.on("error", (err) => {
-    console.error("❌ Sentiment Analysis Worker error:", err.message);
-  });
-
-  console.log(
-    "✅ Sentiment Analysis Worker initialized and listening to sentiment-analysis-queue",
-  );
-};
-
-export const initRecalculateImportanceWorker = (app) => {
-  const connection = getWorkerConnection();
-  if (!connection) {
-    console.warn(
-      "⚠️ Redis not configured. Recalculate Importance Worker will not start.",
-    );
-    return;
-  }
-
-  const worker = new Worker(
-    "recalculate-importance-queue",
-    async (job) => await recalculateImportanceJob(job, app),
-    { connection, concurrency: 1 },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(
-      `✅ Recalculate Importance Job ${job.id} completed successfully`,
-    );
-  });
-
-  worker.on("failed", (job, err) => {
-    console.error(
-      `❌ Recalculate Importance Job ${job.id} failed with error:`,
-      err.message,
-    );
-  });
-
-  worker.on("error", (err) => {
-    console.error("❌ Recalculate Importance Worker error:", err.message);
-  });
-
-  console.log(
-    "✅ Recalculate Importance Worker initialized and listening to recalculate-importance-queue",
-  );
-};
-
-export const initMemoryLifecycleWorker = (app) => {
-  const connection = getWorkerConnection();
-  if (!connection) {
-    console.warn(
-      "⚠️ Redis not configured. Memory Lifecycle Worker will not start.",
-    );
-    return;
-  }
-
-  const worker = new Worker(
-    "memory-lifecycle-queue",
-    async (job) => await memoryLifecycleJob(job, app),
-    { connection, concurrency: 1 },
-  );
-
-  worker.on("completed", (job) => {
-    console.log(`✅ Memory Lifecycle Job ${job.id} completed successfully`);
-  });
-
-  worker.on("failed", (job, err) => {
-    console.error(
-      `❌ Memory Lifecycle Job ${job.id} failed with error:`,
-      err.message,
-    );
-  });
-
-  worker.on("error", (err) => {
-    console.error("❌ Memory Lifecycle Worker error:", err.message);
-  });
-
-  console.log(
-    "✅ Memory Lifecycle Worker initialized and listening to memory-lifecycle-queue",
-  );
+  if (!worker) return null;
 
   // Automatic, recurring sweep (Issue #377 acceptance criterion: memories
   // transition according to configured policies without manual triggering).
   // Runs once a day across all organizations; interval is configurable via
   // env so ops can tune it without a code change.
-  const intervalMs =
-    parseInt(process.env.LIFECYCLE_SWEEP_INTERVAL_MS, 10) ||
-    24 * 60 * 60 * 1000;
+  const intervalMs = readPositiveIntEnv(
+    "LIFECYCLE_SWEEP_INTERVAL_MS",
+    24 * 60 * 60 * 1000,
+  );
 
-  memoryLifecycleQueue
-    .add(
+  try {
+    await memoryLifecycleQueue.add(
       "scheduled-lifecycle-sweep",
       {},
       {
         repeat: { every: intervalMs },
         jobId: "scheduled-lifecycle-sweep",
       },
-    )
-    .catch((err) =>
-      console.error(
-        "⚠️ Failed to schedule recurring memory lifecycle sweep:",
-        err.message,
-      ),
     );
+  } catch (err) {
+    console.error(
+      "⚠️ Failed to schedule recurring memory lifecycle sweep:",
+      err.message,
+    );
+  }
+
+  return worker;
 };
+
+/**
+ * Drains every registered worker, then closes queues and shared Redis
+ * connections. Safe to call more than once.
+ *
+ * Called by the graceful-shutdown handler in server.js. Exported separately so
+ * tests and scripts can tear the queue layer down without sending a signal.
+ *
+ * @param {object} [options] forwarded to the registry's closeAll
+ */
+export const shutdownQueues = async (options) => {
+  const result = await queueRegistry.closeAll(options);
+  _queueInstances.clear();
+  _producerConnection = null;
+  _workerConnection = null;
+  return result;
+};
+
+/** Diagnostics: which queues and workers are currently live. */
+export const getQueueStatus = () => ({
+  redisConfigured: redisConfigured(),
+  queues: queueRegistry.listQueues(),
+  workers: queueRegistry.listWorkers(),
+  shuttingDown: queueRegistry.isClosing(),
+});

--- a/server/services/redisService.js
+++ b/server/services/redisService.js
@@ -67,6 +67,36 @@ export const overrideRedisClientForTesting = (client) => {
   customTestClient = client;
 };
 
+/**
+ * Closes the shared Redis client (Issue #975).
+ *
+ * Nothing previously closed this connection on shutdown, so the process held an
+ * open socket that could keep the event loop alive past `server.close()` — one
+ * of the reasons the old shutdown path could hang until SIGKILL.
+ *
+ * Prefers `quit()` (drains pending replies) and falls back to `disconnect()`.
+ * Never throws: shutdown must continue even if the connection is already gone.
+ */
+export const closeRedis = async () => {
+  const client = redisClient;
+  redisClient = null;
+  isRedisDisabled = true;
+
+  if (!client) return false;
+
+  try {
+    if (typeof client.quit === "function") {
+      await client.quit();
+    } else if (typeof client.disconnect === "function") {
+      await client.disconnect();
+    }
+    return true;
+  } catch (err) {
+    console.warn("⚠️ Redis close failed (ignoring):", err.message);
+    return false;
+  }
+};
+
 export const getRedisClient = () =>
   customTestClient !== null
     ? customTestClient

--- a/server/services/webhookDispatcherService.js
+++ b/server/services/webhookDispatcherService.js
@@ -6,6 +6,9 @@ import Webhook from "../models/Webhook.js";
 import WebhookDelivery from "../models/WebhookDelivery.js";
 import eventBus from "./eventBus.js";
 import { validateWebhookDestination } from "../utils/webhookUrlSafety.js";
+import queueRegistry, { resolveJobOptions } from "./queueRegistry.js";
+
+const WEBHOOK_QUEUE_NAME = "webhook-dispatches";
 
 // Redis connection management
 let _producerConnection = null;
@@ -22,6 +25,8 @@ function getProducerConnection() {
     _producerConnection.on("error", (err) => {
       console.error("⚠️ Webhook Producer Redis Connection Error:", err.message);
     });
+    // Issue #975: nothing used to close these on shutdown.
+    queueRegistry.registerConnection("webhook-producer", _producerConnection);
   }
   return _producerConnection;
 }
@@ -36,6 +41,7 @@ function getWorkerConnection() {
     _workerConnection.on("error", (err) => {
       console.error("⚠️ Webhook Worker Redis Connection Error:", err.message);
     });
+    queueRegistry.registerConnection("webhook-worker", _workerConnection);
   }
   return _workerConnection;
 }
@@ -45,9 +51,14 @@ function getWebhookQueue() {
   if (!_webhookQueueInstance) {
     const conn = getProducerConnection();
     if (conn) {
-      _webhookQueueInstance = new Queue("webhook-dispatches", {
+      _webhookQueueInstance = new Queue(WEBHOOK_QUEUE_NAME, {
         connection: conn,
+        // This queue already passed attempts/backoff at enqueue time, but it
+        // had no retention caps — so every completed and failed dispatch stayed
+        // in Redis forever. The shared defaults supply both (Issue #975).
+        defaultJobOptions: resolveJobOptions(WEBHOOK_QUEUE_NAME),
       });
+      queueRegistry.registerQueue(WEBHOOK_QUEUE_NAME, _webhookQueueInstance);
     }
   }
   return _webhookQueueInstance;
@@ -369,18 +380,13 @@ export const dispatchWebhookEvent = async (organizationId, event, data) => {
 
     for (const webhook of webhooks) {
       if (getWebhookQueue()) {
-        // Add to BullMQ with exponential backoff retries for reliability
-        await webhookQueue.add(
-          "dispatch-webhook",
-          { webhookId: webhook._id, payload },
-          {
-            attempts: 5,
-            backoff: {
-              type: "exponential",
-              delay: 2000, // 2s initial delay
-            },
-          },
-        );
+        // Retries/backoff (5 attempts, 2s exponential) now come from the
+        // queue's shared defaults in queueRegistry.js rather than being
+        // repeated at every call site — same values, one place to change them.
+        await webhookQueue.add("dispatch-webhook", {
+          webhookId: webhook._id,
+          payload,
+        });
       } else {
         // Fallback: Synchronous dispatch in local/dev environment without Redis
         performDispatch(webhook._id, payload, {
@@ -412,7 +418,7 @@ export const initWebhookWorker = () => {
   }
 
   const worker = new Worker(
-    "webhook-dispatches",
+    WEBHOOK_QUEUE_NAME,
     async (job) => {
       const { webhookId, payload } = job.data;
       const attempt = job.attemptsMade + 1;
@@ -423,6 +429,10 @@ export const initWebhookWorker = () => {
     },
     { connection, concurrency: 10 },
   );
+
+  // Issue #975: register so SIGTERM drains in-flight dispatches instead of
+  // killing them mid-request.
+  queueRegistry.registerWorker(WEBHOOK_QUEUE_NAME, worker);
 
   worker.on("completed", (job) => {
     console.log(`✅ Webhook job ${job.id} completed successfully`);

--- a/server/tests/gracefulShutdown.test.js
+++ b/server/tests/gracefulShutdown.test.js
@@ -1,0 +1,275 @@
+/**
+ * Issue #975 — graceful shutdown.
+ *
+ * The behaviour under test is the ordering and the deadline, both of which are
+ * pure control flow over injected dependencies. Nothing here touches a real
+ * HTTP server, Redis, or Mongo.
+ */
+
+import { jest } from "@jest/globals";
+import { createGracefulShutdown } from "../utils/gracefulShutdown.js";
+
+const silentLogger = { log: () => {}, warn: () => {}, error: () => {} };
+
+/** A stub http.Server whose close() invokes its callback. */
+const makeServer = (order) => ({
+  close: jest.fn((cb) => {
+    order.push("http");
+    cb();
+  }),
+});
+
+/** A stub socket.io server whose close() invokes its callback. */
+const makeIo = (order) => ({
+  close: jest.fn((cb) => {
+    order.push("io");
+    cb();
+  }),
+});
+
+describe("createGracefulShutdown (Issue #975)", () => {
+  it("closes HTTP, then Socket.IO, then workers, then datastores", async () => {
+    const order = [];
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer(order),
+      io: makeIo(order),
+      closeQueues: jest.fn(async () => order.push("queues")),
+      closeDatabase: jest.fn(async () => order.push("db")),
+      closeRedis: jest.fn(async () => order.push("redis")),
+      logger: silentLogger,
+      exit,
+    });
+
+    await shutdownController.shutdown("SIGTERM");
+
+    // Workers must drain before Mongo/Redis close, because a draining job is
+    // still issuing queries against both.
+    expect(order).toEqual(["http", "io", "queues", "db", "redis"]);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("drains workers even when there is no Socket.IO server", async () => {
+    const order = [];
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer(order),
+      io: null,
+      closeQueues: jest.fn(async () => order.push("queues")),
+      logger: silentLogger,
+      exit,
+    });
+
+    await shutdownController.shutdown("SIGINT");
+
+    expect(order).toEqual(["http", "queues"]);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("is idempotent — a second signal does not start a second teardown", async () => {
+    const closeQueues = jest.fn(async () => {});
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer([]),
+      closeQueues,
+      logger: silentLogger,
+      exit,
+    });
+
+    await Promise.all([
+      shutdownController.shutdown("SIGTERM"),
+      shutdownController.shutdown("SIGINT"),
+    ]);
+
+    expect(closeQueues).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports isShuttingDown() once a signal has been handled", async () => {
+    const shutdownController = createGracefulShutdown({
+      server: makeServer([]),
+      logger: silentLogger,
+      exit: jest.fn(),
+    });
+
+    expect(shutdownController.isShuttingDown()).toBe(false);
+    await shutdownController.shutdown("SIGTERM");
+    expect(shutdownController.isShuttingDown()).toBe(true);
+  });
+
+  it("continues the remaining steps when one step throws", async () => {
+    const order = [];
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer(order),
+      closeQueues: jest.fn(async () => {
+        throw new Error("worker drain failed");
+      }),
+      closeDatabase: jest.fn(async () => order.push("db")),
+      closeRedis: jest.fn(async () => order.push("redis")),
+      logger: silentLogger,
+      exit,
+    });
+
+    await shutdownController.shutdown("SIGTERM");
+
+    // A failure to drain must not leave Mongo and Redis connections open —
+    // that is the leak the old handler produced on every failure path.
+    expect(order).toEqual(["http", "db", "redis"]);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("force-exits when a step never settles", async () => {
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer([]),
+      // The exact failure mode that used to hang the process until the platform
+      // sent SIGKILL.
+      closeQueues: jest.fn(() => new Promise(() => {})),
+      forceExitAfterMs: 40,
+      logger: silentLogger,
+      exit,
+    });
+
+    shutdownController.shutdown("SIGTERM");
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not force-exit when shutdown completes inside the deadline", async () => {
+    const exit = jest.fn();
+
+    const shutdownController = createGracefulShutdown({
+      server: makeServer([]),
+      closeQueues: jest.fn(async () => {}),
+      forceExitAfterMs: 500,
+      logger: silentLogger,
+      exit,
+    });
+
+    await shutdownController.shutdown("SIGTERM");
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("tolerates a missing server without throwing", async () => {
+    const exit = jest.fn();
+    const shutdownController = createGracefulShutdown({
+      server: null,
+      closeQueues: jest.fn(async () => {}),
+      logger: silentLogger,
+      exit,
+    });
+
+    await expect(
+      shutdownController.shutdown("SIGTERM"),
+    ).resolves.toBeUndefined();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("skips steps that were not provided", async () => {
+    const exit = jest.fn();
+    const shutdownController = createGracefulShutdown({
+      server: makeServer([]),
+      logger: silentLogger,
+      exit,
+    });
+
+    await expect(shutdownController.shutdown()).resolves.toBeUndefined();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  describe("registerSignalHandlers", () => {
+    /** Minimal EventEmitter-ish stub so we don't touch the real process. */
+    const makeProc = () => {
+      const handlers = {};
+      return {
+        handlers,
+        on: (event, fn) => {
+          (handlers[event] ||= []).push(fn);
+        },
+      };
+    };
+
+    it("subscribes to SIGTERM, SIGINT and the fatal-error events", () => {
+      const proc = makeProc();
+      const shutdownController = createGracefulShutdown({
+        server: makeServer([]),
+        logger: silentLogger,
+        exit: jest.fn(),
+      });
+
+      shutdownController.registerSignalHandlers(proc);
+
+      expect(Object.keys(proc.handlers).sort()).toEqual([
+        "SIGINT",
+        "SIGTERM",
+        "uncaughtException",
+        "unhandledRejection",
+      ]);
+    });
+
+    it("runs the shutdown sequence when SIGTERM fires", async () => {
+      const proc = makeProc();
+      const closeQueues = jest.fn(async () => {});
+      const shutdownController = createGracefulShutdown({
+        server: makeServer([]),
+        closeQueues,
+        logger: silentLogger,
+        exit: jest.fn(),
+      });
+
+      shutdownController.registerSignalHandlers(proc);
+      await proc.handlers.SIGTERM[0]();
+
+      expect(closeQueues).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs an unhandled rejection without tearing the process down", async () => {
+      const proc = makeProc();
+      const error = jest.fn();
+      const closeQueues = jest.fn(async () => {});
+      const shutdownController = createGracefulShutdown({
+        server: makeServer([]),
+        closeQueues,
+        logger: { ...silentLogger, error },
+        exit: jest.fn(),
+      });
+
+      shutdownController.registerSignalHandlers(proc);
+      proc.handlers.unhandledRejection[0](new Error("nope"));
+
+      expect(error).toHaveBeenCalled();
+      // A rejected promise is a bug to investigate, not a reason to drop
+      // in-flight jobs on the floor.
+      expect(closeQueues).not.toHaveBeenCalled();
+    });
+
+    it("drains and exits non-zero on an uncaught exception", async () => {
+      const proc = makeProc();
+      const exit = jest.fn();
+      const closeQueues = jest.fn(async () => {});
+      const shutdownController = createGracefulShutdown({
+        server: makeServer([]),
+        closeQueues,
+        logger: silentLogger,
+        exit,
+      });
+
+      shutdownController.registerSignalHandlers(proc);
+      proc.handlers.uncaughtException[0](new Error("fatal"));
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(closeQueues).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/server/tests/queueRegistry.test.js
+++ b/server/tests/queueRegistry.test.js
@@ -1,0 +1,348 @@
+/**
+ * Issue #975 — background job durability.
+ *
+ * These suites are intentionally Redis-free. tests/setup.js deletes REDIS_URI so
+ * BullMQ never connects, which is exactly the point: the durability policy and
+ * the shutdown ordering are pure logic and must be verifiable without
+ * infrastructure. Anything that needs a live Redis would never run in CI, and a
+ * guarantee that isn't tested is a guarantee that regresses.
+ */
+
+import { jest } from "@jest/globals";
+import {
+  BASE_JOB_OPTIONS,
+  QUEUE_DEFINITIONS,
+  createQueueRegistry,
+  readPositiveIntEnv,
+  resolveJobOptions,
+  resolveWorkerOptions,
+} from "../services/queueRegistry.js";
+
+describe("queueRegistry — durability defaults (Issue #975)", () => {
+  describe("every declared queue gets retries and bounded retention", () => {
+    const queueNames = Object.keys(QUEUE_DEFINITIONS);
+
+    it("declares at least the seven queues that previously had no defaults", () => {
+      expect(queueNames.length).toBeGreaterThanOrEqual(7);
+    });
+
+    it.each(queueNames)(
+      "%s resolves to attempts > 1 with exponential backoff",
+      (name) => {
+        const opts = resolveJobOptions(name);
+
+        // The regression this guards: BullMQ's default is attempts: 1, which
+        // made every transient failure permanent.
+        expect(opts.attempts).toBeGreaterThan(1);
+        expect(opts.backoff.type).toBe("exponential");
+        expect(opts.backoff.delay).toBeGreaterThan(0);
+      },
+    );
+
+    it.each(queueNames)("%s bounds completed/failed job retention", (name) => {
+      const opts = resolveJobOptions(name);
+
+      // Unbounded retention leaked transcript-bearing payloads into the same
+      // Redis that backs the rate limiter and the Socket.IO adapter.
+      expect(opts.removeOnComplete).toBeDefined();
+      expect(opts.removeOnFail).toBeDefined();
+    });
+  });
+
+  describe("resolveJobOptions", () => {
+    it("falls back to the base options for an unknown queue", () => {
+      const opts = resolveJobOptions("queue-that-does-not-exist");
+
+      expect(opts.attempts).toBe(BASE_JOB_OPTIONS.attempts);
+      expect(opts.backoff).toEqual({ ...BASE_JOB_OPTIONS.backoff });
+    });
+
+    it("lets a queue definition override the base attempts", () => {
+      // ai-mom-generation deliberately retries harder than the base default.
+      expect(resolveJobOptions("ai-mom-generation").attempts).toBe(5);
+      expect(resolveJobOptions("memory-lifecycle-queue").attempts).toBe(2);
+    });
+
+    it("lets a per-call override win over the queue definition", () => {
+      const opts = resolveJobOptions("ai-mom-generation", { attempts: 9 });
+      expect(opts.attempts).toBe(9);
+    });
+
+    it("merges backoff field-by-field instead of replacing it wholesale", () => {
+      const opts = resolveJobOptions("data-export-queue", {
+        backoff: { delay: 1234 },
+      });
+
+      expect(opts.backoff.delay).toBe(1234);
+      // `type` was not overridden, so it must survive.
+      expect(opts.backoff.type).toBe("exponential");
+    });
+
+    it("passes through a non-object retention override unchanged", () => {
+      // conflictScanTrigger.js historically passed `removeOnComplete: true`.
+      // Spreading that into the default object would silently discard the
+      // caller's intent, so booleans/numbers must replace rather than merge.
+      const opts = resolveJobOptions("conflict-scan-queue", {
+        removeOnComplete: true,
+        removeOnFail: 50,
+      });
+
+      expect(opts.removeOnComplete).toBe(true);
+      expect(opts.removeOnFail).toBe(50);
+    });
+
+    it("merges an object retention override field-by-field", () => {
+      const opts = resolveJobOptions("data-export-queue", {
+        removeOnComplete: { count: 5 },
+      });
+
+      expect(opts.removeOnComplete.count).toBe(5);
+      // `age` came from the base defaults and must be preserved.
+      expect(opts.removeOnComplete.age).toBe(
+        BASE_JOB_OPTIONS.removeOnComplete.age,
+      );
+    });
+
+    it("preserves unrelated per-call options such as jobId and repeat", () => {
+      const opts = resolveJobOptions("memory-lifecycle-queue", {
+        jobId: "scheduled-lifecycle-sweep",
+        repeat: { every: 1000 },
+      });
+
+      expect(opts.jobId).toBe("scheduled-lifecycle-sweep");
+      expect(opts.repeat).toEqual({ every: 1000 });
+      // …without losing the durability policy.
+      expect(opts.attempts).toBe(2);
+    });
+
+    it("returns a fresh object so callers cannot mutate the shared defaults", () => {
+      const first = resolveJobOptions("data-export-queue");
+      first.attempts = 999;
+      first.backoff.delay = 999;
+      first.removeOnComplete.count = 999;
+
+      const second = resolveJobOptions("data-export-queue");
+      expect(second.attempts).not.toBe(999);
+      expect(second.backoff.delay).not.toBe(999);
+      expect(second.removeOnComplete.count).not.toBe(999);
+    });
+  });
+
+  describe("resolveWorkerOptions", () => {
+    it("returns the declared concurrency for a known queue", () => {
+      expect(resolveWorkerOptions("ai-mom-generation").concurrency).toBe(1);
+      expect(resolveWorkerOptions("data-export-queue").concurrency).toBe(2);
+    });
+
+    it("merges caller overrides such as the Gemini rate limiter", () => {
+      const opts = resolveWorkerOptions("ai-mom-generation", {
+        limiter: { max: 5, duration: 60000 },
+      });
+
+      expect(opts.concurrency).toBe(1);
+      expect(opts.limiter).toEqual({ max: 5, duration: 60000 });
+    });
+
+    it("returns an empty object for an unknown queue", () => {
+      expect(resolveWorkerOptions("nope")).toEqual({});
+    });
+  });
+
+  describe("readPositiveIntEnv", () => {
+    const KEY = "QUEUE_TEST_ENV_VALUE";
+    afterEach(() => {
+      delete process.env[KEY];
+    });
+
+    it("returns the fallback when unset", () => {
+      expect(readPositiveIntEnv(KEY, 42)).toBe(42);
+    });
+
+    it("parses a valid positive integer", () => {
+      process.env[KEY] = "1500";
+      expect(readPositiveIntEnv(KEY, 42)).toBe(1500);
+    });
+
+    it.each(["0", "-5", "abc", ""])(
+      "falls back for the invalid value %p",
+      (value) => {
+        process.env[KEY] = value;
+        expect(readPositiveIntEnv(KEY, 42)).toBe(42);
+      },
+    );
+  });
+});
+
+describe("queueRegistry — shutdown ordering (Issue #975)", () => {
+  /** Records the order in which things closed, so ordering can be asserted. */
+  const makeTracker = () => {
+    const order = [];
+    return {
+      order,
+      worker: (name, impl) => ({
+        close: jest.fn(async () => {
+          if (impl) await impl();
+          order.push(`worker:${name}`);
+        }),
+      }),
+      queue: (name) => ({
+        close: jest.fn(async () => {
+          order.push(`queue:${name}`);
+        }),
+      }),
+      connection: (name) => ({
+        quit: jest.fn(async () => {
+          order.push(`connection:${name}`);
+        }),
+      }),
+    };
+  };
+
+  const silentLogger = { log: () => {}, warn: () => {}, error: () => {} };
+
+  it("closes workers, then queues, then connections", async () => {
+    const t = makeTracker();
+    const registry = createQueueRegistry({ logger: silentLogger });
+
+    registry.registerWorker("ai", t.worker("ai"));
+    registry.registerQueue("ai", t.queue("ai"));
+    registry.registerConnection("producer", t.connection("producer"));
+
+    await registry.closeAll();
+
+    // Workers must drain before the connections their in-flight jobs depend on
+    // are torn down. Closing connections first is precisely the data loss this
+    // registry exists to prevent.
+    expect(t.order).toEqual(["worker:ai", "queue:ai", "connection:producer"]);
+  });
+
+  it("waits for an in-flight job before reporting the worker closed", async () => {
+    const t = makeTracker();
+    const registry = createQueueRegistry({ logger: silentLogger });
+
+    let jobFinished = false;
+    const slowWorker = t.worker("slow", async () => {
+      await new Promise((r) => setTimeout(r, 50));
+      jobFinished = true;
+    });
+
+    registry.registerWorker("slow", slowWorker);
+    await registry.closeAll();
+
+    expect(jobFinished).toBe(true);
+  });
+
+  it("is idempotent — a second signal reuses the first teardown", async () => {
+    const t = makeTracker();
+    const registry = createQueueRegistry({ logger: silentLogger });
+
+    const worker = t.worker("ai");
+    registry.registerWorker("ai", worker);
+
+    const [first, second] = await Promise.all([
+      registry.closeAll(),
+      registry.closeAll(),
+    ]);
+
+    expect(worker.close).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("reports isClosing() once shutdown has begun", async () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+    expect(registry.isClosing()).toBe(false);
+    await registry.closeAll();
+    expect(registry.isClosing()).toBe(true);
+  });
+
+  it("continues closing the rest when one worker throws", async () => {
+    const t = makeTracker();
+    const registry = createQueueRegistry({ logger: silentLogger });
+
+    registry.registerWorker("broken", {
+      close: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const healthy = t.worker("healthy");
+    registry.registerWorker("healthy", healthy);
+    registry.registerConnection("producer", t.connection("producer"));
+
+    const result = await registry.closeAll();
+
+    expect(healthy.close).toHaveBeenCalled();
+    expect(t.order).toContain("connection:producer");
+    expect(result.workers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "worker:broken", status: "error" }),
+        expect.objectContaining({ name: "worker:healthy", status: "closed" }),
+      ]),
+    );
+  });
+
+  it("gives up on a worker that never closes, rather than hanging forever", async () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+
+    registry.registerWorker("hung", {
+      // Never settles — the case that used to turn a graceful shutdown into a
+      // SIGKILL.
+      close: jest.fn(() => new Promise(() => {})),
+    });
+
+    const result = await registry.closeAll({ workerTimeoutMs: 30 });
+
+    expect(result.workers[0]).toEqual(
+      expect.objectContaining({ name: "worker:hung", status: "timeout" }),
+    );
+  });
+
+  it("falls back to disconnect() for a connection without quit()", async () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+    const disconnect = jest.fn(async () => {});
+
+    registry.registerConnection("legacy", { disconnect });
+    await registry.closeAll();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it("ignores a null connection", async () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+    expect(registry.registerConnection("none", null)).toBeNull();
+    await expect(registry.closeAll()).resolves.toBeDefined();
+  });
+
+  it("returns the existing queue when the same name is registered twice", () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+    const first = { close: jest.fn() };
+    const second = { close: jest.fn() };
+
+    expect(registry.registerQueue("dup", first)).toBe(first);
+    expect(registry.registerQueue("dup", second)).toBe(first);
+    expect(registry.listQueues()).toEqual(["dup"]);
+  });
+
+  it("refuses to register a second worker for the same queue", () => {
+    // Two workers on one queue would double-process every job.
+    const warn = jest.fn();
+    const registry = createQueueRegistry({
+      logger: { ...silentLogger, warn },
+    });
+    const first = { close: jest.fn() };
+    const second = { close: jest.fn() };
+
+    registry.registerWorker("dup", first);
+    expect(registry.registerWorker("dup", second)).toBe(first);
+    expect(warn).toHaveBeenCalled();
+    expect(registry.listWorkers()).toEqual(["dup"]);
+  });
+
+  it("lists registered queues and workers for diagnostics", () => {
+    const registry = createQueueRegistry({ logger: silentLogger });
+    registry.registerQueue("a", { close: jest.fn() });
+    registry.registerWorker("b", { close: jest.fn() });
+
+    expect(registry.listQueues()).toEqual(["a"]);
+    expect(registry.listWorkers()).toEqual(["b"]);
+  });
+});

--- a/server/utils/gracefulShutdown.js
+++ b/server/utils/gracefulShutdown.js
@@ -1,0 +1,163 @@
+// server/utils/gracefulShutdown.js
+//
+// Issue #975, Problem 3 — workers are never drained on shutdown.
+//
+// The previous handlers in server.js were:
+//
+//   process.on("SIGTERM", () => {
+//     server.close(() => process.exit(0));
+//   });
+//
+// `server.close()` stops the HTTP listener and nothing else. It does not close
+// BullMQ workers, so an in-flight job was killed mid-execution — and because
+// every queue ran with `attempts: 1`, BullMQ never re-delivered it. On a
+// platform that redeploys by sending SIGTERM (Render, Fly, Kubernetes, …) that
+// meant losing in-flight background work on *every single deploy*.
+//
+// It also had no forced-exit deadline. If any handle stayed open, the
+// `server.close()` callback never fired, the process hung, and the platform
+// eventually SIGKILLed it — killing in-flight jobs even on the "graceful" path.
+//
+// This module fixes both, and makes the sequence idempotent so a second signal
+// (impatient operator, or SIGINT arriving right after SIGTERM) doesn't start a
+// second teardown on top of the first.
+
+/**
+ * Builds a graceful-shutdown controller.
+ *
+ * Ordering is deliberate:
+ *   1. stop accepting new HTTP connections  — new work stops arriving
+ *   2. close Socket.IO                      — realtime clients get a clean close
+ *   3. drain BullMQ workers                 — in-flight jobs run to completion
+ *   4. close datastores (Mongo, Redis)      — nothing can still be issuing queries
+ *
+ * Each step is individually try/caught: a failure in one must not prevent the
+ * remaining steps from running, because the alternative is leaking the very
+ * connections we're trying to close.
+ *
+ * @param {object} deps
+ * @param {import("http").Server} deps.server
+ * @param {object} [deps.io] Socket.IO server
+ * @param {Function} [deps.closeQueues] async () => void
+ * @param {Function} [deps.closeDatabase] async () => void
+ * @param {Function} [deps.closeRedis] async () => void
+ * @param {number} [deps.forceExitAfterMs] hard deadline before process.exit
+ * @param {Console|object} [deps.logger]
+ * @param {Function} [deps.exit] injectable process.exit, for tests
+ */
+export const createGracefulShutdown = ({
+  server,
+  io = null,
+  closeQueues = null,
+  closeDatabase = null,
+  closeRedis = null,
+  forceExitAfterMs = Number.parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10) ||
+    30000,
+  logger = console,
+  exit = (code) => process.exit(code),
+} = {}) => {
+  let shuttingDown = false;
+  /** @type {Promise<void>|null} */
+  let inFlight = null;
+
+  /**
+   * Runs a shutdown step, logging and swallowing any failure.
+   * @param {string} label
+   * @param {Function|null} fn
+   */
+  const step = async (label, fn) => {
+    if (typeof fn !== "function") return;
+    try {
+      await fn();
+      logger.log?.(`   ✓ ${label}`);
+    } catch (err) {
+      logger.error?.(`   ✗ ${label} failed:`, err?.message || err);
+    }
+  };
+
+  /** Promisified `server.close()` — the callback form never rejects. */
+  const closeHttpServer = () =>
+    new Promise((resolve) => {
+      if (!server || typeof server.close !== "function") return resolve();
+      server.close(() => resolve());
+    });
+
+  const closeSocketIo = () =>
+    new Promise((resolve) => {
+      if (!io || typeof io.close !== "function") return resolve();
+      io.close(() => resolve());
+    });
+
+  /**
+   * @param {string} signal
+   * @returns {Promise<void>}
+   */
+  const shutdown = async (signal = "SHUTDOWN") => {
+    if (shuttingDown) {
+      logger.warn?.(
+        `⚠️ ${signal} received while shutdown already in progress — ignoring.`,
+      );
+      return inFlight;
+    }
+    shuttingDown = true;
+
+    logger.log?.(`\n🛑 ${signal} received. Shutting down gracefully...`);
+
+    // Arm the deadline *before* doing any work. Whatever happens below —
+    // including a promise that never settles — the process exits.
+    const forceTimer = setTimeout(() => {
+      logger.error?.(
+        `⏱️ Shutdown exceeded ${forceExitAfterMs}ms. Forcing exit.`,
+      );
+      exit(1);
+    }, forceExitAfterMs);
+    // Don't let the deadline timer itself be the thing keeping us alive.
+    forceTimer.unref?.();
+
+    inFlight = (async () => {
+      await step("HTTP server closed", closeHttpServer);
+      await step("Socket.IO closed", closeSocketIo);
+      // Workers before datastores: a draining job still needs Mongo and Redis.
+      await step("Background workers drained", closeQueues);
+      await step("Database connection closed", closeDatabase);
+      await step("Redis connection closed", closeRedis);
+
+      clearTimeout(forceTimer);
+      logger.log?.("👋 Shutdown complete.");
+      exit(0);
+    })();
+
+    return inFlight;
+  };
+
+  /**
+   * Attaches the signal and fatal-error handlers.
+   *
+   * `unhandledRejection` and `uncaughtException` are included because reaching
+   * either means process state is no longer trustworthy — the correct response
+   * is to drain and exit non-zero so the supervisor restarts us, not to limp on.
+   *
+   * @param {NodeJS.Process} [proc]
+   */
+  const registerSignalHandlers = (proc = process) => {
+    proc.on("SIGTERM", () => shutdown("SIGTERM"));
+    proc.on("SIGINT", () => shutdown("SIGINT"));
+
+    proc.on("unhandledRejection", (reason) => {
+      logger.error?.("❌ Unhandled promise rejection:", reason);
+    });
+
+    proc.on("uncaughtException", (err) => {
+      logger.error?.("❌ Uncaught exception:", err?.stack || err);
+      shutdown("uncaughtException").then(() => exit(1));
+    });
+  };
+
+  return {
+    shutdown,
+    registerSignalHandlers,
+    isShuttingDown: () => shuttingDown,
+  };
+};
+
+export default createGracefulShutdown;


### PR DESCRIPTION
# Pull Request

## Description

Makes background jobs durable across transient failures and deploys.

Every BullMQ queue in `queueService.js` was constructed as `new Queue(name, { connection })` with **no `defaultJobOptions`**. BullMQ's default is `attempts: 1`, so any throw — a Redis blip, a Mongo failover, a Gemini `429` — permanently destroyed the job. Nothing retried it and nothing recorded that it had vanished. Separately, `SIGTERM` only called `server.close()`, which stops the HTTP listener and nothing else, so in-flight jobs were killed mid-execution on every deploy and never re-delivered.

Retry, retention and shutdown are now **structural** rather than something each call site has to remember.

### `services/queueRegistry.js` (new)

The durability policy, in one place:

- `BASE_JOB_OPTIONS` — `attempts: 3`, exponential backoff, and bounded `removeOnComplete`/`removeOnFail`. The retry values match what `webhookDispatcherService.js` and `MeetingService.js` had already chosen by hand; this makes that the default for every queue instead of an opt-in.
- `QUEUE_DEFINITIONS` — per-queue overrides with the rationale recorded inline (`ai-mom-generation` retries harder and backs off longer because it's the most likely to hit a provider rate limit; `memory-lifecycle-queue` fails fast because the sweep is idempotent and re-runs on a schedule anyway).
- `createQueueRegistry()` — tracks every queue, worker and shared Redis connection so shutdown can close them **in dependency order**: workers → queues → connections. Closing connections first (the naive ordering) makes in-flight jobs fail with a connection error, which is exactly the data loss this prevents. Every close is individually timeout-bounded, and `closeAll()` is idempotent.

Retention merging handles all three shapes BullMQ accepts. `conflictScanTrigger.js` used to pass `removeOnComplete: true`; blindly spreading that into the default object would have silently discarded the caller's intent, so booleans and numbers replace rather than merge.

### `services/queueService.js` (rewritten around two factories)

Seven near-identical queue getters, seven `add()` wrappers and seven `initXWorker` functions collapse into `getQueue`/`createQueueFacade`/`createWorker`. Adding an eighth queue is now one table entry, and **it cannot accidentally ship without a retry policy**. The public API (`aiQueue.add(...)`, `initAIWorker(app)`, …) is unchanged, so no caller needed to be touched.

Worker logging now distinguishes a retry from a final failure — previously every attempt logged an identical line, so a job about to be retried was indistinguishable from one that had been abandoned:

```
↻ AI Worker: job 42 failed attempt 1/5, will retry — 429 Too Many Requests
❌ AI Worker: job 42 permanently failed after 5/5 attempts — 429 Too Many Requests
⚠️ AI Worker: job 43 stalled and will be re-queued.
```

### `utils/gracefulShutdown.js` (new) + `server.js`

Replaces the two ad-hoc signal handlers with one controller:

```
SIGTERM → HTTP listener → Socket.IO → BullMQ workers → MongoDB → Redis → exit(0)
```

Each step is individually try/caught, so a failure in one does not leak the connections the later steps would have closed. The whole sequence has a hard deadline (`SHUTDOWN_TIMEOUT_MS`, default 30s) — if anything hangs, the process force-exits rather than waiting for the platform to `SIGKILL` it, which is how in-flight jobs died even on the "graceful" path. Shutdown is idempotent, so a second signal reuses the first teardown.

### Supporting fixes

- `redisService.js` — added `closeRedis()`. Nothing closed that socket, so it could keep the event loop alive past `server.close()`.
- `webhookDispatcherService.js` — registers its queue, worker and both connections with the registry so they're drained too, and picks up the shared retention caps it was missing (its dispatch semantics are unchanged; the attempts/backoff values moved to the shared definitions verbatim).
- `config/workers.js` — `safeInit` was declared `async` but called **without `await`**, so its try/catch could never catch anything an initializer rejected with; the rejection escaped as an unhandled rejection instead. Now awaited, and boot reports which workers started and which failed.

## Type of Change

- [x] Bug Fix
- [x] Refactor
- [x] Performance Improvement
- [ ] New Feature
- [ ] Documentation Update
- [x] Other — reliability / operational hardening

## Related Issue

Closes #975

## Testing

Added **58 tests** across two new suites:

**`tests/queueRegistry.test.js`**
- every declared queue resolves to `attempts > 1` with exponential backoff and bounded retention (the direct regression guard)
- per-call overrides beat queue definitions beat base defaults
- `backoff` merges field-by-field (override `delay`, keep `type`)
- non-object retention values pass through unchanged; object values merge
- unrelated options (`jobId`, `repeat`) survive the merge
- returned options are fresh objects — a caller mutating one can't corrupt the shared defaults
- shutdown closes workers → queues → connections, waits for in-flight jobs, is idempotent, continues past a throwing worker, times out on a worker that never closes, and falls back to `disconnect()` for connections without `quit()`

**`tests/gracefulShutdown.test.js`**
- full ordering; steps skipped cleanly when not provided
- one failing step does not prevent the rest (no leaked connections)
- force-exit fires when a step never settles; does **not** fire on a clean shutdown
- idempotent under concurrent signals
- signal handlers registered correctly; `unhandledRejection` logs without tearing down; `uncaughtException` drains and exits non-zero

Every test is Redis-free, which is deliberate — `tests/setup.js` deletes `REDIS_URI`, so anything requiring live infrastructure would simply never run in CI, and an untested guarantee is one that regresses.

```
Test Suites: 2 passed, 2 total
Tests:       58 passed, 58 total
```

Also re-ran the suites most likely to be affected by the queue/webhook changes:

```
tests/webhook.test.js  tests/health.test.js  tests/webhookUrlSafety.test.js
Test Suites: 3 passed, 3 total
Tests:       23 passed, 23 total
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors
- [x] `eslint` and `prettier --check` clean on all changed files

## Screenshots

Not applicable — backend reliability change with no UI surface.

## Notes for reviewers

- **No behaviour change when `REDIS_URI` is unset.** `add()` still warns and resolves to `null`, workers still don't start, the app still boots. Frontend-only development is unaffected.
- **New env knobs, all with safe defaults:** `SHUTDOWN_TIMEOUT_MS` (30s), `QUEUE_WORKER_CLOSE_TIMEOUT_MS` (15s), `QUEUE_CLOSE_TIMEOUT_MS` (5s). `SHUTDOWN_TIMEOUT_MS` should be set **below** the platform's `SIGTERM`→`SIGKILL` grace period so the app wins the race.
- **Signal handlers are skipped under `NODE_ENV=test`** — Jest owns process lifecycle there and an exit-on-SIGINT handler would fight it.
- `docs/background-job-durability.md` documents the model, the per-queue rationale, the env knobs, and how to add a new queue.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable background-job processing with shared retries, backoff, retention, timeouts, and queue status diagnostics.
  - Added coordinated graceful shutdown for servers, background workers, databases, and Redis.
  - Improved startup reporting by identifying successfully initialized and failed services.
  - Added observability for retries, failures, stalled jobs, and shutdown issues.

- **Documentation**
  - Added guidance for configuring queue durability, overrides, shutdown behavior, Redis-disabled operation, and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->