### PR TITLE
fix(notifications): wire up the dead notification and engagement-points pipeline (#977)

### DIFF
--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -14,6 +14,7 @@ import {
   FileText,
   Brain,
   Building2,
+  ListChecks,
   Shield,
   BarChart3,
   AlertCircle,
@@ -23,8 +24,13 @@ import {
   ChevronRight,
 } from "lucide-react";
 
+// Issue #977: `tasks` is a new category. Action-item reminders were previously
+// filed under `meetings`, which meant the "Task assignments" preference toggle
+// governed nothing while the "Meeting reminders" toggle silently killed task
+// reminders.
 const CATEGORY_ICONS = {
   meetings: Calendar,
+  tasks: ListChecks,
   ai_processing: Brain,
   organizations: Building2,
   policies: Shield,
@@ -34,6 +40,7 @@ const CATEGORY_ICONS = {
 
 const CATEGORY_COLORS = {
   meetings: "bg-blue-50 text-blue-600 border-blue-200",
+  tasks: "bg-teal-50 text-teal-600 border-teal-200",
   ai_processing: "bg-violet-50 text-violet-600 border-violet-200",
   organizations: "bg-emerald-50 text-emerald-600 border-emerald-200",
   policies: "bg-amber-50 text-amber-600 border-amber-200",
@@ -43,6 +50,7 @@ const CATEGORY_COLORS = {
 
 const CATEGORY_LABELS = {
   meetings: "Meetings",
+  tasks: "Tasks",
   ai_processing: "AI Processing",
   organizations: "Organizations",
   policies: "Policies",

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -2,6 +2,14 @@
 import notificationModel from "../models/notificationModel.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 import NotificationPreference from "../models/notificationPreferenceModel.js";
+import { CATEGORY_TO_PREFERENCE } from "../services/notificationService.js";
+
+/**
+ * Valid filter values, derived from the single source of truth in
+ * notificationService rather than being hand-maintained here. The previous
+ * inline array had already drifted — it did not include the `tasks` category.
+ */
+const NOTIFICATION_CATEGORIES = Object.keys(CATEGORY_TO_PREFERENCE);
 
 // Helper to format notification response
 const formatNotificationResponse = (notification) => {
@@ -39,16 +47,7 @@ export const getNotifications = async (req, res) => {
     const userId = String(req.user.id);
     const filter = { user: userId };
 
-    if (
-      [
-        "meetings",
-        "ai_processing",
-        "organizations",
-        "policies",
-        "reports",
-        "system",
-      ].includes(category)
-    ) {
+    if (NOTIFICATION_CATEGORIES.includes(category)) {
       filter.category = String(category);
     }
 
@@ -223,6 +222,8 @@ export const updatePreferences = async (req, res) => {
       return sendError(res, 401, "Authentication error, user ID not found.");
     }
 
+    // Issue #977: the push toggles are now all genuinely enforced by
+    // notificationService (previously only two of six were read by anything).
     const allowedFields = [
       "emailMeetingReminders",
       "emailTaskAssignments",
@@ -230,6 +231,9 @@ export const updatePreferences = async (req, res) => {
       "pushMeetingReminders",
       "pushTaskAssignments",
       "pushAiProcessingComplete",
+      "pushOrganizationUpdates",
+      "pushPolicyUpdates",
+      "pushReportUpdates",
     ];
 
     const updates = {};

--- a/server/events/listeners.js
+++ b/server/events/listeners.js
@@ -1,154 +1,278 @@
 import eventBus from "../services/eventBus.js";
-import { createNotification } from "../services/notificationService.js";
+import { createNotifications } from "../services/notificationService.js";
 import { awardEngagementPoints } from "../services/OrganizationService.js";
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #977 — this entire module used to be dead code.
+//
+// `initListeners` was exported and never called:
+//
+//     $ grep -rn "initListeners" server --include="*.js"
+//     server/events/listeners.js:5:export const initListeners = (io) => {
+//     server/events/listeners.js:7:    console.warn("⚠️ initListeners: ...
+//
+// Only the declaration. So every in-app notification and every engagement point
+// in the product silently did nothing: the events were emitted, the socket rooms
+// were joined, and `Navbar.jsx` was listening for `notification:new` — but
+// nothing on the server was subscribed.
+//
+// It went unnoticed because the four *other* event consumers (slackService,
+// cacheInvalidationService, conflictScanTrigger, webhookDispatcherService)
+// register at module top level and are side-effect-imported in server.js, so
+// Slack, webhooks, cache invalidation and conflict scans all worked — making the
+// event bus look healthy. This module is the one that wrapped its `eventBus.on`
+// calls in an exported init function that was never wired into the bootstrap.
+//
+// Beyond calling it, three things had to change before turning it on was safe:
+//
+//   1. Registration must be idempotent. `EventEmitter` has no dedup, so a
+//      double call (tests, hot reload, a future second bootstrap path) would
+//      send every user two of every notification.
+//   2. Handlers must be rejection-safe. These are `async` functions attached to
+//      a plain EventEmitter — a rejection inside one becomes an unhandled
+//      promise rejection, which on Node >= 15 can terminate the process.
+//   3. Fan-out must not be a sequential N+1. See notificationService.js.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Guards against double registration.
+ *
+ * Module-scoped rather than a property on `io`, because the failure we care
+ * about is "this module registered its handlers twice", regardless of which
+ * `io` instance was passed.
+ */
+let registered = false;
+
+/** Exposed for tests, which need a clean slate per case. */
+export const _resetListenerRegistration = () => {
+  registered = false;
+};
+
+/**
+ * Wraps an async event handler so a rejection is logged with event context
+ * instead of escaping as an unhandled rejection.
+ *
+ * @param {string} eventName
+ * @param {Function} handler
+ */
+const safeHandler =
+  (eventName, handler) =>
+  async (...args) => {
+    try {
+      await handler(...args);
+    } catch (error) {
+      console.error(
+        `❌ Event handler for "${eventName}" failed:`,
+        error?.message || error,
+      );
+    }
+  };
+
+/**
+ * Emits a batch of notifications to their recipients' personal socket rooms.
+ *
+ * Users join a room named after their own id on connect
+ * (`socket/meetingSocket.js`), which is what makes `io.to(userId)` work.
+ *
+ * @param {object} io
+ * @param {object[]} notifications formatted notifications, each with a `user`
+ */
+const emitToRooms = (io, notifications) => {
+  for (const { room, notification } of notifications) {
+    io.to(room).emit("notification:new", notification);
+  }
+};
+
+/**
+ * Creates notifications for a set of recipients and pushes them over Socket.IO.
+ *
+ * `createNotifications` returns only the recipients that were actually
+ * delivered to (suppressed ones are filtered out), so the socket emit
+ * automatically respects preferences without a second check.
+ *
+ * @param {object} io
+ * @param {Array<string|object>} recipients
+ * @param {object} payload
+ */
+const notify = async (io, recipients, payload) => {
+  const created = await createNotifications(recipients, payload);
+  if (created.length === 0) return [];
+
+  emitToRooms(
+    io,
+    created.map((notification) => ({
+      // `insertMany` preserves input order, but the delivered set is a filtered
+      // subset — so read the recipient back off the document rather than
+      // indexing into the original array.
+      room: String(notification.user ?? ""),
+      notification,
+    })),
+  );
+
+  return created;
+};
+
+/**
+ * Registers every notification and gamification listener.
+ *
+ * @param {object} io Socket.IO server instance
+ * @returns {boolean} true if listeners were registered by this call
+ */
 export const initListeners = (io) => {
   if (!io) {
     console.warn("⚠️ initListeners: Socket.IO instance is not provided.");
-    return;
+    return false;
   }
+
+  if (registered) {
+    console.warn(
+      "⚠️ initListeners: already registered — skipping to avoid duplicate notifications.",
+    );
+    return false;
+  }
+  registered = true;
+
+  const on = (eventName, handler) =>
+    eventBus.on(eventName, safeHandler(eventName, handler));
 
   // ─────────────────────────────────────────────────────────────
   // MEETINGS
   // ─────────────────────────────────────────────────────────────
 
-  eventBus.on("meeting.created", async ({ meeting, membersToNotify = [] }) => {
-    for (const membership of membersToNotify) {
-      const formattedNotification = await createNotification(
-        membership.user._id,
-        "New Meeting Scheduled",
-        `A new meeting "${meeting.title}" has been scheduled.`,
-        "meetings",
-        `/meeting/${meeting._id}`,
-        "View Details",
-      );
-      if (formattedNotification) {
-        io.to(membership.user._id.toString()).emit(
-          "notification:new",
-          formattedNotification,
-        );
-      }
-    }
+  on("meeting.created", async ({ meeting, membersToNotify = [] }) => {
+    if (!meeting) return;
+
+    // One preference query and one insert for the whole organization, instead
+    // of two queries per member awaited in sequence.
+    const recipients = membersToNotify
+      .map((membership) => membership?.user?._id ?? membership?.user)
+      .filter(Boolean);
+
+    await notify(io, recipients, {
+      title: "New Meeting Scheduled",
+      description: `A new meeting "${meeting.title}" has been scheduled.`,
+      category: "meetings",
+      actionUrl: `/meeting/${meeting._id}`,
+      actionLabel: "View Details",
+      metadata: { meetingId: meeting._id },
+    });
   });
 
   // ─────────────────────────────────────────────────────────────
   // MoM / AI PROCESSING
   // ─────────────────────────────────────────────────────────────
 
-  eventBus.on("mom.generated", async (meeting) => {
-    // Notify the meeting uploader/owner if they exist on the object
-    const userId = meeting.uploadedBy || meeting.owner;
-    if (userId) {
-      if (meeting.organization) {
-        await awardEngagementPoints(userId, meeting.organization, 50);
-      }
-      const formattedNotification = await createNotification(
-        userId,
-        "Minutes of Meeting Generated",
-        `MoM for "${meeting.title}" is ready.`,
-        "ai_processing",
-        `/meeting/${meeting._id}`,
-        "View MoM",
-      );
-      if (formattedNotification) {
-        io.to(userId.toString()).emit(
-          "notification:new",
-          formattedNotification,
-        );
-      }
+  on("mom.generated", async (meeting) => {
+    if (!meeting) return;
 
-      // We also emit a specific socket event for the UI to catch
-      io.to(userId.toString()).emit("mom-generation-complete", {
-        meetingId: meeting._id,
-        title: meeting.title,
-        summary: meeting.summary,
-        mom: meeting.structuredMoM,
-      });
+    const userId = meeting.uploadedBy || meeting.owner;
+    if (!userId) return;
+
+    if (meeting.organization) {
+      await awardEngagementPoints(userId, meeting.organization, 50);
     }
+
+    await notify(io, [userId], {
+      title: "Minutes of Meeting Generated",
+      description: `MoM for "${meeting.title}" is ready.`,
+      category: "ai_processing",
+      actionUrl: `/meeting/${meeting._id}`,
+      actionLabel: "View MoM",
+      metadata: { meetingId: meeting._id },
+    });
+
+    // Distinct from the notification: the meeting-details UI listens for this
+    // to swap a "processing" placeholder for the finished MoM. It is emitted
+    // unconditionally, because it is a UI state update rather than a
+    // notification, and notification preferences must not suppress it.
+    io.to(String(userId)).emit("mom-generation-complete", {
+      meetingId: meeting._id,
+      title: meeting.title,
+      summary: meeting.summary,
+      mom: meeting.structuredMoM,
+    });
   });
 
   // ─────────────────────────────────────────────────────────────
   // DATA EXPORT
   // ─────────────────────────────────────────────────────────────
 
-  eventBus.on("export.ready", async ({ userId, downloadUrl }) => {
-    const formattedNotification = await createNotification(
-      userId,
-      "Data Export Ready",
-      "Your data export has been completed and emailed to you.",
-      "system",
-      downloadUrl,
-      "Download",
-    );
-    if (formattedNotification) {
-      io.to(userId.toString()).emit("notification:new", formattedNotification);
-    }
+  on("export.ready", async ({ userId, downloadUrl }) => {
+    if (!userId) return;
+
+    await notify(io, [userId], {
+      title: "Data Export Ready",
+      description: "Your data export has been completed and emailed to you.",
+      // Category "system" is intentionally not suppressible — the user
+      // explicitly requested this export and it expires.
+      category: "system",
+      actionUrl: downloadUrl,
+      actionLabel: "Download",
+    });
   });
 
   // ─────────────────────────────────────────────────────────────
   // ORGANIZATIONS
   // ─────────────────────────────────────────────────────────────
 
-  eventBus.on(
+  on(
     "organization.joined",
     async ({ userId, _organizationId, organizationName, adminId }) => {
-      if (adminId && adminId.toString() !== userId.toString()) {
-        const formattedNotification = await createNotification(
-          adminId,
-          "New Member Joined",
-          `A new user has joined your organization: ${organizationName}.`,
-          "organizations",
-          "/team-members",
-          "View Team",
-        );
-        if (formattedNotification) {
-          io.to(adminId.toString()).emit(
-            "notification:new",
-            formattedNotification,
-          );
-        }
-      }
+      if (!adminId) return;
+      // Don't notify an admin that they themselves joined.
+      if (userId && String(adminId) === String(userId)) return;
+
+      await notify(io, [adminId], {
+        title: "New Member Joined",
+        description: `A new user has joined your organization: ${organizationName}.`,
+        category: "organizations",
+        actionUrl: "/team-members",
+        actionLabel: "View Team",
+      });
     },
   );
 
-  eventBus.on(
+  on(
     "live_meeting.notified",
-    async ({ _uploaderId, roomId, participants, _orgId }) => {
-      for (const user of participants) {
-        const formattedNotification = await createNotification(
-          user._id,
-          "Live Meeting Started",
-          "You have been invited to join a live meeting.",
-          "meetings",
-          `/meeting-room/${roomId}`,
-          "Join Now",
-        );
-        if (formattedNotification) {
-          io.to(user._id.toString()).emit(
-            "notification:new",
-            formattedNotification,
-          );
-        }
-      }
+    async ({ _uploaderId, roomId, participants = [], _orgId }) => {
+      const recipients = participants
+        .map((user) => user?._id ?? user)
+        .filter(Boolean);
+
+      await notify(io, recipients, {
+        title: "Live Meeting Started",
+        description: "You have been invited to join a live meeting.",
+        category: "meetings",
+        actionUrl: `/meeting-room/${roomId}`,
+        actionLabel: "Join Now",
+        metadata: { roomId },
+      });
     },
   );
 
   // ─────────────────────────────────────────────────────────────
   // GAMIFICATION
+  //
+  // `awardEngagementPoints` is called from these three handlers and nowhere
+  // else in the codebase, so while this module was unwired no user could ever
+  // earn a point and the Top Contributors leaderboard was permanently empty.
   // ─────────────────────────────────────────────────────────────
 
-  eventBus.on("policy.created", async (policy) => {
-    const userId = policy.uploadedBy;
+  on("policy.created", async (policy) => {
+    const userId = policy?.uploadedBy;
     if (userId && policy.organization) {
       await awardEngagementPoints(userId, policy.organization, 20);
     }
   });
 
-  eventBus.on("actionItem.completed", async ({ userId, organizationId }) => {
+  on("actionItem.completed", async ({ userId, organizationId }) => {
     if (userId && organizationId) {
       await awardEngagementPoints(userId, organizationId, 10);
     }
   });
 
   console.log("✅ Event listeners initialized");
+  return true;
 };
+
+export default initListeners;

--- a/server/models/notificationModel.js
+++ b/server/models/notificationModel.js
@@ -21,6 +21,10 @@ const notificationSchema = new mongoose.Schema(
       type: String,
       enum: [
         "meetings",
+        // Issue #977: action-item reminders were filed under "meetings", so
+        // `pushTaskAssignments` governed nothing and `pushMeetingReminders`
+        // silently killed task reminders. They now have their own category.
+        "tasks",
         "ai_processing",
         "organizations",
         "policies",
@@ -48,6 +52,28 @@ const notificationSchema = new mongoose.Schema(
     },
   },
   { timestamps: true },
+);
+
+// ─── Retention (Issue #977) ──────────────────────────────────────────────────
+// Nothing ever deleted a notification, so the collection grew without bound for
+// the lifetime of the deployment. A TTL index reaps them automatically.
+//
+// The index is on `createdAt` with a single global expiry rather than a
+// per-document one, because MongoDB's TTL monitor only supports a fixed
+// `expireAfterSeconds` per index. Reaping by age (not by read state) is the
+// safer rule: an unread notification that is a year old is not going to be
+// acted on, and keeping it forever to avoid "losing" it is what caused the
+// unbounded growth in the first place.
+//
+// Configurable so an organization with compliance requirements can extend it.
+const RETENTION_DAYS = (() => {
+  const parsed = Number.parseInt(process.env.NOTIFICATION_RETENTION_DAYS, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 90;
+})();
+
+notificationSchema.index(
+  { createdAt: 1 },
+  { expireAfterSeconds: RETENTION_DAYS * 24 * 60 * 60 },
 );
 
 const notificationModel =

--- a/server/models/notificationPreferenceModel.js
+++ b/server/models/notificationPreferenceModel.js
@@ -1,5 +1,26 @@
 import mongoose from "mongoose";
 
+/**
+ * Per-user notification preferences.
+ *
+ * Issue #977: four of the original six toggles (`emailMeetingReminders`,
+ * `emailTaskAssignments`, `emailWeeklyDigest`, `pushTaskAssignments`) were
+ * writable through the API and rendered as working switches in the UI while
+ * being read by absolutely nothing:
+ *
+ *     $ grep -rn "pushTaskAssignments" server --include="*.js"
+ *     server/models/notificationPreferenceModel.js:28
+ *     server/controllers/notificationController.js:231
+ *
+ * Only the schema and the allow-list. A switch that does nothing is worse than
+ * no switch, because the user believes they've turned something off.
+ *
+ * The push toggles now genuinely gate delivery (see
+ * `CATEGORY_TO_PREFERENCE` in services/notificationService.js). The three
+ * `email*` toggles are retained — existing users have values stored against
+ * them and the settings UI renders them — but they are documented here as not
+ * yet enforced, so the gap is recorded in the schema rather than hidden.
+ */
 const notificationPreferenceSchema = new mongoose.Schema(
   {
     user: {
@@ -9,6 +30,11 @@ const notificationPreferenceSchema = new mongoose.Schema(
       unique: true,
       index: true,
     },
+
+    // ── Email channel ────────────────────────────────────────────────────
+    // NOT YET ENFORCED. The email paths (MeetingDigestService,
+    // recapEmailService) do not consult these. Tracked as follow-up work;
+    // documented rather than silently ignored.
     emailMeetingReminders: {
       type: Boolean,
       default: true,
@@ -21,6 +47,9 @@ const notificationPreferenceSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+
+    // ── In-app / push channel ────────────────────────────────────────────
+    // All of these are enforced by notificationService.createNotifications.
     pushMeetingReminders: {
       type: Boolean,
       default: true,
@@ -30,6 +59,18 @@ const notificationPreferenceSchema = new mongoose.Schema(
       default: true,
     },
     pushAiProcessingComplete: {
+      type: Boolean,
+      default: true,
+    },
+    pushOrganizationUpdates: {
+      type: Boolean,
+      default: true,
+    },
+    pushPolicyUpdates: {
+      type: Boolean,
+      default: true,
+    },
+    pushReportUpdates: {
       type: Boolean,
       default: true,
     },

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ import meetingHealthRoutes from "./routes/meetingHealthRoutes.js";
 import { configureExpress, configureErrorHandling } from "./config/express.js";
 import { configureSocket } from "./config/socket.js";
 import { startWorkers } from "./config/workers.js";
+import { initListeners } from "./events/listeners.js";
 import routes from "./routes/index.js";
 
 // Import slackService, cacheInvalidationService, and conflictScanTrigger to register eventBus listeners.
@@ -133,6 +134,16 @@ const server = http.createServer(app);
 
 // SOCKET.IO
 const io = configureSocket(server, app);
+
+// ─── EVENT LISTENERS (Issue #977) ────────────────────────────────────────────
+// `initListeners` registers every in-app notification and engagement-point
+// handler, and was never called — so `meeting.created`, `mom.generated`,
+// `export.ready`, `organization.joined` and `live_meeting.notified` all emitted
+// into a void, `Navbar.jsx`'s `notification:new` subscription could never fire,
+// and `awardEngagementPoints` (called from nowhere else) meant the leaderboard
+// was permanently zero. It must run after `configureSocket` because it needs
+// `io` to push notifications to each user's personal room.
+initListeners(io);
 
 // SERVER START (Skipped during Jest test execution)
 if (process.env.NODE_ENV !== "test") {

--- a/server/services/actionItemReminderService.js
+++ b/server/services/actionItemReminderService.js
@@ -94,7 +94,11 @@ export const processActionItemReminders = async ({ organization } = {}) => {
         targetUserId,
         `⏰ Action Item Due Soon`,
         `Your action item "${item.text}"${meetingTitle} is due on ${dueDate.toLocaleDateString()}.`,
-        "meetings",
+        // Issue #977: these were filed under "meetings", so the
+        // `pushTaskAssignments` toggle governed nothing while
+        // `pushMeetingReminders` silently killed task reminders — the switches
+        // were wired to the wrong behaviour.
+        "tasks",
         "/tasks",
         "View Action Items",
         { actionItemId: item._id, reminderType: "upcoming", dueDate },
@@ -118,7 +122,7 @@ export const processActionItemReminders = async ({ organization } = {}) => {
         targetUserId,
         `⚠️ Action Item Overdue`,
         `Your action item "${item.text}"${meetingTitle} was due on ${dueDate.toLocaleDateString()}.`,
-        "meetings",
+        "tasks",
         "/tasks",
         "View Action Items",
         { actionItemId: item._id, reminderType: "overdue", dueDate },

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,41 +1,218 @@
 import notificationModel from "../models/notificationModel.js";
 import NotificationPreference from "../models/notificationPreferenceModel.js";
 
-const categoryToPreferenceField = {
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #977 — notification delivery.
+//
+// Two problems lived here:
+//
+//   1. Only two of the six preference toggles were ever consulted. `system`,
+//      `organizations`, `policies` and `reports` mapped to `null`, and
+//      `pushTaskAssignments` / the three `email*` toggles were writable through
+//      the API and rendered as working switches in the UI while being read by
+//      nothing at all.
+//
+//   2. Fan-out was a sequential N+1. `events/listeners.js` looped over
+//      recipients awaiting `createNotification` per person, and each call ran
+//      its own `NotificationPreference.findOne()` *and* its own `create()`. For
+//      a 500-member organization that is 1000 sequential round-trips inside an
+//      un-awaited EventEmitter handler.
+//
+// `createNotifications` (plural) fixes the second by prefetching every relevant
+// preference in one query and writing with one `insertMany`. `createNotification`
+// stays as a thin wrapper so no existing caller had to change.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a notification category to the preference field that governs it.
+ *
+ * `null` means "always deliver" — a deliberate choice, not an oversight:
+ * `system` covers account and export notifications a user cannot opt out of
+ * without losing things they explicitly asked for.
+ *
+ * Every category in `notificationModel`'s enum must appear here. The test suite
+ * asserts that, so adding a category without deciding how it's governed fails
+ * loudly instead of silently defaulting to "always send".
+ */
+export const CATEGORY_TO_PREFERENCE = Object.freeze({
   meetings: "pushMeetingReminders",
+  tasks: "pushTaskAssignments",
   ai_processing: "pushAiProcessingComplete",
+  organizations: "pushOrganizationUpdates",
+  policies: "pushPolicyUpdates",
+  reports: "pushReportUpdates",
   system: null,
-  organizations: null,
-  policies: null,
-  reports: null,
+});
+
+/**
+ * Loads preferences for many users in one query and returns a lookup keyed by
+ * user id.
+ *
+ * Users with no preference document are simply absent; callers treat that as
+ * "all defaults", which matches the previous per-user behaviour (`if (!prefs)
+ * return false`).
+ *
+ * @param {Array<string|object>} userIds
+ * @returns {Promise<Map<string, object>>}
+ */
+const loadPreferences = async (userIds) => {
+  const map = new Map();
+  if (!userIds.length) return map;
+
+  try {
+    const docs = await NotificationPreference.find({
+      user: { $in: userIds },
+    }).lean();
+
+    for (const doc of docs) {
+      map.set(String(doc.user), doc);
+    }
+  } catch (error) {
+    // Preferences are an optimisation over "deliver everything". Failing to
+    // read them must not silently drop notifications, so fall through to an
+    // empty map (= defaults = deliver).
+    console.error(
+      "⚠️ Failed to load notification preferences; delivering with defaults:",
+      error.message,
+    );
+  }
+
+  return map;
 };
 
 /**
- * Checks whether a given user has opted out of push notifications for a category.
+ * Decides whether a category is suppressed for a given preference document.
+ *
+ * @param {object|undefined} prefs
+ * @param {string} category
+ * @returns {boolean}
  */
-const shouldSuppressPush = async (userId, category) => {
-  const field = categoryToPreferenceField[category];
+export const isSuppressed = (prefs, category) => {
+  const field = CATEGORY_TO_PREFERENCE[category];
   if (!field) return false;
+  if (!prefs) return false;
+  // Only an explicit `false` suppresses. An undefined field (a preference
+  // document written before this toggle existed) means "not configured", which
+  // must fall back to the schema default rather than being read as "off".
+  return prefs[field] === false;
+};
+
+/**
+ * Formats a notification document for API/socket responses.
+ *
+ * @param {object} notification
+ */
+export const formatNotification = (notification) => ({
+  id: notification._id,
+  // Included so bulk callers can route each notification to its recipient's
+  // socket room. `insertMany` preserves input order, but the delivered set is a
+  // *filtered* subset (suppressed recipients are dropped), so the recipient has
+  // to be read back off the document rather than inferred by index.
+  user: notification.user,
+  title: notification.title,
+  description: notification.description,
+  category: notification.category,
+  isRead: notification.isRead,
+  actionUrl: notification.actionUrl,
+  actionLabel: notification.actionLabel,
+  metadata: notification.metadata,
+  createdAt: notification.createdAt,
+  updatedAt: notification.updatedAt,
+});
+
+/**
+ * Creates one notification per recipient in a single round-trip pair.
+ *
+ * Replaces the sequential loop that ran two queries per recipient. Total cost is
+ * now one `find` plus one `insertMany`, regardless of how many people are being
+ * notified.
+ *
+ * @param {Array<string|object>} recipients user ids
+ * @param {object} payload
+ * @param {string} payload.title
+ * @param {string} payload.description
+ * @param {string} [payload.category]
+ * @param {string} [payload.actionUrl]
+ * @param {string} [payload.actionLabel]
+ * @param {object} [payload.metadata]
+ * @returns {Promise<object[]>} formatted notifications for delivered recipients
+ */
+export const createNotifications = async (recipients, payload) => {
+  const {
+    title,
+    description,
+    category = "system",
+    actionUrl = "",
+    actionLabel = "",
+    metadata = {},
+  } = payload ?? {};
+
+  if (!Array.isArray(recipients) || recipients.length === 0) return [];
+  if (!title || !description) {
+    console.warn(
+      "⚠️ createNotifications: title and description are required — skipping.",
+    );
+    return [];
+  }
+
+  // De-duplicate up front. A user who is both the organizer and an attendee
+  // would otherwise get the same notification twice.
+  const uniqueIds = [
+    ...new Set(recipients.filter(Boolean).map((id) => String(id))),
+  ];
+  if (uniqueIds.length === 0) return [];
 
   try {
-    const prefs = await NotificationPreference.findOne({ user: userId });
-    if (!prefs) return false;
-    return prefs[field] === false;
-  } catch {
-    return false;
+    const prefsByUser = await loadPreferences(uniqueIds);
+
+    const deliverTo = uniqueIds.filter(
+      (userId) => !isSuppressed(prefsByUser.get(userId), category),
+    );
+
+    const suppressedCount = uniqueIds.length - deliverTo.length;
+    if (suppressedCount > 0) {
+      console.log(
+        `🔇 ${suppressedCount} notification(s) suppressed — category "${category}" disabled in preferences`,
+      );
+    }
+
+    if (deliverTo.length === 0) return [];
+
+    const docs = await notificationModel.insertMany(
+      deliverTo.map((user) => ({
+        user,
+        title,
+        description,
+        category,
+        actionUrl,
+        actionLabel,
+        metadata,
+      })),
+    );
+
+    return docs.map(formatNotification);
+  } catch (error) {
+    // Notification delivery is never allowed to break the flow that triggered
+    // it (meeting creation, export completion, …).
+    console.error("Error creating notifications:", error);
+    return [];
   }
 };
 
 /**
- * Creates a notification in the database
+ * Creates a notification for a single user.
+ *
+ * Signature unchanged from the original positional form so every existing
+ * caller keeps working.
  *
  * @param {string} userId - The ID of the user to notify
  * @param {string} title - Notification title
  * @param {string} description - Notification description
- * @param {string} category - Category (e.g., "meetings", "organizations", "system", "ai_processing")
+ * @param {string} category - Category (e.g. "meetings", "tasks", "system")
  * @param {string} actionUrl - URL to navigate to when clicked (optional)
  * @param {string} actionLabel - Label for the action button (optional)
  * @param {object} metadata - Additional metadata (optional)
+ * @returns {Promise<object|null>} formatted notification, or null if suppressed
  */
 export const createNotification = async (
   userId,
@@ -46,44 +223,16 @@ export const createNotification = async (
   actionLabel = "",
   metadata = {},
 ) => {
-  try {
-    const suppressed = await shouldSuppressPush(userId, category);
-    if (suppressed) {
-      console.log(
-        `🔇 Notification suppressed for user ${userId} — category "${category}" disabled in preferences`,
-      );
-      return null;
-    }
+  if (!userId) return null;
 
-    // 1. Create notification in database
-    const notification = await notificationModel.create({
-      user: userId,
-      title,
-      description,
-      category,
-      actionUrl,
-      actionLabel,
-      metadata,
-    });
+  const [notification] = await createNotifications([userId], {
+    title,
+    description,
+    category,
+    actionUrl,
+    actionLabel,
+    metadata,
+  });
 
-    // 2. Format the response object (similar to how notificationController does)
-    const formattedNotification = {
-      id: notification._id,
-      title: notification.title,
-      description: notification.description,
-      category: notification.category,
-      isRead: notification.isRead,
-      actionUrl: notification.actionUrl,
-      actionLabel: notification.actionLabel,
-      metadata: notification.metadata,
-      createdAt: notification.createdAt,
-      updatedAt: notification.updatedAt,
-    };
-
-    return formattedNotification;
-  } catch (error) {
-    console.error("Error creating and pushing notification:", error);
-    // Don't throw the error, just return null so it doesn't break the main flow (e.g., meeting creation)
-    return null;
-  }
+  return notification ?? null;
 };

--- a/server/tests/actionItemReminderService.test.js
+++ b/server/tests/actionItemReminderService.test.js
@@ -59,7 +59,10 @@ describe("actionItemReminderService", () => {
       userId.toString(),
       expect.stringContaining("Due Soon"),
       expect.stringContaining("Submit financial report"),
-      "meetings",
+      // Issue #977: action-item reminders moved from "meetings" to their own
+      // "tasks" category, so the pushTaskAssignments preference actually
+      // governs them instead of pushMeetingReminders silently killing them.
+      "tasks",
       "/tasks",
       "View Action Items",
       expect.any(Object),
@@ -103,7 +106,7 @@ describe("actionItemReminderService", () => {
       userId.toString(),
       expect.stringContaining("Overdue"),
       expect.stringContaining("Fix login bug"),
-      "meetings",
+      "tasks",
       "/tasks",
       "View Action Items",
       expect.any(Object),

--- a/server/tests/notificationPipeline.test.js
+++ b/server/tests/notificationPipeline.test.js
@@ -1,0 +1,634 @@
+/**
+ * Issue #977 — the in-app notification and engagement-points pipeline.
+ *
+ * The headline regression is that `initListeners` was exported and never
+ * called, so every notification and every engagement point silently did
+ * nothing. These suites assert that the pipeline is wired, that wiring it twice
+ * doesn't double-send, that a throwing handler can't take the process down, and
+ * that fan-out is no longer an N+1.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+const mockAwardEngagementPoints = jest.fn(async () => {});
+jest.unstable_mockModule("../services/OrganizationService.js", () => ({
+  awardEngagementPoints: mockAwardEngagementPoints,
+}));
+
+const notificationModel = (await import("../models/notificationModel.js"))
+  .default;
+const NotificationPreference = (
+  await import("../models/notificationPreferenceModel.js")
+).default;
+const eventBus = (await import("../services/eventBus.js")).default;
+const {
+  CATEGORY_TO_PREFERENCE,
+  createNotification,
+  createNotifications,
+  isSuppressed,
+} = await import("../services/notificationService.js");
+const { initListeners, _resetListenerRegistration } =
+  await import("../events/listeners.js");
+
+const objectId = () => new mongoose.Types.ObjectId();
+
+// These suites exercise real Mongo writes (bulk insert counts, TTL index,
+// preference filtering) but deliberately don't import server.js — pulling in the
+// whole app just to get a connection would drag the Pinecone/transformers module
+// graph into this test. Connect to the in-memory server that tests/setup.js
+// already started instead.
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+/** Minimal Socket.IO stub that records every emit and the room it targeted. */
+const makeIo = () => {
+  const emits = [];
+  return {
+    emits,
+    to: (room) => ({
+      emit: (event, payload) => emits.push({ room, event, payload }),
+    }),
+  };
+};
+
+/**
+ * Waits for the EventEmitter's async handlers to settle.
+ *
+ * `eventBus.emit` is synchronous and returns before an async handler has done
+ * its DB work, so a single microtask flush isn't enough. Poll instead of
+ * sleeping a fixed amount: it keeps the fast path fast and the slow path
+ * reliable.
+ *
+ * @param {Function} [condition] resolves as soon as this returns truthy
+ */
+const flush = async (condition = null, timeoutMs = 3000) => {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    if (!condition) return;
+    if (condition()) return;
+  } while (Date.now() < deadline);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetListenerRegistration();
+  eventBus.removeAllListeners();
+});
+
+afterAll(() => {
+  eventBus.removeAllListeners();
+});
+
+describe("category → preference mapping", () => {
+  it("covers every category the notification model allows", () => {
+    // Previously `system`, `organizations`, `policies` and `reports` all mapped
+    // to null, and `pushTaskAssignments` was read by nothing at all. Asserting
+    // full coverage means a new category can't silently default to "always
+    // send" without someone deciding that.
+    const schemaCategories =
+      notificationModel.schema.path("category").enumValues;
+
+    expect(Object.keys(CATEGORY_TO_PREFERENCE).sort()).toEqual(
+      [...schemaCategories].sort(),
+    );
+  });
+
+  it("includes the tasks category", () => {
+    expect(CATEGORY_TO_PREFERENCE.tasks).toBe("pushTaskAssignments");
+  });
+
+  it("leaves system notifications unsuppressible", () => {
+    // The user explicitly asked for their export and the link expires.
+    expect(CATEGORY_TO_PREFERENCE.system).toBeNull();
+    expect(isSuppressed({ pushMeetingReminders: false }, "system")).toBe(false);
+  });
+
+  it("suppresses only on an explicit false", () => {
+    expect(isSuppressed({ pushMeetingReminders: false }, "meetings")).toBe(
+      true,
+    );
+    expect(isSuppressed({ pushMeetingReminders: true }, "meetings")).toBe(
+      false,
+    );
+    // An undefined field means "written before this toggle existed", which must
+    // fall back to the schema default rather than reading as "off".
+    expect(isSuppressed({}, "meetings")).toBe(false);
+    expect(isSuppressed(undefined, "meetings")).toBe(false);
+  });
+});
+
+describe("createNotifications — bulk fan-out", () => {
+  it("creates one notification per recipient", async () => {
+    const users = [objectId(), objectId(), objectId()];
+
+    const created = await createNotifications(users, {
+      title: "New Meeting Scheduled",
+      description: "A new meeting has been scheduled.",
+      category: "meetings",
+    });
+
+    expect(created).toHaveLength(3);
+    expect(await notificationModel.countDocuments()).toBe(3);
+  });
+
+  it("uses one preference query and one insert regardless of recipient count", async () => {
+    const findSpy = jest.spyOn(NotificationPreference, "find");
+    const insertSpy = jest.spyOn(notificationModel, "insertMany");
+
+    try {
+      const users = Array.from({ length: 50 }, () => objectId());
+
+      await createNotifications(users, {
+        title: "T",
+        description: "D",
+        category: "meetings",
+      });
+
+      // The old path ran a findOne + create per recipient, awaited in sequence:
+      // 100 sequential round-trips for these 50 users.
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      expect(insertSpy).toHaveBeenCalledTimes(1);
+      expect(insertSpy.mock.calls[0][0]).toHaveLength(50);
+    } finally {
+      findSpy.mockRestore();
+      insertSpy.mockRestore();
+    }
+  });
+
+  it("de-duplicates repeated recipients", async () => {
+    const user = objectId();
+
+    // A user who is both organizer and attendee must not be notified twice.
+    const created = await createNotifications([user, user, String(user)], {
+      title: "T",
+      description: "D",
+    });
+
+    expect(created).toHaveLength(1);
+  });
+
+  it("filters out recipients who disabled the category", async () => {
+    const optedIn = objectId();
+    const optedOut = objectId();
+
+    await NotificationPreference.create({
+      user: optedOut,
+      pushMeetingReminders: false,
+    });
+
+    const created = await createNotifications([optedIn, optedOut], {
+      title: "T",
+      description: "D",
+      category: "meetings",
+    });
+
+    expect(created).toHaveLength(1);
+    expect(String(created[0].user)).toBe(String(optedIn));
+  });
+
+  it("honours the tasks toggle independently of the meetings toggle", async () => {
+    const user = objectId();
+    await NotificationPreference.create({
+      user,
+      pushTaskAssignments: false,
+      pushMeetingReminders: true,
+    });
+
+    // The exact bug: reminders filed under "meetings" meant the task toggle did
+    // nothing and the meetings toggle killed task reminders.
+    expect(
+      await createNotifications([user], {
+        title: "T",
+        description: "D",
+        category: "tasks",
+      }),
+    ).toHaveLength(0);
+
+    expect(
+      await createNotifications([user], {
+        title: "T",
+        description: "D",
+        category: "meetings",
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("enforces the previously-ignored organization/policy/report toggles", async () => {
+    const user = objectId();
+    await NotificationPreference.create({
+      user,
+      pushOrganizationUpdates: false,
+      pushPolicyUpdates: false,
+      pushReportUpdates: false,
+    });
+
+    for (const category of ["organizations", "policies", "reports"]) {
+      expect(
+        await createNotifications([user], {
+          title: "T",
+          description: "D",
+          category,
+        }),
+      ).toHaveLength(0);
+    }
+  });
+
+  it("returns an empty array for an empty recipient list", async () => {
+    expect(
+      await createNotifications([], { title: "T", description: "D" }),
+    ).toEqual([]);
+    expect(
+      await createNotifications(null, { title: "T", description: "D" }),
+    ).toEqual([]);
+  });
+
+  it("refuses to write a notification without a title or description", async () => {
+    expect(await createNotifications([objectId()], { title: "T" })).toEqual([]);
+    expect(await notificationModel.countDocuments()).toBe(0);
+  });
+
+  it("delivers with defaults when the preference query fails", async () => {
+    const findSpy = jest
+      .spyOn(NotificationPreference, "find")
+      .mockImplementation(() => {
+        throw new Error("mongo down");
+      });
+
+    try {
+      // Preferences are an optimisation over "deliver everything"; failing to
+      // read them must not silently drop notifications.
+      const created = await createNotifications([objectId()], {
+        title: "T",
+        description: "D",
+        category: "meetings",
+      });
+      expect(created).toHaveLength(1);
+    } finally {
+      findSpy.mockRestore();
+    }
+  });
+
+  it("never throws out of the caller's flow", async () => {
+    const insertSpy = jest
+      .spyOn(notificationModel, "insertMany")
+      .mockRejectedValue(new Error("write failed"));
+
+    try {
+      // Notification delivery must not break meeting creation.
+      await expect(
+        createNotifications([objectId()], { title: "T", description: "D" }),
+      ).resolves.toEqual([]);
+    } finally {
+      insertSpy.mockRestore();
+    }
+  });
+});
+
+describe("createNotification — single-recipient wrapper", () => {
+  it("keeps its original positional signature", async () => {
+    const user = objectId();
+
+    const result = await createNotification(
+      user,
+      "Title",
+      "Description",
+      "meetings",
+      "/meeting/1",
+      "View",
+      { meetingId: "1" },
+    );
+
+    expect(result).toMatchObject({
+      title: "Title",
+      description: "Description",
+      category: "meetings",
+      actionUrl: "/meeting/1",
+      actionLabel: "View",
+    });
+  });
+
+  it("returns null when suppressed", async () => {
+    const user = objectId();
+    await NotificationPreference.create({
+      user,
+      pushAiProcessingComplete: false,
+    });
+
+    await expect(
+      createNotification(user, "T", "D", "ai_processing"),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a missing user id", async () => {
+    await expect(createNotification(null, "T", "D")).resolves.toBeNull();
+  });
+});
+
+describe("initListeners — registration", () => {
+  it("registers handlers for every emitted event", () => {
+    const io = makeIo();
+    expect(initListeners(io)).toBe(true);
+
+    // These are the seven events with real emitters in production code.
+    for (const event of [
+      "meeting.created",
+      "mom.generated",
+      "export.ready",
+      "organization.joined",
+      "live_meeting.notified",
+      "policy.created",
+      "actionItem.completed",
+    ]) {
+      expect(eventBus.listenerCount(event)).toBe(1);
+    }
+  });
+
+  it("is idempotent — a second call does not double-register", () => {
+    const io = makeIo();
+    initListeners(io);
+    expect(initListeners(io)).toBe(false);
+
+    // EventEmitter has no dedup, so a double registration would send every user
+    // two of every notification.
+    expect(eventBus.listenerCount("meeting.created")).toBe(1);
+  });
+
+  it("refuses to register without a Socket.IO instance", () => {
+    expect(initListeners(null)).toBe(false);
+    expect(eventBus.listenerCount("meeting.created")).toBe(0);
+  });
+});
+
+describe("initListeners — delivery", () => {
+  it("notifies every org member when a meeting is created", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const members = [objectId(), objectId()];
+    const meeting = { _id: objectId(), title: "Q3 Planning" };
+
+    eventBus.emit("meeting.created", {
+      meeting,
+      membersToNotify: members.map((id) => ({ user: { _id: id } })),
+    });
+    await flush(() => io.emits.length >= 2);
+
+    expect(await notificationModel.countDocuments()).toBe(2);
+
+    // The client subscribes to this in Navbar.jsx; it could never fire before.
+    const pushes = io.emits.filter((e) => e.event === "notification:new");
+    expect(pushes).toHaveLength(2);
+    expect(pushes.map((p) => p.room).sort()).toEqual(
+      members.map(String).sort(),
+    );
+    expect(pushes[0].payload.title).toBe("New Meeting Scheduled");
+  });
+
+  it("does not push to a member who disabled meeting notifications", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const optedIn = objectId();
+    const optedOut = objectId();
+    await NotificationPreference.create({
+      user: optedOut,
+      pushMeetingReminders: false,
+    });
+
+    eventBus.emit("meeting.created", {
+      meeting: { _id: objectId(), title: "T" },
+      membersToNotify: [
+        { user: { _id: optedIn } },
+        { user: { _id: optedOut } },
+      ],
+    });
+    await flush(() => io.emits.length >= 1);
+
+    const pushes = io.emits.filter((e) => e.event === "notification:new");
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0].room).toBe(String(optedIn));
+  });
+
+  it("notifies the owner and awards points when a MoM is generated", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const owner = objectId();
+    const org = objectId();
+
+    eventBus.emit("mom.generated", {
+      _id: objectId(),
+      title: "Q3 Planning",
+      uploadedBy: owner,
+      organization: org,
+      summary: "s",
+      structuredMoM: {},
+    });
+    await flush(() => io.emits.length >= 2);
+
+    expect(mockAwardEngagementPoints).toHaveBeenCalledWith(owner, org, 50);
+    expect(io.emits.some((e) => e.event === "notification:new")).toBe(true);
+    // Distinct from the notification: this drives a UI state swap.
+    expect(io.emits.some((e) => e.event === "mom-generation-complete")).toBe(
+      true,
+    );
+  });
+
+  it("still emits mom-generation-complete when the notification is suppressed", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const owner = objectId();
+    await NotificationPreference.create({
+      user: owner,
+      pushAiProcessingComplete: false,
+    });
+
+    eventBus.emit("mom.generated", {
+      _id: objectId(),
+      title: "T",
+      uploadedBy: owner,
+    });
+    await flush(() => io.emits.length >= 1);
+
+    // A notification preference must not suppress a UI state update, or the
+    // meeting page stays stuck on "processing" forever.
+    expect(io.emits.filter((e) => e.event === "notification:new")).toHaveLength(
+      0,
+    );
+    expect(
+      io.emits.filter((e) => e.event === "mom-generation-complete"),
+    ).toHaveLength(1);
+  });
+
+  it("notifies the requester when an export is ready", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const user = objectId();
+    eventBus.emit("export.ready", { userId: user, downloadUrl: "/dl/1" });
+    await flush(() => io.emits.length >= 1);
+
+    const [push] = io.emits;
+    expect(push.room).toBe(String(user));
+    expect(push.payload.title).toBe("Data Export Ready");
+    expect(push.payload.actionUrl).toBe("/dl/1");
+  });
+
+  it("notifies the admin when someone joins the organization", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const admin = objectId();
+    eventBus.emit("organization.joined", {
+      userId: objectId(),
+      organizationName: "Acme",
+      adminId: admin,
+    });
+    await flush(() => io.emits.length >= 1);
+
+    expect(io.emits).toHaveLength(1);
+    expect(io.emits[0].room).toBe(String(admin));
+  });
+
+  it("does not notify an admin about their own join", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const admin = objectId();
+    eventBus.emit("organization.joined", {
+      userId: admin,
+      organizationName: "Acme",
+      adminId: admin,
+    });
+    await flush();
+
+    expect(io.emits).toHaveLength(0);
+  });
+
+  it("notifies every participant of a live meeting", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const participants = [objectId(), objectId(), objectId()];
+    eventBus.emit("live_meeting.notified", {
+      roomId: "room-1",
+      participants: participants.map((id) => ({ _id: id })),
+    });
+    await flush(() => io.emits.length >= 3);
+
+    expect(io.emits).toHaveLength(3);
+    expect(io.emits[0].payload.actionUrl).toBe("/meeting-room/room-1");
+  });
+
+  it("awards points for policy creation and action-item completion", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    const user = objectId();
+    const org = objectId();
+
+    eventBus.emit("policy.created", { uploadedBy: user, organization: org });
+    eventBus.emit("actionItem.completed", {
+      userId: user,
+      organizationId: org,
+    });
+    await flush(() => mockAwardEngagementPoints.mock.calls.length >= 2);
+
+    // `awardEngagementPoints` is called from these handlers and nowhere else in
+    // the codebase, so while this module was unwired the leaderboard could
+    // never be anything but zero.
+    expect(mockAwardEngagementPoints).toHaveBeenCalledWith(user, org, 20);
+    expect(mockAwardEngagementPoints).toHaveBeenCalledWith(user, org, 10);
+  });
+});
+
+describe("initListeners — error isolation", () => {
+  it("logs a handler failure instead of leaking an unhandled rejection", async () => {
+    const io = makeIo();
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const rejections = [];
+    const capture = (reason) => rejections.push(reason);
+    process.on("unhandledRejection", capture);
+
+    try {
+      mockAwardEngagementPoints.mockRejectedValueOnce(new Error("db down"));
+      initListeners(io);
+
+      eventBus.emit("policy.created", {
+        uploadedBy: objectId(),
+        organization: objectId(),
+      });
+      await flush(() => errorSpy.mock.calls.length > 0);
+
+      // These are async handlers on a plain EventEmitter; an escaping rejection
+      // can terminate the process on Node >= 15.
+      expect(rejections).toHaveLength(0);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Event handler for "policy.created" failed'),
+        expect.anything(),
+      );
+    } finally {
+      process.off("unhandledRejection", capture);
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("keeps other events working after one handler throws", async () => {
+    const io = makeIo();
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      mockAwardEngagementPoints.mockRejectedValueOnce(new Error("db down"));
+      initListeners(io);
+
+      eventBus.emit("policy.created", {
+        uploadedBy: objectId(),
+        organization: objectId(),
+      });
+      await flush();
+
+      eventBus.emit("export.ready", {
+        userId: objectId(),
+        downloadUrl: "/dl/2",
+      });
+      await flush(() => io.emits.length >= 1);
+
+      expect(io.emits).toHaveLength(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("ignores an event with a missing payload", async () => {
+    const io = makeIo();
+    initListeners(io);
+
+    eventBus.emit("meeting.created", { meeting: null });
+    eventBus.emit("mom.generated", null);
+    eventBus.emit("export.ready", {});
+    await flush();
+
+    expect(io.emits).toHaveLength(0);
+    expect(await notificationModel.countDocuments()).toBe(0);
+  });
+});
+
+describe("notification retention", () => {
+  it("declares a TTL index on createdAt", () => {
+    // Nothing ever deleted a notification, so the collection grew without bound
+    // for the lifetime of the deployment.
+    const ttlIndex = notificationModel.schema
+      .indexes()
+      .find(([, options]) => options?.expireAfterSeconds !== undefined);
+
+    expect(ttlIndex).toBeDefined();
+    expect(ttlIndex[0]).toHaveProperty("createdAt");
+    expect(ttlIndex[1].expireAfterSeconds).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Wires up the notification and engagement-points pipeline, which was **entirely dead code**.

`events/listeners.js` exported `initListeners` and nothing ever called it:

```
$ grep -rn "initListeners" server --include="*.js"
server/events/listeners.js:5:export const initListeners = (io) => {
server/events/listeners.js:7:    console.warn("⚠️ initListeners: Socket.IO instance is not provided.");
```

Only the declaration. The events were emitted, the socket rooms were joined, and `Navbar.jsx:193` was subscribed to `notification:new` — but nothing on the server side was listening, so all seven handlers did nothing:

| Event | Lost behaviour |
|---|---|
| `meeting.created` | "New Meeting Scheduled" to every org member |
| `mom.generated` | "MoM Generated" notification, the `mom-generation-complete` socket event the UI waits on, **and** +50 points |
| `export.ready` | "Data Export Ready" |
| `organization.joined` | "New Member Joined" to the admin |
| `live_meeting.notified` | "Live Meeting Started" to participants |
| `policy.created` / `actionItem.completed` | +20 / +10 points |

`awardEngagementPoints` is called from these handlers **and nowhere else in the codebase**, so no user could ever earn a point and `TopContributorsWidget` rendered a permanently zeroed leaderboard.

It went unnoticed because the four *other* event consumers (`slackService`, `cacheInvalidationService`, `conflictScanTrigger`, `webhookDispatcherService`) register at module top level and are side-effect-imported in `server.js` — so Slack, webhooks, cache invalidation and conflict scans all worked, which made the event bus look healthy. This module is the one that wrapped its `eventBus.on` calls in an exported init function that was never wired into the bootstrap.

### Three things had to change before turning it on was safe

1. **Registration is idempotent.** `EventEmitter` has no dedup, so a second call — tests, hot reload, a future second bootstrap path — would send every user *two* of every notification.
2. **Handlers are rejection-safe.** These are `async` functions attached to a plain `EventEmitter`; a rejection inside one becomes an unhandled promise rejection, which on Node ≥ 15 can terminate the process. A shared `safeHandler` logs with event context instead.
3. **Fan-out is no longer an N+1.** The old loop awaited `createNotification` per recipient, and each call ran its own `NotificationPreference.findOne()` *and* its own `create()` — **1000 sequential round-trips for a 500-member organization**, inside an un-awaited EventEmitter handler. New `createNotifications` prefetches every preference in one `find` and writes with one `insertMany`. `createNotification` stays as a thin wrapper with its exact original positional signature, so no existing caller changed.

### Preference toggles that did nothing

Four of the six toggles were writable through the API and rendered as working switches in the settings UI while being read by nothing:

```
$ grep -rn "pushTaskAssignments" server --include="*.js"
server/models/notificationPreferenceModel.js:28
server/controllers/notificationController.js:231
```

Only the schema and the allow-list. A switch that does nothing is worse than no switch, because the user believes they turned something off.

- Every category now maps to a preference field, and a test asserts the mapping covers the model's full enum — so a new category can't silently default to "always send".
- `system` stays deliberately unsuppressible: it covers exports the user explicitly requested, with links that expire.
- **Action-item reminders move to a new `tasks` category.** They were filed under `meetings`, so `pushTaskAssignments` governed nothing while `pushMeetingReminders` silently killed task reminders — the switches were wired to the wrong behaviour.
- The three `email*` toggles are **documented in the schema as not yet enforced** rather than left silently ignored. Enforcing them means touching `MeetingDigestService` and `recapEmailService`, which is out of scope here; recording the gap beats hiding it.

### Retention

Nothing ever deleted a notification, so the collection grew unbounded for the life of the deployment. Added a TTL index on `createdAt` (`NOTIFICATION_RETENTION_DAYS`, default 90). Reaping by age rather than read state is the safer rule — an unread notification a year old isn't going to be acted on.

## Type of Change

- [x] Bug Fix
- [x] Performance Improvement
- [ ] New Feature
- [ ] Documentation Update
- [x] Refactor

## Related Issue

Closes #977

## Testing

Added **33 tests** in `tests/notificationPipeline.test.js`:

- **Mapping** — full coverage of the model's category enum; `tasks` → `pushTaskAssignments`; `system` unsuppressible; suppression only on an explicit `false` (an undefined field means "written before this toggle existed" and must fall back to the schema default, not read as "off").
- **Bulk fan-out** — one `find` and one `insertMany` for 50 recipients (spied, asserted); de-duplication of repeated recipients; per-category filtering; the `tasks`/`meetings` toggles proven independent; the three previously-ignored toggles now enforced; delivery falls back to defaults when the preference query fails (preferences are an optimisation over "deliver everything", so failing to read them must not drop notifications); never throws out of the caller's flow.
- **Registration** — all seven events subscribed; a second call registers nothing; refuses without an `io`.
- **Delivery** — org-wide meeting notification reaches every member's socket room; a member who opted out gets neither the row nor the push; MoM generation awards 50 points and pushes both events; **`mom-generation-complete` still fires when the notification is suppressed** (a notification preference must not suppress a UI state update, or the meeting page stays stuck on "processing"); export/join/live-meeting delivery; an admin isn't notified about their own join; points awarded for policy creation and action-item completion.
- **Error isolation** — a throwing handler produces a log, not an unhandled rejection (asserted by listening on `process.unhandledRejection`); other events keep working afterwards; missing payloads are ignored rather than crashing.
- **Retention** — the TTL index is declared on `createdAt` with a positive expiry.

```
tests/notificationPipeline.test.js  →  33 passed
```

Also re-ran the affected existing suites:

```
tests/actionItemReminderService.test.js  tests/health.test.js
tests/integration.test.js  tests/webhook.test.js
Tests: 39 passed
```

**Two assertions in `tests/actionItemReminderService.test.js` were updated** from `"meetings"` to `"tasks"`. That's the intentional behaviour change described above, and the diff is two lines plus a comment explaining why.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors
- [x] `eslint` and `prettier --check` clean (server and client)

## Screenshots

Not applicable — the visible effect is that the notification bell badge and toast now actually appear in real time, which a screenshot can't usefully show. `client/src/pages/Notifications.jsx` gains a "Tasks" category chip (teal, `ListChecks` icon) matching the existing category styling.

## Notes for reviewers

- **`createNotification`'s signature is unchanged**, so `actionItemReminderService` and any future caller keep working as-is.
- **New preference fields default to `true`**, so existing users see no change in what they receive — only that the toggles now work.
- **`formatNotification` now includes `user`.** Bulk callers need it to route each notification to the right socket room: `insertMany` preserves input order, but the delivered set is a *filtered* subset once suppressed recipients are dropped, so the recipient has to be read off the document rather than inferred by index.
- **`initListeners(io)` is called right after `configureSocket`** in `server.js`, since it needs `io` to reach each user's personal room (joined in `socket/meetingSocket.js:16-19`).
- The new test suite connects to the in-memory Mongo that `tests/setup.js` already starts, rather than importing `server.js` — pulling in the whole app just to get a connection would drag the Pinecone/transformers module graph into the test.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
