### PR TITLE
fix(activity): resolve organization lookup for activity feed

### DIFF
--- a/server/controllers/activityController.js
+++ b/server/controllers/activityController.js
@@ -6,7 +6,8 @@ import * as activityService from "../services/activityService.js";
  */
 export const getActivities = async (req, res) => {
   try {
-    const orgId = req.user.currentOrganization;
+    const orgId = req.user.organization;
+
     if (!orgId) {
       return res.status(400).json({ error: "No organization selected." });
     }
@@ -14,8 +15,8 @@ export const getActivities = async (req, res) => {
     const { page, limit, action, actor } = req.query;
 
     const result = await activityService.getOrgActivities(orgId, {
-      page: parseInt(page) || 1,
-      limit: parseInt(limit) || 20,
+      page: parseInt(page, 10) || 1,
+      limit: parseInt(limit, 10) || 20,
       action,
       actor,
     });
@@ -33,7 +34,8 @@ export const getActivities = async (req, res) => {
  */
 export const getActivityStats = async (req, res) => {
   try {
-    const orgId = req.user.currentOrganization;
+    const orgId = req.user.organization;
+
     if (!orgId) {
       return res.status(400).json({ error: "No organization selected." });
     }


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes the activity feed organization lookup by replacing the outdated `currentOrganization` reference with the correct `organization` property from the authenticated user.

### Changes made

- Updated the activity controller to use `req.user.organization` when resolving the user's organization.
- Fixed false "No organization selected" errors for users who already belong to an organization.
- Preserved the existing authorization flow and activity feed behavior.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #812

## Testing

Validated locally by running:

- `npm run format:check:changed --prefix server`
- `npm run lint:changed --prefix server`
- `npm run validate:pr --prefix server`
- `git diff --check`

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (backend-only change).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity retrieval by using the authenticated user’s organization context.
  * Ensured activity pagination values are interpreted consistently as decimal numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->