### PR TITLE
fix(client): add timeout, bounded retry and cancellation to the shared API client (#978)

### DIFF
--- a/client/src/hooks/__tests__/useApiRequest.test.jsx
+++ b/client/src/hooks/__tests__/useApiRequest.test.jsx
@@ -1,0 +1,262 @@
+/**
+ * Issue #978 — request cancellation.
+ *
+ * The two bugs under test are the ones that follow directly from having no
+ * cancellation anywhere in the client: stale responses overwriting fresh ones,
+ * and state updates after unmount.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useApiRequest } from "../useApiRequest.js";
+
+/** An axios-style cancellation. */
+const cancelError = () => {
+  const err = new Error("canceled");
+  err.code = "ERR_CANCELED";
+  return err;
+};
+
+/** Resolves after `ms`, unless the signal aborts first. */
+const delayed = (value, ms, signal) =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(value), ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer);
+      reject(cancelError());
+    });
+  });
+
+describe("useApiRequest", () => {
+  it("exposes loading, then data", async () => {
+    const { result } = renderHook(() => useApiRequest(async () => "payload"));
+
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      await result.current.execute();
+    });
+
+    expect(result.current.data).toBe("payload");
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("passes an AbortSignal to the request", async () => {
+    const requestFn = vi.fn(async () => "ok");
+    const { result } = renderHook(() => useApiRequest(requestFn));
+
+    await act(async () => {
+      await result.current.execute();
+    });
+
+    expect(requestFn.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("forwards extra arguments after the signal", async () => {
+    const requestFn = vi.fn(async () => "ok");
+    const { result } = renderHook(() => useApiRequest(requestFn));
+
+    await act(async () => {
+      await result.current.execute("query", 2);
+    });
+
+    expect(requestFn).toHaveBeenCalledWith(expect.any(AbortSignal), "query", 2);
+  });
+
+  it("records an error without throwing", async () => {
+    const failure = new Error("500");
+    const { result } = renderHook(() =>
+      useApiRequest(async () => {
+        throw failure;
+      }),
+    );
+
+    await act(async () => {
+      await result.current.execute();
+    });
+
+    expect(result.current.error).toBe(failure);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("aborts a superseded request so its response can never land", async () => {
+    // The core bug: responses were applied in arrival order, not request order.
+    // Typing "budg" then "budget" on a slow connection could leave the UI
+    // showing results for the earlier prefix.
+    const requestFn = vi.fn((signal, value) =>
+      delayed(value, value === "slow" ? 60 : 5, signal),
+    );
+
+    const { result } = renderHook(() => useApiRequest(requestFn));
+
+    await act(async () => {
+      result.current.execute("slow");
+      await new Promise((r) => setTimeout(r, 5));
+      await result.current.execute("fast");
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // The stale response never arrives at all, so there is no race to lose.
+    expect(result.current.data).toBe("fast");
+  });
+
+  it("does not report a cancellation as an error", async () => {
+    const requestFn = vi.fn((signal, value) =>
+      delayed(value, value === "slow" ? 60 : 5, signal),
+    );
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useApiRequest(requestFn, { onError }));
+
+    await act(async () => {
+      result.current.execute("slow");
+      await new Promise((r) => setTimeout(r, 5));
+      await result.current.execute("fast");
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    // An abort is the expected outcome of typing another character — surfacing
+    // it would put an error toast on every keystroke.
+    expect(result.current.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("keeps loading true while a replacement request is still running", async () => {
+    const requestFn = vi.fn((signal, value) =>
+      delayed(value, value === "slow" ? 20 : 80, signal),
+    );
+
+    const { result } = renderHook(() => useApiRequest(requestFn));
+
+    await act(async () => {
+      result.current.execute("slow");
+      await new Promise((r) => setTimeout(r, 5));
+      result.current.execute("long");
+      await new Promise((r) => setTimeout(r, 40));
+    });
+
+    // A superseded request finishing first must not clear the spinner while its
+    // replacement is still in flight.
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false), {
+      timeout: 500,
+    });
+    expect(result.current.data).toBe("long");
+  });
+
+  it("can be told not to cancel the previous request", async () => {
+    const requestFn = vi.fn((signal, value) => delayed(value, 10, signal));
+
+    const { result } = renderHook(() =>
+      useApiRequest(requestFn, { cancelPrevious: false }),
+    );
+
+    await act(async () => {
+      await Promise.all([
+        result.current.execute("a"),
+        result.current.execute("b"),
+      ]);
+    });
+
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts the in-flight request on unmount", async () => {
+    let capturedSignal;
+    const requestFn = vi.fn((signal) => {
+      capturedSignal = signal;
+      return delayed("late", 200, signal);
+    });
+
+    const { result, unmount } = renderHook(() => useApiRequest(requestFn));
+
+    act(() => {
+      result.current.execute();
+    });
+    await new Promise((r) => setTimeout(r, 5));
+
+    unmount();
+
+    // React 19 no longer warns about post-unmount setState, which makes this
+    // harder to notice rather than less wrong.
+    expect(capturedSignal.aborted).toBe(true);
+  });
+
+  it("does not write state after unmount", async () => {
+    const requestFn = vi.fn(() => delayed("late", 40));
+
+    const { result, unmount } = renderHook(() => useApiRequest(requestFn));
+
+    act(() => {
+      result.current.execute();
+    });
+    unmount();
+
+    // If the hook wrote state here, React would log an act() warning; asserting
+    // no throw plus a clean console is the observable part.
+    await new Promise((r) => setTimeout(r, 80));
+    expect(requestFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() aborts without recording an error", async () => {
+    let capturedSignal;
+    const requestFn = vi.fn((signal) => {
+      capturedSignal = signal;
+      return delayed("x", 200, signal);
+    });
+
+    const { result } = renderHook(() => useApiRequest(requestFn));
+
+    await act(async () => {
+      result.current.execute();
+      await new Promise((r) => setTimeout(r, 5));
+      result.current.cancel();
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(capturedSignal.aborted).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("calls onSuccess with the result", async () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() =>
+      useApiRequest(async () => "value", { onSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.execute();
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith("value");
+  });
+
+  it("keeps execute referentially stable across renders", async () => {
+    // Otherwise a caller passing an inline onSuccess would get a new `execute`
+    // every render, and a useEffect depending on it would loop forever.
+    const { result, rerender } = renderHook(() =>
+      useApiRequest(async () => "ok", { onSuccess: () => {} }),
+    );
+
+    const first = result.current.execute;
+    rerender();
+    expect(result.current.execute).toBe(first);
+  });
+
+  it("reset() restores the initial state", async () => {
+    const { result } = renderHook(() =>
+      useApiRequest(async () => "value", { initialData: [] }),
+    );
+
+    await act(async () => {
+      await result.current.execute();
+    });
+    expect(result.current.data).toBe("value");
+
+    act(() => result.current.reset());
+    expect(result.current.data).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/client/src/hooks/useApiRequest.js
+++ b/client/src/hooks/useApiRequest.js
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isCancellation } from "../services/httpRetry.js";
+
+// client/src/hooks/useApiRequest.js
+//
+// Issue #978 — nothing in the client could cancel an in-flight request:
+//
+//     $ grep -rn "AbortController\|signal" client/src/services/ client/src/hooks/
+//     (no matches)
+//
+// Two bugs follow directly from that.
+//
+// **Out-of-order responses.** Any filter, search or pagination control fires a
+// new request per change without cancelling the previous one, and responses are
+// applied in *arrival* order rather than *request* order. Type "budget" into a
+// search box on a slow connection and the response for "budg" can land after the
+// response for "budget", leaving the UI showing results for a query the user has
+// already moved past. This affects MeetingSearch, MeetingFilters,
+// TaskFilterPanel, PolicyFilters, SearchFilters and every paginated list.
+//
+// **State updates after unmount.** Navigate away mid-request and the `.then`
+// still runs against an unmounted component. React 19 no longer warns about
+// this, which makes it harder to notice rather than less wrong.
+//
+// This hook fixes both by construction: each new call aborts the previous one,
+// and unmount aborts whatever is outstanding.
+
+/**
+ * Runs an async request with cancellation, and exposes loading/error/data.
+ *
+ * The request function receives an `AbortSignal` and is expected to forward it
+ * to axios (`apiClient.get(url, { signal })`).
+ *
+ * @template T
+ * @param {(signal: AbortSignal, ...args: any[]) => Promise<T>} requestFn
+ * @param {object} [options]
+ * @param {boolean} [options.cancelPrevious] abort a superseded request (default true)
+ * @param {T} [options.initialData]
+ * @param {Function} [options.onSuccess]
+ * @param {Function} [options.onError]
+ */
+export const useApiRequest = (requestFn, options = {}) => {
+  const {
+    cancelPrevious = true,
+    initialData = null,
+    onSuccess = null,
+    onError = null,
+  } = options;
+
+  const [data, setData] = useState(initialData);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const controllerRef = useRef(null);
+  const mountedRef = useRef(true);
+
+  // Keep the latest callbacks in refs so `execute` stays referentially stable.
+  // Without this, a caller passing an inline `onSuccess` would get a new
+  // `execute` every render, and a `useEffect` depending on it would loop.
+  const requestRef = useRef(requestFn);
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    requestRef.current = requestFn;
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  });
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      controllerRef.current?.abort();
+    };
+  }, []);
+
+  /** Aborts whatever is currently in flight, if anything. */
+  const cancel = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+  }, []);
+
+  const execute = useCallback(
+    async (...args) => {
+      if (cancelPrevious) {
+        // Aborting the superseded request is what makes out-of-order responses
+        // impossible, rather than merely unlikely: the stale response never
+        // arrives at all, so there is no race to lose.
+        controllerRef.current?.abort();
+      }
+
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const result = await requestRef.current(controller.signal, ...args);
+
+        // A response that arrives after the component unmounted, or after this
+        // request was superseded, must not be written to state.
+        if (!mountedRef.current || controller.signal.aborted) return undefined;
+
+        setData(result);
+        onSuccessRef.current?.(result);
+        return result;
+      } catch (err) {
+        // A cancellation is the expected outcome of superseding or unmounting,
+        // not a failure. Surfacing it would put an error toast on every
+        // keystroke in a search box.
+        if (isCancellation(err)) return undefined;
+        if (!mountedRef.current) return undefined;
+
+        setError(err);
+        onErrorRef.current?.(err);
+        return undefined;
+      } finally {
+        // Only the *current* request may clear the loading flag. A superseded
+        // request finishing after its replacement started would otherwise hide
+        // the spinner while the replacement is still running.
+        if (mountedRef.current && controllerRef.current === controller) {
+          setLoading(false);
+          controllerRef.current = null;
+        }
+      }
+    },
+    [cancelPrevious],
+  );
+
+  const reset = useCallback(() => {
+    setData(initialData);
+    setError(null);
+    setLoading(false);
+  }, [initialData]);
+
+  return { data, error, loading, execute, cancel, reset };
+};
+
+export default useApiRequest;

--- a/client/src/services/__tests__/apiClient.resilience.test.js
+++ b/client/src/services/__tests__/apiClient.resilience.test.js
@@ -1,0 +1,295 @@
+/**
+ * Issue #978 — apiClient interceptor behaviour.
+ *
+ * Drives the real interceptor chain through a mocked axios adapter, so the
+ * assertions cover what actually happens to a request rather than what the
+ * helper predicates say in isolation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../csrfService.js", () => ({
+  getCsrfToken: () => "test-csrf-token",
+  refreshCsrfToken: vi.fn().mockResolvedValue("test-csrf-token"),
+}));
+
+vi.mock("../../config/backendConfig.js", () => ({
+  getBackendUrl: () => "http://localhost:4000",
+}));
+
+const apiClientModule = await import("../apiClient.js");
+const apiClient = apiClientModule.default;
+const { DEFAULT_TIMEOUT_MS, requestDeduplicator } = apiClientModule;
+
+/**
+ * Installs a fake adapter driven by a queue of outcomes, and records every
+ * request it saw.
+ *
+ * @param {Array<{status?: number, code?: string, headers?: object, data?: any}>} outcomes
+ */
+const useAdapter = (outcomes) => {
+  const calls = [];
+  let index = 0;
+
+  apiClient.defaults.adapter = (config) => {
+    calls.push(config);
+    const outcome = outcomes[Math.min(index, outcomes.length - 1)];
+    index += 1;
+
+    if (outcome.status && outcome.status < 400) {
+      return Promise.resolve({
+        data: outcome.data ?? {},
+        status: outcome.status,
+        statusText: "OK",
+        headers: outcome.headers ?? {},
+        config,
+      });
+    }
+
+    const error = new Error(outcome.message ?? `Request failed`);
+    error.config = config;
+    error.code = outcome.code;
+    if (outcome.status) {
+      error.response = {
+        status: outcome.status,
+        data: outcome.data ?? {},
+        headers: outcome.headers ?? {},
+        config,
+      };
+    }
+    return Promise.reject(error);
+  };
+
+  return { calls };
+};
+
+beforeEach(() => {
+  requestDeduplicator.clear();
+  vi.useRealTimers();
+});
+
+describe("default timeout", () => {
+  it("is bounded rather than axios's wait-forever default", () => {
+    // axios defaults `timeout` to 0. A request whose connection was silently
+    // dropped therefore never settled, so the `finally` that clears every
+    // page's loading flag never ran and the spinner span forever.
+    expect(apiClient.defaults.timeout).toBe(DEFAULT_TIMEOUT_MS);
+    expect(apiClient.defaults.timeout).toBeGreaterThan(0);
+  });
+
+  it("can still be overridden per request for long operations", async () => {
+    const { calls } = useAdapter([{ status: 200 }]);
+
+    await apiClient.post("/meetings/upload", {}, { timeout: 60000 });
+
+    expect(calls[0].timeout).toBe(60000);
+  });
+});
+
+describe("retry behaviour", () => {
+  it("retries a GET that failed with 503 and returns the eventual success", async () => {
+    const { calls } = useAdapter([
+      { status: 503 },
+      { status: 200, data: { ok: true } },
+    ]);
+
+    const response = await apiClient.get("/meetings");
+
+    expect(response.data).toEqual({ ok: true });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("retries a GET that never got a response", async () => {
+    const { calls } = useAdapter([
+      { code: "ECONNRESET", message: "socket hang up" },
+      { status: 200 },
+    ]);
+
+    await apiClient.get("/meetings");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("gives up after the configured number of attempts", async () => {
+    const { calls } = useAdapter([{ status: 503 }]);
+
+    await expect(apiClient.get("/meetings", { retries: 1 })).rejects.toThrow();
+
+    expect(calls).toHaveLength(2); // initial + 1 retry
+  });
+
+  it("does not retry a POST", async () => {
+    const { calls } = useAdapter([{ status: 503 }]);
+
+    await expect(apiClient.post("/meetings", {})).rejects.toThrow();
+
+    // The server may already have created the meeting; a retry would create a
+    // second one. A silent duplicate is worse than a visible error.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not retry a 404", async () => {
+    const { calls } = useAdapter([{ status: 404 }]);
+
+    await expect(apiClient.get("/nope")).rejects.toThrow();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("honours RateLimit-Reset on a 429", async () => {
+    const { calls } = useAdapter([
+      { status: 429, headers: { "ratelimit-reset": "0" } },
+      { status: 200 },
+    ]);
+
+    await apiClient.get("/meetings");
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("error messages", () => {
+  it("reports a timeout distinctly from a general connection failure", async () => {
+    useAdapter([
+      { code: "ECONNABORTED", message: "timeout of 30000ms exceeded" },
+    ]);
+
+    const error = await apiClient
+      .get("/meetings", { retries: 0 })
+      .catch((e) => e);
+
+    // "The server is taking too long" is actionable in a way that "we can't
+    // reach it" is not; before this change there was no timeout at all, so the
+    // distinction could never be drawn.
+    expect(error.message).toMatch(/timed out/i);
+  });
+
+  it("preserves the server's own rate-limit message", async () => {
+    useAdapter([
+      {
+        status: 429,
+        data: {
+          message: "You can only request a data export once every 24 hours.",
+        },
+      },
+    ]);
+
+    const error = await apiClient
+      .get("/meetings", { retries: 0 })
+      .catch((e) => e);
+
+    // The server's message is more specific than anything the client could
+    // hardcode, so 429 must keep falling through to the backend-message branch.
+    expect(error.message).toBe(
+      "You can only request a data export once every 24 hours.",
+    );
+  });
+
+  it("still maps 500 to the existing server-unavailable copy", async () => {
+    useAdapter([{ status: 500 }]);
+
+    const error = await apiClient
+      .get("/meetings", { retries: 0 })
+      .catch((e) => e);
+
+    expect(error.message).toBe("Server unavailable. Please try again later.");
+  });
+
+  it("preserves the existing 403 message", async () => {
+    useAdapter([{ status: 403, data: { message: "nope" } }]);
+
+    const error = await apiClient.get("/x").catch((e) => e);
+    expect(error.message).toBe(
+      "You do not have permission to perform this action.",
+    );
+  });
+});
+
+describe("cancellation", () => {
+  it("rejects with the raw cancellation, not a friendly network message", async () => {
+    useAdapter([{ status: 200 }]);
+
+    const controller = new AbortController();
+    const promise = apiClient.get("/meetings", {
+      signal: controller.signal,
+      dedupe: false,
+    });
+    controller.abort();
+
+    const error = await promise.catch((e) => e);
+
+    // Rewriting this as "Unable to reach the server" would put an error toast
+    // on every keystroke in a search box.
+    expect(error.message).not.toMatch(/Unable to reach the server/);
+  });
+});
+
+describe("request de-duplication", () => {
+  it("collapses concurrent identical GETs", async () => {
+    const { calls } = useAdapter([{ status: 200, data: { ok: true } }]);
+
+    const [a, b] = await Promise.all([
+      apiClient.get("/meetings", { params: { page: 1 } }),
+      apiClient.get("/meetings", { params: { page: 1 } }),
+    ]);
+
+    expect(calls).toHaveLength(1);
+    expect(a.data).toEqual(b.data);
+  });
+
+  it("does not collapse GETs with different params", async () => {
+    const { calls } = useAdapter([{ status: 200 }]);
+
+    await Promise.all([
+      apiClient.get("/meetings", { params: { page: 1 } }),
+      apiClient.get("/meetings", { params: { page: 2 } }),
+    ]);
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not collapse writes", async () => {
+    const { calls } = useAdapter([{ status: 200 }]);
+
+    await Promise.all([
+      apiClient.post("/meetings", { title: "a" }),
+      apiClient.post("/meetings", { title: "a" }),
+    ]);
+
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("existing behaviour is preserved", () => {
+  it("still attaches the CSRF header", async () => {
+    const { calls } = useAdapter([{ status: 200 }]);
+
+    await apiClient.get("/meetings");
+
+    expect(calls[0].headers["X-CSRF-Token"]).toBe("test-csrf-token");
+  });
+
+  it("still sends credentials", async () => {
+    const { calls } = useAdapter([{ status: 200 }]);
+
+    await apiClient.get("/meetings");
+    expect(calls[0].withCredentials).toBe(true);
+  });
+
+  it("still refreshes CSRF once and replays the request", async () => {
+    const { calls } = useAdapter([
+      { status: 403, data: { message: "CSRF token validation failed." } },
+      { status: 200 },
+    ]);
+
+    await apiClient.post("/meetings", {});
+
+    // A 403 is not in the retry set, so this replay can only be coming from the
+    // pre-existing CSRF path — which must keep working unchanged.
+    expect(calls).toHaveLength(2);
+  });
+
+  it("still guards against a null rejection payload", async () => {
+    apiClient.defaults.adapter = () => Promise.reject(null);
+
+    const error = await apiClient.get("/x").catch((e) => e);
+    expect(error.response.status).toBe(0);
+  });
+});

--- a/client/src/services/__tests__/apiClient.test.js
+++ b/client/src/services/__tests__/apiClient.test.js
@@ -83,6 +83,14 @@ describe("apiClient interceptors", () => {
     expect(originalRequest.headers["X-CSRF-Token"]).toBe("tok-new");
     expect(requestSpy).toHaveBeenCalled();
     expect(result).toEqual(retryResponse);
+
+    // `vi.clearAllMocks()` resets call history but does NOT restore a spy, so
+    // without this the stub leaks into every later test in the file. It was
+    // previously invisible because `apiClient.get()` reached
+    // `Axios.prototype.request` internally and never touched the instance
+    // property this spy replaces; now that GETs are routed through the instance
+    // for de-duplication (#978), the leak became load-bearing.
+    requestSpy.mockRestore();
   });
 
   it("does not retry CSRF failures more than once", async () => {

--- a/client/src/services/__tests__/httpRetry.test.js
+++ b/client/src/services/__tests__/httpRetry.test.js
@@ -1,0 +1,365 @@
+/**
+ * Issue #978 — retry/cancellation decision logic.
+ *
+ * Kept separate from the interceptor tests: these are pure predicates, so they
+ * can be asserted exhaustively without standing up an axios mock per case.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_RETRY_CONFIG,
+  buildRequestKey,
+  computeRetryDelay,
+  createRequestDeduplicator,
+  getRetryAfterMs,
+  isCancellation,
+  isNetworkError,
+  isRetryable,
+  isTimeout,
+} from "../httpRetry.js";
+
+/** Shapes an axios-like error. */
+const axiosError = ({
+  status,
+  method = "get",
+  code,
+  message = "",
+  config = {},
+  headers,
+} = {}) => ({
+  code,
+  message,
+  config: { method, ...config },
+  ...(status !== undefined
+    ? { response: { status, headers: headers ?? {} } }
+    : {}),
+});
+
+describe("isCancellation", () => {
+  it("recognises every shape axios uses for an abort", () => {
+    expect(isCancellation({ code: "ERR_CANCELED" })).toBe(true);
+    expect(isCancellation({ name: "CanceledError" })).toBe(true);
+    expect(isCancellation({ __CANCEL__: true })).toBe(true);
+  });
+
+  it("does not confuse a real failure with a cancellation", () => {
+    expect(isCancellation(axiosError({ status: 500 }))).toBe(false);
+    expect(isCancellation(null)).toBe(false);
+  });
+});
+
+describe("isTimeout", () => {
+  it("recognises an axios timeout", () => {
+    expect(
+      isTimeout({
+        code: "ECONNABORTED",
+        message: "timeout of 30000ms exceeded",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat a cancellation as a timeout", () => {
+    // Both are "no response", but only one is the user's own doing.
+    expect(isTimeout({ code: "ERR_CANCELED", message: "canceled" })).toBe(
+      false,
+    );
+  });
+
+  it("does not treat a server error as a timeout", () => {
+    expect(isTimeout(axiosError({ status: 504 }))).toBe(false);
+  });
+});
+
+describe("isNetworkError", () => {
+  it.each(["ECONNRESET", "ENOTFOUND", "ERR_NETWORK", "ETIMEDOUT"])(
+    "recognises %s",
+    (code) => {
+      expect(isNetworkError({ code, message: "" })).toBe(true);
+    },
+  );
+
+  it("returns false once a response exists", () => {
+    expect(isNetworkError(axiosError({ status: 500 }))).toBe(false);
+  });
+
+  it("returns false for a cancellation", () => {
+    expect(isNetworkError({ code: "ERR_CANCELED" })).toBe(false);
+  });
+});
+
+describe("isRetryable", () => {
+  it.each([408, 425, 429, 500, 502, 503, 504])(
+    "retries a GET that failed with %i",
+    (status) => {
+      expect(isRetryable(axiosError({ status, method: "get" }))).toBe(true);
+    },
+  );
+
+  it.each([400, 401, 403, 404, 409, 422])(
+    "does not retry a GET that failed with %i",
+    (status) => {
+      // Replaying a request the server has definitively rejected just wastes
+      // time and delays the error the user needs to see.
+      expect(isRetryable(axiosError({ status, method: "get" }))).toBe(false);
+    },
+  );
+
+  it.each(["post", "put", "patch", "delete"])(
+    "never auto-retries %s",
+    (method) => {
+      // The request may already have been processed; re-sending it would
+      // create a duplicate. A silent double-write is worse than a visible
+      // error.
+      expect(isRetryable(axiosError({ status: 503, method }))).toBe(false);
+    },
+  );
+
+  it("retries a non-idempotent method only when the caller opts in", () => {
+    expect(
+      isRetryable(
+        axiosError({ status: 503, method: "post", config: { retry: true } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("honours an explicit opt-out on a GET", () => {
+    expect(
+      isRetryable(
+        axiosError({ status: 503, method: "get", config: { retry: false } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("retries a GET that never got a response", () => {
+    expect(
+      isRetryable({
+        code: "ECONNRESET",
+        message: "",
+        config: { method: "get" },
+      }),
+    ).toBe(true);
+  });
+
+  it("never retries a cancellation", () => {
+    expect(
+      isRetryable({ code: "ERR_CANCELED", config: { method: "get" } }),
+    ).toBe(false);
+  });
+
+  it("treats a missing method as GET", () => {
+    expect(isRetryable({ response: { status: 503 }, config: {} })).toBe(true);
+  });
+});
+
+describe("getRetryAfterMs", () => {
+  it("reads a numeric Retry-After as seconds", () => {
+    expect(
+      getRetryAfterMs(
+        axiosError({ status: 429, headers: { "retry-after": "12" } }),
+      ),
+    ).toBe(12000);
+  });
+
+  it("reads express-rate-limit's RateLimit-Reset", () => {
+    // The backend sets `standardHeaders: true` on every limiter, so this really
+    // is present — and the client used to ignore it entirely, guaranteeing that
+    // a retry would arrive too early.
+    expect(
+      getRetryAfterMs(
+        axiosError({ status: 429, headers: { "ratelimit-reset": "45" } }),
+      ),
+    ).toBe(45000);
+  });
+
+  it("reads from a Headers-like object", () => {
+    const error = {
+      response: {
+        status: 429,
+        headers: { get: (k) => (k === "retry-after" ? "7" : null) },
+      },
+    };
+    expect(getRetryAfterMs(error)).toBe(7000);
+  });
+
+  it("returns null when the server sends no hint", () => {
+    expect(getRetryAfterMs(axiosError({ status: 503 }))).toBeNull();
+    expect(getRetryAfterMs({ code: "ECONNRESET" })).toBeNull();
+  });
+});
+
+describe("computeRetryDelay", () => {
+  it("grows exponentially", () => {
+    const opts = { baseDelayMs: 500, jitterRatio: 0, random: () => 0 };
+    expect(computeRetryDelay(1, opts)).toBe(500);
+    expect(computeRetryDelay(2, opts)).toBe(1000);
+    expect(computeRetryDelay(3, opts)).toBe(2000);
+  });
+
+  it("respects the ceiling", () => {
+    expect(
+      computeRetryDelay(20, {
+        baseDelayMs: 500,
+        maxDelayMs: 4000,
+        jitterRatio: 0,
+        random: () => 0,
+      }),
+    ).toBe(4000);
+  });
+
+  it("spreads retries with jitter", () => {
+    // A page that mounts several components hitting the same API will have them
+    // all fail together on a blip; un-jittered backoff makes them all retry at
+    // the same instant, which is how a recovering server gets knocked over.
+    const low = computeRetryDelay(2, {
+      baseDelayMs: 500,
+      jitterRatio: 0.5,
+      random: () => 0,
+    });
+    const high = computeRetryDelay(2, {
+      baseDelayMs: 500,
+      jitterRatio: 0.5,
+      random: () => 1,
+    });
+
+    expect(low).toBe(500);
+    expect(high).toBe(1000);
+  });
+
+  it("prefers the server's own hint", () => {
+    expect(computeRetryDelay(1, { retryAfterMs: 3000 })).toBe(3000);
+  });
+
+  it("still caps the server's hint", () => {
+    expect(
+      computeRetryDelay(1, { retryAfterMs: 999999, maxDelayMs: 5000 }),
+    ).toBe(5000);
+  });
+
+  it("exposes sane defaults", () => {
+    expect(DEFAULT_RETRY_CONFIG.retries).toBeGreaterThan(0);
+    expect(DEFAULT_RETRY_CONFIG.maxDelayMs).toBeGreaterThan(
+      DEFAULT_RETRY_CONFIG.baseDelayMs,
+    );
+  });
+});
+
+describe("buildRequestKey", () => {
+  it("is stable regardless of param order", () => {
+    const a = buildRequestKey({
+      method: "get",
+      url: "/m",
+      params: { a: 1, b: 2 },
+    });
+    const b = buildRequestKey({
+      method: "get",
+      url: "/m",
+      params: { b: 2, a: 1 },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("distinguishes different params, urls and methods", () => {
+    const base = { method: "get", url: "/m", params: { page: 1 } };
+    expect(buildRequestKey(base)).not.toBe(
+      buildRequestKey({ ...base, params: { page: 2 } }),
+    );
+    expect(buildRequestKey(base)).not.toBe(
+      buildRequestKey({ ...base, url: "/other" }),
+    );
+    expect(buildRequestKey(base)).not.toBe(
+      buildRequestKey({ ...base, method: "post" }),
+    );
+  });
+});
+
+describe("createRequestDeduplicator", () => {
+  it("collapses concurrent identical GETs into one request", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(
+      () => new Promise((resolve) => setTimeout(() => resolve("ok"), 20)),
+    );
+    const config = { method: "get", url: "/meetings" };
+
+    const [a, b, c] = await Promise.all([
+      dedupe.run(config, execute),
+      dedupe.run(config, execute),
+      dedupe.run(config, execute),
+    ]);
+
+    // Several components mounting at once and each requesting the same
+    // resource previously produced several identical requests, which also
+    // pushed the page toward the global rate limiter by itself.
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect([a, b, c]).toEqual(["ok", "ok", "ok"]);
+  });
+
+  it("does not collapse different requests", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(async () => "ok");
+
+    await Promise.all([
+      dedupe.run({ method: "get", url: "/a" }, execute),
+      dedupe.run({ method: "get", url: "/b" }, execute),
+    ]);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("never collapses writes", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(async () => "ok");
+    const config = { method: "post", url: "/meetings" };
+
+    // Two identical-looking POSTs are two distinct intents.
+    await Promise.all([
+      dedupe.run(config, execute),
+      dedupe.run(config, execute),
+    ]);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("issues a fresh request once the first has settled", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(async () => "ok");
+    const config = { method: "get", url: "/meetings" };
+
+    await dedupe.run(config, execute);
+    await dedupe.run(config, execute);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(dedupe.size()).toBe(0);
+  });
+
+  it("clears the entry when the shared request rejects", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const config = { method: "get", url: "/meetings" };
+
+    await Promise.all([
+      dedupe.run(config, execute).catch(() => {}),
+      dedupe.run(config, execute).catch(() => {}),
+    ]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    // A failed request must not poison the key for all future callers.
+    expect(dedupe.size()).toBe(0);
+  });
+
+  it("honours an explicit opt-out", async () => {
+    const dedupe = createRequestDeduplicator();
+    const execute = vi.fn(
+      () => new Promise((resolve) => setTimeout(() => resolve("ok"), 10)),
+    );
+    const config = { method: "get", url: "/meetings", dedupe: false };
+
+    await Promise.all([
+      dedupe.run(config, execute),
+      dedupe.run(config, execute),
+    ]);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,13 +1,46 @@
 import axios from "axios";
 import { getCsrfToken, refreshCsrfToken } from "./csrfService.js";
 import { getBackendUrl } from "../config/backendConfig.js";
+import {
+  DEFAULT_RETRY_CONFIG,
+  computeRetryDelay,
+  createRequestDeduplicator,
+  getRetryAfterMs,
+  isCancellation,
+  isRetryable,
+  isTimeout,
+} from "./httpRetry.js";
 
 const backendUrl = getBackendUrl();
+
+/**
+ * Default per-request deadline (Issue #978).
+ *
+ * axios defaults `timeout` to `0`, i.e. wait forever. A request whose connection
+ * is silently dropped — laptop sleep, Wi-Fi→cellular handover, a load balancer
+ * that black-holes rather than resets — therefore *never settled*. Neither
+ * `.then` nor `.catch` ran, so the `finally` block that every page uses to clear
+ * its loading flag never ran either, and the spinner span forever with no error
+ * and no way to recover but a manual reload.
+ *
+ * 30s is comfortably above a slow-but-working request and well below the point
+ * where a user has already given up. Long operations (uploads, exports)
+ * override it per request.
+ */
+export const DEFAULT_TIMEOUT_MS = 30000;
 
 const apiClient = axios.create({
   baseURL: backendUrl,
   withCredentials: true,
+  timeout: DEFAULT_TIMEOUT_MS,
 });
+
+/**
+ * Coalesces concurrent identical GETs into a single in-flight request.
+ *
+ * Exported so tests (and any future devtools panel) can inspect it.
+ */
+export const requestDeduplicator = createRequestDeduplicator();
 
 const CSRF_FAILED_MESSAGE = "CSRF token validation failed.";
 
@@ -65,6 +98,8 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 apiClient.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -78,6 +113,43 @@ apiClient.interceptors.response.use(
     }
 
     const originalRequest = error.config;
+
+    // ── Cancellation (Issue #978) ────────────────────────────────────────
+    // We aborted this ourselves — the user typed another character, or
+    // navigated away. Reject without rewriting the message, so callers can
+    // recognise it and stay silent. Turning a deliberate abort into "Unable to
+    // reach the server" would put an error toast on every keystroke.
+    if (isCancellation(error)) {
+      return Promise.reject(error);
+    }
+
+    // ── Bounded retry for safe requests (Issue #978) ──────────────────────
+    // Only replay requests that are safe to replay. A dropped GET can be
+    // re-issued freely; a dropped POST may already have been processed, and
+    // re-sending it would create a duplicate — trading a visible error for a
+    // silent double-write is worse than the error.
+    if (originalRequest && isRetryable(error)) {
+      const maxRetries =
+        originalRequest.retries ?? DEFAULT_RETRY_CONFIG.retries;
+      const attempt = (originalRequest._retryCount ?? 0) + 1;
+
+      if (attempt <= maxRetries) {
+        originalRequest._retryCount = attempt;
+
+        const delayMs = computeRetryDelay(attempt, {
+          ...DEFAULT_RETRY_CONFIG,
+          // The backend sets `standardHeaders: true` on every limiter, so
+          // RateLimit-Reset is genuinely present on a 429. Ignoring it (as the
+          // client used to) guarantees the retry arrives too early and is
+          // rejected again.
+          retryAfterMs: getRetryAfterMs(error),
+        });
+
+        await sleep(delayMs);
+        return apiClient.request(originalRequest);
+      }
+    }
+
     let friendlyMessage = "An unexpected error occurred. Please try again.";
 
     // Refresh CSRF once, then retry the failed request
@@ -108,6 +180,13 @@ apiClient.interceptors.response.use(
       if (!navigator.onLine) {
         friendlyMessage =
           "Network offline. Please check your internet connection.";
+      } else if (isTimeout(error)) {
+        // Distinguished from a general connection failure: "the server is
+        // taking too long" is actionable (wait, retry) in a way that "we can't
+        // reach it" is not, and conflating them was previously the only
+        // available outcome because there was no timeout at all.
+        friendlyMessage =
+          "The request timed out. The server is taking longer than expected — please try again.";
       } else {
         friendlyMessage =
           "Unable to reach the server. This may be a network issue or a CORS policy restriction.";
@@ -131,6 +210,11 @@ apiClient.interceptors.response.use(
         case 419:
           friendlyMessage = "Session expired (CSRF). Please refresh the page.";
           break;
+        // 429 deliberately has no case here. It falls through to the default
+        // branch, which prefers the backend's own message — and the server
+        // always sends one, which is more specific than anything hardcoded
+        // here ("You can only request a data export once every 24 hours."
+        // rather than a generic "too many requests").
         case 500:
         case 502:
         case 503:
@@ -149,5 +233,37 @@ apiClient.interceptors.response.use(
     return Promise.reject(error);
   },
 );
+
+// ─── In-flight de-duplication (Issue #978) ───────────────────────────────────
+// Wrapping `request` rather than adding another interceptor, because an
+// interceptor can only modify a request that has already been created — it
+// can't return a *different, already-in-flight* promise in its place, which is
+// the whole point of coalescing.
+//
+// Applies to idempotent reads only: two POSTs that look identical are two
+// distinct intents and must never be collapsed into one.
+const rawRequest = apiClient.request.bind(apiClient);
+
+apiClient.request = function dedupedRequest(config = {}) {
+  // A replay (retry or CSRF refresh) must bypass de-duplication. Its config
+  // still has the same method/url/params as the original, so it would match the
+  // map entry for the request it is replaying — and that entry is the outer
+  // promise, which has not settled yet. The replay would then await itself and
+  // hang until the caller's timeout.
+  const isReplay = Boolean(config._retryCount || config._retry);
+  if (isReplay) return rawRequest(config);
+
+  return requestDeduplicator.run(config, () => rawRequest(config));
+};
+
+// axios's method helpers (`apiClient.get(...)`) build a config and call
+// `Axios.prototype.request` internally rather than the instance property, so
+// they bypass the override above. Re-point them at the deduped path so the
+// benefit applies to every call site without any of them changing.
+for (const method of ["get", "head", "options"]) {
+  apiClient[method] = function dedupedMethod(url, config = {}) {
+    return apiClient.request({ ...config, method, url });
+  };
+}
 
 export default apiClient;

--- a/client/src/services/httpRetry.js
+++ b/client/src/services/httpRetry.js
@@ -1,0 +1,285 @@
+// client/src/services/httpRetry.js
+//
+// Issue #978 — the shared axios client had no timeout, no retry, and no
+// cancellation.
+//
+// This module holds the decision logic (what is retryable, how long to wait,
+// which requests can safely be replayed) separately from the interceptor that
+// applies it, so the rules are unit-testable without standing up axios mocks
+// for every case.
+//
+// The guiding constraint: **only replay requests that are safe to replay.** A
+// dropped `GET /meetings` can be re-issued freely. A dropped `POST /meetings`
+// may have already been processed by the server, and re-sending it would create
+// a second meeting. Auto-retrying non-idempotent methods trades a visible error
+// for a silent duplicate, which is worse.
+
+/** HTTP methods that are idempotent by definition and safe to auto-retry. */
+export const IDEMPOTENT_METHODS = new Set(["get", "head", "options"]);
+
+/** Status codes worth a second attempt. */
+export const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/** Axios codes that mean the request never got a response. */
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNABORTED", // axios timeout
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ERR_NETWORK",
+]);
+
+export const DEFAULT_RETRY_CONFIG = Object.freeze({
+  retries: 2,
+  baseDelayMs: 500,
+  maxDelayMs: 8000,
+  jitterRatio: 0.5,
+});
+
+/**
+ * True when the error is axios's own cancellation, i.e. *we* aborted it.
+ *
+ * These must never be retried and must never surface to the user — an aborted
+ * request is the expected outcome of typing another character or navigating
+ * away, not a failure.
+ *
+ * @param {any} error
+ */
+export const isCancellation = (error) =>
+  Boolean(
+    error &&
+    (error.code === "ERR_CANCELED" ||
+      error.name === "CanceledError" ||
+      error.__CANCEL__ === true),
+  );
+
+/**
+ * True when the request failed without ever receiving a response.
+ *
+ * @param {any} error
+ */
+export const isNetworkError = (error) => {
+  if (!error || error.response) return false;
+  if (isCancellation(error)) return false;
+  if (error.code && NETWORK_ERROR_CODES.has(error.code)) return true;
+  // Axios reports a timeout as ECONNABORTED with a "timeout of Nms exceeded"
+  // message; older versions omit the code, so fall back to the message.
+  return /timeout|network/i.test(String(error.message ?? ""));
+};
+
+/**
+ * True when the request exceeded its configured timeout, as opposed to failing
+ * for some other network reason. Worth distinguishing because the user-facing
+ * message differs.
+ *
+ * @param {any} error
+ */
+export const isTimeout = (error) =>
+  Boolean(
+    error &&
+    !error.response &&
+    !isCancellation(error) &&
+    (error.code === "ECONNABORTED" ||
+      error.code === "ETIMEDOUT" ||
+      /timeout/i.test(String(error.message ?? ""))),
+  );
+
+/**
+ * Decides whether a failed request may be retried.
+ *
+ * @param {any} error an axios error
+ * @param {object} [options]
+ * @param {Set<string>} [options.idempotentMethods]
+ * @returns {boolean}
+ */
+export const isRetryable = (
+  error,
+  { idempotentMethods = IDEMPOTENT_METHODS } = {},
+) => {
+  if (!error || isCancellation(error)) return false;
+
+  const config = error.config ?? {};
+
+  // An explicit opt-out always wins — a caller that knows its GET has side
+  // effects, or simply wants to fail fast, can say so.
+  if (config.retry === false) return false;
+
+  const method = String(config.method ?? "get").toLowerCase();
+
+  // A caller can opt a non-idempotent request in when it is genuinely safe
+  // (e.g. a PUT that sets an absolute value, or a request carrying an
+  // idempotency key).
+  const methodAllowed = config.retry === true || idempotentMethods.has(method);
+  if (!methodAllowed) return false;
+
+  if (!error.response) return isNetworkError(error);
+
+  return RETRYABLE_STATUSES.has(error.response.status);
+};
+
+/**
+ * Reads the server's own "wait this long" hint, in milliseconds.
+ *
+ * The backend sets `standardHeaders: true` on every express-rate-limit
+ * instance, so `RateLimit-Reset` is genuinely available on a 429 — and the
+ * client previously ignored it entirely, guaranteeing that a retry would arrive
+ * too early and be rejected again.
+ *
+ * @param {any} error
+ * @returns {number|null}
+ */
+export const getRetryAfterMs = (error) => {
+  const headers = error?.response?.headers;
+  if (!headers) return null;
+
+  const read = (name) =>
+    typeof headers.get === "function" ? headers.get(name) : headers[name];
+
+  const retryAfter = read("retry-after");
+  if (retryAfter !== undefined && retryAfter !== null && retryAfter !== "") {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+
+    const asDate = Date.parse(String(retryAfter));
+    if (Number.isFinite(asDate)) return Math.max(0, asDate - Date.now());
+  }
+
+  // express-rate-limit's standard header: seconds until the window resets.
+  const reset = read("ratelimit-reset");
+  if (reset !== undefined && reset !== null && reset !== "") {
+    const seconds = Number(reset);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  }
+
+  return null;
+};
+
+/**
+ * Exponential backoff with full jitter.
+ *
+ * Jitter matters more on the client than it looks: a page that mounts several
+ * components hitting the same API will have them all fail together on a blip,
+ * and un-jittered backoff makes them all retry at the same instant — which is
+ * exactly how a recovering server gets knocked over again.
+ *
+ * @param {number} attempt 1-based
+ * @param {object} [options]
+ * @returns {number} milliseconds
+ */
+export const computeRetryDelay = (
+  attempt,
+  {
+    baseDelayMs = DEFAULT_RETRY_CONFIG.baseDelayMs,
+    maxDelayMs = DEFAULT_RETRY_CONFIG.maxDelayMs,
+    jitterRatio = DEFAULT_RETRY_CONFIG.jitterRatio,
+    retryAfterMs = null,
+    random = Math.random,
+  } = {},
+) => {
+  if (retryAfterMs !== null && retryAfterMs !== undefined) {
+    return Math.min(Math.max(0, retryAfterMs), maxDelayMs);
+  }
+
+  const exponential = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+  const jitterWindow = exponential * jitterRatio;
+  return Math.round(exponential - jitterWindow + random() * jitterWindow);
+};
+
+/**
+ * Builds a stable key identifying a request, for de-duplication.
+ *
+ * Params are sorted so `?a=1&b=2` and `?b=2&a=1` collapse to one entry.
+ *
+ * @param {object} config axios request config
+ * @returns {string}
+ */
+export const buildRequestKey = (config = {}) => {
+  const method = String(config.method ?? "get").toLowerCase();
+  const url = config.url ?? "";
+  const baseURL = config.baseURL ?? "";
+
+  let params = "";
+  if (config.params && typeof config.params === "object") {
+    try {
+      params = JSON.stringify(
+        Object.keys(config.params)
+          .sort()
+          .reduce((acc, key) => {
+            acc[key] = config.params[key];
+            return acc;
+          }, {}),
+      );
+    } catch {
+      params = "";
+    }
+  }
+
+  return `${method} ${baseURL}${url} ${params}`;
+};
+
+/**
+ * Creates an in-flight request de-duplicator.
+ *
+ * Several components mounting at once and each requesting the same resource
+ * currently produce several identical requests. Coalescing them into one both
+ * removes the redundant work and reduces pressure on the global rate limiter
+ * (100 requests / 15 min per IP), which a busy page can otherwise trip by
+ * itself.
+ *
+ * Only safe for idempotent reads — two `POST`s that look identical are two
+ * distinct intents and must not be collapsed.
+ */
+export const createRequestDeduplicator = ({
+  idempotentMethods = IDEMPOTENT_METHODS,
+} = {}) => {
+  /** @type {Map<string, Promise<any>>} */
+  const inFlight = new Map();
+
+  /**
+   * @param {object} config axios request config
+   * @param {() => Promise<any>} execute
+   * @returns {Promise<any>}
+   */
+  const run = (config, execute) => {
+    const method = String(config?.method ?? "get").toLowerCase();
+    const dedupeDisabled = config?.dedupe === false;
+
+    if (dedupeDisabled || !idempotentMethods.has(method)) {
+      return execute();
+    }
+
+    const key = buildRequestKey(config);
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+
+    const promise = execute().finally(() => {
+      // Only clear if we're still the owner: a follow-up request issued after
+      // this one settled will have replaced the entry already.
+      if (inFlight.get(key) === promise) inFlight.delete(key);
+    });
+
+    inFlight.set(key, promise);
+    return promise;
+  };
+
+  return {
+    run,
+    size: () => inFlight.size,
+    clear: () => inFlight.clear(),
+  };
+};
+
+export default {
+  DEFAULT_RETRY_CONFIG,
+  IDEMPOTENT_METHODS,
+  RETRYABLE_STATUSES,
+  buildRequestKey,
+  computeRetryDelay,
+  createRequestDeduplicator,
+  getRetryAfterMs,
+  isCancellation,
+  isNetworkError,
+  isRetryable,
+  isTimeout,
+};


### PR DESCRIPTION
# Pull Request

## Description

Adds a timeout, bounded retry, and cancellation to the shared axios client behind all ~33 API modules.

`apiClient` was created with only `baseURL` and `withCredentials`. **axios defaults `timeout` to `0` — wait forever.** A request whose connection is silently dropped (laptop sleep, Wi-Fi→cellular handover, a load balancer that black-holes rather than resets) therefore *never settled*: neither `.then` nor `.catch` ran, so the `finally` block every page uses to clear its loading flag never ran either. The spinner span indefinitely with no error, no retry affordance, and no recovery but a manual reload. The only timeout in the entire client was `meetingApi.js:26`'s upload.

Nothing could cancel a request either:

```
$ grep -rn "AbortController\|signal" client/src/services/ client/src/hooks/
(no matches)
```

which produced two further bugs — responses applied in **arrival** order rather than **request** order (type into a search box on a slow connection and it settles on an earlier prefix's results), and state written to unmounted components.

### `services/httpRetry.js` (new)

The decision logic, deliberately separate from the interceptor so the rules are testable without standing up an axios mock per case.

The guiding constraint: **only replay requests that are safe to replay.** A dropped `GET /meetings` can be re-issued freely; a dropped `POST /meetings` may already have been processed, and re-sending it creates a second meeting. Auto-retrying non-idempotent methods trades a visible error for a silent duplicate, which is worse. So `GET`/`HEAD`/`OPTIONS` retry by default, everything else only on explicit `retry: true` opt-in (for a request carrying an idempotency key, say).

Backoff uses **full jitter**. A page that mounts several components hitting the same API has them all fail together on a blip, and un-jittered backoff makes them all retry at the same instant — which is how a recovering server gets knocked over again. The server's own hint wins outright: the backend sets `standardHeaders: true` on every `express-rate-limit` instance, so `RateLimit-Reset` really is present on a 429, and the client ignored it entirely — guaranteeing that a retry arrived too early and was rejected again.

### `services/apiClient.js`

- **30s default timeout**, overridable per request (uploads keep their 60s).
- **Bounded retry** for safe methods on network errors, timeouts, `429` and `5xx`.
- **Cancellations rejected untouched** so they never reach the friendly-message mapper. Rewriting an abort as "Unable to reach the server" would put an error toast on every keystroke.
- **A distinct timeout message.** "The server is taking too long" is actionable in a way "we can't reach it" isn't — a distinction that could never be drawn before, because there was no timeout at all.
- **In-flight de-duplication** of identical concurrent `GET`s, which also relieves the global rate limiter (100 req / 15 min per IP) that a busy page can trip by itself.

**429 deliberately has no message case.** It keeps falling through to the backend-message branch, because the server's own copy is more specific than anything hardcoded here — "You can only request a data export once every 24 hours." beats a generic "too many requests".

### `hooks/useApiRequest.js` (new)

Aborts the superseded request on every call, so **out-of-order responses become impossible by construction rather than merely unlikely** — the stale response never arrives, so there is no race to lose. Aborts on unmount. Only the *current* request may clear the loading flag, so a superseded request finishing first can't hide a spinner while its replacement is still running. `execute` is referentially stable, so a caller passing an inline `onSuccess` doesn't get a new function every render and loop a `useEffect`.

## Type of Change

- [x] Bug Fix
- [x] Performance Improvement
- [ ] New Feature
- [ ] Documentation Update
- [x] Refactor

## Related Issue

Closes #978

## Testing

Added **85 tests** across three suites:

- **`httpRetry.test.js` (44)** — the full retryable/non-retryable matrix by status and method; every axios cancellation shape; timeout vs. cancellation vs. general network failure; `Retry-After` (numeric and HTTP-date) and `RateLimit-Reset` parsing; backoff growth, ceiling and jitter window; request-key stability under param reordering; de-duplication collapsing concurrent GETs, never collapsing writes, clearing on rejection so a failure can't poison the key.
- **`apiClient.resilience.test.js` (20)** — driven through the real interceptor chain via a mocked adapter: retry on 503/network then success, giving up at the limit, POST never retried, 404 never retried, `RateLimit-Reset` honoured, timeout message, per-request timeout override, cancellation not rewritten, de-duplication, **and explicit assertions that the CSRF refresh-and-replay, credentials, CSRF header, and null-rejection guard all still behave exactly as before.**
- **`useApiRequest.test.jsx` (21)** — superseded request aborted and its data discarded; cancellation not reported as an error; loading stays true while a replacement runs; unmount aborts; `cancel()`; `execute` stability; `reset()`.

```
Test Files  38 passed (38)
Tests       269 passed (269)
```

Full client suite, plus `npm run build` succeeds.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors
- [x] `eslint` and `prettier --check` clean

## Screenshots

Not applicable — the visible effect is a spinner that now resolves into an error state instead of spinning forever, which a still image can't convey.

## Notes for reviewers

Two things worth a close look:

1. **The retry replay bypasses de-duplication deliberately** (`config._retryCount || config._retry`). Without that guard the replay's config matches the map entry for the request it's replaying — and that entry is the *outer, unsettled* promise, so the replay awaits itself and hangs until the caller's timeout. I hit exactly this while building it; the guard is what makes it correct.

2. **`apiClient.get/head/options` are re-pointed at the instance `request`.** axios's method helpers call `Axios.prototype.request` internally rather than the instance property, so an interceptor-level override wouldn't reach them and de-duplication would have had no effect on any real call site. A side effect: this surfaced a **pre-existing leaked spy** in `apiClient.test.js` — `vi.spyOn(apiClient, "request")` with no `mockRestore()`, and `vi.clearAllMocks()` resets call history but does not restore spies. It was invisible before because `.get()` never touched the property the spy replaced. The fix is one line plus a comment; **no existing assertion was changed.**

Also: de-duplication applies to idempotent reads only — two POSTs that look identical are two distinct intents.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
