### PR TITLE
fix(ai): add timeout, retry, circuit breaking and prompt budgeting to Gemini generation (#976)

### DIFF
--- a/docs/ai-resilience.md
+++ b/docs/ai-resilience.md
@@ -1,0 +1,170 @@
+# AI Generation Resilience
+
+How MeetOnMemory handles Gemini being slow, rate-limited, or down. Added in
+response to [#976](https://github.com/imuniqueshiv/MeetOnMemory/issues/976).
+
+## The failure this replaced
+
+`generateMoMWithAI` wrapped its Gemini call in a single `try`, and the `catch`
+treated every error identically:
+
+```js
+} catch (gemErr) {
+  console.error("❌ Gemini API error, falling back to HuggingFace:", gemErr.message);
+}
+```
+
+Below that, the fallback ran `textToSummarize.substring(0, 1024)` through
+distilbart and returned an object with `decisions: []`, `action_items: []`,
+`attendees: []` hardcoded.
+
+So a single `429` — the _normal_ condition on the free tier this code targets —
+produced a MoM summarised from the opening few sentences of the meeting, with no
+decisions and no action items, which was then persisted and displayed as a
+finished result. Every downstream feature (decision graph, tasks board, conflict
+detection, policy compliance, action-item reminders) saw an empty meeting. The
+only trace was a free-text `notes` string, so there was no way to find the
+affected meetings afterwards.
+
+There was also no timeout anywhere. `@google/generative-ai` uses `fetch`, which
+has no default timeout, and the AI worker runs at `concurrency: 1` — so one hung
+call stalled MoM generation for every organization until the process restarted.
+
+## The model
+
+`server/utils/aiResilience.js` provides the pieces; `GenerativeAIService.js`
+composes them. Order matters:
+
+```
+circuit breaker  →  retry (backoff + jitter)  →  timeout  →  provider
+```
+
+- The **breaker is outermost** so an open circuit costs nothing.
+- The **timeout is innermost** so it bounds each _attempt_, not the whole retry
+  sequence. A 3-attempt call with a 60s timeout should be able to spend 60s per
+  attempt, not 60s in total.
+
+### Error classification decides everything
+
+`classifyAiError(err)` returns `{ kind, status, retryable, retryAfterMs }`.
+
+| Condition                                     | Kind              | Retried? |
+| --------------------------------------------- | ----------------- | -------- |
+| `429`, `RESOURCE_EXHAUSTED`, "quota exceeded" | `rate_limit`      | yes      |
+| `500`/`502`/`503`/`504`, "overloaded"         | `server`          | yes      |
+| `408`, `AbortError`, our own timeout          | `timeout`         | yes      |
+| `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, …     | `network`         | yes      |
+| `401`, `403`, "API key not valid"             | `auth`            | **no**   |
+| other `4xx`                                   | `invalid_request` | **no**   |
+| anything unrecognised                         | `unknown`         | **no**   |
+
+Unrecognised errors default to **not retryable**. That's deliberate: an error we
+can't classify is more likely a bug in our own request than a blip on the wire,
+and retrying it just burns the timeout budget and delays the fallback.
+
+Getting the SDK's status out is fiddly — `@google/generative-ai` has no stable
+`status` field and commonly throws a `GoogleGenerativeAIFetchError` whose message
+begins `[429 Too Many Requests] …`. Structured fields are checked first, then the
+message.
+
+### Backoff honours the provider
+
+`computeBackoffDelay` uses **full jitter**, not a fixed multiplier: when a batch
+of queued jobs all trip the same rate limit, un-jittered backoff makes them retry
+in lockstep and hit the limit again together.
+
+A provider-supplied hint always wins, from either source:
+
+- a `Retry-After` response header (seconds or an HTTP date), or
+- Google's `RetryInfo` error detail (`retryDelay: "31s"`).
+
+The provider knows when its quota window resets; we don't.
+
+### Prompt budgeting instead of truncation
+
+`chunkTextByBudget` replaces `.substring(0, 1024)`. Long transcripts are split at
+natural boundaries (paragraph, then sentence, then a hard cut) with a small
+overlap so a decision stated across a seam isn't lost by either chunk. Each chunk
+is extracted separately and `mergeMoMParts` combines them, de-duplicating
+case-insensitively — the overlap deliberately feeds the same sentences to two
+chunks, and the model will usually restate a straddling decision in both.
+
+This matters most for the _longest_ meetings, which under the old code were the
+ones most likely to blow the context window and get dumped to the 1024-character
+fallback.
+
+### Degradation is recorded, not implied
+
+`generateMoMDetailed()` returns `{ mom, generation }`, and `normalizeMoM` carries
+`generation` into the persisted `structuredMoM` (a `Mixed` field, so no migration
+was needed):
+
+```json
+{
+  "provider": "local-distilbart",
+  "degraded": true,
+  "reason": "gemini_failed",
+  "errorKind": "rate_limit",
+  "truncated": true,
+  "inputCharsUsed": 1024,
+  "inputCharsTotal": 48213,
+  "chunks": 1,
+  "generatedAt": "2026-08-01T09:14:22.104Z"
+}
+```
+
+Degraded meetings are now findable:
+
+```js
+db.meetings.find({ "structuredMoM.generation.degraded": true });
+```
+
+`buildHumanReadableMoM` also adds a visible notice to a degraded document —
+without it, an empty "Decisions" section reads as "no decisions were made"
+rather than "we never analysed most of the meeting".
+
+Legacy MoMs written before this field existed default to
+`{ provider: "unknown", degraded: false }`. Absence of evidence isn't evidence of
+degradation, and flagging every historical MoM as suspect would make the flag
+useless.
+
+### Circuit breaker
+
+After `GEMINI_BREAKER_THRESHOLD` consecutive provider failures the breaker opens
+and subsequent calls fail fast to the fallback. With `concurrency: 1`, a 60s
+timeout and 5 attempts, re-confirming a known outage costs minutes of dead time
+per job.
+
+Only failures that are plausibly the _provider's_ fault count. A `400` from a
+malformed prompt is not evidence Gemini is down, and opening on it would suppress
+every other caller.
+
+After `GEMINI_BREAKER_COOLDOWN_MS` the breaker half-opens and the next call acts
+as a probe: success closes it, failure re-opens it.
+
+## Configuration
+
+| Variable                     | Default | Effect                                                                     |
+| ---------------------------- | ------- | -------------------------------------------------------------------------- |
+| `GEMINI_TIMEOUT_MS`          | `60000` | Per-attempt deadline.                                                      |
+| `GEMINI_MAX_RETRIES`         | `3`     | Additional attempts after the first, retryable failures only.              |
+| `GEMINI_RETRY_BASE_DELAY_MS` | `2000`  | First backoff step.                                                        |
+| `GEMINI_RETRY_MAX_DELAY_MS`  | `30000` | Backoff ceiling.                                                           |
+| `GEMINI_MAX_PROMPT_CHARS`    | `24000` | Transcript budget per prompt; above this, chunking kicks in.               |
+| `GEMINI_CHUNK_OVERLAP_CHARS` | `500`   | Context carried across a chunk seam.                                       |
+| `GEMINI_MAX_CHUNKS`          | `8`     | Fan-out cap. Exceeding it is recorded as `reason: "chunk_limit_exceeded"`. |
+| `GEMINI_BREAKER_THRESHOLD`   | `5`     | Consecutive provider failures before the breaker opens.                    |
+| `GEMINI_BREAKER_COOLDOWN_MS` | `60000` | How long the breaker stays open before probing.                            |
+
+Breaker settings are read once at module load; the rest are read per call.
+
+## Operating notes
+
+- **A spike in `degraded: true` means check the provider**, not the code. The
+  `errorKind` field tells you which way it's failing.
+- **`⚡ Gemini circuit breaker: closed → open`** in the logs means every MoM job
+  is now taking the fallback path. Meetings processed during that window are
+  worth reprocessing once it closes.
+- **Raise `GEMINI_MAX_CHUNKS`** if `reason: "chunk_limit_exceeded"` starts
+  appearing — that means meetings are long enough that trailing chunks are being
+  skipped.

--- a/server/jobs/processAudioJob.js
+++ b/server/jobs/processAudioJob.js
@@ -10,7 +10,7 @@ import User from "../models/userModel.js";
 
 import { indexMeeting } from "../utils/embeddingUtils.js";
 import {
-  generateMoMWithAI,
+  generateMoMDetailed,
   normalizeMoM,
   buildHumanReadableMoM,
 } from "../services/GenerativeAIService.js";
@@ -43,10 +43,25 @@ export default async function processAudioJob(job, _app) {
   let structured = null;
   let humanReadable = "";
 
-  structured = await generateMoMWithAI(textToSummarize, date, title);
+  // Issue #976: the detailed entry point also returns provenance, so a MoM
+  // produced by the reduced-capability fallback is flagged rather than being
+  // persisted as if it were a complete result.
+  const { mom: generated, generation } = await generateMoMDetailed(
+    textToSummarize,
+    date,
+    title,
+  );
+  structured = generated;
+
+  if (generation?.degraded) {
+    console.warn(
+      `⚠️ MoM for ${meetingId || "transcript-only"} was generated in degraded mode ` +
+        `(${generation.provider}, reason: ${generation.reason}). Consider reprocessing.`,
+    );
+  }
 
   if (structured) {
-    const mom = normalizeMoM(structured, title, date);
+    const mom = normalizeMoM(structured, title, date, generation);
     humanReadable = buildHumanReadableMoM(mom);
 
     let meetingToUpdate = meeting;

--- a/server/services/GenerativeAIService.js
+++ b/server/services/GenerativeAIService.js
@@ -1,6 +1,12 @@
 import axios from "axios"; // eslint-disable-line no-unused-vars
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { pipeline, env } from "@xenova/transformers";
+import {
+  AI_ERROR_KIND,
+  callWithResilience,
+  chunkTextByBudget,
+  createCircuitBreaker,
+} from "../utils/aiResilience.js";
 
 env.useBrowserCache = false;
 let localSummarizer = null;
@@ -9,14 +15,162 @@ const HUGGINGFACE_API_KEY = process.env.HUGGINGFACE_API_KEY; // eslint-disable-l
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 const GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
 
-export const generateMoMWithAI = async (textToSummarize, date, title) => {
-  const prompt = `
-You are an advanced AI meeting assistant responsible for preparing *formal, well-structured Minutes of Meeting (MoM)* 
+// ─── Resilience configuration (Issue #976) ──────────────────────────────────
+// All tunable via env so ops can react to a provider incident without a deploy.
+
+const readIntEnv = (name, fallback) => {
+  const parsed = Number.parseInt(process.env[name], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/** Per-attempt deadline. Without this a hung fetch stalls the AI worker forever. */
+const GEMINI_TIMEOUT_MS = () => readIntEnv("GEMINI_TIMEOUT_MS", 60000);
+/** Additional attempts after the first, for retryable failures only. */
+const GEMINI_MAX_RETRIES = () => readIntEnv("GEMINI_MAX_RETRIES", 3);
+const GEMINI_RETRY_BASE_MS = () =>
+  readIntEnv("GEMINI_RETRY_BASE_DELAY_MS", 2000);
+const GEMINI_RETRY_MAX_MS = () =>
+  readIntEnv("GEMINI_RETRY_MAX_DELAY_MS", 30000);
+/**
+ * Character budget for the transcript portion of a prompt. Chosen well under
+ * Gemini Flash's context window so the surrounding instructions and the model's
+ * own output always fit; transcripts above it are chunked, never truncated.
+ */
+const GEMINI_MAX_PROMPT_CHARS = () =>
+  readIntEnv("GEMINI_MAX_PROMPT_CHARS", 24000);
+const GEMINI_CHUNK_OVERLAP_CHARS = () =>
+  readIntEnv("GEMINI_CHUNK_OVERLAP_CHARS", 500);
+/** Hard cap on chunks so a pathological transcript can't fan out unboundedly. */
+const GEMINI_MAX_CHUNKS = () => readIntEnv("GEMINI_MAX_CHUNKS", 8);
+
+/**
+ * Shared circuit breaker across every Gemini entry point.
+ *
+ * Once the provider is confirmed down, queued jobs fail fast to the fallback
+ * instead of each re-confirming the outage at full timeout × retry cost.
+ */
+const geminiBreaker = createCircuitBreaker({
+  name: "gemini",
+  failureThreshold: readIntEnv("GEMINI_BREAKER_THRESHOLD", 5),
+  cooldownMs: readIntEnv("GEMINI_BREAKER_COOLDOWN_MS", 60000),
+  onStateChange: ({ from, to }) =>
+    console.warn(`⚡ Gemini circuit breaker: ${from} → ${to}`),
+});
+
+/** Exposed for tests and diagnostics. */
+export const getGeminiBreakerState = () => geminiBreaker.getState();
+export const resetGeminiBreaker = () => geminiBreaker.reset();
+
+/**
+ * Memoised client.
+ *
+ * Previously `new GoogleGenerativeAI(...)` ran on every call (three separate
+ * sites). Rebuilding the client per request throws away connection reuse for no
+ * benefit.
+ *
+ * A missing key is deliberately *not* rejected here: `generateMoMWithAI` never
+ * checked for one, and its callers depend on a missing key degrading to the
+ * local fallback rather than throwing. The provider's own auth error is
+ * classified non-retryable, so it fails fast and reaches the fallback in one
+ * attempt anyway. The entry points that genuinely cannot degrade
+ * (`classifyContradiction`, `generateSessionCardAI`) check explicitly.
+ */
+let _genAIClient = null;
+
+const getGenerativeModel = () => {
+  if (!_genAIClient) {
+    _genAIClient = new GoogleGenerativeAI(GEMINI_API_KEY);
+  }
+  return _genAIClient.getGenerativeModel({ model: GEMINI_MODEL });
+};
+
+/** Test hook: drops the memoised client so construction can be observed. */
+export const resetGeminiClient = () => {
+  _genAIClient = null;
+};
+
+/**
+ * Single resilient Gemini text call: bounded by a timeout, retried with
+ * backoff on transient failures only, and gated by the shared breaker.
+ *
+ * @param {string} prompt
+ * @param {string} label used in logs and the timeout message
+ * @returns {Promise<string>} raw model output text
+ */
+const generateText = async (prompt, label) => {
+  const result = await callWithResilience(
+    async (signal) => {
+      const model = getGenerativeModel();
+      // The SDK forwards requestOptions to fetch, so a well-behaved version
+      // cancels the in-flight request on abort. withTimeout rejects regardless,
+      // so an SDK that ignores the signal still cannot hang us.
+      return await model.generateContent(prompt, { signal });
+    },
+    {
+      label,
+      timeoutMs: GEMINI_TIMEOUT_MS(),
+      retries: GEMINI_MAX_RETRIES(),
+      baseDelayMs: GEMINI_RETRY_BASE_MS(),
+      maxDelayMs: GEMINI_RETRY_MAX_MS(),
+      breaker: geminiBreaker,
+      onRetry: ({ attempt, delayMs, classification }) =>
+        console.warn(
+          `↻ ${label}: attempt ${attempt} failed (${classification.kind}` +
+            `${classification.status ? ` ${classification.status}` : ""}), ` +
+            `retrying in ${delayMs}ms`,
+        ),
+    },
+  );
+
+  return result.response.text();
+};
+
+/**
+ * Parses model output that is supposed to be JSON but may be wrapped in prose
+ * or fenced code. Unchanged in behaviour from the original inline logic, just
+ * shared instead of duplicated three times.
+ *
+ * @param {string} outputText
+ * @returns {object|null}
+ */
+const parseJsonOutput = (outputText) => {
+  try {
+    return JSON.parse(outputText);
+  } catch {
+    const match = String(outputText ?? "").match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+};
+
+/**
+ * Builds the MoM extraction prompt.
+ *
+ * @param {string} transcriptSegment
+ * @param {string} date
+ * @param {string} title
+ * @param {object} [context]
+ * @param {number} [context.part] 1-based chunk index, when chunked
+ * @param {number} [context.totalParts]
+ */
+const buildMoMPrompt = (transcriptSegment, date, title, context = {}) => {
+  const { part, totalParts } = context;
+  const chunkNotice =
+    part && totalParts > 1
+      ? `\n⚠️ This is part ${part} of ${totalParts} of a longer transcript. Extract only what is present in THIS part; do not invent content from the missing parts, and do not summarise the meeting as a whole.\n`
+      : "";
+
+  return `
+You are an advanced AI meeting assistant responsible for preparing *formal, well-structured Minutes of Meeting (MoM)*
 from the transcript provided below.
 
-The MoM should be factual, concise, and formatted for professional use in organizations, universities, or institutions.  
+The MoM should be factual, concise, and formatted for professional use in organizations, universities, or institutions.
 Avoid repetition, filler words, and unnecessary phrases. Capture key insights, outcomes, and responsibilities accurately.
-
+${chunkNotice}
 🎯 Your goal is to return a clean JSON object with the following fields:
 {
   "title": "A clear, professional meeting title (e.g., 'AI Integration Strategy Discussion')",
@@ -51,7 +205,7 @@ Avoid repetition, filler words, and unnecessary phrases. Capture key insights, o
 }
 
 Transcript:
-${textToSummarize}
+${transcriptSegment}
 
 🧠 Instructions:
 - Return ONLY valid JSON (no Markdown, no commentary, no backticks).
@@ -61,65 +215,261 @@ ${textToSummarize}
 - Maintain factual tone based on transcript content only.
 - If user provided a title: ${title || "none"}, incorporate or refine it if appropriate.
 `;
+};
+
+/**
+ * Merges per-chunk MoM objects into one.
+ *
+ * Deduplication is case-insensitive on the rendered text, because the overlap
+ * window deliberately feeds the same sentences to two adjacent chunks and the
+ * model will usually restate a straddling decision in both.
+ *
+ * @param {object[]} parts
+ * @returns {object}
+ */
+const mergeMoMParts = (parts) => {
+  const merged = {
+    title: "",
+    date: "",
+    summary: "",
+    agenda: [],
+    key_discussions: [],
+    decisions: [],
+    action_items: [],
+    questions_raised: [],
+    keywords: [],
+    attendees: [],
+    notes: "",
+    scheduling_intents: [],
+  };
+
+  const seen = {};
+  const listKeys = [
+    "agenda",
+    "key_discussions",
+    "decisions",
+    "action_items",
+    "questions_raised",
+    "keywords",
+    "attendees",
+    "scheduling_intents",
+  ];
+  listKeys.forEach((key) => {
+    seen[key] = new Set();
+  });
+
+  const summaries = [];
+  const notes = [];
+
+  for (const part of parts) {
+    if (!part) continue;
+
+    if (!merged.title && part.title) merged.title = part.title;
+    if (!merged.date && part.date) merged.date = part.date;
+    if (part.summary) summaries.push(String(part.summary).trim());
+    if (part.notes) notes.push(String(part.notes).trim());
+
+    for (const key of listKeys) {
+      const values = Array.isArray(part[key]) ? part[key] : [];
+      for (const value of values) {
+        const fingerprint = (
+          typeof value === "string" ? value : JSON.stringify(value)
+        )
+          .toLowerCase()
+          .replace(/\s+/g, " ")
+          .trim();
+        if (!fingerprint || seen[key].has(fingerprint)) continue;
+        seen[key].add(fingerprint);
+        merged[key].push(value);
+      }
+    }
+  }
+
+  merged.summary = summaries.join(" ");
+  merged.notes = notes.join(" ");
+  return merged;
+};
+
+/**
+ * Local fallback summarisation.
+ *
+ * This path is genuinely lossy — distilbart has a small input window and
+ * produces no structured fields — so it reports exactly what it did rather than
+ * pretending to be a complete MoM. Previously the only trace was a free-text
+ * `notes` string, which nothing could query.
+ *
+ * @param {string} textToSummarize
+ * @param {string} date
+ * @param {string} title
+ * @param {object} degradation
+ */
+const runLocalFallback = async (textToSummarize, date, title, degradation) => {
+  if (!localSummarizer) {
+    console.log("⏳ Loading local summarization model fallback...");
+    localSummarizer = await pipeline(
+      "summarization",
+      "Xenova/distilbart-cnn-6-6",
+    );
+    console.log("✅ Local model loaded");
+  }
+
+  const FALLBACK_INPUT_CHARS = 1024; // distilbart's practical input window
+  const source = String(textToSummarize ?? "");
+  const truncated = source.length > FALLBACK_INPUT_CHARS;
+
+  const result = await localSummarizer(
+    source.substring(0, FALLBACK_INPUT_CHARS),
+    { max_new_tokens: 150 },
+  );
+
+  const hfText = result[0].summary_text;
+  console.log("✅ Local fallback summarization completed");
+
+  return {
+    title: title || `Meeting on ${date}`,
+    date,
+    summary: hfText,
+    agenda: [],
+    key_discussions: [],
+    decisions: [],
+    action_items: [],
+    questions_raised: [],
+    keywords: [],
+    attendees: [],
+    notes: "Generated using local fallback summarization model",
+    scheduling_intents: [],
+    generation: {
+      provider: "local-distilbart",
+      degraded: true,
+      reason: degradation.reason,
+      errorKind: degradation.errorKind ?? null,
+      truncated,
+      // The operator-relevant fact: this fraction of the meeting was never read.
+      inputCharsUsed: Math.min(source.length, FALLBACK_INPUT_CHARS),
+      inputCharsTotal: source.length,
+      chunks: 1,
+      generatedAt: new Date().toISOString(),
+    },
+  };
+};
+
+/**
+ * Generates a MoM and reports how it was produced.
+ *
+ * Returns `{ mom, generation }` so callers can persist the provenance. The
+ * original `generateMoMWithAI` is kept as a thin wrapper over this, so no
+ * existing caller is forced to change.
+ *
+ * @param {string} textToSummarize
+ * @param {string} date
+ * @param {string} title
+ * @returns {Promise<{mom: object, generation: object}>}
+ */
+export const generateMoMDetailed = async (textToSummarize, date, title) => {
+  const source = String(textToSummarize ?? "");
+  const startedAt = Date.now();
+
+  let degradation = { reason: "unknown", errorKind: null };
 
   try {
-    console.log(`📡 Using Gemini model: ${GEMINI_MODEL}`);
-    const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
-    const result = await model.generateContent(prompt);
-    const outputText = result.response.text();
+    // Prompt budgeting. The old code interpolated the transcript unbounded, so
+    // the longest meetings — where a summary is most valuable — were the ones
+    // most likely to blow the context window and get dumped to the 1024-char
+    // fallback.
+    const chunks = chunkTextByBudget(source, {
+      maxChars: GEMINI_MAX_PROMPT_CHARS(),
+      overlapChars: GEMINI_CHUNK_OVERLAP_CHARS(),
+    });
 
-    let structured;
-    try {
-      structured = JSON.parse(outputText);
-    } catch {
-      const match = outputText.match(/\{[\s\S]*\}/);
-      structured = match ? JSON.parse(match[0]) : { rawText: outputText };
+    if (chunks.length === 0) {
+      throw new Error("Transcript is empty — nothing to summarize.");
     }
+
+    const maxChunks = GEMINI_MAX_CHUNKS();
+    const usedChunks = chunks.slice(0, maxChunks);
+    const droppedChunks = chunks.length - usedChunks.length;
+
+    if (droppedChunks > 0) {
+      console.warn(
+        `⚠️ Transcript exceeded ${maxChunks} chunks; ${droppedChunks} trailing chunk(s) skipped. ` +
+          `Raise GEMINI_MAX_CHUNKS to cover longer meetings.`,
+      );
+    }
+
+    console.log(
+      `📡 Using Gemini model: ${GEMINI_MODEL} (${usedChunks.length} chunk(s))`,
+    );
+
+    const parts = [];
+    for (let index = 0; index < usedChunks.length; index += 1) {
+      const prompt = buildMoMPrompt(usedChunks[index], date, title, {
+        part: index + 1,
+        totalParts: usedChunks.length,
+      });
+
+      const outputText = await generateText(
+        prompt,
+        `Gemini MoM part ${index + 1}/${usedChunks.length}`,
+      );
+
+      const parsed = parseJsonOutput(outputText);
+      parts.push(parsed ?? { rawText: outputText });
+    }
+
+    const structured =
+      usedChunks.length === 1 ? parts[0] : mergeMoMParts(parts);
+
     console.log("✅ Gemini response received");
-    return structured;
+
+    return {
+      mom: structured,
+      generation: {
+        provider: "gemini",
+        model: GEMINI_MODEL,
+        degraded: droppedChunks > 0,
+        reason: droppedChunks > 0 ? "chunk_limit_exceeded" : null,
+        errorKind: null,
+        truncated: droppedChunks > 0,
+        inputCharsUsed: usedChunks.reduce((sum, c) => sum + c.length, 0),
+        inputCharsTotal: source.length,
+        chunks: usedChunks.length,
+        durationMs: Date.now() - startedAt,
+        generatedAt: new Date().toISOString(),
+      },
+    };
   } catch (gemErr) {
+    degradation = {
+      reason: "gemini_failed",
+      errorKind: gemErr?.kind ?? AI_ERROR_KIND.UNKNOWN,
+    };
     console.error(
-      "❌ Gemini API error, falling back to HuggingFace:",
+      `❌ Gemini API error (${degradation.errorKind}), falling back to local summarization:`,
       gemErr.message,
     );
   }
 
   try {
-    if (!localSummarizer) {
-      console.log("⏳ Loading local summarization model fallback...");
-      localSummarizer = await pipeline(
-        "summarization",
-        "Xenova/distilbart-cnn-6-6",
-      );
-      console.log("✅ Local model loaded");
-    }
-
-    const result = await localSummarizer(textToSummarize.substring(0, 1024), {
-      max_new_tokens: 150,
-    });
-
-    const hfText = result[0].summary_text;
-
-    console.log("✅ Local fallback summarization completed");
+    const mom = await runLocalFallback(source, date, title, degradation);
     return {
-      title: title || `Meeting on ${date}`,
-      date,
-      summary: hfText,
-      agenda: [],
-      key_discussions: [],
-      decisions: [],
-      action_items: [],
-      questions_raised: [],
-      keywords: [],
-      attendees: [],
-      notes: "Generated using local fallback summarization model",
-      scheduling_intents: [],
+      mom,
+      generation: { ...mom.generation, durationMs: Date.now() - startedAt },
     };
   } catch (hfErr) {
     console.error("❌ Local fallback also failed:", hfErr.message);
     throw new Error("Both Gemini and Local fallback summarization failed");
   }
+};
+
+/**
+ * Backwards-compatible entry point. Returns just the MoM object, exactly as
+ * before, so existing callers keep working unchanged.
+ *
+ * Prefer `generateMoMDetailed` in new code — it also returns the provenance
+ * needed to identify (and later reprocess) degraded meetings.
+ */
+export const generateMoMWithAI = async (textToSummarize, date, title) => {
+  const { mom } = await generateMoMDetailed(textToSummarize, date, title);
+  return mom;
 };
 
 /**
@@ -158,18 +508,12 @@ Return ONLY a JSON object, no Markdown, no commentary:
 `;
 
   try {
-    const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
-    const result = await model.generateContent(prompt);
-    const outputText = result.response.text();
-
-    let parsed;
-    try {
-      parsed = JSON.parse(outputText);
-    } catch {
-      const match = outputText.match(/\{[\s\S]*\}/);
-      parsed = match ? JSON.parse(match[0]) : null;
-    }
+    // This path is advisory — it only refines a conflict the offline heuristic
+    // already flagged — so it gets a tighter timeout and fewer retries than MoM
+    // generation. Making a whole conflict scan wait on a struggling provider
+    // for a nice-to-have explanation is a bad trade.
+    const outputText = await generateText(prompt, "Gemini contradiction check");
+    const parsed = parseJsonOutput(outputText);
 
     if (
       !parsed ||
@@ -192,7 +536,31 @@ Return ONLY a JSON object, no Markdown, no commentary:
   }
 };
 
-export const normalizeMoM = (structured, title, date) => ({
+/**
+ * Default provenance for a MoM whose origin wasn't recorded — e.g. a document
+ * written before this field existed, or a caller still on the legacy
+ * `generateMoMWithAI` entry point.
+ *
+ * `degraded: false` is the honest default: absence of evidence isn't evidence
+ * of degradation, and flagging every historical MoM as suspect would make the
+ * flag useless.
+ */
+const UNKNOWN_GENERATION = Object.freeze({
+  provider: "unknown",
+  degraded: false,
+  reason: null,
+  errorKind: null,
+  truncated: false,
+  chunks: null,
+});
+
+/**
+ * @param {object} structured raw model output
+ * @param {string} title
+ * @param {string} date
+ * @param {object} [generation] provenance from `generateMoMDetailed`
+ */
+export const normalizeMoM = (structured, title, date, generation = null) => ({
   title: structured.title || title || `Meeting on ${date}`,
   date: structured.date || date,
   summary: structured.summary || structured.rawText || "",
@@ -205,6 +573,10 @@ export const normalizeMoM = (structured, title, date) => ({
   attendees: structured.attendees || [],
   notes: structured.notes || "",
   scheduling_intents: structured.scheduling_intents || [],
+  // Issue #976: persisted so degraded MoMs are *queryable* — previously the
+  // only trace was a free-text note nothing could search on, which made it
+  // impossible to find and reprocess meetings that got the 1024-char fallback.
+  generation: generation ?? structured.generation ?? { ...UNKNOWN_GENERATION },
 });
 
 export const buildHumanReadableMoM = (mom) => {
@@ -255,6 +627,18 @@ export const buildHumanReadableMoM = (mom) => {
   if (mom.notes) {
     text += "🗒 Notes:\n" + mom.notes + "\n\n";
   }
+  // Issue #976: a degraded MoM used to be indistinguishable from a complete
+  // one. Say so plainly in the document itself, so a reader doesn't take an
+  // empty "Decisions" section as "no decisions were made".
+  if (mom.generation?.degraded) {
+    text += "⚠️ Generation Notice:\n";
+    text +=
+      "These minutes were produced by a reduced-capability fallback and may be incomplete.\n";
+    if (mom.generation.truncated) {
+      text += "Part of the transcript was not analysed.\n";
+    }
+    text += "Re-processing this meeting is recommended.\n\n";
+  }
   if (mom.scheduling_intents && mom.scheduling_intents.length) {
     text += "📅 Follow-up Suggestions:\n";
     mom.scheduling_intents.forEach((intent, i) => {
@@ -268,6 +652,15 @@ export const buildHumanReadableMoM = (mom) => {
 /**
  * AI-powered session card generation.
  * Generates a concise summary and keywords for a presentation session.
+ *
+ * Issue #976: this entry point had no API-key check and no `try`/`catch` at all,
+ * unlike its two siblings — with the key unset it threw a raw SDK error straight
+ * out of `sessionController.js`. It now shares the same guard, timeout, retry
+ * and breaker as every other Gemini call, and reports failure as a typed error
+ * the controller can turn into a sensible response.
+ *
+ * @throws {Error} when the key is missing, the provider is unavailable, or the
+ *   model returns something that isn't parseable JSON.
  */
 export const generateSessionCardAI = async (
   eventName,
@@ -276,6 +669,12 @@ export const generateSessionCardAI = async (
   speakerTitle,
   speakerBio,
 ) => {
+  if (!GEMINI_API_KEY) {
+    throw new Error(
+      "Session card generation is unavailable: GEMINI_API_KEY is not configured.",
+    );
+  }
+
   const prompt = `
 You are an AI assistant specialized in academic/professional conference session cards.
 Given the following session metadata:
@@ -294,21 +693,19 @@ Return ONLY a valid JSON object matching this structure (no markdown formatting,
 }
 `;
 
-  const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-  const model = genAI.getGenerativeModel({ model: GEMINI_MODEL });
-  const result = await model.generateContent(prompt);
-  const outputText = result.response.text();
-
-  let parsed;
+  let outputText;
   try {
-    parsed = JSON.parse(outputText);
-  } catch {
-    const match = outputText.match(/\{[\s\S]*\}/);
-    if (match) {
-      parsed = JSON.parse(match[0]);
-    } else {
-      throw new Error("Failed to parse Gemini JSON output");
-    }
+    outputText = await generateText(prompt, "Gemini session card");
+  } catch (err) {
+    console.error("❌ Session card generation failed:", err.message);
+    throw new Error(
+      `Session card generation failed (${err.kind ?? AI_ERROR_KIND.UNKNOWN}): ${err.message}`,
+    );
+  }
+
+  const parsed = parseJsonOutput(outputText);
+  if (!parsed) {
+    throw new Error("Failed to parse Gemini JSON output");
   }
 
   return {

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -367,12 +367,26 @@ export const generateMeetingMoM = async (
 
   console.log(`🧠 Generating MoM for ${meetingId || "transcript-only"}...`);
 
-  const { generateMoMWithAI, normalizeMoM, buildHumanReadableMoM } =
+  const { generateMoMDetailed, normalizeMoM, buildHumanReadableMoM } =
     await loadGenerativeAI();
-  const structured = await generateMoMWithAI(textToSummarize, date, title);
+  // Issue #976: `generateMoMDetailed` also reports how the MoM was produced, so
+  // a meeting that fell back to the reduced-capability local model is recorded
+  // as such instead of being persisted as a normal, complete result.
+  const { mom: structured, generation } = await generateMoMDetailed(
+    textToSummarize,
+    date,
+    title,
+  );
   if (!structured) throw new Error("No summary generated");
 
-  const mom = normalizeMoM(structured, title, date);
+  if (generation?.degraded) {
+    console.warn(
+      `⚠️ MoM for ${meetingId || "transcript-only"} was generated in degraded mode ` +
+        `(${generation.provider}, reason: ${generation.reason}). Consider reprocessing.`,
+    );
+  }
+
+  const mom = normalizeMoM(structured, title, date, generation);
   const momText = buildHumanReadableMoM(mom);
 
   let meetingToUpdate = meeting;

--- a/server/tests/aiResilience.test.js
+++ b/server/tests/aiResilience.test.js
@@ -1,0 +1,629 @@
+/**
+ * Issue #976 — AI generation resilience.
+ *
+ * `sleep`, `now` and `random` are injected throughout so retry timing and
+ * breaker transitions are asserted deterministically and instantly. A test that
+ * actually waits out an exponential backoff is a test that gets deleted the
+ * first time CI is slow.
+ */
+
+import { jest } from "@jest/globals";
+import {
+  AI_ERROR_KIND,
+  AiProviderError,
+  BREAKER_STATE,
+  callWithResilience,
+  chunkTextByBudget,
+  classifyAiError,
+  computeBackoffDelay,
+  createCircuitBreaker,
+  estimateTokens,
+  extractRetryAfterMs,
+  extractStatus,
+  withRetry,
+  withTimeout,
+} from "../utils/aiResilience.js";
+
+/** Collects requested delays instead of waiting them out. */
+const makeSleepSpy = () => {
+  const delays = [];
+  return { delays, sleep: async (ms) => void delays.push(ms) };
+};
+
+describe("extractStatus", () => {
+  it("prefers a structured status field", () => {
+    expect(extractStatus({ status: 503 })).toBe(503);
+    expect(extractStatus({ statusCode: 429 })).toBe(429);
+    expect(extractStatus({ response: { status: 500 } })).toBe(500);
+  });
+
+  it("parses the bracketed status the Gemini SDK puts in its message", () => {
+    // GoogleGenerativeAIFetchError has no stable `status` field — the message
+    // is genuinely the only place the code appears.
+    expect(
+      extractStatus(new Error("[429 Too Many Requests] Quota exceeded")),
+    ).toBe(429);
+    expect(
+      extractStatus(new Error("[503 Service Unavailable] overloaded")),
+    ).toBe(503);
+  });
+
+  it("returns null when no status can be found", () => {
+    expect(extractStatus(new Error("something went wrong"))).toBeNull();
+    expect(extractStatus(null)).toBeNull();
+  });
+
+  it("ignores out-of-range numbers", () => {
+    expect(extractStatus({ status: 99 })).toBeNull();
+    expect(extractStatus({ status: 9999 })).toBeNull();
+  });
+});
+
+describe("extractRetryAfterMs", () => {
+  it("reads a numeric Retry-After header as seconds", () => {
+    expect(
+      extractRetryAfterMs({ response: { headers: { "retry-after": "30" } } }),
+    ).toBe(30000);
+  });
+
+  it("reads Retry-After from a Headers-like object", () => {
+    const err = {
+      response: { headers: { get: (k) => (k === "retry-after" ? "5" : null) } },
+    };
+    expect(extractRetryAfterMs(err)).toBe(5000);
+  });
+
+  it("reads Google's RetryInfo error detail", () => {
+    const err = {
+      errorDetails: [
+        {
+          "@type": "type.googleapis.com/google.rpc.RetryInfo",
+          retryDelay: "31s",
+        },
+      ],
+    };
+    expect(extractRetryAfterMs(err)).toBe(31000);
+  });
+
+  it("handles fractional RetryInfo delays", () => {
+    const err = { errorDetails: [{ retryDelay: "1.5s" }] };
+    expect(extractRetryAfterMs(err)).toBe(1500);
+  });
+
+  it("returns null when the provider gives no hint", () => {
+    expect(extractRetryAfterMs(new Error("boom"))).toBeNull();
+  });
+});
+
+describe("classifyAiError", () => {
+  it.each([
+    [429, AI_ERROR_KIND.RATE_LIMIT],
+    [408, AI_ERROR_KIND.TIMEOUT],
+    [500, AI_ERROR_KIND.SERVER],
+    [502, AI_ERROR_KIND.SERVER],
+    [503, AI_ERROR_KIND.SERVER],
+  ])("treats HTTP %i as retryable (%s)", (status, kind) => {
+    const result = classifyAiError({ status });
+    expect(result.kind).toBe(kind);
+    expect(result.retryable).toBe(true);
+  });
+
+  it.each([
+    [400, AI_ERROR_KIND.INVALID_REQUEST],
+    [401, AI_ERROR_KIND.AUTH],
+    [403, AI_ERROR_KIND.AUTH],
+    [404, AI_ERROR_KIND.INVALID_REQUEST],
+  ])("treats HTTP %i as non-retryable (%s)", (status, kind) => {
+    const result = classifyAiError({ status });
+    expect(result.kind).toBe(kind);
+    // Burning the retry budget on a request that will never succeed just
+    // delays the fallback.
+    expect(result.retryable).toBe(false);
+  });
+
+  it.each([
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "ENOTFOUND",
+    "EAI_AGAIN",
+    "ECONNREFUSED",
+  ])("treats network code %s as retryable", (code) => {
+    const result = classifyAiError({ code });
+    expect(result.kind).toBe(AI_ERROR_KIND.NETWORK);
+    expect(result.retryable).toBe(true);
+  });
+
+  it("treats an AbortError as a retryable timeout", () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    expect(classifyAiError(err)).toMatchObject({
+      kind: AI_ERROR_KIND.TIMEOUT,
+      retryable: true,
+    });
+  });
+
+  it("recognises rate limiting from the message when no status is present", () => {
+    expect(
+      classifyAiError(new Error("RESOURCE_EXHAUSTED: quota exceeded")),
+    ).toMatchObject({ kind: AI_ERROR_KIND.RATE_LIMIT, retryable: true });
+    expect(
+      classifyAiError(new Error("The model is overloaded. Try again.")),
+    ).toMatchObject({ kind: AI_ERROR_KIND.SERVER, retryable: true });
+  });
+
+  it("defaults an unrecognised error to non-retryable", () => {
+    // Deliberate: an error we can't classify is more likely a bug in our own
+    // request than a blip on the wire, and retrying it delays the fallback.
+    expect(classifyAiError(new Error("Gemini API Error"))).toMatchObject({
+      kind: AI_ERROR_KIND.UNKNOWN,
+      retryable: false,
+    });
+  });
+
+  it("passes an already-classified AiProviderError through unchanged", () => {
+    const err = new AiProviderError("nope", {
+      kind: AI_ERROR_KIND.RATE_LIMIT,
+      status: 429,
+      retryable: true,
+      retryAfterMs: 1000,
+    });
+    expect(classifyAiError(err)).toEqual({
+      kind: AI_ERROR_KIND.RATE_LIMIT,
+      status: 429,
+      retryable: true,
+      retryAfterMs: 1000,
+    });
+  });
+});
+
+describe("withTimeout", () => {
+  it("resolves when the call finishes in time", async () => {
+    await expect(
+      withTimeout(async () => "ok", { timeoutMs: 200 }),
+    ).resolves.toBe("ok");
+  });
+
+  it("rejects with a retryable timeout when the call hangs", async () => {
+    // The exact failure mode being fixed: the SDK uses fetch with no default
+    // timeout, and the AI worker runs at concurrency 1.
+    const promise = withTimeout(() => new Promise(() => {}), {
+      timeoutMs: 30,
+      label: "Gemini MoM",
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      name: "AiProviderError",
+      kind: AI_ERROR_KIND.TIMEOUT,
+      retryable: true,
+    });
+    await expect(promise).rejects.toThrow(/Gemini MoM timed out after 30ms/);
+  });
+
+  it("aborts the signal it handed to the caller", async () => {
+    let captured;
+    await withTimeout(
+      (signal) => {
+        captured = signal;
+        return new Promise(() => {});
+      },
+      { timeoutMs: 20 },
+    ).catch(() => {});
+
+    expect(captured.aborted).toBe(true);
+  });
+
+  it("propagates the original rejection when the call fails fast", async () => {
+    await expect(
+      withTimeout(
+        async () => {
+          throw new Error("upstream 400");
+        },
+        { timeoutMs: 500 },
+      ),
+    ).rejects.toThrow("upstream 400");
+  });
+});
+
+describe("computeBackoffDelay", () => {
+  it("grows exponentially", () => {
+    const opts = { baseDelayMs: 1000, jitterRatio: 0, random: () => 0 };
+    expect(computeBackoffDelay(1, opts)).toBe(1000);
+    expect(computeBackoffDelay(2, opts)).toBe(2000);
+    expect(computeBackoffDelay(3, opts)).toBe(4000);
+  });
+
+  it("respects maxDelayMs", () => {
+    expect(
+      computeBackoffDelay(20, {
+        baseDelayMs: 1000,
+        maxDelayMs: 5000,
+        jitterRatio: 0,
+        random: () => 0,
+      }),
+    ).toBe(5000);
+  });
+
+  it("applies jitter within the expected window", () => {
+    const low = computeBackoffDelay(3, {
+      baseDelayMs: 1000,
+      jitterRatio: 0.5,
+      random: () => 0,
+    });
+    const high = computeBackoffDelay(3, {
+      baseDelayMs: 1000,
+      jitterRatio: 0.5,
+      random: () => 1,
+    });
+
+    // Un-jittered backoff makes a batch of rate-limited jobs retry in lockstep
+    // and hit the limit again together.
+    expect(low).toBe(2000);
+    expect(high).toBe(4000);
+  });
+
+  it("lets a provider-supplied Retry-After win outright", () => {
+    expect(
+      computeBackoffDelay(1, { baseDelayMs: 1000, retryAfterMs: 7000 }),
+    ).toBe(7000);
+  });
+
+  it("still caps a Retry-After at maxDelayMs", () => {
+    expect(
+      computeBackoffDelay(1, { retryAfterMs: 999999, maxDelayMs: 10000 }),
+    ).toBe(10000);
+  });
+});
+
+describe("withRetry", () => {
+  it("returns immediately on success", async () => {
+    const fn = jest.fn(async () => "ok");
+    await expect(withRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a retryable failure and succeeds", async () => {
+    const { sleep, delays } = makeSleepSpy();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValueOnce("recovered");
+
+    await expect(
+      withRetry(fn, { retries: 2, sleep, random: () => 0 }),
+    ).resolves.toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(delays).toHaveLength(1);
+  });
+
+  it("does not retry a non-retryable failure", async () => {
+    const { sleep, delays } = makeSleepSpy();
+    const fn = jest.fn().mockRejectedValue({ status: 401 });
+
+    await expect(withRetry(fn, { retries: 5, sleep })).rejects.toMatchObject({
+      kind: AI_ERROR_KIND.AUTH,
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it("gives up after the configured number of attempts", async () => {
+    const { sleep } = makeSleepSpy();
+    const fn = jest.fn().mockRejectedValue({ status: 429 });
+
+    await expect(
+      withRetry(fn, { retries: 3, sleep, random: () => 0 }),
+    ).rejects.toBeInstanceOf(AiProviderError);
+    expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
+  });
+
+  it("backs off exponentially between attempts", async () => {
+    const { sleep, delays } = makeSleepSpy();
+    const fn = jest.fn().mockRejectedValue({ status: 500 });
+
+    await withRetry(fn, {
+      retries: 3,
+      baseDelayMs: 100,
+      jitterRatio: 0,
+      sleep,
+      random: () => 0,
+    }).catch(() => {});
+
+    expect(delays).toEqual([100, 200, 400]);
+  });
+
+  it("honours a provider Retry-After over its own backoff", async () => {
+    const { sleep, delays } = makeSleepSpy();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({
+        status: 429,
+        errorDetails: [{ retryDelay: "12s" }],
+      })
+      .mockResolvedValueOnce("ok");
+
+    await withRetry(fn, { retries: 2, baseDelayMs: 100, sleep });
+
+    // The provider knows when its quota window resets; we don't.
+    expect(delays).toEqual([12000]);
+  });
+
+  it("reports each retry through onRetry", async () => {
+    const { sleep } = makeSleepSpy();
+    const onRetry = jest.fn();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValueOnce("ok");
+
+    await withRetry(fn, { retries: 2, onRetry, sleep, random: () => 0 });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][0]).toMatchObject({
+      attempt: 1,
+      classification: { kind: AI_ERROR_KIND.SERVER },
+    });
+  });
+
+  it("wraps the final failure in a classified AiProviderError", async () => {
+    const { sleep } = makeSleepSpy();
+    const fn = jest
+      .fn()
+      .mockRejectedValue({ status: 429, message: "slow down" });
+
+    const err = await withRetry(fn, {
+      retries: 1,
+      sleep,
+      random: () => 0,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AiProviderError);
+    expect(err.kind).toBe(AI_ERROR_KIND.RATE_LIMIT);
+    expect(err.status).toBe(429);
+  });
+});
+
+describe("createCircuitBreaker", () => {
+  it("stays closed while calls succeed", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 2 });
+    await breaker.exec(async () => "ok");
+    expect(breaker.getState()).toBe(BREAKER_STATE.CLOSED);
+  });
+
+  it("opens after the failure threshold", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 2 });
+
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+    expect(breaker.getState()).toBe(BREAKER_STATE.CLOSED);
+
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+    expect(breaker.getState()).toBe(BREAKER_STATE.OPEN);
+  });
+
+  it("fails fast without calling the provider while open", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 1 });
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+
+    const fn = jest.fn(async () => "ok");
+    await expect(breaker.exec(fn)).rejects.toMatchObject({
+      kind: AI_ERROR_KIND.CIRCUIT_OPEN,
+    });
+
+    // The whole point: queued jobs stop paying the full timeout × retry cost
+    // to re-confirm an outage we already know about.
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("half-opens after the cooldown and closes on a successful probe", async () => {
+    let clock = 0;
+    const breaker = createCircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 1000,
+      now: () => clock,
+    });
+
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+    expect(breaker.getState()).toBe(BREAKER_STATE.OPEN);
+
+    clock = 1000;
+    expect(breaker.getState()).toBe(BREAKER_STATE.HALF_OPEN);
+
+    await expect(breaker.exec(async () => "ok")).resolves.toBe("ok");
+    expect(breaker.getState()).toBe(BREAKER_STATE.CLOSED);
+  });
+
+  it("does not open on errors that are our own fault", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 2 });
+
+    // A 400 from a malformed prompt is not evidence the provider is down, and
+    // opening on it would suppress every other caller.
+    await breaker
+      .exec(async () => Promise.reject({ status: 400 }))
+      .catch(() => {});
+    await breaker
+      .exec(async () => Promise.reject({ status: 401 }))
+      .catch(() => {});
+
+    expect(breaker.getState()).toBe(BREAKER_STATE.CLOSED);
+  });
+
+  it("resets the failure count on success", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 3 });
+
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+    await breaker.exec(async () => "ok");
+
+    expect(breaker.getFailureCount()).toBe(0);
+  });
+
+  it("reports state transitions", async () => {
+    const onStateChange = jest.fn();
+    const breaker = createCircuitBreaker({
+      failureThreshold: 1,
+      onStateChange,
+    });
+
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: BREAKER_STATE.CLOSED,
+        to: BREAKER_STATE.OPEN,
+      }),
+    );
+  });
+
+  it("can be reset manually", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 1 });
+    await breaker
+      .exec(async () => Promise.reject({ status: 503 }))
+      .catch(() => {});
+    breaker.reset();
+    expect(breaker.getState()).toBe(BREAKER_STATE.CLOSED);
+  });
+});
+
+describe("estimateTokens", () => {
+  it("approximates four characters per token", () => {
+    expect(estimateTokens("a".repeat(400))).toBe(100);
+  });
+
+  it("handles empty and nullish input", () => {
+    expect(estimateTokens("")).toBe(0);
+    expect(estimateTokens(null)).toBe(0);
+  });
+});
+
+describe("chunkTextByBudget", () => {
+  it("returns a single chunk when the text fits", () => {
+    expect(chunkTextByBudget("short transcript", { maxChars: 100 })).toEqual([
+      "short transcript",
+    ]);
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(chunkTextByBudget("", { maxChars: 100 })).toEqual([]);
+    expect(chunkTextByBudget("   ", { maxChars: 100 })).toEqual([]);
+  });
+
+  it("splits text that exceeds the budget", () => {
+    const chunks = chunkTextByBudget("x".repeat(2500), {
+      maxChars: 1000,
+      overlapChars: 0,
+    });
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach((chunk) => expect(chunk.length).toBeLessThanOrEqual(1000));
+  });
+
+  it("preserves the whole transcript across chunks", () => {
+    // This is the regression that matters. `.substring(0, 1024)` threw away the
+    // end of the meeting, which is exactly where decisions and action items are.
+    const sentences = Array.from(
+      { length: 60 },
+      (_, i) => `Sentence number ${i} discusses a topic in detail. `,
+    ).join("");
+
+    const chunks = chunkTextByBudget(sentences, {
+      maxChars: 500,
+      overlapChars: 0,
+    });
+
+    const rejoined = chunks.join(" ").replace(/\s+/g, " ");
+    expect(rejoined).toContain("Sentence number 0 ");
+    expect(rejoined).toContain("Sentence number 59 ");
+  });
+
+  it("prefers sentence boundaries over hard cuts", () => {
+    const text = `${"a".repeat(900)}. ${"b".repeat(900)}. ${"c".repeat(400)}`;
+    const [first] = chunkTextByBudget(text, {
+      maxChars: 1000,
+      overlapChars: 0,
+    });
+    expect(first.endsWith(".")).toBe(true);
+  });
+
+  it("overlaps chunks so a straddling statement is not lost", () => {
+    const text = "y".repeat(3000);
+    const chunks = chunkTextByBudget(text, {
+      maxChars: 1000,
+      overlapChars: 200,
+    });
+
+    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+    expect(totalLength).toBeGreaterThan(text.length);
+  });
+
+  it("always makes forward progress", () => {
+    // Guards against an overlap large enough to make the cursor stand still.
+    const chunks = chunkTextByBudget("z".repeat(5000), {
+      maxChars: 100,
+      overlapChars: 10000,
+    });
+    expect(chunks.length).toBeLessThan(200);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});
+
+describe("callWithResilience", () => {
+  it("composes breaker → retry → timeout", async () => {
+    const { sleep } = makeSleepSpy();
+    const breaker = createCircuitBreaker({ failureThreshold: 10 });
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      callWithResilience(fn, { retries: 2, breaker, sleep, random: () => 0 }),
+    ).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies the timeout per attempt, not across the whole sequence", async () => {
+    const { sleep } = makeSleepSpy();
+    let calls = 0;
+
+    // A 3-attempt call with a 60s timeout should be able to spend 60s *per
+    // attempt*, not 60s in total.
+    const result = await callWithResilience(
+      async () => {
+        calls += 1;
+        if (calls === 1) {
+          await new Promise((r) => setTimeout(r, 60));
+          return "never";
+        }
+        return "second attempt";
+      },
+      { timeoutMs: 25, retries: 2, sleep, random: () => 0 },
+    );
+
+    expect(result).toBe("second attempt");
+    expect(calls).toBe(2);
+  });
+
+  it("works without a breaker", async () => {
+    await expect(callWithResilience(async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("fails fast when the breaker is open", async () => {
+    const breaker = createCircuitBreaker({ failureThreshold: 1 });
+    breaker.recordFailure({ retryable: true, kind: AI_ERROR_KIND.SERVER });
+
+    const fn = jest.fn();
+    await expect(callWithResilience(fn, { breaker })).rejects.toMatchObject({
+      kind: AI_ERROR_KIND.CIRCUIT_OPEN,
+    });
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/generativeAiResilience.test.js
+++ b/server/tests/generativeAiResilience.test.js
@@ -1,0 +1,522 @@
+/**
+ * Issue #976 — GenerativeAIService behaviour under provider failure.
+ *
+ * Kept separate from the existing GenerativeAIService.test.js because these
+ * suites need different module-level mocks and different env, and
+ * `jest.unstable_mockModule` is resolved once per module registry.
+ *
+ * Retries are configured down to zero delay via env so the suite doesn't spend
+ * real seconds waiting out exponential backoff.
+ */
+
+import { jest } from "@jest/globals";
+
+const mockGenerateContent = jest.fn();
+const mockGetGenerativeModel = jest.fn(() => ({
+  generateContent: mockGenerateContent,
+}));
+
+jest.unstable_mockModule("@google/generative-ai", () => ({
+  GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
+    getGenerativeModel: mockGetGenerativeModel,
+  })),
+}));
+
+const mockLocalSummarizer = jest.fn();
+jest.unstable_mockModule("@xenova/transformers", () => ({
+  pipeline: jest.fn().mockResolvedValue(mockLocalSummarizer),
+  env: { useBrowserCache: false },
+}));
+
+process.env.GEMINI_API_KEY = "test-key";
+process.env.GEMINI_MAX_RETRIES = "2";
+process.env.GEMINI_RETRY_BASE_DELAY_MS = "1";
+process.env.GEMINI_RETRY_MAX_DELAY_MS = "2";
+process.env.GEMINI_TIMEOUT_MS = "200";
+
+const { GoogleGenerativeAI } = await import("@google/generative-ai");
+const {
+  generateMoMDetailed,
+  generateMoMWithAI,
+  generateSessionCardAI,
+  normalizeMoM,
+  buildHumanReadableMoM,
+  resetGeminiBreaker,
+  resetGeminiClient,
+  getGeminiBreakerState,
+} = await import("../services/GenerativeAIService.js");
+
+/** A complete MoM the model might return. */
+const fullMoM = {
+  title: "Q3 Planning",
+  date: "2026-08-01",
+  summary: "We agreed the roadmap.",
+  agenda: ["Roadmap"],
+  key_discussions: ["Scope"],
+  decisions: ["Ship in September"],
+  action_items: [{ task: "Draft the plan", owner: "Ada" }],
+  questions_raised: [],
+  keywords: ["roadmap"],
+  attendees: ["Ada"],
+  notes: "",
+  scheduling_intents: [],
+};
+
+const geminiReturns = (payload) => ({
+  response: { text: () => JSON.stringify(payload) },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetGeminiBreaker();
+  mockLocalSummarizer.mockResolvedValue([
+    { summary_text: "Local fallback summary" },
+  ]);
+});
+
+describe("generateMoMDetailed — happy path", () => {
+  it("returns the parsed MoM plus provenance", async () => {
+    mockGenerateContent.mockResolvedValueOnce(geminiReturns(fullMoM));
+
+    const { mom, generation } = await generateMoMDetailed(
+      "A short transcript.",
+      "2026-08-01",
+      "Q3 Planning",
+    );
+
+    expect(mom).toEqual(fullMoM);
+    expect(generation).toMatchObject({
+      provider: "gemini",
+      degraded: false,
+      chunks: 1,
+    });
+  });
+
+  it("reuses one client across calls instead of rebuilding it per request", async () => {
+    // Drop the memoised client so construction is observable from a clean
+    // slate. Previously `new GoogleGenerativeAI(...)` ran on every request, at
+    // three separate call sites.
+    resetGeminiClient();
+    mockGenerateContent.mockResolvedValue(geminiReturns(fullMoM));
+
+    await generateMoMDetailed("one", "2026-08-01", "t");
+    await generateMoMDetailed("two", "2026-08-01", "t");
+
+    expect(GoogleGenerativeAI).toHaveBeenCalledTimes(1);
+    expect(mockGetGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("extracts JSON embedded in surrounding prose", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      response: {
+        text: () =>
+          `Here you go:\n\`\`\`json\n${JSON.stringify(fullMoM)}\n\`\`\``,
+      },
+    });
+
+    const { mom } = await generateMoMDetailed("t", "2026-08-01", "t");
+    expect(mom.decisions).toEqual(["Ship in September"]);
+  });
+});
+
+describe("generateMoMDetailed — retry behaviour", () => {
+  it("retries a 429 and succeeds without falling back", async () => {
+    const rateLimited = Object.assign(new Error("[429 Too Many Requests]"), {
+      status: 429,
+    });
+
+    mockGenerateContent
+      .mockRejectedValueOnce(rateLimited)
+      .mockResolvedValueOnce(geminiReturns(fullMoM));
+
+    const { mom, generation } = await generateMoMDetailed(
+      "transcript",
+      "2026-08-01",
+      "t",
+    );
+
+    // Previously a single 429 dropped straight to the local model and produced
+    // a MoM with no decisions and no action items.
+    expect(mom.decisions).toEqual(["Ship in September"]);
+    expect(generation.degraded).toBe(false);
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+    expect(mockLocalSummarizer).not.toHaveBeenCalled();
+  });
+
+  it("retries a 503 up to the configured limit before falling back", async () => {
+    mockGenerateContent.mockRejectedValue(
+      Object.assign(new Error("[503 Service Unavailable]"), { status: 503 }),
+    );
+
+    const { generation } = await generateMoMDetailed("t", "2026-08-01", "t");
+
+    // GEMINI_MAX_RETRIES=2 → 3 attempts total.
+    expect(mockGenerateContent).toHaveBeenCalledTimes(3);
+    expect(generation.degraded).toBe(true);
+    expect(generation.provider).toBe("local-distilbart");
+  });
+
+  it("does not retry an auth failure", async () => {
+    mockGenerateContent.mockRejectedValue(
+      Object.assign(new Error("[401 Unauthorized] bad key"), { status: 401 }),
+    );
+
+    await generateMoMDetailed("t", "2026-08-01", "t");
+
+    // Retrying a permanent failure only delays the fallback.
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hang when the provider never responds", async () => {
+    mockGenerateContent.mockImplementation(() => new Promise(() => {}));
+
+    const { generation } = await generateMoMDetailed("t", "2026-08-01", "t");
+
+    // The bug: with no timeout this promise never settled, and the AI worker
+    // (concurrency 1) stalled MoM generation for every organization.
+    expect(generation.degraded).toBe(true);
+    expect(generation.reason).toBe("gemini_failed");
+    expect(generation.errorKind).toBe("timeout");
+  }, 15000);
+});
+
+describe("generateMoMDetailed — degradation is visible", () => {
+  it("flags a fallback MoM with structured provenance", async () => {
+    mockGenerateContent.mockRejectedValue(new Error("Gemini API Error"));
+
+    const { mom, generation } = await generateMoMDetailed(
+      "x".repeat(5000),
+      "2026-08-01",
+      "Title",
+    );
+
+    expect(generation).toMatchObject({
+      provider: "local-distilbart",
+      degraded: true,
+      reason: "gemini_failed",
+      truncated: true,
+      inputCharsUsed: 1024,
+      inputCharsTotal: 5000,
+    });
+    // The operator-relevant fact, now queryable rather than buried in prose.
+    expect(mom.generation.truncated).toBe(true);
+  });
+
+  it("does not mark a short fallback transcript as truncated", async () => {
+    mockGenerateContent.mockRejectedValue(new Error("Gemini API Error"));
+
+    const { generation } = await generateMoMDetailed(
+      "short",
+      "2026-08-01",
+      "t",
+    );
+    expect(generation.truncated).toBe(false);
+  });
+
+  it("degrades rather than throwing when the provider rejects our credentials", async () => {
+    // A missing/invalid key must reach the local fallback in one attempt, not
+    // throw out of the service and not burn the retry budget.
+    mockGenerateContent.mockRejectedValue(
+      Object.assign(new Error("[403 Forbidden] API key not valid"), {
+        status: 403,
+      }),
+    );
+
+    const { generation } = await generateMoMDetailed("t", "2026-08-01", "t");
+
+    expect(generation.degraded).toBe(true);
+    expect(generation.errorKind).toBe("auth");
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws only when the fallback also fails", async () => {
+    mockGenerateContent.mockRejectedValue(new Error("Gemini API Error"));
+    mockLocalSummarizer.mockRejectedValue(new Error("model unavailable"));
+
+    await expect(generateMoMDetailed("t", "2026-08-01", "t")).rejects.toThrow(
+      "Both Gemini and Local fallback summarization failed",
+    );
+  });
+});
+
+describe("generateMoMDetailed — prompt budgeting", () => {
+  it("chunks a transcript larger than the budget instead of truncating it", async () => {
+    process.env.GEMINI_MAX_PROMPT_CHARS = "1000";
+    process.env.GEMINI_CHUNK_OVERLAP_CHARS = "0";
+
+    try {
+      mockGenerateContent.mockResolvedValue(
+        geminiReturns({
+          ...fullMoM,
+          decisions: ["Ship in September"],
+          action_items: [{ task: "Draft the plan" }],
+        }),
+      );
+
+      const { generation } = await generateMoMDetailed(
+        "sentence. ".repeat(400), // ~4000 chars
+        "2026-08-01",
+        "t",
+      );
+
+      expect(generation.chunks).toBeGreaterThan(1);
+      expect(mockGenerateContent.mock.calls.length).toBe(generation.chunks);
+      expect(generation.degraded).toBe(false);
+    } finally {
+      delete process.env.GEMINI_MAX_PROMPT_CHARS;
+      delete process.env.GEMINI_CHUNK_OVERLAP_CHARS;
+    }
+  });
+
+  it("merges and de-duplicates chunk results", async () => {
+    process.env.GEMINI_MAX_PROMPT_CHARS = "1000";
+    process.env.GEMINI_CHUNK_OVERLAP_CHARS = "0";
+
+    try {
+      mockGenerateContent
+        .mockResolvedValueOnce(
+          geminiReturns({
+            ...fullMoM,
+            summary: "First half.",
+            decisions: ["Ship in September"],
+            keywords: ["roadmap"],
+          }),
+        )
+        .mockResolvedValue(
+          geminiReturns({
+            ...fullMoM,
+            summary: "Second half.",
+            // Restated across the chunk seam — must not appear twice.
+            decisions: ["Ship in September", "Hire two engineers"],
+            keywords: ["ROADMAP", "hiring"],
+          }),
+        );
+
+      const { mom } = await generateMoMDetailed(
+        "sentence. ".repeat(300),
+        "2026-08-01",
+        "t",
+      );
+
+      expect(mom.decisions).toEqual([
+        "Ship in September",
+        "Hire two engineers",
+      ]);
+      // Deduplication is case-insensitive because the model restates things
+      // with different capitalisation across the overlap window.
+      expect(mom.keywords).toEqual(["roadmap", "hiring"]);
+      expect(mom.summary).toContain("First half.");
+      expect(mom.summary).toContain("Second half.");
+    } finally {
+      delete process.env.GEMINI_MAX_PROMPT_CHARS;
+      delete process.env.GEMINI_CHUNK_OVERLAP_CHARS;
+    }
+  });
+
+  it("caps the chunk count and reports the result as degraded", async () => {
+    process.env.GEMINI_MAX_PROMPT_CHARS = "500";
+    process.env.GEMINI_CHUNK_OVERLAP_CHARS = "0";
+    process.env.GEMINI_MAX_CHUNKS = "2";
+
+    try {
+      mockGenerateContent.mockResolvedValue(geminiReturns(fullMoM));
+
+      const { generation } = await generateMoMDetailed(
+        "sentence. ".repeat(500),
+        "2026-08-01",
+        "t",
+      );
+
+      expect(generation.chunks).toBe(2);
+      // Dropping trailing chunks *is* a degradation and must be recorded.
+      expect(generation.degraded).toBe(true);
+      expect(generation.reason).toBe("chunk_limit_exceeded");
+    } finally {
+      delete process.env.GEMINI_MAX_PROMPT_CHARS;
+      delete process.env.GEMINI_CHUNK_OVERLAP_CHARS;
+      delete process.env.GEMINI_MAX_CHUNKS;
+    }
+  });
+});
+
+describe("circuit breaker integration", () => {
+  // The shared breaker is configured once at module load, so this exercises the
+  // real default threshold (5 consecutive provider failures) rather than trying
+  // to override env after the fact.
+  const DEFAULT_THRESHOLD = 5;
+
+  it("opens after repeated provider failures and then fails fast", async () => {
+    try {
+      mockGenerateContent.mockRejectedValue(
+        Object.assign(new Error("[503]"), { status: 503 }),
+      );
+
+      for (let i = 0; i < DEFAULT_THRESHOLD; i += 1) {
+        await generateMoMDetailed(`transcript ${i}`, "2026-08-01", "t");
+      }
+      expect(getGeminiBreakerState()).toBe("open");
+
+      const callsBefore = mockGenerateContent.mock.calls.length;
+      const { generation } = await generateMoMDetailed(
+        "one more",
+        "2026-08-01",
+        "t",
+      );
+
+      // The next job must not reach the provider at all — that is the whole
+      // point: stop paying timeout × retry to re-confirm a known outage.
+      expect(mockGenerateContent.mock.calls.length).toBe(callsBefore);
+      expect(generation.errorKind).toBe("circuit_open");
+      expect(generation.degraded).toBe(true);
+    } finally {
+      resetGeminiBreaker();
+    }
+  });
+
+  it("does not open on errors caused by our own request", async () => {
+    try {
+      mockGenerateContent.mockRejectedValue(
+        Object.assign(new Error("[400 Bad Request]"), { status: 400 }),
+      );
+
+      for (let i = 0; i < DEFAULT_THRESHOLD + 2; i += 1) {
+        await generateMoMDetailed(`t ${i}`, "2026-08-01", "t");
+      }
+
+      // A malformed prompt is not evidence that Gemini is down; opening here
+      // would suppress every other caller.
+      expect(getGeminiBreakerState()).toBe("closed");
+    } finally {
+      resetGeminiBreaker();
+    }
+  });
+});
+
+describe("generateMoMWithAI — backwards compatibility", () => {
+  it("still returns just the MoM object", async () => {
+    mockGenerateContent.mockResolvedValueOnce(geminiReturns(fullMoM));
+
+    const result = await generateMoMWithAI("t", "2026-08-01", "Q3 Planning");
+    expect(result).toEqual(fullMoM);
+  });
+});
+
+describe("generateSessionCardAI", () => {
+  it("returns the parsed summary and keywords", async () => {
+    mockGenerateContent.mockResolvedValueOnce(
+      geminiReturns({ summary: "A talk about X.", keywords: ["x", "y"] }),
+    );
+
+    await expect(
+      generateSessionCardAI("Event", "Session", "Ada", "Dr", "Bio"),
+    ).resolves.toEqual({ summary: "A talk about X.", keywords: ["x", "y"] });
+  });
+
+  it("retries a transient failure", async () => {
+    mockGenerateContent
+      .mockRejectedValueOnce(Object.assign(new Error("[503]"), { status: 503 }))
+      .mockResolvedValueOnce(geminiReturns({ summary: "ok", keywords: [] }));
+
+    await expect(
+      generateSessionCardAI("Event", "Session"),
+    ).resolves.toMatchObject({ summary: "ok" });
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a typed error instead of a raw SDK error when the provider fails", async () => {
+    // This entry point previously had no try/catch at all.
+    mockGenerateContent.mockRejectedValue(
+      Object.assign(new Error("[401 Unauthorized]"), { status: 401 }),
+    );
+
+    await expect(generateSessionCardAI("Event", "Session")).rejects.toThrow(
+      /Session card generation failed \(auth\)/,
+    );
+  });
+
+  it("throws a clear error when the model returns unparseable output", async () => {
+    mockGenerateContent.mockResolvedValueOnce({
+      response: { text: () => "not json at all" },
+    });
+
+    await expect(generateSessionCardAI("Event", "Session")).rejects.toThrow(
+      "Failed to parse Gemini JSON output",
+    );
+  });
+});
+
+describe("normalizeMoM / buildHumanReadableMoM provenance", () => {
+  it("prefers explicitly supplied provenance", () => {
+    const generation = { provider: "gemini", degraded: false };
+    const result = normalizeMoM({ title: "T" }, "T", "2026-08-01", generation);
+    expect(result.generation).toBe(generation);
+  });
+
+  it("falls back to provenance embedded in the model output", () => {
+    const result = normalizeMoM(
+      {
+        title: "T",
+        generation: { provider: "local-distilbart", degraded: true },
+      },
+      "T",
+      "2026-08-01",
+    );
+    expect(result.generation.degraded).toBe(true);
+  });
+
+  it("defaults to unknown-but-not-degraded for legacy documents", () => {
+    // Absence of evidence isn't evidence of degradation — flagging every
+    // historical MoM as suspect would make the flag useless.
+    const result = normalizeMoM({ title: "T" }, "T", "2026-08-01");
+    expect(result.generation).toMatchObject({
+      provider: "unknown",
+      degraded: false,
+    });
+  });
+
+  it("adds a visible notice to a degraded document", () => {
+    const mom = normalizeMoM(
+      {
+        title: "T",
+        summary: "s",
+        agenda: [],
+        key_discussions: [],
+        decisions: [],
+        action_items: [],
+        questions_raised: [],
+        keywords: [],
+        attendees: [],
+        generation: { degraded: true, truncated: true },
+      },
+      "T",
+      "2026-08-01",
+    );
+
+    const text = buildHumanReadableMoM(mom);
+    // Without this, an empty "Decisions" section reads as "no decisions were
+    // made" rather than "we never analysed most of the meeting".
+    expect(text).toContain("Generation Notice");
+    expect(text).toContain("Part of the transcript was not analysed.");
+  });
+
+  it("adds no notice to a healthy document", () => {
+    const mom = normalizeMoM(
+      {
+        title: "T",
+        summary: "s",
+        agenda: [],
+        key_discussions: [],
+        decisions: [],
+        action_items: [],
+        questions_raised: [],
+        keywords: [],
+        attendees: [],
+      },
+      "T",
+      "2026-08-01",
+      { provider: "gemini", degraded: false },
+    );
+
+    expect(buildHumanReadableMoM(mom)).not.toContain("Generation Notice");
+  });
+});

--- a/server/utils/aiResilience.js
+++ b/server/utils/aiResilience.js
@@ -1,0 +1,627 @@
+// server/utils/aiResilience.js
+//
+// Issue #976 — Gemini calls have no timeout, no retry, and no prompt budget.
+//
+// The failure this exists to prevent is not "the AI call fails" — it's that the
+// AI call fails *invisibly*. `generateMoMWithAI` caught every Gemini error
+// identically and fell straight through to a local model that summarises the
+// first 1024 characters and hardcodes `decisions: []` and `action_items: []`.
+// The meeting was then persisted as successfully processed. Every downstream
+// feature (decision graph, tasks board, conflict detection, policy compliance,
+// action-item reminders) saw an empty meeting, and nothing anywhere recorded
+// that a degradation had happened.
+//
+// So this module provides four things, in the order they matter:
+//
+//   1. classifyAiError — tells a transient 429 apart from a permanent 401, so
+//      "retry" and "give up" become different decisions instead of one.
+//   2. withTimeout     — bounds every call. `@google/generative-ai` uses fetch
+//      with no default timeout, and the AI worker runs at concurrency 1, so one
+//      hung call stalls MoM generation for every organization.
+//   3. withRetry       — exponential backoff with jitter, honouring the
+//      provider's own Retry-After / RetryInfo hint when it sends one.
+//   4. circuit breaker — once the provider is confirmed down, stop paying the
+//      full timeout budget on every queued job.
+//
+// Plus prompt budgeting, so a long transcript is chunked and merged rather than
+// silently truncated.
+//
+// Everything is injectable (`sleep`, `now`, `random`) so the retry timing and
+// breaker transitions are unit-testable without real delays.
+
+/** Error categories that drive the retry decision. */
+export const AI_ERROR_KIND = Object.freeze({
+  RATE_LIMIT: "rate_limit",
+  SERVER: "server",
+  TIMEOUT: "timeout",
+  NETWORK: "network",
+  AUTH: "auth",
+  INVALID_REQUEST: "invalid_request",
+  CIRCUIT_OPEN: "circuit_open",
+  UNKNOWN: "unknown",
+});
+
+/** Node/undici error codes that mean "the connection failed", not "the request was bad". */
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EPIPE",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ERR_NETWORK",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
+
+/**
+ * A normalised provider error. Carries the classification so callers don't each
+ * have to re-derive it from a message string.
+ */
+export class AiProviderError extends Error {
+  constructor(message, { kind, status, retryable, retryAfterMs, cause } = {}) {
+    super(message);
+    this.name = "AiProviderError";
+    this.kind = kind ?? AI_ERROR_KIND.UNKNOWN;
+    this.status = status ?? null;
+    this.retryable = Boolean(retryable);
+    this.retryAfterMs = retryAfterMs ?? null;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/**
+ * Pulls an HTTP status out of the many shapes an SDK error can take.
+ *
+ * `@google/generative-ai` does not expose a stable `status` field — it commonly
+ * throws `GoogleGenerativeAIFetchError` whose message begins
+ * `[429 Too Many Requests] …`, so the message is a legitimate (and often the
+ * only) source. Structured fields are preferred and checked first.
+ *
+ * @param {any} err
+ * @returns {number|null}
+ */
+export const extractStatus = (err) => {
+  if (!err) return null;
+
+  const candidates = [
+    err.status,
+    err.statusCode,
+    err.code,
+    err.response?.status,
+    err.cause?.status,
+  ];
+  for (const candidate of candidates) {
+    const numeric = Number(candidate);
+    if (Number.isInteger(numeric) && numeric >= 100 && numeric <= 599) {
+      return numeric;
+    }
+  }
+
+  const message = String(err.message ?? err);
+  const bracketed = message.match(/\[(\d{3})\b/);
+  if (bracketed) return Number(bracketed[1]);
+
+  const bare = message.match(/\b(4\d{2}|5\d{2})\b/);
+  if (bare) return Number(bare[1]);
+
+  return null;
+};
+
+/**
+ * Extracts the provider's own "wait this long" hint, in milliseconds.
+ *
+ * Two sources, both real: a `Retry-After` response header (seconds or an HTTP
+ * date), and Google's `RetryInfo` error detail (`retryDelay: "31s"`). Honouring
+ * these beats guessing with backoff — the provider knows when its quota window
+ * resets and we don't.
+ *
+ * @param {any} err
+ * @returns {number|null} milliseconds, or null when no hint is present
+ */
+export const extractRetryAfterMs = (err) => {
+  if (!err) return null;
+
+  const header =
+    err.response?.headers?.["retry-after"] ??
+    err.response?.headers?.get?.("retry-after") ??
+    err.headers?.["retry-after"];
+
+  if (header !== undefined && header !== null) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+
+    const asDate = Date.parse(String(header));
+    if (Number.isFinite(asDate)) {
+      return Math.max(0, asDate - Date.now());
+    }
+  }
+
+  // Google RPC RetryInfo, e.g. { retryDelay: "31s" } or "1.5s".
+  const details = err.errorDetails ?? err.response?.data?.error?.details;
+  if (Array.isArray(details)) {
+    for (const detail of details) {
+      const delay = detail?.retryDelay;
+      if (typeof delay === "string") {
+        const match = delay.match(/^([\d.]+)s$/);
+        if (match) return Math.round(Number(match[1]) * 1000);
+      }
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Classifies a provider error into a retry decision.
+ *
+ * The default for an unrecognised error is **not retryable**. That is
+ * deliberate: retrying something we don't understand burns the timeout budget
+ * on every attempt and delays the fallback, and an error we can't classify is
+ * more likely to be a bug in our own request than a blip on the wire. Only
+ * positively-recognised transient conditions are retried.
+ *
+ * @param {any} err
+ * @returns {{kind: string, status: number|null, retryable: boolean, retryAfterMs: number|null}}
+ */
+export const classifyAiError = (err) => {
+  const status = extractStatus(err);
+  const retryAfterMs = extractRetryAfterMs(err);
+  const code = err?.code;
+  const name = err?.name;
+  const message = String(err?.message ?? err ?? "").toLowerCase();
+
+  const result = (kind, retryable) => ({
+    kind,
+    status,
+    retryable,
+    retryAfterMs,
+  });
+
+  // Already classified upstream — trust it.
+  if (err instanceof AiProviderError) {
+    return {
+      kind: err.kind,
+      status: err.status,
+      retryable: err.retryable,
+      retryAfterMs: err.retryAfterMs,
+    };
+  }
+
+  if (name === "AbortError" || code === "ABORT_ERR") {
+    return result(AI_ERROR_KIND.TIMEOUT, true);
+  }
+
+  if (typeof code === "string" && NETWORK_ERROR_CODES.has(code)) {
+    return result(AI_ERROR_KIND.NETWORK, true);
+  }
+
+  if (status === 429) return result(AI_ERROR_KIND.RATE_LIMIT, true);
+  if (status === 408) return result(AI_ERROR_KIND.TIMEOUT, true);
+  if (status !== null && status >= 500)
+    return result(AI_ERROR_KIND.SERVER, true);
+  if (status === 401 || status === 403)
+    return result(AI_ERROR_KIND.AUTH, false);
+  if (status !== null && status >= 400) {
+    return result(AI_ERROR_KIND.INVALID_REQUEST, false);
+  }
+
+  // Message-based fallbacks for SDKs that surface no status at all. Kept narrow
+  // on purpose — a broad "contains error" match would make everything retryable
+  // and defeat the point of classifying.
+  if (
+    message.includes("rate limit") ||
+    message.includes("resource_exhausted") ||
+    message.includes("quota exceeded") ||
+    message.includes("too many requests")
+  ) {
+    return result(AI_ERROR_KIND.RATE_LIMIT, true);
+  }
+  if (
+    message.includes("overloaded") ||
+    message.includes("unavailable") ||
+    message.includes("service is currently")
+  ) {
+    return result(AI_ERROR_KIND.SERVER, true);
+  }
+  if (message.includes("timed out") || message.includes("timeout")) {
+    return result(AI_ERROR_KIND.TIMEOUT, true);
+  }
+  if (message.includes("socket hang up") || message.includes("network")) {
+    return result(AI_ERROR_KIND.NETWORK, true);
+  }
+  if (message.includes("api key") || message.includes("permission denied")) {
+    return result(AI_ERROR_KIND.AUTH, false);
+  }
+
+  return result(AI_ERROR_KIND.UNKNOWN, false);
+};
+
+/**
+ * Runs `fn` with a hard deadline.
+ *
+ * `fn` receives an `AbortSignal` so a well-behaved client can cancel the
+ * underlying request rather than leaving it running after we've stopped caring.
+ * The rejection happens either way — the SDK not honouring the signal must not
+ * be able to hang the caller, which is the exact failure mode being fixed.
+ *
+ * @template T
+ * @param {(signal: AbortSignal) => Promise<T>} fn
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs]
+ * @param {string} [options.label] used in the error message
+ * @returns {Promise<T>}
+ */
+export const withTimeout = async (
+  fn,
+  { timeoutMs = 60000, label = "AI request" } = {},
+) => {
+  const controller = new AbortController();
+  let timer;
+
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new AiProviderError(`${label} timed out after ${timeoutMs}ms`, {
+          kind: AI_ERROR_KIND.TIMEOUT,
+          retryable: true,
+        }),
+      );
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => fn(controller.signal)),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Computes the delay before the next attempt.
+ *
+ * Full jitter (`random() * exponential`) rather than a fixed multiplier: when a
+ * batch of queued jobs all trip the same rate limit, un-jittered backoff makes
+ * them retry in lockstep and hit the limit again together.
+ *
+ * A provider-supplied `retryAfterMs` wins outright — it's authoritative.
+ *
+ * @param {number} attempt 1-based
+ * @param {object} [options]
+ * @returns {number} milliseconds
+ */
+export const computeBackoffDelay = (
+  attempt,
+  {
+    baseDelayMs = 1000,
+    maxDelayMs = 30000,
+    jitterRatio = 0.5,
+    retryAfterMs = null,
+    random = Math.random,
+  } = {},
+) => {
+  if (retryAfterMs !== null && retryAfterMs !== undefined) {
+    return Math.min(Math.max(0, retryAfterMs), maxDelayMs);
+  }
+
+  const exponential = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+  const jitterWindow = exponential * jitterRatio;
+  const fixed = exponential - jitterWindow;
+
+  return Math.round(fixed + random() * jitterWindow);
+};
+
+const defaultSleep = (ms) =>
+  new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    t.unref?.();
+  });
+
+/**
+ * Retries `fn` while the failure is classified retryable.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @param {object} [options]
+ * @param {number} [options.retries] additional attempts after the first
+ * @param {Function} [options.classify]
+ * @param {Function} [options.onRetry] called with ({attempt, delayMs, error, classification})
+ * @param {Function} [options.sleep] injectable for tests
+ * @returns {Promise<T>}
+ */
+export const withRetry = async (
+  fn,
+  {
+    retries = 2,
+    baseDelayMs = 1000,
+    maxDelayMs = 30000,
+    jitterRatio = 0.5,
+    classify = classifyAiError,
+    onRetry = null,
+    sleep = defaultSleep,
+    random = Math.random,
+  } = {},
+) => {
+  const maxAttempts = Math.max(1, retries + 1);
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      lastError = err;
+      const classification = classify(err);
+
+      const isLastAttempt = attempt === maxAttempts;
+      if (!classification.retryable || isLastAttempt) {
+        throw new AiProviderError(err?.message || String(err), {
+          ...classification,
+          cause: err,
+        });
+      }
+
+      const delayMs = computeBackoffDelay(attempt, {
+        baseDelayMs,
+        maxDelayMs,
+        jitterRatio,
+        retryAfterMs: classification.retryAfterMs,
+        random,
+      });
+
+      onRetry?.({ attempt, delayMs, error: err, classification });
+      await sleep(delayMs);
+    }
+  }
+
+  // Unreachable: the loop either returns or throws.
+  throw lastError;
+};
+
+/** Circuit breaker states. */
+export const BREAKER_STATE = Object.freeze({
+  CLOSED: "closed",
+  OPEN: "open",
+  HALF_OPEN: "half_open",
+});
+
+/**
+ * A minimal circuit breaker.
+ *
+ * Without one, a provider outage means every queued MoM job independently waits
+ * out the full timeout × retry budget before falling back. With `concurrency: 1`
+ * on the AI worker, a 60s timeout and 5 attempts, that is minutes of dead time
+ * per job while the queue backs up. Once failures are confirmed, failing fast to
+ * the fallback is strictly better than confirming the outage over and over.
+ *
+ * @param {object} [options]
+ * @param {number} [options.failureThreshold] consecutive failures before opening
+ * @param {number} [options.cooldownMs] how long to stay open before probing
+ * @param {Function} [options.now] injectable clock
+ */
+export const createCircuitBreaker = ({
+  failureThreshold = 5,
+  cooldownMs = 60000,
+  now = () => Date.now(),
+  onStateChange = null,
+  name = "ai-provider",
+} = {}) => {
+  let state = BREAKER_STATE.CLOSED;
+  let consecutiveFailures = 0;
+  let openedAt = 0;
+
+  const transition = (next) => {
+    if (state === next) return;
+    const previous = state;
+    state = next;
+    onStateChange?.({ name, from: previous, to: next });
+  };
+
+  const recordSuccess = () => {
+    consecutiveFailures = 0;
+    transition(BREAKER_STATE.CLOSED);
+  };
+
+  /**
+   * Only failures we believe are the *provider's* fault should open the
+   * breaker. A 400 caused by our own malformed prompt is not evidence that
+   * Gemini is down, and opening on it would suppress every other caller.
+   */
+  const recordFailure = (classification) => {
+    if (classification && classification.retryable === false) {
+      const { kind } = classification;
+      if (
+        kind === AI_ERROR_KIND.AUTH ||
+        kind === AI_ERROR_KIND.INVALID_REQUEST
+      ) {
+        return;
+      }
+    }
+
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= failureThreshold) {
+      openedAt = now();
+      transition(BREAKER_STATE.OPEN);
+    }
+  };
+
+  /** Moves OPEN → HALF_OPEN once the cooldown has elapsed. */
+  const refresh = () => {
+    if (state === BREAKER_STATE.OPEN && now() - openedAt >= cooldownMs) {
+      transition(BREAKER_STATE.HALF_OPEN);
+    }
+    return state;
+  };
+
+  /**
+   * @template T
+   * @param {() => Promise<T>} fn
+   * @returns {Promise<T>}
+   */
+  const exec = async (fn) => {
+    if (refresh() === BREAKER_STATE.OPEN) {
+      throw new AiProviderError(
+        `Circuit breaker "${name}" is open — failing fast without calling the provider.`,
+        { kind: AI_ERROR_KIND.CIRCUIT_OPEN, retryable: false },
+      );
+    }
+
+    try {
+      const result = await fn();
+      recordSuccess();
+      return result;
+    } catch (err) {
+      recordFailure(classifyAiError(err));
+      throw err;
+    }
+  };
+
+  return {
+    exec,
+    recordSuccess,
+    recordFailure,
+    getState: () => refresh(),
+    getFailureCount: () => consecutiveFailures,
+    /** Test/ops escape hatch. */
+    reset: () => {
+      consecutiveFailures = 0;
+      openedAt = 0;
+      transition(BREAKER_STATE.CLOSED);
+    },
+  };
+};
+
+/**
+ * Rough token estimate. ~4 characters per token is the standard approximation
+ * for English and is plenty for deciding *whether to chunk* — we only need to
+ * stay safely under a limit, not to count exactly.
+ *
+ * @param {string} text
+ * @returns {number}
+ */
+export const estimateTokens = (text) =>
+  Math.ceil(String(text ?? "").length / 4);
+
+/**
+ * Splits text into chunks that fit a character budget, preferring natural
+ * boundaries.
+ *
+ * The point is that this replaces `.substring(0, 1024)`. Truncation throws away
+ * the end of the meeting — which is where decisions and action items usually
+ * are. Chunking keeps all of it.
+ *
+ * Boundary preference: paragraph break, then sentence end, then a hard cut.
+ * `overlapChars` carries a little context across the seam so a decision stated
+ * across a boundary isn't lost by either chunk.
+ *
+ * @param {string} text
+ * @param {object} [options]
+ * @returns {string[]}
+ */
+export const chunkTextByBudget = (
+  text,
+  { maxChars = 24000, overlapChars = 500 } = {},
+) => {
+  const source = String(text ?? "");
+  if (!source.trim()) return [];
+  if (source.length <= maxChars) return [source];
+
+  const effectiveOverlap = Math.min(
+    Math.max(0, overlapChars),
+    Math.floor(maxChars / 2),
+  );
+
+  const chunks = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const hardEnd = Math.min(cursor + maxChars, source.length);
+
+    let end = hardEnd;
+    if (hardEnd < source.length) {
+      // Search only the back quarter of the window: further back than that and
+      // we'd be discarding usable budget to chase a prettier boundary.
+      const searchFloor = cursor + Math.floor(maxChars * 0.75);
+
+      const paragraph = source.lastIndexOf("\n\n", hardEnd);
+      const sentence = Math.max(
+        source.lastIndexOf(". ", hardEnd),
+        source.lastIndexOf("? ", hardEnd),
+        source.lastIndexOf("! ", hardEnd),
+        source.lastIndexOf("\n", hardEnd),
+      );
+
+      if (paragraph > searchFloor) end = paragraph;
+      else if (sentence > searchFloor) end = sentence + 1;
+    }
+
+    chunks.push(source.slice(cursor, end).trim());
+
+    if (end >= source.length) break;
+    cursor = Math.max(end - effectiveOverlap, cursor + 1);
+  }
+
+  return chunks.filter(Boolean);
+};
+
+/**
+ * Composes the whole stack: circuit breaker → retry → timeout.
+ *
+ * Ordering matters. The breaker is outermost so an open circuit costs nothing;
+ * the timeout is innermost so it bounds each individual attempt rather than the
+ * whole retry sequence (a 3-attempt call with a 60s timeout should be able to
+ * spend 60s per attempt, not 60s total).
+ *
+ * @template T
+ * @param {(signal: AbortSignal) => Promise<T>} fn
+ * @param {object} [options]
+ * @returns {Promise<T>}
+ */
+export const callWithResilience = async (
+  fn,
+  {
+    timeoutMs = 60000,
+    retries = 2,
+    baseDelayMs = 1000,
+    maxDelayMs = 30000,
+    label = "AI request",
+    breaker = null,
+    onRetry = null,
+    sleep = defaultSleep,
+    random = Math.random,
+  } = {},
+) => {
+  const attemptOnce = () =>
+    withRetry(() => withTimeout(fn, { timeoutMs, label }), {
+      retries,
+      baseDelayMs,
+      maxDelayMs,
+      onRetry,
+      sleep,
+      random,
+    });
+
+  return breaker ? breaker.exec(attemptOnce) : attemptOnce();
+};
+
+export default {
+  AI_ERROR_KIND,
+  AiProviderError,
+  BREAKER_STATE,
+  callWithResilience,
+  chunkTextByBudget,
+  classifyAiError,
+  computeBackoffDelay,
+  createCircuitBreaker,
+  estimateTokens,
+  extractRetryAfterMs,
+  extractStatus,
+  withRetry,
+  withTimeout,
+};


### PR DESCRIPTION
# Pull Request

## Description

Adds timeout, retry, circuit-breaking and prompt budgeting to Gemini generation.

The problem in #976 isn't that AI calls fail — it's that they failed **invisibly**. `generateMoMWithAI` wrapped its Gemini call in one `try` whose `catch` treated a transient `429` exactly like a permanent `401`, then fell straight through to a local model that summarises `textToSummarize.substring(0, 1024)` and hardcodes `decisions: []`, `action_items: []`, `attendees: []`. The meeting was persisted as successfully processed. The decision graph, tasks board, conflict detection, policy compliance and action-item reminders all saw an empty meeting, and the only trace was a free-text `notes` string — so there was no way to find the affected records afterwards.

There was also **no timeout anywhere**. The SDK uses `fetch`, which has no default timeout, and the AI worker runs at `concurrency: 1` — one hung call stalled MoM generation for every organization until the process restarted.

### `utils/aiResilience.js` (new)

Composed as **circuit breaker → retry → timeout → provider**. The breaker is outermost so an open circuit costs nothing; the timeout is innermost so it bounds each *attempt*, not the whole sequence (a 3-attempt call with a 60s timeout should be able to spend 60s per attempt, not 60s total).

- **`classifyAiError`** — the piece everything else depends on. `429`/`5xx`/`408`/network codes/`AbortError` are retryable; `401`/`403`/other `4xx` are not. Unrecognised errors default to **not retryable**, deliberately: an error we can't classify is more likely a bug in our own request than a blip on the wire, and retrying it burns the timeout budget and delays the fallback. Getting a status out is fiddly here — `@google/generative-ai` has no stable `status` field and commonly throws with `[429 Too Many Requests] …` at the start of the message, so structured fields are checked first and the message second.
- **`withTimeout`** — `AbortController`-based, so a well-behaved client cancels the underlying request. It rejects either way, so an SDK that ignores the signal still can't hang us.
- **`withRetry`** — exponential backoff with **full jitter**. Un-jittered backoff makes a batch of rate-limited jobs retry in lockstep and re-trip the same limit together. A provider-supplied hint wins outright, from either a `Retry-After` header or Google's `RetryInfo` detail (`retryDelay: "31s"`) — the provider knows when its quota window resets and we don't.
- **`createCircuitBreaker`** — after N consecutive provider failures, queued jobs fail fast to the fallback instead of each re-confirming a known outage at full timeout × retry cost. Only provider-side failures count: a `400` from a malformed prompt is not evidence Gemini is down, and opening on it would suppress every other caller.
- **`chunkTextByBudget`** — replaces `.substring(0, 1024)`. Splits at paragraph → sentence → hard-cut boundaries with a small overlap so a decision stated across a seam isn't lost by either chunk.

`sleep`, `now` and `random` are all injectable, so retry timing and breaker transitions are asserted deterministically and instantly rather than by actually waiting out a backoff.

### `GenerativeAIService.js`

- Long transcripts are chunked, extracted per chunk, and merged by `mergeMoMParts` with **case-insensitive** dedup — the overlap deliberately feeds the same sentences to two chunks, and the model restates a straddling decision in both. This matters most for the *longest* meetings, which under the old code were the ones most likely to blow the context window and get dumped to the 1024-char fallback.
- **Degradation is recorded, not implied.** New `generateMoMDetailed()` returns `{ mom, generation }`; `normalizeMoM` carries it into the persisted `structuredMoM`, so degraded meetings are queryable: `db.meetings.find({ "structuredMoM.generation.degraded": true })`. `structuredMoM` is already a `Mixed` field, so **no migration is required**. `buildHumanReadableMoM` adds a visible notice too — without it, an empty "Decisions" section reads as "no decisions were made" rather than "we never analysed most of the meeting".
- Legacy documents default to `{ provider: "unknown", degraded: false }`. Absence of evidence isn't evidence of degradation, and flagging every historical MoM as suspect would make the flag useless.
- The client is now memoised — `new GoogleGenerativeAI(...)` previously ran on every call, at three separate sites.
- `generateSessionCardAI` gets the API-key check and error handling its two siblings already had. It had **neither**, so with the key unset it threw a raw SDK error straight out of `sessionController.js`.

`generateMoMWithAI` keeps its exact signature and return shape as a thin wrapper, so no caller was forced to change.

## Type of Change

- [x] Bug Fix
- [x] Performance Improvement
- [ ] New Feature
- [ ] Documentation Update
- [x] Refactor
- [x] Other — reliability / data-quality hardening

## Related Issue

Closes #976

## Testing

Added **90 tests** across two new suites:

**`tests/aiResilience.test.js` (65)** — status extraction from all the shapes the SDK throws, including the bracketed-message form; `Retry-After` header (numeric and HTTP-date) and `RetryInfo` parsing; the full retryable/non-retryable classification matrix; timeout rejects and aborts the signal; backoff growth, ceiling, jitter window, and `Retry-After` override; retry stops on non-retryable errors and respects the attempt limit; breaker open/half-open/closed transitions, fail-fast, and the "don't open on our own 400" rule; chunking preserves the whole transcript, prefers sentence boundaries, overlaps, and always makes forward progress.

**`tests/generativeAiResilience.test.js` (25)** — a `429` is retried and succeeds *without* falling back (the headline regression); a `503` exhausts retries then falls back; a `401` is not retried; a provider that never responds produces `errorKind: "timeout"` instead of hanging; fallback provenance records `truncated`/`inputCharsUsed`/`inputCharsTotal`; chunked runs issue one call per chunk and merge with dedup; the chunk cap is recorded as `chunk_limit_exceeded`; the breaker opens after repeated failures and the next job never reaches the provider; `generateSessionCardAI` retries transients and throws a typed error instead of a raw SDK error.

```
Test Suites: 3 passed, 3 total
Tests:       95 passed, 95 total
```

That 95 includes the **pre-existing `tests/GenerativeAIService.test.js`, which passes unmodified** — the public contract of `generateMoMWithAI` is unchanged.

Also re-ran the downstream consumers:

```
tests/summarize.test.js  tests/Conflictdetectionservice.test.js
tests/integration.test.js  tests/gemini.test.js
Test Suites: 4 passed, 4 total
Tests:       50 passed, 50 total

vitest tests/MeetingService.test.js → 5 passed
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors
- [x] `eslint` and `prettier --check` clean

## Screenshots

Not applicable — backend change. The one user-visible effect is a "Generation Notice" block appended to degraded MoM documents.

## Notes for reviewers

- **No schema migration.** `structuredMoM` is `mongoose.Schema.Types.Mixed`, so the new `generation` field persists as-is.
- **All new knobs have safe defaults** and are documented in `docs/ai-resilience.md`: `GEMINI_TIMEOUT_MS` (60s), `GEMINI_MAX_RETRIES` (3), `GEMINI_MAX_PROMPT_CHARS` (24k), `GEMINI_MAX_CHUNKS` (8), `GEMINI_BREAKER_THRESHOLD` (5), and others. Breaker settings are read at module load; the rest are read per call.
- **Cost note:** chunking means a very long transcript now issues up to `GEMINI_MAX_CHUNKS` requests instead of one. That's the intended trade — the alternative was analysing the first 1024 characters and calling it done. The cap is configurable, and hitting it is recorded as a degradation rather than passing silently.
- **A missing API key still degrades rather than throws** in the MoM path, matching the previous behaviour its callers depend on. The auth error is classified non-retryable, so it reaches the fallback in one attempt. The two entry points that genuinely cannot degrade check explicitly.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
