### PR TITLE
fix: scope RAG assistant socket responses to requesting client

### DIFF
--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -125,15 +125,25 @@ router.post("/sessions/:id/message", messageLimiter, async (req, res) => {
     }
 
     const sessionId = req.params.id;
+    const userId = req.user._id?.toString() || req.user.id?.toString();
     const io = req.app.get("io");
+    const targetSocket = io
+      ? io.to(
+          [userId, `user:${userId}`, `session:${sessionId}`].filter(Boolean),
+        )
+      : null;
 
-    processMessage(sessionId, req.user._id, content, io).catch((err) => {
-      console.error("Error processing message:", err);
-      io.emit("assistant_error", {
-        sessionId,
-        error: "Failed to process message.",
-      });
-    });
+    processMessage(sessionId, req.user._id, content, targetSocket).catch(
+      (err) => {
+        console.error("Error processing message:", err);
+        if (targetSocket) {
+          targetSocket.emit("assistant_error", {
+            sessionId,
+            error: "Failed to process message.",
+          });
+        }
+      },
+    );
 
     res.status(202).json({ status: "Processing" });
   } catch (error) {

--- a/server/services/ragAssistantService.js
+++ b/server/services/ragAssistantService.js
@@ -365,12 +365,17 @@ ${contextText}
 
   const result = await chat.sendMessageStream(content);
 
+  const emitter =
+    socket && typeof socket.to === "function" && socket.sockets
+      ? socket.to([userId.toString(), `user:${userId}`, `session:${sessionId}`])
+      : socket;
+
   let fullResponse = "";
   for await (const chunk of result.stream) {
     const chunkText = chunk.text();
     fullResponse += chunkText;
-    if (socket) {
-      socket.emit("assistant_message_chunk", { sessionId, chunk: chunkText });
+    if (emitter) {
+      emitter.emit("assistant_message_chunk", { sessionId, chunk: chunkText });
     }
   }
 
@@ -399,8 +404,8 @@ ${contextText}
   session.messages.push(assistantMessage);
   await session.save();
 
-  if (socket) {
-    socket.emit("assistant_message_done", {
+  if (emitter) {
+    emitter.emit("assistant_message_done", {
       sessionId,
       message: session.messages[session.messages.length - 1],
       title: session.title,

--- a/server/tests/ragAssistantSocketScope.test.js
+++ b/server/tests/ragAssistantSocketScope.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { processMessage } from "../services/ragAssistantService.js";
+
+vi.mock("@google/generative-ai", () => {
+  return {
+    GoogleGenerativeAI: vi.fn().mockImplementation(function () {
+      return {
+        getGenerativeModel: vi.fn().mockReturnValue({
+          generateContent: vi.fn().mockResolvedValue({
+            response: { text: () => "Generated Title" },
+          }),
+          startChat: vi.fn().mockReturnValue({
+            sendMessageStream: vi.fn().mockResolvedValue({
+              stream: (async function* () {
+                yield { text: () => "Hello " };
+                yield { text: () => "world!" };
+              })(),
+            }),
+          }),
+        }),
+      };
+    }),
+  };
+});
+
+vi.mock("../utils/embeddingUtils.js", () => ({
+  embedText: vi.fn().mockResolvedValue([0.1, 0.2]),
+  initVectorStore: vi.fn().mockResolvedValue({
+    query: vi.fn().mockResolvedValue({ matches: [] }),
+    namespace: vi.fn().mockReturnValue({
+      query: vi.fn().mockResolvedValue({ matches: [] }),
+    }),
+  }),
+}));
+
+vi.mock("../models/ChatSession.js", () => {
+  const mockSession = {
+    _id: "session-123",
+    organizationId: "org-1",
+    userId: "user-1",
+    messages: [],
+    title: "New Chat",
+    save: vi.fn().mockResolvedValue(true),
+  };
+  return {
+    default: {
+      findOne: vi.fn().mockResolvedValue(mockSession),
+    },
+  };
+});
+
+describe("RAG Assistant Socket Scoping (#810)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should emit streaming response chunks only to scoped target room", async () => {
+    const mockScopedEmitter = {
+      emit: vi.fn(),
+    };
+
+    const mockIo = {
+      sockets: {},
+      to: vi.fn().mockReturnValue(mockScopedEmitter),
+      emit: vi.fn(),
+    };
+
+    await processMessage("session-123", "user-1", "Hi assistant", mockIo);
+
+    // Verify io.to was called with user/session rooms
+    expect(mockIo.to).toHaveBeenCalledWith([
+      "user-1",
+      "user:user-1",
+      "session:session-123",
+    ]);
+
+    // Verify scoped emitter emitted chunk and done events
+    expect(mockScopedEmitter.emit).toHaveBeenCalledWith(
+      "assistant_message_chunk",
+      { sessionId: "session-123", chunk: "Hello " },
+    );
+    expect(mockScopedEmitter.emit).toHaveBeenCalledWith(
+      "assistant_message_chunk",
+      { sessionId: "session-123", chunk: "world!" },
+    );
+    expect(mockScopedEmitter.emit).toHaveBeenCalledWith(
+      "assistant_message_done",
+      expect.objectContaining({ sessionId: "session-123" }),
+    );
+
+    // Ensure global io.emit was NOT called
+    expect(mockIo.emit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# 🔒 Scope RAG Assistant Responses to Requesting Client

Fixes #810

## 📌 Description
The RAG Assistant was using global socket broadcasting (`io.emit`) for streaming message chunks (`assistant_message_chunk`), completion events (`assistant_message_done`), and error notifications (`assistant_error`). This allowed connected clients across all users to receive unrelated assistant streaming events.

## 🛠️ Changes Made
- **[assistantRoutes.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/routes/assistantRoutes.js)**: Replaced `io.emit` with scoped room emitter targeting `io.to([userId, \`user:${userId}\`, \`session:${sessionId}\`])`.
- **[ragAssistantService.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/services/ragAssistantService.js)**: Updated `processMessage` to use a room-scoped socket emitter, ensuring streaming chunks and completion events are dispatched exclusively to the requesting user/session rooms.
- **[ragAssistantSocketScope.test.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/tests/ragAssistantSocketScope.test.js)**: Added unit test suite verifying that streaming events target room channels and never invoke global `io.emit`.

## 🧪 Testing & Verification
- Ran vitest unit tests (`npx vitest run server/tests/ragAssistantSocketScope.test.js`): 1/1 tests passed.
- Verified that streaming chunks are delivered strictly to the target user/session room.
- Ran Prettier code formatting (`npm run format:check:changed`): Clean pass.
- Ran ESLint check (`npm run lint:changed`): Clean pass.

## ✅ Checklist
- [x] Related issue linked (`Fixes #810`).
- [x] Streaming chunks are scoped exclusively to requesting user/session.
- [x] Global broadcasting (`io.emit`) removed for assistant responses.
- [x] Unit test suite added and passing.
- [x] Code passes formatting and linting rules.
