### PR TITLE
fix(server): add security headers, real health probes and request correlation (#979)

### DIFF
--- a/docs/security-and-health.md
+++ b/docs/security-and-health.md
@@ -1,0 +1,146 @@
+# Security Headers & Health Probes
+
+Added in response to [#979](https://github.com/imuniqueshiv/MeetOnMemory/issues/979).
+
+## What was missing
+
+```
+$ grep -rn "helmet\|X-Frame-Options\|Content-Security-Policy" server/config server/server.js server/package.json
+(no matches)
+```
+
+`configureExpress` applied CORS, body parsers, `cookie-parser`, CSRF and the rate
+limiter — and nothing else. Every response, including the SPA and every JSON
+payload, was served without `nosniff`, without frame protection, without a CSP,
+without HSTS, and with `X-Powered-By: Express`.
+
+Separately, `/health` was a static handler that returned `200 UP` unconditionally
+— even with MongoDB down — and `.github/workflows/health-check.yml` polls it, so
+the monitoring that existed was structurally incapable of detecting a database
+outage.
+
+## Security headers
+
+| Header                         | Value                             | Why                                                                                           |
+| ------------------------------ | --------------------------------- | --------------------------------------------------------------------------------------------- |
+| `X-Content-Type-Options`       | `nosniff`                         | Stops a browser MIME-sniffing a JSON or user-uploaded response into an executable type.       |
+| `X-Frame-Options`              | `DENY`                            | The whole authenticated app could previously be framed by any origin.                         |
+| CSP `frame-ancestors`          | `'none'`                          | The modern equivalent, for browsers that honour CSP over the legacy header.                   |
+| `Referrer-Policy`              | `strict-origin-when-cross-origin` | Full URLs, including paths carrying meeting and organization IDs, leaked to third parties.    |
+| `Strict-Transport-Security`    | 1 year, production only           | Sending HSTS from a local HTTP dev server pins the browser to `https://localhost` for a year. |
+| `Cross-Origin-Resource-Policy` | `cross-origin`                    | `same-origin` would break split-origin deployments.                                           |
+
+Clickjacking is worth calling out: **CSRF tokens do not mitigate it.** The victim
+performs the click themselves, inside the frame, so the request carries a valid
+token.
+
+### CSP is report-only by default
+
+`CSP_ENFORCE=true` switches it to enforcing. Shipping an enforcing CSP blind is
+how CSP rollouts get reverted and never attempted again — deploy report-only,
+read the violation reports, then flip.
+
+The directives are written out explicitly rather than inheriting helmet's
+defaults, because several have to be loosened for this app and it should be
+obvious _which_ and _why_:
+
+- `styleSrc` allows `'unsafe-inline'` — Vite injects inline styles and Tailwind
+  sets style attributes. Far less dangerous than the script equivalent.
+- `scriptSrc` allows **neither** `'unsafe-inline'` nor `'unsafe-eval'`. If the
+  build turns out to need one, that should be a reviewed change rather than
+  something the policy grants pre-emptively.
+- `imgSrc` / `mediaSrc` allow `https:` and `blob:` — attachments, org logos,
+  avatars, uploaded recordings, and in-browser recording previews.
+- `connectSrc` allows `wss:`/`ws:` for Socket.IO.
+
+CSP matters here specifically: this repo has an ongoing series of HTML-injection
+hardening issues (#833, #804, #613). A CSP is the layer that contains the impact
+of the next one that slips through.
+
+## Health probes
+
+Three endpoints with genuinely different contracts:
+
+| Endpoint            | Checks dependencies? | A failure means                 |
+| ------------------- | -------------------- | ------------------------------- |
+| `GET /health/live`  | No                   | "restart me"                    |
+| `GET /health/ready` | Yes                  | "route around me"               |
+| `GET /health`       | Yes                  | aggregate, backwards-compatible |
+
+**Liveness never fails for a downstream outage.** Restarting wouldn't fix a dead
+database, and doing it fleet-wide during a database incident turns a partial
+outage into a total one.
+
+`GET /health` keeps its original `status` / `timestamp` / `env` fields exactly,
+so `health-check.yml` and any external monitor keep working. It adds
+`dependencies`, `uptimeSeconds`, and returns `503` when a required dependency is
+down.
+
+### Dependency checks
+
+- **MongoDB** — required. `readyState` alone isn't trusted (it can report
+  `connected` while the socket is dead), so a real `admin().ping()` is issued.
+- **Redis** — **degraded, not down**, and `required: false`. The app is
+  explicitly designed to run without it: `redisService` disables itself after 3
+  failed retries and the rate limiter, cache and Socket.IO adapter all fall back.
+  Failing readiness on Redis would take the whole deployment out for a non-fatal
+  condition.
+
+Every check is individually timeout-bounded (`HEALTH_CHECK_TIMEOUT_MS`, default
+2s). A probe that _hangs_ is worse than one that fails: the orchestrator gets no
+answer and falls back to its own much longer timeout, during which a broken
+instance keeps taking traffic.
+
+Health routes are registered **before** the global rate limiter — a rate-limited
+readiness probe would report an instance as unhealthy purely because it was being
+polled.
+
+## Request correlation
+
+`middleware/requestContext.js` attaches an id to every request, echoes it as
+`X-Request-Id`, and includes it in error logs and 500 response bodies. Previously
+`errorHandler` logged only `console.error("❌ Unhandled error:", err)` — no
+request id, no path, no user — so a user reporting "it failed" gave nothing to
+search for.
+
+An inbound `X-Request-Id` is reused when it matches `^[A-Za-z0-9._-]{1,128}$`,
+so a trace started at a load balancer carries through. Anything else is replaced:
+the value is echoed in a header and written into logs, so it is
+attacker-controlled input, and a newline in a log line can forge entries.
+
+Log context is passed through `redact()`, which masks `password`, `token`,
+`secret`, `authorization`, `cookie`, `apiKey` and friends at any depth. This repo
+has already had to fix sensitive auth data in server logs once (#612); redacting
+at the logging boundary means a future field can't quietly become a leak.
+
+## Body size limits
+
+`express.json({ limit: "50mb" })` was applied **globally**, so every endpoint —
+login, notification preferences, comment creation — would buffer and JSON-parse a
+50 MB body before any handler, validator or auth check ran.
+
+Now `BODY_LIMIT` (default `2mb`) applies everywhere, and `LARGE_BODY_LIMIT`
+(default `50mb`) applies only to an explicit allow-list of routes that genuinely
+receive large payloads. Raising a limit is a visible decision rather than a
+global default.
+
+An oversized body now returns **413** rather than 500 — it previously fell
+through to the catch-all, telling the client "we broke" when in fact they sent
+too much.
+
+## Configuration
+
+| Variable                  | Default | Effect                                             |
+| ------------------------- | ------- | -------------------------------------------------- |
+| `CSP_ENFORCE`             | `false` | `true` switches CSP from report-only to enforcing. |
+| `HEALTH_CHECK_TIMEOUT_MS` | `2000`  | Per-dependency probe deadline.                     |
+| `BODY_LIMIT`              | `2mb`   | Default request body limit.                        |
+| `LARGE_BODY_LIMIT`        | `50mb`  | Limit for upload/transcript routes.                |
+
+## Deployment notes
+
+- Point orchestrator probes at `/health/live` (liveness) and `/health/ready`
+  (readiness). Keep any existing monitor on `/health` — its response shape is
+  unchanged, it just tells the truth now.
+- Roll out with `CSP_ENFORCE` unset, collect violation reports, then set it to
+  `true`.

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -9,6 +9,34 @@ import {
 } from "../middleware/csrfProtection.js";
 import { globalLimiter } from "../middleware/rateLimiter.js";
 import errorHandler from "../middleware/errorHandler.js";
+import { configureSecurity } from "./security.js";
+import { configureHealthEndpoints } from "./health.js";
+import { requestContext } from "../middleware/requestContext.js";
+
+/**
+ * Body-parser limits (Issue #979).
+ *
+ * These used to be `50mb` globally, so *every* endpoint — login, notification
+ * preferences, comment creation — would buffer and JSON-parse a 50 MB body
+ * before any handler, validator or auth check ran. A handful of concurrent
+ * large posts to an unauthenticated route is enough to exhaust heap on a small
+ * instance. The large limit is needed by a few upload/transcript routes, not by
+ * the entire API surface.
+ */
+const BODY_LIMIT = process.env.BODY_LIMIT || "2mb";
+const LARGE_BODY_LIMIT = process.env.LARGE_BODY_LIMIT || "50mb";
+
+/**
+ * Routes that legitimately receive large payloads (base64 audio, long
+ * transcripts, document content). Kept as an explicit allow-list so raising a
+ * limit is a visible decision rather than a global default.
+ */
+const LARGE_BODY_ROUTES = [
+  "/api/meetings",
+  "/api/transcripts",
+  "/api/sessions",
+  "/api/policies",
+];
 
 // Import webhook routes that bypass CSRF
 import webhookRoutes from "../routes/webhookRoutes.js";
@@ -19,6 +47,14 @@ import publicSharedRoutes from "../routes/publicSharedRoutes.js";
 export function configureExpress(app) {
   // Trust proxy for Render/Vercel
   app.set("trust proxy", 1);
+
+  // ==========================================
+  // SECURITY HEADERS + REQUEST CORRELATION (Issue #979)
+  //   Registered first so *every* response carries them, including the ones
+  //   produced by the Slack/webhook routes mounted below and by error handlers.
+  // ==========================================
+  configureSecurity(app);
+  app.use(requestContext());
 
   // MIDDLEWARES
   app.use(cors(corsOptions));
@@ -31,8 +67,18 @@ export function configureExpress(app) {
   // ==========================================
   app.use("/api/slack", slackWebhookParser, slackRoutes);
 
-  app.use(express.json({ limit: "50mb" }));
-  app.use(express.urlencoded({ extended: true, limit: "50mb" }));
+  // Large limits only where they're actually needed (see LARGE_BODY_ROUTES).
+  app.use(LARGE_BODY_ROUTES, express.json({ limit: LARGE_BODY_LIMIT }));
+  app.use(
+    LARGE_BODY_ROUTES,
+    express.urlencoded({ extended: true, limit: LARGE_BODY_LIMIT }),
+  );
+
+  // Everything else gets a limit sized for ordinary JSON payloads. Express's
+  // body parsers are no-ops once a body has already been parsed, so the routes
+  // above keep their larger allowance.
+  app.use(express.json({ limit: BODY_LIMIT }));
+  app.use(express.urlencoded({ extended: true, limit: BODY_LIMIT }));
 
   // ==========================================
   // 1. BYPASSED ROUTES (No CSRF Protection)
@@ -52,15 +98,14 @@ export function configureExpress(app) {
     res.json({ csrfToken: req.csrfToken() });
   });
 
-  // Health check endpoint — registered BEFORE the global rate limiter so
-  // keep-alive pings (e.g. from GitHub Actions cron job) are never blocked.
-  app.get(["/health", "/api/health"], (req, res) => {
-    res.status(200).json({
-      status: "UP",
-      timestamp: new Date().toISOString(),
-      env: process.env.NODE_ENV,
-    });
-  });
+  // Health endpoints — registered BEFORE the global rate limiter so keep-alive
+  // pings (e.g. from the GitHub Actions cron job) and orchestrator probes are
+  // never blocked. A rate-limited readiness probe would report an instance as
+  // unhealthy purely because it was being polled.
+  //
+  // Issue #979: this replaces a static handler that returned `200 UP`
+  // unconditionally — even with MongoDB down — with real dependency checks.
+  configureHealthEndpoints(app);
 
   // GLOBAL RATE LIMITER
   app.use(globalLimiter);

--- a/server/config/health.js
+++ b/server/config/health.js
@@ -1,0 +1,263 @@
+import mongoose from "mongoose";
+import { getRedisClient } from "../services/redisService.js";
+
+// server/config/health.js
+//
+// Issue #979 — `/health` lied.
+//
+// The old handler was static:
+//
+//     app.get(["/health", "/api/health"], (req, res) => {
+//       res.status(200).json({ status: "UP", timestamp: ..., env: ... });
+//     });
+//
+// It returned `200 UP` regardless of whether anything it depends on was
+// reachable. `config/mongodb.js` exits if the *initial* connect fails, but
+// nothing watches for a later disconnect — so `readyState` could sit at 0
+// indefinitely while `/health` kept answering UP and every real request 500'd.
+// The repo runs `.github/workflows/health-check.yml` against this endpoint, so
+// the monitoring that exists was structurally incapable of detecting a database
+// outage.
+//
+// It also conflated **liveness** (is the process alive? must stay cheap and
+// dependency-free, and a failure means "restart me") with **readiness** (should
+// this instance receive traffic? must check dependencies, and a failure means
+// "route around me"). With one shallow endpoint, a rolling deploy sends traffic
+// to an instance whose dependencies aren't up, and a hung instance is never
+// restarted because its liveness probe passes.
+
+/** Mongoose connection states, by the numbers it actually reports. */
+const MONGO_STATES = {
+  0: "disconnected",
+  1: "connected",
+  2: "connecting",
+  3: "disconnecting",
+  99: "uninitialized",
+};
+
+const readIntEnv = (name, fallback) => {
+  const parsed = Number.parseInt(process.env[name], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/**
+ * Races a check against a deadline.
+ *
+ * Every dependency check is individually bounded, because a probe that hangs is
+ * worse than a probe that fails: the orchestrator gets no answer at all and
+ * falls back to its own (usually much longer) timeout, during which a broken
+ * instance keeps receiving traffic.
+ *
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} timeoutMs
+ * @param {T} timeoutValue
+ */
+const withDeadline = (promise, timeoutMs, timeoutValue) => {
+  let timer;
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(timeoutValue), timeoutMs);
+    timer.unref?.();
+  });
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+};
+
+/**
+ * Checks MongoDB.
+ *
+ * `readyState` alone isn't enough — it can report `connected` while the socket
+ * is actually dead — so a real `ping` is issued against the admin command
+ * interface.
+ *
+ * @param {object} [options]
+ * @returns {Promise<{status: string, required: boolean, detail?: string, latencyMs?: number}>}
+ */
+export const checkMongo = async ({
+  timeoutMs = readIntEnv("HEALTH_CHECK_TIMEOUT_MS", 2000),
+  connection = mongoose.connection,
+} = {}) => {
+  const state = MONGO_STATES[connection?.readyState] ?? "unknown";
+
+  if (connection?.readyState !== 1) {
+    return { status: "down", required: true, detail: state };
+  }
+
+  const startedAt = Date.now();
+
+  const ping = (async () => {
+    try {
+      await connection.db.admin().ping();
+      return {
+        status: "up",
+        required: true,
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return { status: "down", required: true, detail: error.message };
+    }
+  })();
+
+  return withDeadline(ping, timeoutMs, {
+    status: "down",
+    required: true,
+    detail: `ping timed out after ${timeoutMs}ms`,
+  });
+};
+
+/**
+ * Checks Redis.
+ *
+ * Reported as **degraded rather than down** when unavailable, and marked
+ * `required: false`, because the app is explicitly designed to run without it:
+ * `redisService` disables itself after 3 failed retries and the rate limiter,
+ * cache and Socket.IO adapter all fall back. Failing readiness on Redis would
+ * take the whole deployment out for a non-fatal condition.
+ *
+ * @param {object} [options]
+ */
+export const checkRedis = async ({
+  timeoutMs = readIntEnv("HEALTH_CHECK_TIMEOUT_MS", 2000),
+  client = undefined,
+} = {}) => {
+  const redis = client ?? getRedisClient();
+
+  if (!process.env.REDIS_URI && !process.env.REDIS_URL) {
+    return { status: "disabled", required: false, detail: "not configured" };
+  }
+
+  if (!redis) {
+    return {
+      status: "degraded",
+      required: false,
+      detail: "client unavailable",
+    };
+  }
+
+  const startedAt = Date.now();
+
+  const ping = (async () => {
+    try {
+      if (typeof redis.ping === "function") {
+        await redis.ping();
+      } else if (redis.isReady === false) {
+        return { status: "degraded", required: false, detail: "not ready" };
+      }
+      return {
+        status: "up",
+        required: false,
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      return { status: "degraded", required: false, detail: error.message };
+    }
+  })();
+
+  return withDeadline(ping, timeoutMs, {
+    status: "degraded",
+    required: false,
+    detail: `ping timed out after ${timeoutMs}ms`,
+  });
+};
+
+/**
+ * Runs every dependency check and rolls them up.
+ *
+ * Overall status is driven only by dependencies marked `required` — a degraded
+ * Redis lowers the reported status without failing the probe.
+ *
+ * @param {object} [options] injectable checks, for tests
+ * @returns {Promise<{status: string, ready: boolean, dependencies: object}>}
+ */
+export const collectHealth = async ({
+  mongoCheck = checkMongo,
+  redisCheck = checkRedis,
+} = {}) => {
+  const [mongo, redis] = await Promise.all([
+    mongoCheck().catch((error) => ({
+      status: "down",
+      required: true,
+      detail: error?.message ?? "check threw",
+    })),
+    redisCheck().catch((error) => ({
+      status: "degraded",
+      required: false,
+      detail: error?.message ?? "check threw",
+    })),
+  ]);
+
+  const dependencies = { mongodb: mongo, redis };
+
+  const requiredDown = Object.values(dependencies).some(
+    (dep) => dep.required && dep.status !== "up",
+  );
+  const anyDegraded = Object.values(dependencies).some(
+    (dep) => dep.status === "degraded",
+  );
+
+  let status = "UP";
+  if (requiredDown) status = "DOWN";
+  else if (anyDegraded) status = "DEGRADED";
+
+  return { status, ready: !requiredDown, dependencies };
+};
+
+/**
+ * Registers the health endpoints.
+ *
+ * Three, with distinct contracts:
+ *
+ *   GET /health/live  — liveness. No dependency checks, always 200 while the
+ *                       process can serve a request. A failure here means
+ *                       "restart me", so it must never fail for a *downstream*
+ *                       outage — restarting wouldn't fix that, and doing it
+ *                       across the fleet during a database incident turns a
+ *                       partial outage into a total one.
+ *   GET /health/ready — readiness. Checks dependencies; 503 means "route around
+ *                       me".
+ *   GET /health       — backwards-compatible aggregate. Keeps `status`,
+ *                       `timestamp` and `env` exactly as before so
+ *                       health-check.yml and any external monitor keep working,
+ *                       and adds `dependencies`, `uptime` and `version`.
+ *
+ * @param {import("express").Express} app
+ * @param {object} [options]
+ */
+export const configureHealthEndpoints = (app, options = {}) => {
+  const startedAt = Date.now();
+
+  app.get(["/health/live", "/api/health/live"], (req, res) => {
+    res.status(200).json({
+      status: "UP",
+      timestamp: new Date().toISOString(),
+      uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+    });
+  });
+
+  app.get(["/health/ready", "/api/health/ready"], async (req, res) => {
+    const health = await collectHealth(options);
+
+    res.status(health.ready ? 200 : 503).json({
+      status: health.status,
+      ready: health.ready,
+      timestamp: new Date().toISOString(),
+      dependencies: health.dependencies,
+    });
+  });
+
+  app.get(["/health", "/api/health"], async (req, res) => {
+    const health = await collectHealth(options);
+
+    res.status(health.ready ? 200 : 503).json({
+      // Unchanged fields — external monitors depend on these.
+      status: health.status,
+      timestamp: new Date().toISOString(),
+      env: process.env.NODE_ENV,
+      // New, additive.
+      uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+      dependencies: health.dependencies,
+    });
+  });
+};
+
+export default configureHealthEndpoints;

--- a/server/config/security.js
+++ b/server/config/security.js
@@ -1,0 +1,137 @@
+import helmet from "helmet";
+
+// server/config/security.js
+//
+// Issue #979 — the app shipped no security response headers at all.
+//
+//     $ grep -rn "helmet\|X-Frame-Options\|Content-Security-Policy" server/config server/server.js
+//     (no matches)
+//
+// `configureExpress` applied cors, body parsers, cookie-parser, CSRF and the
+// rate limiter — and nothing else. Every response, including the SPA and every
+// JSON payload, was served without `nosniff`, without frame protection, without
+// a CSP, without HSTS, and with `X-Powered-By: Express` advertising the stack.
+//
+// The frame-protection gap is the sharpest one: **the whole authenticated app
+// could be embedded by any origin**, which is a live clickjacking vector against
+// state-changing UI and is *not* mitigated by CSRF tokens, because the victim
+// performs the click themselves inside the frame.
+//
+// CSP matters here specifically: this repo has an ongoing series of
+// HTML-injection hardening issues (#833 digest preview HTML, #804 digest HTML +
+// iframe sandboxing, #613 transcript viewer XSS). A CSP is the layer that
+// contains the impact of the next one that slips through.
+
+const isProduction = () => process.env.NODE_ENV === "production";
+
+/**
+ * Content-Security-Policy directives.
+ *
+ * Deliberately explicit rather than relying on helmet's defaults, because a
+ * few of them have to be loosened for this app and it should be obvious *which*
+ * and *why* rather than being implied by silence.
+ */
+const buildCspDirectives = () => ({
+  defaultSrc: ["'self'"],
+
+  // Vite injects inline styles, and Tailwind's runtime utilities set style
+  // attributes. 'unsafe-inline' for styles is the standard trade-off; it is far
+  // less dangerous than the script equivalent.
+  styleSrc: ["'self'", "'unsafe-inline'", "https:"],
+
+  // No 'unsafe-inline' / 'unsafe-eval' for scripts. If the SPA build turns out
+  // to need one, that should be a deliberate, reviewed change rather than
+  // something the policy grants pre-emptively.
+  scriptSrc: ["'self'"],
+
+  // Meeting attachments, organization logos and avatars come from external
+  // storage; `data:` covers inline chart/QR rendering.
+  imgSrc: ["'self'", "data:", "blob:", "https:"],
+
+  fontSrc: ["'self'", "data:", "https:"],
+
+  // The SPA talks to this API cross-origin in split-origin deployments, and
+  // Socket.IO needs ws/wss for the realtime features.
+  connectSrc: ["'self'", "https:", "wss:", "ws:"],
+
+  // Audio/video playback of uploaded recordings, plus blob: for in-browser
+  // recording previews.
+  mediaSrc: ["'self'", "blob:", "https:"],
+
+  // The modern equivalent of X-Frame-Options: nothing may embed us.
+  frameAncestors: ["'none'"],
+
+  // Nothing should be loading Flash/Java-era plugins.
+  objectSrc: ["'none'"],
+
+  baseUri: ["'self'"],
+  formAction: ["'self'"],
+});
+
+/**
+ * Builds the helmet middleware.
+ *
+ * CSP defaults to **report-only** so it can be deployed without any risk of
+ * breaking the SPA, and switched to enforcing with a single env var once the
+ * violation reports come back clean. Shipping an enforcing CSP blind is how CSP
+ * rollouts get reverted and never tried again.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.enforceCsp]
+ * @param {boolean} [options.enableHsts]
+ * @returns {import("express").RequestHandler}
+ */
+export const buildSecurityMiddleware = ({
+  enforceCsp = process.env.CSP_ENFORCE === "true",
+  enableHsts = isProduction(),
+} = {}) =>
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: buildCspDirectives(),
+      reportOnly: !enforceCsp,
+    },
+
+    // Prevents MIME-sniffing a JSON or user-uploaded response into an
+    // executable type.
+    xContentTypeOptions: true,
+
+    // Belt-and-braces alongside CSP frame-ancestors, for older browsers.
+    frameguard: { action: "deny" },
+
+    // Full URLs — including paths carrying meeting and organization IDs — used
+    // to leak to third parties in the Referer header.
+    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+
+    // HSTS only in production: sending it from a local HTTP dev server pins the
+    // browser to https://localhost for a year, which is a miserable thing to
+    // debug.
+    hsts: enableHsts
+      ? { maxAge: 31536000, includeSubDomains: true, preload: false }
+      : false,
+
+    // COEP would break the cross-origin images and media the app legitimately
+    // loads (attachments, avatars, recordings), so it stays off deliberately.
+    crossOriginEmbedderPolicy: false,
+
+    // `same-origin` would break split-origin deployments where the SPA is
+    // served from a different host than this API.
+    crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" },
+    crossOriginResourcePolicy: { policy: "cross-origin" },
+  });
+
+/**
+ * Applies security headers to an Express app.
+ *
+ * @param {import("express").Express} app
+ * @param {object} [options] forwarded to buildSecurityMiddleware
+ */
+export const configureSecurity = (app, options = {}) => {
+  // Express advertises itself on every response; there is no reason to tell an
+  // attacker which stack to look up CVEs for.
+  app.disable("x-powered-by");
+
+  app.use(buildSecurityMiddleware(options));
+};
+
+export default configureSecurity;

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -1,5 +1,7 @@
 import { AppError } from "../utils/errors.js";
 import { sendCsrfInvalid } from "../utils/csrfErrors.js";
+import logger from "../utils/logger.js";
+import { buildLogContext, redact } from "./requestContext.js";
 
 /**
  * Structural ZodError check (no `import "zod"`).
@@ -76,6 +78,25 @@ const errorHandler = (err, req, res, next) => {
     });
   }
 
+  // ── Oversized request body ───────────────────────────────────
+  // body-parser raises `entity.too.large`, which previously fell through to the
+  // catch-all and was reported as a 500 — telling the client "we broke" when in
+  // fact they sent too much. 413 is both accurate and actionable.
+  if (err.type === "entity.too.large" || err.status === 413) {
+    return res.status(413).json({
+      success: false,
+      message: "Request payload is too large.",
+    });
+  }
+
+  // ── Malformed JSON body ──────────────────────────────────────
+  if (err.type === "entity.parse.failed") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid JSON in request body.",
+    });
+  }
+
   // ── Mongoose CastError (bad ObjectId format) ─────────────────
   if (err.name === "CastError") {
     return res.status(400).json({
@@ -87,7 +108,14 @@ const errorHandler = (err, req, res, next) => {
   // ── Everything else → 500 ────────────────────────────────────
   // Log the full error for server-side debugging but never expose
   // raw stack traces or internal messages in production.
-  console.error("❌ Unhandled error:", err);
+  //
+  // Issue #979: this used to be a bare `console.error("❌ Unhandled error:",
+  // err)` with no request context at all, so a user reporting "it failed" gave
+  // us nothing to search for. It now goes through the structured logger with a
+  // correlation id — which is also echoed to the client in `X-Request-Id`, so
+  // the user has an identifier to quote.
+  const context = buildLogContext(req);
+  logger.error("Unhandled request error", err, redact(context));
 
   const isProd = process.env.NODE_ENV === "production";
   return res.status(500).json({
@@ -95,6 +123,9 @@ const errorHandler = (err, req, res, next) => {
     message: isProd
       ? "Internal Server Error"
       : err.message || "Internal Server Error",
+    // Safe to expose in both environments: it identifies the log line, not the
+    // failure, and the client already received it as a response header.
+    ...(context.requestId ? { requestId: context.requestId } : {}),
     ...(isProd ? {} : { stack: err.stack }),
   });
 };

--- a/server/middleware/requestContext.js
+++ b/server/middleware/requestContext.js
@@ -1,0 +1,124 @@
+import crypto from "crypto";
+
+// server/middleware/requestContext.js
+//
+// Issue #979 — errors were untraceable.
+//
+// `middleware/errorHandler.js` logged failures as:
+//
+//     console.error("❌ Unhandled error:", err);
+//
+// No request id, no method, no path, no user, and no correlation with the
+// response the client received. When a user reports "it failed", there was no
+// identifier to search for — and because responses carried no correlation
+// header either, there was nothing for them to quote.
+//
+// There is already a structured logger in `utils/logger.js`; the error handler
+// just wasn't using it.
+
+/** Header the id is read from and echoed on. */
+export const REQUEST_ID_HEADER = "X-Request-Id";
+
+/**
+ * Rejects an inbound id that isn't plausibly one.
+ *
+ * The value is echoed back in a response header and written into logs, so it is
+ * attacker-controlled input. Restricting it to a short, safe character set stops
+ * header injection and log forging (a newline in a log line can fabricate
+ * entries).
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export const isValidRequestId = (value) =>
+  typeof value === "string" &&
+  value.length > 0 &&
+  value.length <= 128 &&
+  /^[A-Za-z0-9._-]+$/.test(value);
+
+/**
+ * Attaches a correlation id to every request.
+ *
+ * An inbound `X-Request-Id` is preferred (so a trace started at a load balancer
+ * or by the SPA carries through), and generated otherwise.
+ *
+ * @returns {import("express").RequestHandler}
+ */
+export const requestContext = () => (req, res, next) => {
+  const inbound = req.get?.(REQUEST_ID_HEADER);
+
+  req.id = isValidRequestId(inbound) ? inbound : crypto.randomUUID();
+  req.startedAt = Date.now();
+
+  // Echo it so a user can quote the id from their network tab, and so a client
+  // can attach it to its own error reports.
+  res.setHeader(REQUEST_ID_HEADER, req.id);
+
+  next();
+};
+
+/** Fields that must never reach a log line. */
+const SENSITIVE_KEYS = new Set([
+  "password",
+  "token",
+  "secret",
+  "authorization",
+  "cookie",
+  "apikey",
+  "api_key",
+  "accesstoken",
+  "refreshtoken",
+  "clientsecret",
+  "signature",
+]);
+
+/**
+ * Recursively redacts sensitive values.
+ *
+ * Errors carry request context into logs, and this repo has already had to fix
+ * "sensitive authentication data in server logs" once (#612). Redacting at the
+ * logging boundary means a future field added to a request body can't quietly
+ * become a credential leak.
+ *
+ * @param {any} value
+ * @param {number} [depth]
+ */
+export const redact = (value, depth = 0) => {
+  if (depth > 4 || value === null || typeof value !== "object") return value;
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map((item) => redact(item, depth + 1));
+  }
+
+  const output = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      output[key] = "[REDACTED]";
+    } else {
+      output[key] = redact(val, depth + 1);
+    }
+  }
+  return output;
+};
+
+/**
+ * Builds the structured context attached to an error log.
+ *
+ * @param {import("express").Request} req
+ * @returns {object}
+ */
+export const buildLogContext = (req) => {
+  if (!req) return {};
+
+  return {
+    requestId: req.id ?? null,
+    method: req.method,
+    path: req.originalUrl ?? req.url,
+    userId: req.user?.id ?? req.user?._id?.toString?.() ?? null,
+    organizationId: req.organizationId ?? null,
+    ip: req.ip,
+    durationMs: req.startedAt ? Date.now() - req.startedAt : null,
+  };
+};
+
+export default requestContext;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,6 +38,7 @@
         "form-data": "^4.0.4",
         "fs": "^0.0.1-security",
         "googleapis": "^165.0.0",
+        "helmet": "^8.3.0",
         "ical-generator": "^10.0.0",
         "ioredis": "^5.11.1",
         "json2csv": "^6.0.0-alpha.2",
@@ -828,6 +829,43 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7744,6 +7782,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/html-escaper": {

--- a/server/package.json
+++ b/server/package.json
@@ -55,6 +55,7 @@
     "form-data": "^4.0.4",
     "fs": "^0.0.1-security",
     "googleapis": "^165.0.0",
+    "helmet": "^8.3.0",
     "ical-generator": "^10.0.0",
     "ioredis": "^5.11.1",
     "json2csv": "^6.0.0-alpha.2",

--- a/server/server.js
+++ b/server/server.js
@@ -115,15 +115,10 @@ app.use("/api/personal-notes", personalNoteRoutes);
 app.use("/api/template-library", templateLibraryRoutes);
 app.use("/api/meeting-health", meetingHealthRoutes);
 
-// Health check endpoint — registered BEFORE the global rate limiter so
-// keep-alive pings (e.g. from GitHub Actions cron job) are never blocked.
-app.get(["/health", "/api/health"], (req, res) => {
-  res.status(200).json({
-    status: "UP",
-    timestamp: new Date().toISOString(),
-    env: process.env.NODE_ENV,
-  });
-});
+// Issue #979: the /health handler that used to be duplicated here was
+// unreachable dead code — configureExpress registers it first, and two copies
+// of the same route are two things to keep in sync. The single definition now
+// lives in config/health.js.
 app.use(routes);
 
 // ERROR HANDLING (Must be after routes)

--- a/server/tests/securityHealth.test.js
+++ b/server/tests/securityHealth.test.js
@@ -1,0 +1,501 @@
+/**
+ * Issue #979 — security headers, health probes and request correlation.
+ */
+
+import { jest } from "@jest/globals";
+import request from "supertest";
+import mongoose from "mongoose";
+import express from "express";
+import { app } from "../server.js";
+import { configureSecurity } from "../config/security.js";
+import {
+  checkMongo,
+  checkRedis,
+  collectHealth,
+  configureHealthEndpoints,
+} from "../config/health.js";
+import {
+  REQUEST_ID_HEADER,
+  buildLogContext,
+  isValidRequestId,
+  redact,
+} from "../middleware/requestContext.js";
+
+describe("security headers (Issue #979)", () => {
+  it("sets X-Content-Type-Options", async () => {
+    // Without this a browser may MIME-sniff a JSON or user-uploaded response
+    // into an executable type.
+    const res = await request(app).get("/health/live");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("forbids framing the app", async () => {
+    // The whole authenticated app could previously be embedded by any origin.
+    // CSRF tokens do not mitigate clickjacking — the victim performs the click
+    // themselves, inside the frame.
+    const res = await request(app).get("/health/live");
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+    expect(res.headers["content-security-policy-report-only"]).toMatch(
+      /frame-ancestors 'none'/,
+    );
+  });
+
+  it("sets a Referrer-Policy", async () => {
+    // Full URLs — including paths carrying meeting and organization IDs — used
+    // to leak to third parties in the Referer header.
+    const res = await request(app).get("/health/live");
+    expect(res.headers["referrer-policy"]).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("removes the X-Powered-By banner", async () => {
+    const res = await request(app).get("/health/live");
+    expect(res.headers["x-powered-by"]).toBeUndefined();
+  });
+
+  it("ships CSP in report-only mode by default", async () => {
+    // An enforcing CSP shipped blind is how CSP rollouts get reverted and never
+    // tried again. Report-only first, flip via env once reports are clean.
+    const res = await request(app).get("/health/live");
+    expect(res.headers["content-security-policy-report-only"]).toBeDefined();
+    expect(res.headers["content-security-policy"]).toBeUndefined();
+  });
+
+  it("can be switched to an enforcing CSP", async () => {
+    const enforcingApp = express();
+    configureSecurity(enforcingApp, { enforceCsp: true });
+    enforcingApp.get("/x", (req, res) => res.json({ ok: true }));
+
+    const res = await request(enforcingApp).get("/x");
+    expect(res.headers["content-security-policy"]).toBeDefined();
+    expect(res.headers["content-security-policy-report-only"]).toBeUndefined();
+  });
+
+  it("omits HSTS outside production", async () => {
+    // Sending HSTS from a local HTTP dev server pins the browser to
+    // https://localhost for a year, which is miserable to debug.
+    const res = await request(app).get("/health/live");
+    expect(res.headers["strict-transport-security"]).toBeUndefined();
+  });
+
+  it("sends HSTS when enabled", async () => {
+    const prodApp = express();
+    configureSecurity(prodApp, { enableHsts: true });
+    prodApp.get("/x", (req, res) => res.json({ ok: true }));
+
+    const res = await request(prodApp).get("/x");
+    expect(res.headers["strict-transport-security"]).toMatch(/max-age=\d+/);
+  });
+
+  it("allows the cross-origin images and media the app legitimately loads", async () => {
+    const res = await request(app).get("/health/live");
+    const csp = res.headers["content-security-policy-report-only"];
+
+    // Attachments, org logos and avatars come from external storage; a policy
+    // that blocked them would be reverted on first contact with production.
+    expect(csp).toMatch(/img-src[^;]*https:/);
+    expect(csp).toMatch(/connect-src[^;]*wss:/); // Socket.IO
+    expect(res.headers["cross-origin-resource-policy"]).toBe("cross-origin");
+  });
+
+  it("does not permit inline or eval'd scripts", async () => {
+    const res = await request(app).get("/health/live");
+    const csp = res.headers["content-security-policy-report-only"];
+
+    const scriptSrc = csp
+      .split(";")
+      .find((d) => d.trim().startsWith("script-src"));
+    expect(scriptSrc).not.toMatch(/unsafe-inline/);
+    expect(scriptSrc).not.toMatch(/unsafe-eval/);
+  });
+});
+
+describe("health probes (Issue #979)", () => {
+  describe("liveness", () => {
+    it("returns 200 without touching dependencies", async () => {
+      const res = await request(app).get("/health/live");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("UP");
+      expect(res.body).not.toHaveProperty("dependencies");
+    });
+
+    it("is available under /api as well", async () => {
+      expect((await request(app).get("/api/health/live")).status).toBe(200);
+    });
+  });
+
+  describe("readiness", () => {
+    it("returns 200 with a per-dependency breakdown when healthy", async () => {
+      const res = await request(app).get("/health/ready");
+
+      expect(res.status).toBe(200);
+      expect(res.body.ready).toBe(true);
+      expect(res.body.dependencies.mongodb.status).toBe("up");
+      expect(res.body.dependencies).toHaveProperty("redis");
+    });
+
+    it("reports latency for a healthy dependency", async () => {
+      const res = await request(app).get("/health/ready");
+      expect(typeof res.body.dependencies.mongodb.latencyMs === "number").toBe(
+        true,
+      );
+    });
+  });
+
+  describe("aggregate /health", () => {
+    it("preserves the original response fields", async () => {
+      // health-check.yml and any external monitor depend on these exact keys.
+      const res = await request(app).get("/health");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("status", "UP");
+      expect(res.body).toHaveProperty("timestamp");
+      expect(res.body).toHaveProperty("env");
+    });
+
+    it("adds dependency and uptime detail", async () => {
+      const res = await request(app).get("/health");
+      expect(res.body).toHaveProperty("dependencies");
+      expect(typeof res.body.uptimeSeconds).toBe("number");
+    });
+
+    it("is registered exactly once", async () => {
+      // It used to be defined in both config/express.js and server.js; the
+      // second was unreachable dead code and the two would drift.
+      const healthRoutes = (
+        app.router?.stack ??
+        app._router?.stack ??
+        []
+      ).filter((layer) => layer.route?.path?.toString?.().includes("/health"));
+      // One layer, registering the path array — not two separate layers.
+      expect(healthRoutes.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("dependency failure reporting", () => {
+    /** Mounts an isolated app with injected checks. */
+    const appWith = (mongoCheck, redisCheck) => {
+      const testApp = express();
+      configureHealthEndpoints(testApp, { mongoCheck, redisCheck });
+      return testApp;
+    };
+
+    const upRedis = async () => ({ status: "up", required: false });
+
+    it("returns 503 when MongoDB is down", async () => {
+      // The whole point: the old handler answered `200 UP` here while every
+      // real request 500'd, so a monitor could never detect a database outage.
+      const testApp = appWith(
+        async () => ({
+          status: "down",
+          required: true,
+          detail: "disconnected",
+        }),
+        upRedis,
+      );
+
+      const res = await request(testApp).get("/health/ready");
+
+      expect(res.status).toBe(503);
+      expect(res.body.status).toBe("DOWN");
+      expect(res.body.ready).toBe(false);
+      expect(res.body.dependencies.mongodb.detail).toBe("disconnected");
+    });
+
+    it("treats Redis as degraded, not failed", async () => {
+      // The app is explicitly designed to run without Redis; failing readiness
+      // on it would take the deployment out for a non-fatal condition.
+      const testApp = appWith(
+        async () => ({ status: "up", required: true }),
+        async () => ({ status: "degraded", required: false, detail: "down" }),
+      );
+
+      const res = await request(testApp).get("/health/ready");
+
+      expect(res.status).toBe(200);
+      expect(res.body.ready).toBe(true);
+      expect(res.body.status).toBe("DEGRADED");
+    });
+
+    it("keeps liveness at 200 even when a dependency is down", async () => {
+      // A failing liveness probe means "restart me", which wouldn't fix a
+      // downstream outage — and doing it fleet-wide during a database incident
+      // turns a partial outage into a total one.
+      const testApp = appWith(
+        async () => ({ status: "down", required: true }),
+        upRedis,
+      );
+
+      expect((await request(testApp).get("/health/live")).status).toBe(200);
+    });
+
+    it("treats a check that throws as a failure rather than crashing", async () => {
+      const testApp = appWith(async () => {
+        throw new Error("boom");
+      }, upRedis);
+
+      const res = await request(testApp).get("/health/ready");
+      expect(res.status).toBe(503);
+      expect(res.body.dependencies.mongodb.detail).toBe("boom");
+    });
+  });
+
+  describe("checkMongo", () => {
+    it("reports the connection state when not connected", async () => {
+      const result = await checkMongo({ connection: { readyState: 0 } });
+      expect(result).toMatchObject({ status: "down", detail: "disconnected" });
+    });
+
+    it("pings a connected database rather than trusting readyState", async () => {
+      // readyState can report `connected` while the socket is actually dead.
+      const ping = jest.fn(async () => ({ ok: 1 }));
+      const result = await checkMongo({
+        connection: { readyState: 1, db: { admin: () => ({ ping }) } },
+      });
+
+      expect(ping).toHaveBeenCalled();
+      expect(result.status).toBe("up");
+    });
+
+    it("reports a failed ping as down", async () => {
+      const result = await checkMongo({
+        connection: {
+          readyState: 1,
+          db: {
+            admin: () => ({
+              ping: async () => {
+                throw new Error("no primary");
+              },
+            }),
+          },
+        },
+      });
+
+      expect(result).toMatchObject({ status: "down", detail: "no primary" });
+    });
+
+    it("bounds a hanging ping with a deadline", async () => {
+      // A probe that hangs is worse than one that fails: the orchestrator gets
+      // no answer and falls back to its own much longer timeout, during which a
+      // broken instance keeps taking traffic.
+      const result = await checkMongo({
+        timeoutMs: 30,
+        connection: {
+          readyState: 1,
+          db: { admin: () => ({ ping: () => new Promise(() => {}) }) },
+        },
+      });
+
+      expect(result.status).toBe("down");
+      expect(result.detail).toMatch(/timed out/);
+    });
+  });
+
+  describe("checkRedis", () => {
+    it("reports disabled when Redis is not configured", async () => {
+      const result = await checkRedis({ client: null });
+      expect(result).toMatchObject({ status: "disabled", required: false });
+    });
+
+    it("reports up for a responsive client", async () => {
+      process.env.REDIS_URI = "redis://localhost:6379";
+      try {
+        const result = await checkRedis({
+          client: { ping: async () => "PONG" },
+        });
+        expect(result.status).toBe("up");
+        expect(result.required).toBe(false);
+      } finally {
+        delete process.env.REDIS_URI;
+      }
+    });
+
+    it("reports degraded when the ping fails", async () => {
+      process.env.REDIS_URI = "redis://localhost:6379";
+      try {
+        const result = await checkRedis({
+          client: {
+            ping: async () => {
+              throw new Error("connection refused");
+            },
+          },
+        });
+        expect(result).toMatchObject({ status: "degraded", required: false });
+      } finally {
+        delete process.env.REDIS_URI;
+      }
+    });
+  });
+
+  describe("collectHealth", () => {
+    it("is UP only when every required dependency is up", async () => {
+      const result = await collectHealth({
+        mongoCheck: async () => ({ status: "up", required: true }),
+        redisCheck: async () => ({ status: "up", required: false }),
+      });
+
+      expect(result).toMatchObject({ status: "UP", ready: true });
+    });
+
+    it("is DEGRADED when an optional dependency is degraded", async () => {
+      const result = await collectHealth({
+        mongoCheck: async () => ({ status: "up", required: true }),
+        redisCheck: async () => ({ status: "degraded", required: false }),
+      });
+
+      expect(result).toMatchObject({ status: "DEGRADED", ready: true });
+    });
+
+    it("is DOWN and not ready when a required dependency fails", async () => {
+      const result = await collectHealth({
+        mongoCheck: async () => ({ status: "down", required: true }),
+        redisCheck: async () => ({ status: "up", required: false }),
+      });
+
+      expect(result).toMatchObject({ status: "DOWN", ready: false });
+    });
+  });
+});
+
+describe("request correlation (Issue #979)", () => {
+  it("echoes a request id on every response", async () => {
+    const res = await request(app).get("/health/live");
+    expect(res.headers["x-request-id"]).toBeTruthy();
+  });
+
+  it("reuses a valid inbound id so a trace carries through", async () => {
+    const res = await request(app)
+      .get("/health/live")
+      .set(REQUEST_ID_HEADER, "trace-abc-123");
+
+    expect(res.headers["x-request-id"]).toBe("trace-abc-123");
+  });
+
+  it("generates a fresh id when the inbound one is unsafe", async () => {
+    // The value is echoed in a header and written to logs, so it's
+    // attacker-controlled input: a newline could forge log entries.
+    const res = await request(app)
+      .get("/health/live")
+      .set(REQUEST_ID_HEADER, "bad value with spaces");
+
+    expect(res.headers["x-request-id"]).not.toBe("bad value with spaces");
+    expect(res.headers["x-request-id"]).toBeTruthy();
+  });
+
+  it("gives different requests different ids", async () => {
+    const [a, b] = await Promise.all([
+      request(app).get("/health/live"),
+      request(app).get("/health/live"),
+    ]);
+
+    expect(a.headers["x-request-id"]).not.toBe(b.headers["x-request-id"]);
+  });
+
+  describe("isValidRequestId", () => {
+    it.each(["abc123", "trace-1_2.3", "a".repeat(128)])("accepts %p", (value) =>
+      expect(isValidRequestId(value)).toBe(true),
+    );
+
+    it.each([
+      "",
+      "with space",
+      "new\nline",
+      "semi;colon",
+      "a".repeat(129),
+      null,
+      undefined,
+      123,
+    ])("rejects %p", (value) => expect(isValidRequestId(value)).toBe(false));
+  });
+
+  describe("redact", () => {
+    it("masks sensitive keys", () => {
+      // This repo has already had to fix "sensitive auth data in server logs"
+      // once (#612); redacting at the logging boundary stops a future field
+      // from quietly becoming a leak.
+      const result = redact({
+        email: "a@b.com",
+        password: "hunter2",
+        token: "abc",
+        authorization: "Bearer x",
+      });
+
+      expect(result.email).toBe("a@b.com");
+      expect(result.password).toBe("[REDACTED]");
+      expect(result.token).toBe("[REDACTED]");
+      expect(result.authorization).toBe("[REDACTED]");
+    });
+
+    it("is case-insensitive about key names", () => {
+      expect(redact({ Password: "x", API_KEY: "y" })).toEqual({
+        Password: "[REDACTED]",
+        API_KEY: "[REDACTED]",
+      });
+    });
+
+    it("redacts nested values", () => {
+      const result = redact({ user: { name: "Ada", secret: "s" } });
+      expect(result.user.name).toBe("Ada");
+      expect(result.user.secret).toBe("[REDACTED]");
+    });
+
+    it("does not recurse forever on a cyclic object", () => {
+      const cyclic = { name: "x" };
+      cyclic.self = cyclic;
+      expect(() => redact(cyclic)).not.toThrow();
+    });
+
+    it("passes primitives through", () => {
+      expect(redact("plain")).toBe("plain");
+      expect(redact(null)).toBeNull();
+    });
+  });
+
+  describe("buildLogContext", () => {
+    it("captures the fields needed to find a failed request", () => {
+      const context = buildLogContext({
+        id: "req-1",
+        method: "POST",
+        originalUrl: "/api/meetings",
+        user: { id: "user-1" },
+        ip: "127.0.0.1",
+        startedAt: Date.now() - 50,
+      });
+
+      expect(context).toMatchObject({
+        requestId: "req-1",
+        method: "POST",
+        path: "/api/meetings",
+        userId: "user-1",
+      });
+      expect(context.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("tolerates an anonymous request", () => {
+      const context = buildLogContext({ id: "r", method: "GET", url: "/x" });
+      expect(context.userId).toBeNull();
+    });
+
+    it("returns an empty object for a missing request", () => {
+      expect(buildLogContext(null)).toEqual({});
+    });
+  });
+});
+
+describe("body size limits (Issue #979)", () => {
+  it("rejects an oversized body on an ordinary route", async () => {
+    // Every endpoint — login included — used to buffer and JSON-parse up to
+    // 50 MB before any handler, validator or auth check ran.
+    const res = await request(app)
+      .post("/api/auth/login")
+      .set("Content-Type", "application/json")
+      .send({ padding: "x".repeat(3 * 1024 * 1024) });
+
+    expect(res.status).toBe(413);
+  });
+});
+
+afterAll(async () => {
+  await mongoose.connection.close().catch(() => {});
+});


### PR DESCRIPTION
# Pull Request

## Description

Adds security response headers, real health probes, and request correlation.

### 1. Zero security headers

```
$ grep -rn "helmet\|X-Frame-Options\|Content-Security-Policy" server/config server/server.js server/package.json
(no matches)
```

`configureExpress` applied CORS, body parsers, `cookie-parser`, CSRF and the rate limiter — and nothing else. `helmet` was not a dependency. Every response, including the SPA and every JSON payload, went out without `nosniff`, without frame protection, without a CSP, without HSTS, and with `X-Powered-By: Express`.

**The frame-protection gap is the sharpest one: the whole authenticated app could be embedded by any origin.** That is a live clickjacking vector against state-changing UI, and it is *not* mitigated by CSRF tokens — the victim performs the click themselves, inside the frame, so the request carries a valid token.

`config/security.js` adds helmet with an explicit, reviewed configuration and calls `app.disable("x-powered-by")`.

**CSP ships report-only by default** (`CSP_ENFORCE=true` to enforce). Shipping an enforcing CSP blind is how CSP rollouts get reverted and never attempted again. The directives are written out rather than inheriting helmet's defaults, because several must be loosened here and it should be obvious *which* and *why*:

- `styleSrc` allows `'unsafe-inline'` — Vite injects inline styles, Tailwind sets style attributes. Far less dangerous than the script equivalent.
- `scriptSrc` allows **neither** `'unsafe-inline'` nor `'unsafe-eval'`. If the build needs one, that should be a reviewed change, not something granted pre-emptively.
- `imgSrc`/`mediaSrc` allow `https:`/`blob:` for attachments, org logos, avatars, recordings and in-browser previews; `connectSrc` allows `wss:`/`ws:` for Socket.IO. A policy that blocked these would be reverted on first contact with production.
- HSTS is production-only — sending it from a local HTTP dev server pins the browser to `https://localhost` for a year.

CSP matters here specifically: this repo has an ongoing series of HTML-injection hardening issues (#833, #804, #613). A CSP is the layer that contains the impact of the next one that slips through.

### 2. `/health` reported UP with the database down

The old handler was static — it returned `200 UP` regardless of whether anything it depends on was reachable. `config/mongodb.js` exits if the *initial* connect fails, but nothing watches for a later disconnect, so `readyState` could sit at `0` indefinitely while `/health` answered `UP` and every real request 500'd. `.github/workflows/health-check.yml` polls this endpoint, so **the monitoring that existed was structurally incapable of detecting a database outage.**

It also conflated liveness with readiness. `config/health.js` splits them:

| Endpoint | Checks deps? | A failure means |
| --- | --- | --- |
| `GET /health/live` | No | "restart me" |
| `GET /health/ready` | Yes | "route around me" |
| `GET /health` | Yes | aggregate, backwards-compatible |

**Liveness never fails for a downstream outage** — restarting wouldn't fix a dead database, and doing it fleet-wide during a database incident turns a partial outage into a total one.

- **MongoDB** is *pinged*, not trusted by `readyState` (which can report `connected` while the socket is dead). Required.
- **Redis** is reported **degraded, not down**, and `required: false` — the app is explicitly designed to run without it (`redisService` disables itself after 3 retries; the limiter, cache and Socket.IO adapter all fall back). Failing readiness on Redis would take the deployment out for a non-fatal condition.
- Every check is **individually timeout-bounded**. A probe that *hangs* is worse than one that fails: the orchestrator gets no answer and falls back to its own much longer timeout, during which a broken instance keeps taking traffic.

`GET /health` keeps `status`, `timestamp` and `env` **exactly** as before, so `health-check.yml` and any external monitor keep working — it just tells the truth now.

### 3. Errors were untraceable

`errorHandler` logged `console.error("❌ Unhandled error:", err)` — no request id, method, path or user, and no correlation with the response the client got. A user reporting "it failed" gave nothing to search for. There was already a structured logger in `utils/logger.js`; the error handler wasn't using it.

`middleware/requestContext.js` attaches an id, echoes it as `X-Request-Id`, and feeds it into the error log and the 500 body. An inbound id is reused (so a trace started at a load balancer carries through) **only** if it matches `^[A-Za-z0-9._-]{1,128}$` — the value is echoed in a header and written into logs, so it is attacker-controlled input, and a newline can forge log entries.

Log context goes through `redact()`, masking `password`/`token`/`secret`/`authorization`/`cookie`/`apiKey` at any depth. This repo has already had to fix sensitive auth data in server logs once (#612).

### 4. 50 MB body limit on every route

`express.json({ limit: "50mb" })` was global, so login, notification preferences and comment creation would all buffer and JSON-parse a 50 MB body **before any handler, validator or auth check ran**. Now `BODY_LIMIT` (2mb) applies everywhere and `LARGE_BODY_LIMIT` (50mb) only to an explicit route allow-list. An oversized body now returns **413** instead of falling through to a 500 — the old behaviour told the client "we broke" when in fact they sent too much.

### 5. Duplicate `/health`

It was defined in both `config/express.js` and `server.js`. The second was unreachable dead code and the two would drift. Removed.

## Type of Change

- [x] Security Improvement
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [x] Other — operational readiness

## Related Issue

Closes #979

## Testing

Added **55 tests** in `tests/securityHealth.test.js`:

- **Headers** — `nosniff`, `X-Frame-Options: DENY` **and** CSP `frame-ancestors 'none'`, `Referrer-Policy`, `X-Powered-By` gone, CSP report-only by default and enforcing when toggled, HSTS off outside production and on when enabled, `https:` images / `wss:` connect still permitted (so the policy doesn't break real usage), and `scriptSrc` proven free of `unsafe-inline`/`unsafe-eval`.
- **Probes** — liveness is dependency-free; readiness returns 200 with a per-dependency breakdown and latency; `/health` keeps its original fields; **503 when Mongo is down**; Redis degraded ≠ failed; **liveness stays 200 while a dependency is down**; a check that throws is reported, not crashed.
- **Checks** — `checkMongo` pings rather than trusting `readyState`, reports a failed ping, and is bounded by its deadline when the ping hangs; `checkRedis` distinguishes disabled / up / degraded; `collectHealth` rolls up UP / DEGRADED / DOWN correctly.
- **Correlation** — id echoed on every response, valid inbound id reused, unsafe inbound id replaced, ids unique per request; `isValidRequestId` accepts/rejects an exhaustive set; `redact` handles case-insensitive keys, nesting, and a cyclic object without recursing forever; `buildLogContext` captures the fields needed to find a request and tolerates an anonymous one.
- **Body limits** — an oversized body on an ordinary route returns 413.

```
tests/securityHealth.test.js  →  55 passed
```

Full server suite:

```
Tests:  482 passed, 3 skipped, 485 total
```

**Pre-existing, unrelated failures** (verified identical on `main` by stashing this branch): 5 Vitest-authored suites Jest cannot load (`Cannot redefine property: Symbol($$jest-matchers-object)` from `@vitest/expect`), and `organizationController.test.js` under vitest (`JWT_SECRET` unset in that env). `npm run test:startup` passes.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors
- [x] `eslint` and `prettier --check` clean

## Screenshots

Not applicable — response headers and JSON probes. `curl -I` output is in the issue.

## Notes for reviewers

- **`/health` response shape is preserved.** `status`, `timestamp` and `env` are unchanged; `dependencies` and `uptimeSeconds` are additive. The only behavioural change is that it can now return 503, which is the point.
- **Adds one dependency:** `helmet` (~1 package, no transitive bloat).
- **Health routes stay ahead of the global rate limiter** — a rate-limited readiness probe would report an instance unhealthy purely because it was being polled.
- **Rollout:** deploy with `CSP_ENFORCE` unset, collect violation reports, then set it to `true`. Point orchestrator probes at `/health/live` and `/health/ready`.
- `LARGE_BODY_ROUTES` is an explicit allow-list (`/api/meetings`, `/api/transcripts`, `/api/sessions`, `/api/policies`). If I've missed a route that genuinely needs a large body, it's a one-line addition — happy to extend it.
- `docs/security-and-health.md` documents the headers, the probe contracts, the env knobs and the rollout.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
