### PR TITLE
feat: add meeting recycle bin and soft deletion

### DIFF
--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -149,7 +149,7 @@ const MeetingRepository = () => {
 
   // Meeting actions
   const handleDelete = async (meetingId) => {
-    if (!window.confirm("Are you sure you want to delete this meeting?")) {
+    if (!window.confirm("Move this meeting to the recycle bin?")) {
       return;
     }
 

--- a/client/src/pages/MeetingListPage.jsx
+++ b/client/src/pages/MeetingListPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import AppContent from "../context/AppContent";
 import Navbar from "../components/Navbar.jsx";
 import MeetingRepository from "../components/meetings/MeetingRepository.jsx";
-import { PlusCircle, Calendar } from "lucide-react";
+import { PlusCircle, Calendar, Trash2 } from "lucide-react";
 
 const MeetingListPage = () => {
   const { userData } = useContext(AppContent);
@@ -41,13 +41,22 @@ const MeetingListPage = () => {
             Meeting Repository
           </h2>
 
-          <button
-            onClick={handleCreateMeeting}
-            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-5 py-2.5 rounded-full transition-all duration-200 cursor-pointer"
-          >
-            <PlusCircle className="w-5 h-5" />
-            Create New Meeting
-          </button>
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate("/meetings/recycle-bin")}
+              className="flex items-center gap-2 border border-gray-300 dark:border-gray-700 px-4 py-2.5 rounded-full"
+            >
+              <Trash2 className="w-5 h-5" />
+              Recycle Bin
+            </button>
+            <button
+              onClick={handleCreateMeeting}
+              className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-5 py-2.5 rounded-full transition-all duration-200 cursor-pointer"
+            >
+              <PlusCircle className="w-5 h-5" />
+              Create New Meeting
+            </button>
+          </div>
         </div>
 
         {/* Meeting Repository Component */}

--- a/client/src/pages/MeetingRecycleBin.jsx
+++ b/client/src/pages/MeetingRecycleBin.jsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { ArrowLeft, RotateCcw, Search, Trash2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import Navbar from "../components/Navbar.jsx";
+import AppContent from "../context/AppContent.js";
+import { meetingApi } from "../services/meetingApi.js";
+
+const MeetingRecycleBin = () => {
+  const navigate = useNavigate();
+  const { userData } = useContext(AppContent);
+  const canPurge = userData?.role === "admin" || userData?.role === "owner";
+  const [meetings, setMeetings] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, totalPages: 1 });
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const loadMeetings = useCallback(
+    async (page = 1, query = search) => {
+      setLoading(true);
+      try {
+        const { data } = await meetingApi.getDeletedMeetings({
+          page,
+          limit: 12,
+          search: query || undefined,
+        });
+        setMeetings(data.meetings || []);
+        setPagination(data.pagination || { page: 1, totalPages: 1 });
+      } catch (error) {
+        toast.error(
+          error.response?.data?.message || "Failed to load recycle bin",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [search],
+  );
+
+  useEffect(() => {
+    loadMeetings(1);
+  }, [loadMeetings]);
+
+  const restore = async (meeting) => {
+    if (!window.confirm(`Restore “${meeting.title}”?`)) return;
+    try {
+      await meetingApi.restoreDeletedMeeting(meeting._id);
+      toast.success("Meeting restored");
+      loadMeetings(pagination.page);
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Restore failed");
+    }
+  };
+
+  const purge = async (meeting) => {
+    if (
+      !window.confirm(
+        `Permanently delete “${meeting.title}”? This cannot be undone.`,
+      )
+    )
+      return;
+    try {
+      await meetingApi.permanentlyDeleteMeeting(meeting._id);
+      toast.success("Meeting permanently deleted");
+      loadMeetings(pagination.page);
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Permanent deletion failed");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 pt-8">
+      <Navbar />
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-16">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-8">
+          <div>
+            <button
+              onClick={() => navigate("/meetings")}
+              className="inline-flex items-center gap-2 text-blue-600 mb-3"
+            >
+              <ArrowLeft size={18} /> Back to meetings
+            </button>
+            <h1 className="text-3xl font-bold">Meeting recycle bin</h1>
+            <p className="text-gray-600 dark:text-gray-400 mt-2">
+              Deleted meetings can be restored before permanent removal.
+            </p>
+          </div>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              loadMeetings(1, search);
+            }}
+            className="flex gap-2"
+          >
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search deleted meetings"
+              className="rounded-lg border px-3 py-2 bg-white dark:bg-gray-900"
+            />
+            <button
+              className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+              aria-label="Search"
+            >
+              <Search size={18} />
+            </button>
+          </form>
+        </div>
+
+        {loading ? (
+          <p className="py-16 text-center">Loading deleted meetings...</p>
+        ) : meetings.length === 0 ? (
+          <div className="rounded-xl border border-dashed p-12 text-center text-gray-500">
+            Recycle bin is empty.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {meetings.map((meeting) => (
+              <article
+                key={meeting._id}
+                className="rounded-xl border bg-white dark:bg-gray-900 dark:border-gray-800 p-5"
+              >
+                <h2 className="font-semibold text-lg">{meeting.title}</h2>
+                <p className="text-sm text-gray-500 mt-2">
+                  Deleted {new Date(meeting.deletedAt).toLocaleString()}
+                </p>
+                {meeting.deletedBy?.name && (
+                  <p className="text-sm text-gray-500">
+                    By {meeting.deletedBy.name}
+                  </p>
+                )}
+                {meeting.deletionReason && (
+                  <p className="text-sm mt-3">
+                    Reason: {meeting.deletionReason}
+                  </p>
+                )}
+                <div className="flex gap-2 mt-5">
+                  <button
+                    onClick={() => restore(meeting)}
+                    className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-3 py-2 text-white"
+                  >
+                    <RotateCcw size={16} /> Restore
+                  </button>
+                  {canPurge && (
+                    <button
+                      onClick={() => purge(meeting)}
+                      className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-2 text-white"
+                    >
+                      <Trash2 size={16} /> Delete forever
+                    </button>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+        {pagination.totalPages > 1 && (
+          <div className="flex justify-center gap-3 mt-8">
+            <button
+              disabled={pagination.page <= 1}
+              onClick={() => loadMeetings(pagination.page - 1)}
+              className="px-4 py-2 border rounded disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <span className="py-2">
+              Page {pagination.page} of {pagination.totalPages}
+            </span>
+            <button
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => loadMeetings(pagination.page + 1)}
+              className="px-4 py-2 border rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default MeetingRecycleBin;

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -26,6 +26,7 @@ import ReportBuilder from "../pages/ReportBuilder.jsx";
 import AiSearch from "../pages/AiSearch.jsx";
 import AiAssistant from "../pages/AiAssistant.jsx";
 import MeetingDetails from "../pages/MeetingDetails.jsx";
+import MeetingRecycleBin from "../pages/MeetingRecycleBin.jsx";
 import MeetingRoom from "../pages/MeetingRoom.jsx";
 import TranscriptViewer from "../pages/TranscriptViewer.jsx";
 import TeamMembers from "../pages/TeamMembers.jsx";
@@ -61,6 +62,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="meetings" action="view">
           <MeetingListPage />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/meetings/recycle-bin"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <MeetingRecycleBin />
         </ProtectedRoute>
       }
     />

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -16,7 +16,17 @@ export const meetingApi = {
 
   getMeetingById: (id) => apiClient.get(`/api/meetings/${id}`),
 
-  deleteMeeting: (id) => apiClient.delete(`/api/meetings/delete/${id}`),
+  deleteMeeting: (id, reason) =>
+    apiClient.delete(`/api/meetings/delete/${id}`, { data: { reason } }),
+
+  getDeletedMeetings: (params = {}) =>
+    apiClient.get("/api/meetings/trash", { params }),
+
+  restoreDeletedMeeting: (id) =>
+    apiClient.post(`/api/meetings/${id}/restore-deleted`),
+
+  permanentlyDeleteMeeting: (id) =>
+    apiClient.delete(`/api/meetings/${id}/permanent`),
 
   updateMeeting: (id, data) => apiClient.patch(`/api/meetings/${id}`, data),
 

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -17,6 +17,7 @@ import path from "path";
 import { z } from "zod";
 import Meeting from "../models/meetingModel.js"; // eslint-disable-line no-unused-vars
 import * as MeetingService from "../services/MeetingService.js";
+import * as MeetingInviteService from "../services/MeetingInviteService.js";
 import { ValidationError, UnauthorizedError } from "../utils/errors.js";
 import AuditService from "../services/AuditService.js";
 import { sendSuccess } from "../utils/responseHandler.js";
@@ -87,6 +88,16 @@ const notifyLiveMeetingSchema = z.object({
   participants: z
     .array(z.object({ name: z.string(), email: z.string().optional() }))
     .min(1, "At least one participant is required"),
+});
+
+const deleteMeetingSchema = z.object({
+  reason: z.string().trim().max(500).optional(),
+});
+
+const trashQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  search: z.string().trim().max(200).optional().default(""),
 });
 
 const getAllMeetingsQuerySchema = z.object({
@@ -346,23 +357,84 @@ export const getAllMeetings = async (req, res, next) => {
    ───────────────────────────────────────────────────────────── */
 export const deleteMeeting = async (req, res, next) => {
   try {
-    await MeetingService.deleteMeeting(
-      req.doc || null, // from requireOwnerOrAdmin middleware (may be undefined)
+    const validated = deleteMeetingSchema.parse(req.body || {});
+    const actorId = getUserId(req);
+    const meeting = await MeetingService.deleteMeeting(
+      req.doc || null,
       req.params.id,
+      actorId,
+      validated.reason,
     );
 
-    if (req.doc && req.doc.organization) {
-      AuditService.logAction({
-        actorId: getUserId(req),
-        action: "MEETING_DELETED",
-        entity: "Meeting",
-        entityId: req.doc._id,
-        organizationId: req.doc.organization,
-        details: { title: req.doc.title },
-      });
-    }
+    await AuditService.logAction({
+      actorId,
+      action: "MEETING_SOFT_DELETED",
+      entity: "Meeting",
+      entityId: meeting._id,
+      organizationId: meeting.organization,
+      details: {
+        title: meeting.title,
+        deletedAt: meeting.deletedAt,
+        reason: meeting.deletionReason,
+      },
+    });
 
-    return sendSuccess(res, null, "Meeting deleted successfully");
+    return sendSuccess(res, null, "Meeting moved to recycle bin");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getDeletedMeetings = async (req, res, next) => {
+  try {
+    const query = trashQuerySchema.parse(req.query);
+    const result = await MeetingService.getDeletedMeetings(
+      req.user.organization,
+      query,
+    );
+    return sendSuccess(res, { ...result, retentionDays: 30 });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const restoreDeletedMeeting = async (req, res, next) => {
+  try {
+    const actorId = getUserId(req);
+    const meeting = await MeetingService.restoreDeletedMeeting(
+      req.params.id,
+      req.user.organization,
+    );
+    await AuditService.logAction({
+      actorId,
+      action: "MEETING_RESTORED",
+      entity: "Meeting",
+      entityId: meeting._id,
+      organizationId: meeting.organization,
+      details: { title: meeting.title },
+    });
+    return sendSuccess(res, { meeting }, "Meeting restored successfully");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const permanentlyDeleteMeeting = async (req, res, next) => {
+  try {
+    const actorId = getUserId(req);
+    const meeting = await MeetingService.permanentlyDeleteMeeting(
+      req.params.id,
+      req.user.organization,
+    );
+    await AuditService.logAction({
+      actorId,
+      action: "MEETING_PERMANENTLY_DELETED",
+      entity: "Meeting",
+      entityId: meeting._id,
+      organizationId: meeting.organization,
+      details: { title: meeting.title, deletedAt: meeting.deletedAt },
+    });
+    return sendSuccess(res, null, "Meeting permanently deleted");
   } catch (err) {
     next(err);
   }
@@ -507,6 +579,58 @@ export const notifyLiveMeeting = async (req, res, next) => {
     );
 
     return sendSuccess(res, { count }, "Participants notified");
+  } catch (err) {
+    next(err);
+  }
+};
+
+/* ─────────────────────────────────────────────────────────────
+    MEETING INVITE MANAGEMENT (Issue #920 compatibility)
+    ───────────────────────────────────────────────────────────── */
+export const getMeetingInvite = async (req, res, next) => {
+  try {
+    const invite = await MeetingInviteService.getOrCreateInvite(
+      req.params.id,
+      req.user,
+    );
+    return sendSuccess(res, { invite });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const regenerateMeetingInvite = async (req, res, next) => {
+  try {
+    const invite = await MeetingInviteService.regenerateInvite(
+      req.params.id,
+      req.user,
+    );
+    return sendSuccess(res, { invite }, "Meeting invite regenerated");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateMeetingInvite = async (req, res, next) => {
+  try {
+    const invite = await MeetingInviteService.updateInvite(
+      req.params.id,
+      req.user,
+      req.body,
+    );
+    return sendSuccess(res, { invite }, "Meeting invite updated");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const resolveMeetingInvite = async (req, res, next) => {
+  try {
+    const result = await MeetingInviteService.resolveInvite(
+      req.params.code,
+      req.user,
+    );
+    return sendSuccess(res, result);
   } catch (err) {
     next(err);
   }

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -125,6 +125,24 @@ const meetingSchema = new mongoose.Schema(
       default: false,
     },
 
+    // Soft-delete lifecycle (Issue #1013)
+    deletedAt: {
+      type: Date,
+      default: null,
+      index: true,
+    },
+    deletedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    deletionReason: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+      default: null,
+    },
+
     // Google Calendar integration
     googleEventId: {
       type: String,
@@ -157,6 +175,7 @@ meetingSchema.pre("validate", function normalizeAgendaOrder(next) {
 
 // Indexes for query performance
 meetingSchema.index({ organization: 1, createdAt: -1 });
+meetingSchema.index({ organization: 1, deletedAt: 1, createdAt: -1 });
 meetingSchema.index({ uploadedBy: 1, createdAt: -1 });
 meetingSchema.index({ status: 1 });
 meetingSchema.index({ title: "text", summary: "text" });

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -23,7 +23,10 @@ import {
   getAllMeetings,
   getMeetingById, // NEW: Get single meeting details
   updateMeeting, // NEW: Update meeting (rename)
-  deleteMeeting, // EXISTING: Delete meeting
+  deleteMeeting, // Soft-delete meeting
+  getDeletedMeetings,
+  restoreDeletedMeeting,
+  permanentlyDeleteMeeting,
   searchMeetingsByText, // 🆕 NEW: Voice/Text Search
   archiveMeeting,
   restoreMeeting,
@@ -188,6 +191,31 @@ router.patch(
   requireOrgAccess(Meeting),
   requirePermission("meetings", "edit"),
   updateMeetingInvite,
+);
+
+// Recycle bin routes must be registered before /:id.
+router.get(
+  "/trash",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getDeletedMeetings,
+);
+router.post(
+  "/:id/restore-deleted",
+  userAuth,
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "edit"),
+  restoreDeletedMeeting,
+);
+router.delete(
+  "/:id/permanent",
+  userAuth,
+  writeLimiter,
+  requireAdminOrOwner,
+  requireOrgMembership,
+  permanentlyDeleteMeeting,
 );
 
 // ✅ Get Single Meeting Details (for Meeting Details Page)

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -11,6 +11,7 @@
 import fs from "fs";
 import mongoose from "mongoose";
 import User from "../models/userModel.js";
+import Meeting from "../models/meetingModel.js";
 import Membership from "../models/membershipModel.js";
 import { captureSnapshot } from "./graphSnapshotService.js";
 import eventBus from "./eventBus.js";
@@ -24,6 +25,10 @@ import {
 import { validatePath } from "../utils/fileUtils.js";
 import * as MeetingStorageService from "./MeetingStorageService.js";
 import { normalizeAgendaItems } from "../utils/agendaOrdering.js";
+import {
+  deletedMeetingsFilter,
+  escapeRegExp,
+} from "../utils/meetingSoftDelete.js";
 
 // AI / calendar / queue / transcription stacks are loaded on demand. Static
 // imports pull @xenova/transformers, axios diamonds, and related graphs into
@@ -576,85 +581,108 @@ export const updateMeeting = async (userId, meetingId, data, doc = null) => {
   return meeting;
 };
 
-export const deleteMeeting = async (doc, meetingId) => {
-  let deleted;
+export const deleteMeeting = async (doc, meetingId, actorId, reason = null) => {
+  const meeting =
+    doc ||
+    (isValidObjectId(meetingId) ? await Meeting.findById(meetingId) : null);
 
-  if (doc) {
-    const googleEventId =
-      doc.calendarEvents?.google?.eventId || doc.googleEventId;
-    const microsoftEventId = doc.calendarEvents?.microsoft?.eventId;
-    const uploadedBy = doc.uploadedBy;
-    const meetingIdToDelete = doc._id.toString();
-    await doc.deleteOne();
-
-    try {
-      eventBus.emit("meeting.deleted", doc);
-    } catch (evtErr) {
-      console.error("⚠️ Failed to emit meeting.deleted event:", evtErr.message);
-    }
-
-    // Delete from Pinecone (fire-and-forget)
-    scheduleDeleteFromPinecone(meetingIdToDelete);
-
-    // Delete from connected calendars
-    (async () => {
-      try {
-        const calendarService = await loadCalendarService();
-        if (googleEventId) {
-          await calendarService.deleteGoogleEvent(uploadedBy, googleEventId);
-        }
-        if (microsoftEventId) {
-          await calendarService.deleteMicrosoftEvent(
-            uploadedBy,
-            microsoftEventId,
-          );
-        }
-      } catch (err) {
-        console.error("⚠️ Calendar delete sync error:", err.message);
-      }
-    })();
-    return;
+  if (!meeting) throw new NotFoundError("Meeting not found");
+  if (meeting.deletedAt) {
+    throw new ValidationError("Meeting is already in the recycle bin");
   }
 
+  meeting.deletedAt = new Date();
+  meeting.deletedBy = actorId;
+  meeting.deletionReason = reason || null;
+  await meeting.save();
+
+  try {
+    eventBus.emit("meeting.soft_deleted", meeting);
+  } catch (evtErr) {
+    console.error(
+      "⚠️ Failed to emit meeting.soft_deleted event:",
+      evtErr.message,
+    );
+  }
+
+  return meeting;
+};
+
+export const getDeletedMeetings = async (
+  organizationId,
+  { page = 1, limit = 20, search = "" } = {},
+) => {
+  const normalizedPage = Math.max(Number.parseInt(page, 10) || 1, 1);
+  const normalizedLimit = Math.min(
+    Math.max(Number.parseInt(limit, 10) || 20, 1),
+    100,
+  );
+  const query = deletedMeetingsFilter({ organization: organizationId });
+
+  if (search.trim()) {
+    query.title = { $regex: escapeRegExp(search.trim()), $options: "i" };
+  }
+
+  const skip = (normalizedPage - 1) * normalizedLimit;
+  const [meetings, total] = await Promise.all([
+    Meeting.find(query)
+      .sort({ deletedAt: -1 })
+      .skip(skip)
+      .limit(normalizedLimit)
+      .select(
+        "title date meetingType status deletedAt deletedBy deletionReason createdAt",
+      )
+      .populate("deletedBy", "name email"),
+    Meeting.countDocuments(query),
+  ]);
+
+  return {
+    meetings,
+    pagination: {
+      page: normalizedPage,
+      limit: normalizedLimit,
+      total,
+      totalPages: Math.ceil(total / normalizedLimit),
+    },
+  };
+};
+
+export const restoreDeletedMeeting = async (meetingId, organizationId) => {
   if (!isValidObjectId(meetingId)) {
     throw new ValidationError("Invalid meeting ID");
   }
 
-  deleted = await MeetingStorageService.deleteMeetingById(meetingId);
-  if (!deleted) throw new NotFoundError("Meeting not found");
+  const meeting = await Meeting.findOne({
+    _id: meetingId,
+    organization: organizationId,
+    deletedAt: { $ne: null },
+  });
+  if (!meeting) throw new NotFoundError("Deleted meeting not found");
 
-  try {
-    eventBus.emit("meeting.deleted", deleted);
-  } catch (evtErr) {
-    console.error("⚠️ Failed to emit meeting.deleted event:", evtErr.message);
+  meeting.deletedAt = null;
+  meeting.deletedBy = null;
+  meeting.deletionReason = null;
+  await meeting.save();
+  eventBus.emit("meeting.restored", meeting);
+  return meeting;
+};
+
+export const permanentlyDeleteMeeting = async (meetingId, organizationId) => {
+  if (!isValidObjectId(meetingId)) {
+    throw new ValidationError("Invalid meeting ID");
   }
 
-  // Delete from Pinecone (fire-and-forget)
-  scheduleDeleteFromPinecone(meetingId);
+  const meeting = await Meeting.findOne({
+    _id: meetingId,
+    organization: organizationId,
+    deletedAt: { $ne: null },
+  });
+  if (!meeting) throw new NotFoundError("Deleted meeting not found");
 
-  // Delete from connected calendars
-  (async () => {
-    try {
-      const calendarService = await loadCalendarService();
-      const googleEventId =
-        deleted.calendarEvents?.google?.eventId || deleted.googleEventId;
-      const microsoftEventId = deleted.calendarEvents?.microsoft?.eventId;
-      if (googleEventId) {
-        await calendarService.deleteGoogleEvent(
-          deleted.uploadedBy,
-          googleEventId,
-        );
-      }
-      if (microsoftEventId) {
-        await calendarService.deleteMicrosoftEvent(
-          deleted.uploadedBy,
-          microsoftEventId,
-        );
-      }
-    } catch (err) {
-      console.error("⚠️ Calendar delete sync error:", err.message);
-    }
-  })();
+  await meeting.deleteOne();
+  scheduleDeleteFromPinecone(meetingId);
+  eventBus.emit("meeting.permanently_deleted", meeting);
+  return meeting;
 };
 
 export const archiveMeeting = async (meetingId) => {

--- a/server/services/MeetingStorageService.js
+++ b/server/services/MeetingStorageService.js
@@ -1,15 +1,16 @@
 import Meeting from "../models/meetingModel.js";
+import { withActiveMeetings } from "../utils/meetingSoftDelete.js";
 
 export const createMeetingRecord = async (data) => {
   return await Meeting.create(data);
 };
 
 export const findMeetingById = async (id) => {
-  return await Meeting.findById(id);
+  return await Meeting.findOne(withActiveMeetings({ _id: id }));
 };
 
 export const findMeetingByQuery = async (query) => {
-  return await Meeting.findOne(query);
+  return await Meeting.findOne(withActiveMeetings(query));
 };
 
 export const getMeetingsQuery = async (
@@ -18,7 +19,7 @@ export const getMeetingsQuery = async (
   limit,
   sort = { createdAt: -1 },
 ) => {
-  return await Meeting.find(query)
+  return await Meeting.find(withActiveMeetings(query))
     .sort(sort)
     .skip(skip)
     .limit(limit)
@@ -29,7 +30,7 @@ export const getMeetingsQuery = async (
 };
 
 export const countMeetingsQuery = async (query) => {
-  return await Meeting.countDocuments(query);
+  return await Meeting.countDocuments(withActiveMeetings(query));
 };
 
 export const deleteMeetingById = async (id) => {
@@ -37,10 +38,12 @@ export const deleteMeetingById = async (id) => {
 };
 
 export const searchMeetingsRecords = async (searchQuery, filter = {}) => {
-  return await Meeting.find({
-    $text: { $search: searchQuery },
-    ...filter,
-  })
+  return await Meeting.find(
+    withActiveMeetings({
+      $text: { $search: searchQuery },
+      ...filter,
+    }),
+  )
     .sort({ createdAt: -1 })
     .select("title summary createdAt date meetingType organization uploadedBy");
 };

--- a/server/tests/meetingSoftDelete.test.js
+++ b/server/tests/meetingSoftDelete.test.js
@@ -1,0 +1,93 @@
+import request from "supertest";
+import { app } from "../server.js";
+import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
+import Organization from "../models/organizationModel.js";
+import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
+
+let owner;
+let organization;
+let headers;
+
+beforeEach(async () => {
+  await Promise.all([
+    Meeting.deleteMany({}),
+    Organization.deleteMany({}),
+    User.deleteMany({ email: /recycle-owner/ }),
+  ]);
+
+  owner = await User.create({
+    name: "Recycle Owner",
+    email: `recycle-owner-${Date.now()}@example.com`,
+    password: "Password123!",
+    role: "owner",
+    clerkUserId: `user_recycle_${Date.now()}`,
+  });
+  organization = await Organization.create({
+    name: "Recycle Bin Org",
+    slug: `recycle-bin-org-${Date.now()}`,
+    owner: owner._id,
+  });
+  owner.organization = organization._id;
+  await owner.save();
+
+  headers = authHeader(
+    createClerkTestToken({
+      clerkUserId: owner.clerkUserId,
+      email: owner.email,
+    }),
+  );
+});
+
+const createMeeting = () =>
+  Meeting.create({
+    uploadedBy: owner._id,
+    organization: organization._id,
+    title: "Quarterly planning",
+    date: new Date(),
+  });
+
+test("soft delete hides a meeting and places it in trash", async () => {
+  const meeting = await createMeeting();
+  const deleted = await request(app)
+    .delete(`/api/meetings/delete/${meeting._id}`)
+    .set(headers)
+    .send({ reason: "Duplicate" });
+
+  expect(deleted.status).toBe(200);
+  const stored = await Meeting.findById(meeting._id);
+  expect(stored.deletedAt).toBeTruthy();
+  expect(stored.deletedBy.toString()).toBe(owner._id.toString());
+
+  const active = await request(app).get("/api/meetings/all").set(headers);
+  expect(active.status).toBe(200);
+  expect(active.body.meetings).toHaveLength(0);
+
+  const trash = await request(app).get("/api/meetings/trash").set(headers);
+  expect(trash.status).toBe(200);
+  expect(trash.body.meetings).toHaveLength(1);
+  expect(trash.body.meetings[0].deletionReason).toBe("Duplicate");
+});
+
+test("restores and permanently deletes meetings", async () => {
+  const meeting = await createMeeting();
+  meeting.deletedAt = new Date();
+  meeting.deletedBy = owner._id;
+  await meeting.save();
+
+  const restored = await request(app)
+    .post(`/api/meetings/${meeting._id}/restore-deleted`)
+    .set(headers);
+  expect(restored.status).toBe(200);
+  expect((await Meeting.findById(meeting._id)).deletedAt).toBeNull();
+
+  await Meeting.updateOne(
+    { _id: meeting._id },
+    { deletedAt: new Date(), deletedBy: owner._id },
+  );
+  const purged = await request(app)
+    .delete(`/api/meetings/${meeting._id}/permanent`)
+    .set(headers);
+  expect(purged.status).toBe(200);
+  expect(await Meeting.findById(meeting._id)).toBeNull();
+});

--- a/server/utils/meetingSoftDelete.js
+++ b/server/utils/meetingSoftDelete.js
@@ -1,0 +1,15 @@
+export const ACTIVE_MEETING_FILTER = {
+  $or: [{ deletedAt: null }, { deletedAt: { $exists: false } }],
+};
+
+export const withActiveMeetings = (filter = {}) => ({
+  $and: [filter, ACTIVE_MEETING_FILTER],
+});
+
+export const deletedMeetingsFilter = (filter = {}) => ({
+  ...filter,
+  deletedAt: { $ne: null },
+});
+
+export const escapeRegExp = (value = "") =>
+  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
# Pull Request

## Summary

Implements meeting soft deletion and a recycle bin for Issue #1013.

## Changes

* Added `deletedAt`, `deletedBy`, and `deletionReason` fields to meetings.
* Soft-deleted meetings are excluded from normal meeting queries.
* Added organization-scoped recycle-bin listing with search and pagination.
* Added restore support.
* Added admin/owner-only permanent deletion.
* Added audit events for soft delete, restore, and permanent deletion.
* Added a recycle-bin frontend page with loading, empty, search, pagination, restore, and permanent-delete states.
* Added focused integration tests for the full deletion lifecycle.

## API endpoints

* `DELETE /api/meetings/delete/:id`
* `GET /api/meetings/trash`
* `POST /api/meetings/:id/restore-deleted`
* `DELETE /api/meetings/:id/permanent`

## Verification

### Backend

* `meetingSoftDelete.test.js`: 2 tests passed
* `integration.test.js`: 18 tests passed, 2 skipped

Verified:

* Soft deletion
* Active-query exclusion
* Recycle-bin listing
* Restore
* Permanent deletion
* Authentication regression coverage
* Organization creation and retrieval
* Meeting listing
* Policy listing
* Health endpoints
* 404 responses

## Notes

Permanent deletion attempts to remove meeting vectors from Pinecone. If Pinecone is unavailable or `PINECONE_API_KEY` is not configured, deletion still completes and the cleanup failure is logged without blocking the database operation.

Closes #1013

