### PR TITLE
fix: prevent cross-tenant leakage in voice search

### DIFF
--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -517,10 +517,11 @@ export const voiceSearch = async (req, res) => {
       });
     }
 
-    // Filter results to include only those from user's organization
+    // Filter results to include only those belonging to user's organization (fail closed)
+    const userOrg = req.user?.organization?.toString();
     const filteredResults = results.filter((r) => {
-      if (!r.organization) return true; // Allow results without org
-      return r.organization === req.user.organization?.toString();
+      if (!r.organization || !userOrg) return false;
+      return r.organization.toString() === userOrg;
     });
 
     res.status(200).json({

--- a/server/tests/voiceSearchTenantIsolation.test.js
+++ b/server/tests/voiceSearchTenantIsolation.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openai", () => {
+  return {
+    default: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  };
+});
+
+vi.mock("../utils/embeddingUtils.js", () => ({
+  searchVectorStore: vi.fn(),
+  indexTranscript: vi.fn(),
+  indexMeeting: vi.fn(),
+}));
+
+import { voiceSearch } from "../controllers/transcriptController.js";
+import * as embeddingUtils from "../utils/embeddingUtils.js";
+
+describe("Voice Search Tenant Isolation (#805)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should fail closed and exclude records missing organization", async () => {
+    const mockResults = [
+      { id: "1", title: "Org A Meeting", organization: "org-123" },
+      { id: "2", title: "Unscoped Meeting", organization: null },
+      { id: "3", title: "Undefined Org Meeting" },
+    ];
+
+    vi.spyOn(embeddingUtils, "searchVectorStore").mockResolvedValue(
+      mockResults,
+    );
+
+    const req = {
+      query: { query: "search terms" },
+      user: { id: "user-1", organization: "org-123" },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await voiceSearch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        results: [{ id: "1", title: "Org A Meeting", organization: "org-123" }],
+      }),
+    );
+  });
+
+  it("should exclude records belonging to a different organization", async () => {
+    const mockResults = [
+      { id: "1", title: "Org A Meeting", organization: "org-123" },
+      { id: "2", title: "Org B Meeting", organization: "org-456" },
+    ];
+
+    vi.spyOn(embeddingUtils, "searchVectorStore").mockResolvedValue(
+      mockResults,
+    );
+
+    const req = {
+      query: { query: "search terms" },
+      user: { id: "user-1", organization: "org-123" },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await voiceSearch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        results: [{ id: "1", title: "Org A Meeting", organization: "org-123" }],
+      }),
+    );
+  });
+
+  it("should return empty array if user has no organization context", async () => {
+    const mockResults = [
+      { id: "1", title: "Org A Meeting", organization: "org-123" },
+      { id: "2", title: "Unscoped Meeting", organization: null },
+    ];
+
+    vi.spyOn(embeddingUtils, "searchVectorStore").mockResolvedValue(
+      mockResults,
+    );
+
+    const req = {
+      query: { query: "search terms" },
+      user: { id: "user-1", organization: null },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await voiceSearch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        results: [],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# 🔐 Prevent Cross-Tenant Leakage in Voice Search

Fixes #805

## 📌 Description
Voice search previously contained a fail-open check (`if (!r.organization) return true;`) in `voiceSearch`, which allowed vector search results missing an `organization` field to bypass tenant filtering. This posed a security risk of exposing unscoped vector search embeddings across tenants.

## 🛠️ Changes Made
- **[transcriptController.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/controllers/transcriptController.js)**: Updated `voiceSearch` filtering logic to fail closed. Results without an `organization` field or results that do not strictly match `req.user.organization` are immediately excluded.
- **[voiceSearchTenantIsolation.test.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/tests/voiceSearchTenantIsolation.test.js)**: Added unit test suite asserting fail-closed behavior for unscoped records and strict cross-tenant filtering.

## 🧪 Testing & Verification
- Ran vitest unit tests (`npx vitest run server/tests/voiceSearchTenantIsolation.test.js`): 3/3 tests passed.
- Verified that unscoped records and cross-tenant records are excluded.
- Ran Prettier code formatting (`npm run format:check:changed`): Clean pass.
- Ran ESLint check (`npm run lint:changed`): Clean pass.

## ✅ Checklist
- [x] Related issue linked (`Fixes #805`).
- [x] Records missing organization field fail closed and are excluded.
- [x] Cross-tenant results are strictly filtered out.
- [x] Unit test suite added and passing.
- [x] Code passes formatting and linting rules.
