### PR TITLE
sec: prevent webhook secrets from being exposed in list API and UI

### DIFF
--- a/client/src/components/WebhookModal.jsx
+++ b/client/src/components/WebhookModal.jsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { X, Globe, Lock, Shield, RefreshCw, Loader2, Activity } from "lucide-react";
+import {
+  X,
+  Globe,
+  Lock,
+  Shield,
+  RefreshCw,
+  Loader2,
+  Activity,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import { webhookApi } from "../services";
 
@@ -51,7 +59,7 @@ const WebhookModal = ({
     if (webhook) {
       setTargetUrl(webhook.targetUrl || "");
       setSelectedEvents(webhook.events || ["meeting.created"]);
-      
+
       // SECURITY FIX: Do NOT pre-fill the actual secret on edit.
       // Show a masked placeholder if it exists, otherwise generate a new one.
       if (webhook.hasSecret) {
@@ -59,7 +67,7 @@ const WebhookModal = ({
       } else {
         setSecret(generateRandomSecret());
       }
-      
+
       setIsActive(webhook.isActive !== false);
     } else {
       setTargetUrl("");
@@ -372,7 +380,11 @@ const WebhookModal = ({
                 type="text"
                 value={secret}
                 onChange={(e) => setSecret(e.target.value)}
-                placeholder={isEdit && webhook?.hasSecret ? "Enter new secret to overwrite (or leave hidden)" : "Secret key for signing payloads"}
+                placeholder={
+                  isEdit && webhook?.hasSecret
+                    ? "Enter new secret to overwrite (or leave hidden)"
+                    : "Secret key for signing payloads"
+                }
                 className="w-full pl-10 pr-4 py-2.5 bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded-xl text-slate-900 dark:text-white text-xs font-mono focus:outline-hidden focus:ring-2 focus:ring-blue-500 transition-all"
                 // Disable copy-paste of the masked value to prevent confusion
                 readOnly={isEdit && secret === SECRET_MASK}

--- a/client/src/components/WebhookModal.jsx
+++ b/client/src/components/WebhookModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { X, Globe, Lock, Shield, RefreshCw, Loader2 } from "lucide-react";
+import { X, Globe, Lock, Shield, RefreshCw, Loader2, Activity } from "lucide-react";
 import { toast } from "react-toastify";
 import { webhookApi } from "../services";
 
@@ -20,6 +20,9 @@ const AVAILABLE_EVENTS = [
     desc: "Fired when organization compliance policies are modified.",
   },
 ];
+
+// Masked placeholder for hidden secrets
+const SECRET_MASK = "••••••••••••••••••••••••••••••••";
 
 const WebhookModal = ({
   isOpen,
@@ -48,7 +51,15 @@ const WebhookModal = ({
     if (webhook) {
       setTargetUrl(webhook.targetUrl || "");
       setSelectedEvents(webhook.events || ["meeting.created"]);
-      setSecret(webhook.secret || "");
+      
+      // SECURITY FIX: Do NOT pre-fill the actual secret on edit.
+      // Show a masked placeholder if it exists, otherwise generate a new one.
+      if (webhook.hasSecret) {
+        setSecret(SECRET_MASK);
+      } else {
+        setSecret(generateRandomSecret());
+      }
+      
       setIsActive(webhook.isActive !== false);
     } else {
       setTargetUrl("");
@@ -187,20 +198,28 @@ const WebhookModal = ({
 
     setLoading(true);
     try {
+      // SECURITY FIX: Only send the secret if it's not the masked placeholder string
+      // If it is the mask, we leave it undefined so the backend doesn't overwrite the existing secret
+      const payloadSecret = secret === SECRET_MASK ? undefined : secret.trim();
+
+      const payload = {
+        targetUrl: targetUrl.trim(),
+        events: selectedEvents,
+        isActive,
+      };
+
+      // Only include secret in payload if it's a new webhook OR if the user explicitly changed it
+      if (!isEdit || payloadSecret) {
+        payload.secret = payloadSecret;
+      }
+
       if (isEdit) {
-        await webhookApi.updateWebhook(webhook._id, {
-          targetUrl: targetUrl.trim(),
-          events: selectedEvents,
-          secret: secret.trim() || undefined,
-          isActive,
-        });
+        await webhookApi.updateWebhook(webhook._id, payload);
         toast.success("Webhook subscription updated successfully!");
       } else {
         await webhookApi.createWebhook({
           organizationId,
-          targetUrl: targetUrl.trim(),
-          events: selectedEvents,
-          secret: secret.trim() || undefined,
+          ...payload,
         });
         toast.success("Webhook registered successfully!");
       }
@@ -324,19 +343,26 @@ const WebhookModal = ({
             </div>
           </div>
 
-          {/* Secret Key */}
+          {/* Secret Key - Updated for Security */}
           <div>
             <div className="flex items-center justify-between mb-2">
               <label className="text-xs font-semibold text-slate-700 dark:text-slate-300 uppercase tracking-wider">
                 HMAC Secret Key
               </label>
-              <button
-                type="button"
-                onClick={() => setSecret(generateRandomSecret())}
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
-              >
-                <RefreshCw className="w-3 h-3" /> Regenerate
-              </button>
+              {/* Only allow regeneration if it's a new webhook or the user has already cleared the mask */}
+              {!isEdit || secret !== SECRET_MASK ? (
+                <button
+                  type="button"
+                  onClick={() => setSecret(generateRandomSecret())}
+                  className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
+                >
+                  <RefreshCw className="w-3 h-3" /> Regenerate
+                </button>
+              ) : (
+                <span className="text-xs text-slate-500 dark:text-slate-400 italic">
+                  Secret is hidden for security
+                </span>
+              )}
             </div>
             <div className="relative">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none text-slate-400">
@@ -346,8 +372,10 @@ const WebhookModal = ({
                 type="text"
                 value={secret}
                 onChange={(e) => setSecret(e.target.value)}
-                placeholder="Secret key for signing payloads"
+                placeholder={isEdit && webhook?.hasSecret ? "Enter new secret to overwrite (or leave hidden)" : "Secret key for signing payloads"}
                 className="w-full pl-10 pr-4 py-2.5 bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700 rounded-xl text-slate-900 dark:text-white text-xs font-mono focus:outline-hidden focus:ring-2 focus:ring-blue-500 transition-all"
+                // Disable copy-paste of the masked value to prevent confusion
+                readOnly={isEdit && secret === SECRET_MASK}
               />
             </div>
             <p className="mt-1 text-[11px] text-slate-500 dark:text-slate-400">

--- a/server/controllers/webhookController.js
+++ b/server/controllers/webhookController.js
@@ -139,7 +139,10 @@ export const createWebhook = async (req, res, next) => {
     const webhook = await Webhook.create(webhookData);
 
     const webhookResponse = webhook.toObject();
+    // SECURITY FIX: Ensure secret is never returned in creation response
     delete webhookResponse.secret;
+    // Add metadata flag for UI consistency
+    webhookResponse.hasSecret = !!webhook.secret;
 
     return sendSuccess(
       res,
@@ -180,7 +183,20 @@ export const getWebhooks = async (req, res, next) => {
       createdAt: -1,
     });
 
-    return sendSuccess(res, { webhooks });
+    // SECURITY FIX: Sanitize the response to prevent secret exposure
+    const sanitizedWebhooks = webhooks.map((webhook) => {
+      const webhookObj = webhook.toObject();
+
+      // Remove the secret field entirely from the list response
+      delete webhookObj.secret;
+
+      // Add a metadata flag to indicate a secret is configured without exposing it
+      webhookObj.hasSecret = webhook.secret ? true : false;
+
+      return webhookObj;
+    });
+
+    return sendSuccess(res, { webhooks: sanitizedWebhooks });
   } catch (error) {
     next(error);
   }
@@ -238,7 +254,10 @@ export const updateWebhook = async (req, res, next) => {
     await webhook.save();
 
     const webhookResponse = webhook.toObject();
+    // SECURITY FIX: Ensure secret is never returned in update response
     delete webhookResponse.secret;
+    // Add metadata flag for UI consistency
+    webhookResponse.hasSecret = !!webhook.secret;
 
     return sendSuccess(
       res,


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves Issue #900 by ensuring webhook secrets are never exposed through the list or management endpoints after creation, adhering to the principle of least privilege and preventing accidental credential disclosure.

Changes include:
- **Backend (`webhookController.js`)**: Updated `getWebhooks` and `createWebhook` to explicitly strip the `secret` field from the response object and replace it with a boolean `hasSecret` flag.
- **Frontend (`WebhookModal.jsx`)**: Prevented the secret input from being pre-filled with plaintext on edit. It now displays a masked placeholder (`••••••••`). Regeneration is disabled for existing webhooks unless the user explicitly types a new secret, preventing accidental overwrites.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #900

## Testing

Describe the testing performed.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
