### PR TITLE
fix: missing /api prefix in comparisonApi and meetingSeriesApi

### DIFF
--- a/client/src/services/__tests__/apiPrefix.test.js
+++ b/client/src/services/__tests__/apiPrefix.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import api from "../apiClient";
+import { compareMeetings, getComparableMeetings } from "../comparisonApi";
+import { meetingSeriesApi } from "../meetingSeriesApi";
+
+vi.mock("../apiClient", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("API Services Endpoint Prefix (#803)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("comparisonApi", () => {
+    it("should call /api/comparison/compare for compareMeetings", async () => {
+      api.post.mockResolvedValueOnce({ data: { result: "success" } });
+      await compareMeetings("m1", "m2");
+      expect(api.post).toHaveBeenCalledWith("/api/comparison/compare", {
+        meetingIdA: "m1",
+        meetingIdB: "m2",
+      });
+    });
+
+    it("should call /api/comparison/comparable/:meetingId for getComparableMeetings", async () => {
+      api.get.mockResolvedValueOnce({ data: [] });
+      await getComparableMeetings("m1");
+      expect(api.get).toHaveBeenCalledWith("/api/comparison/comparable/m1");
+    });
+  });
+
+  describe("meetingSeriesApi", () => {
+    it("should call /api/meeting-series for createSeries", async () => {
+      meetingSeriesApi.createSeries({ name: "Weekly Sync" });
+      expect(api.post).toHaveBeenCalledWith("/api/meeting-series", {
+        name: "Weekly Sync",
+      });
+    });
+
+    it("should call /api/meeting-series/:id for getSeriesById", async () => {
+      meetingSeriesApi.getSeriesById("s1");
+      expect(api.get).toHaveBeenCalledWith("/api/meeting-series/s1");
+    });
+
+    it("should call /api/meeting-series/:id/meetings with pagination for getSeriesMeetings", async () => {
+      meetingSeriesApi.getSeriesMeetings("s1", 2, 10);
+      expect(api.get).toHaveBeenCalledWith(
+        "/api/meeting-series/s1/meetings?page=2&limit=10",
+      );
+    });
+
+    it("should call /api/meeting-series/:id/cancel for cancelSeries", async () => {
+      meetingSeriesApi.cancelSeries("s1");
+      expect(api.patch).toHaveBeenCalledWith("/api/meeting-series/s1/cancel");
+    });
+  });
+});

--- a/client/src/services/comparisonApi.js
+++ b/client/src/services/comparisonApi.js
@@ -1,6 +1,6 @@
 import api from "./apiClient";
 
-const COMPARISON_URL = "/comparison";
+const COMPARISON_URL = "/api/comparison";
 
 // Compare two meetings
 export const compareMeetings = async (meetingIdA, meetingIdB) => {

--- a/client/src/services/meetingSeriesApi.js
+++ b/client/src/services/meetingSeriesApi.js
@@ -1,9 +1,9 @@
 import api from "./apiClient";
 
 export const meetingSeriesApi = {
-  createSeries: (data) => api.post("/meeting-series", data),
-  getSeriesById: (id) => api.get(`/meeting-series/${id}`),
+  createSeries: (data) => api.post("/api/meeting-series", data),
+  getSeriesById: (id) => api.get(`/api/meeting-series/${id}`),
   getSeriesMeetings: (id, page = 1, limit = 20) =>
-    api.get(`/meeting-series/${id}/meetings?page=${page}&limit=${limit}`),
-  cancelSeries: (id) => api.patch(`/meeting-series/${id}/cancel`),
+    api.get(`/api/meeting-series/${id}/meetings?page=${page}&limit=${limit}`),
+  cancelSeries: (id) => api.patch(`/api/meeting-series/${id}/cancel`),
 };


### PR DESCRIPTION
# 🐞 Fix Missing /api Prefix in comparisonApi and meetingSeriesApi

Fixes #803

## 📌 Description
The frontend API services `comparisonApi` and `meetingSeriesApi` were issuing HTTP requests targeting `/comparison` and `/meeting-series` paths instead of `/api/comparison` and `/api/meeting-series`. In environments without a custom route-rewriting proxy, these API calls resulted in `404 Not Found` errors.

## 🛠️ Changes Made
- **[comparisonApi.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/services/comparisonApi.js)**: Updated `COMPARISON_URL` from `/comparison` to `/api/comparison`.
- **[meetingSeriesApi.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/services/meetingSeriesApi.js)**: Updated endpoint paths to prefix `/api/meeting-series` across `createSeries`, `getSeriesById`, `getSeriesMeetings`, and `cancelSeries`.
- **[apiPrefix.test.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/services/__tests__/apiPrefix.test.js)**: Added unit test suite ensuring all endpoint paths include `/api` prefix.

## 🧪 Testing & Verification
- Ran vitest unit tests (`npx vitest run client/src/services/__tests__/apiPrefix.test.js`): 6/6 tests passed.
- Ran Prettier code formatting (`npm run format:check:changed`): Clean pass.
- Ran ESLint check (`npm run lint:changed`): Clean pass.

## ✅ Checklist
- [x] Related issue linked (`Fixes #803`).
- [x] All comparison API calls succeed with `/api/comparison`.
- [x] All meeting series API calls succeed with `/api/meeting-series`.
- [x] Unit test suite added and passing.
- [x] Code passes formatting and linting rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated comparison and meeting-series requests to use the correct API endpoint paths.
  * Improved reliability for comparison, meeting-series, meeting listing, and cancellation operations.

* **Tests**
  * Added coverage to verify request methods, paths, payloads, and pagination parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->