### PR TITLE
fix: update dashboard metrics query fields to match schema

### DIFF
--- a/server/controllers/dashboardController.js
+++ b/server/controllers/dashboardController.js
@@ -14,24 +14,31 @@ export const getDashboardMetrics = async (req, res) => {
 
     const now = new Date();
 
+    const ownerIdentifiers = [
+      userId?.toString(),
+      userId,
+      req.user?.email,
+      req.user?.name,
+    ].filter(Boolean);
+
     // Fire all three queries concurrently to ensure fast response times
     const [overdueTasks, unreadNotifications, upcomingMeetings] =
       await Promise.all([
-        // 1. Overdue action items assigned to the user
+        // 1. Overdue action items assigned to the user (owner field matches user id, email, or name)
         ActionItem.countDocuments({
           organization,
-          assignees: userId,
+          owner: { $in: ownerIdentifiers },
           status: { $nin: ["resolved", "superseded"] },
           dueDate: { $lt: now },
         }),
-        // 2. Unread notifications for the user
+        // 2. Unread notifications for the user (user field)
         Notification.countDocuments({
-          recipient: userId,
+          user: userId,
           isRead: false,
         }),
-        // 3. Upcoming meetings in the organization
+        // 3. Upcoming meetings in the organization (organization field)
         Meeting.countDocuments({
-          organizationId: organization,
+          organization,
           date: { $gte: now },
         }),
       ]);

--- a/server/tests/dashboardController.test.js
+++ b/server/tests/dashboardController.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getDashboardMetrics } from "../controllers/dashboardController.js";
+import ActionItem from "../models/actionItemModel.js";
+import Notification from "../models/notificationModel.js";
+import Meeting from "../models/meetingModel.js";
+
+vi.mock("../models/actionItemModel.js", () => ({
+  default: {
+    countDocuments: vi.fn(),
+  },
+}));
+
+vi.mock("../models/notificationModel.js", () => ({
+  default: {
+    countDocuments: vi.fn(),
+  },
+}));
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    countDocuments: vi.fn(),
+  },
+}));
+
+describe("Dashboard Controller Metrics (#811)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return correct non-zero metric counts when valid data exists", async () => {
+    ActionItem.countDocuments.mockResolvedValue(5);
+    Notification.countDocuments.mockResolvedValue(3);
+    Meeting.countDocuments.mockResolvedValue(8);
+
+    const req = {
+      user: {
+        id: "user-123",
+        email: "user@example.com",
+        name: "Test User",
+        organization: "org-123",
+      },
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await getDashboardMetrics(req, res);
+
+    expect(ActionItem.countDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: "org-123",
+        owner: {
+          $in: ["user-123", "user-123", "user@example.com", "Test User"],
+        },
+      }),
+    );
+
+    expect(Notification.countDocuments).toHaveBeenCalledWith({
+      user: "user-123",
+      isRead: false,
+    });
+
+    expect(Meeting.countDocuments).toHaveBeenCalledWith({
+      organization: "org-123",
+      date: expect.objectContaining({ $gte: expect.any(Date) }),
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Success",
+      metrics: {
+        overdueTasks: 5,
+        unreadNotifications: 3,
+        upcomingMeetings: 8,
+      },
+    });
+  });
+
+  it("should return 400 error when organization context is missing", async () => {
+    const req = { user: { id: "user-123" } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await getDashboardMetrics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Organization context is missing",
+    });
+  });
+});


### PR DESCRIPTION
# 🐞 Fix Dashboard Metrics Returning Zero Values

Fixes #811

## 📌 Description
Several dashboard metrics in `getDashboardMetrics` were returning zero because queries used field names that mismatched the current database schema:
1. `ActionItem.countDocuments` queried `assignees: userId` instead of the `owner` schema field.
2. `Notification.countDocuments` queried `recipient: userId` instead of the `user` schema field.
3. `Meeting.countDocuments` queried `organizationId: organization` instead of the `organization` schema field.

## 🛠️ Changes Made
- **[dashboardController.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/controllers/dashboardController.js)**: Updated queries in `getDashboardMetrics`:
  - `ActionItem`: query `owner: { $in: ownerIdentifiers }` where `ownerIdentifiers` matches user ID, email, or name.
  - `Notification`: query `user: userId`.
  - `Meeting`: query `organization: organization`.
- **[dashboardController.test.js](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/server/tests/dashboardController.test.js)**: Added unit test suite asserting correct schema query parameters and non-zero return values.

## 🧪 Testing & Verification
- Ran vitest unit tests (`npx vitest run server/tests/dashboardController.test.js`): 2/2 tests passed.
- Verified metric queries against `ActionItem`, `Notification`, and `Meeting` Mongoose schemas.
- Ran Prettier code formatting (`npm run format:check:changed`): Clean pass.
- Ran ESLint check (`npm run lint:changed`): Clean pass.

## ✅ Checklist
- [x] Related issue linked (`Fixes #811`).
- [x] Overdue tasks, unread notifications, and upcoming meetings query valid schema fields.
- [x] Dashboard metric calculations return correct non-zero counts.
- [x] Unit test suite added and passing.
- [x] Code passes formatting and linting rules.
