### PR TITLE
fix: improve meeting room video grid responsiveness

### DIFF
--- a/client/src/components/meetings/PeerVideo.jsx
+++ b/client/src/components/meetings/PeerVideo.jsx
@@ -12,7 +12,7 @@ export default function PeerVideo({ peer, userInfo }) {
   }, [peer]);
 
   return (
-    <div className="relative bg-black rounded-2xl overflow-hidden shadow-lg aspect-video flex-1 min-w-[280px] max-w-[600px] border border-gray-800">
+    <div className="relative bg-black rounded-2xl overflow-hidden shadow-lg aspect-video w-full border border-gray-800">
       <video
         playsInline
         autoPlay

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -94,6 +94,14 @@ const MeetingRoom = () => {
     joinMeeting(null);
   };
 
+  const totalParticipants = peers.length + 1;
+  let gridColsClass = "grid-cols-1";
+  if (totalParticipants === 2) gridColsClass = "grid-cols-1 md:grid-cols-2";
+  else if (totalParticipants >= 3 && totalParticipants <= 4) gridColsClass = "grid-cols-2";
+  else if (totalParticipants >= 5 && totalParticipants <= 6) gridColsClass = "grid-cols-2 lg:grid-cols-3";
+  else if (totalParticipants >= 7) gridColsClass = "grid-cols-3 lg:grid-cols-4";
+
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-900 relative overflow-hidden font-sans">
       {/* ---------- DEVICE SETUP / INTRO SCREEN ---------- */}
@@ -138,9 +146,9 @@ const MeetingRoom = () => {
                 showNotes ? "hidden md:flex" : "flex"
               }`}
             >
-              <div className="w-full h-full max-w-5xl flex flex-col md:flex-row gap-6 items-center justify-center min-h-[300px]">
+              <div className={`w-full max-w-7xl grid gap-4 place-content-center items-center min-h-[300px] mx-auto ${gridColsClass}`}>
                 {/* Local Stream */}
-                <div className="relative bg-black rounded-2xl overflow-hidden shadow-lg aspect-video flex-1 min-w-[280px] max-w-[600px] border border-gray-800">
+                <div className="relative bg-black rounded-2xl overflow-hidden shadow-lg aspect-video w-full border border-gray-800">
                   <video
                     ref={userVideoRef}
                     autoPlay


### PR DESCRIPTION
# Pull Request

## Description

Improves the Meeting Room video layout by replacing the fixed Flexbox layout with a responsive CSS Grid that dynamically adapts to the number of participants and screen size.

### Changes Made

- Replaced the participant video layout with a responsive CSS Grid.
- Dynamically calculated the total participant count to determine the optimal grid configuration.
- Scaled video tiles automatically based on the number of participants.
- Removed fixed width constraints from both local and remote participant video tiles to allow them to fill available grid space naturally.
- Increased the maximum grid container width to better utilize large desktop displays.
- Preserved participant overlays, mute indicators, names, and controls.
- Kept the notes sidebar behavior unchanged across desktop, tablet, and mobile layouts.
- Preserved all existing WebRTC, media streaming, and meeting functionality.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [x] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #907

## Testing

### Performed

- Verified the video grid adapts correctly as participants join and leave.
- Verified responsive layouts across desktop, tablet, and mobile screen sizes.
- Verified participant tiles maintain the correct aspect ratio.
- Verified participant names, mute indicators, and controls remain accessible.
- Verified the notes sidebar behavior remains unchanged.
- Verified no WebRTC, signaling, or media streaming functionality was modified.
- Verified `npm run lint` and `npm run build` complete successfully after installing project dependencies.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (responsive layout improvement).

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required (not required for this change)
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
```