### PR TITLE
fix(feedback): authorize getFeedbackForMeeting — close cross-org IDOR (#933)

### DIFF
--- a/server/controllers/meetingFeedbackController.js
+++ b/server/controllers/meetingFeedbackController.js
@@ -77,11 +77,34 @@ export const submitFeedback = async (req, res, next) => {
 export const getFeedbackForMeeting = async (req, res) => {
   try {
     const { meetingId } = req.params;
+    const userId = req.user._id;
 
     if (!mongoose.isValidObjectId(meetingId)) {
       return res
         .status(400)
         .json({ success: false, message: "Invalid meeting ID" });
+    }
+
+    // Authorize: only the meeting owner or a participant may read its feedback,
+    // matching submitFeedback in this file. Without this, any authenticated user
+    // could read another org's feedback and submitter PII (IDOR).
+    const meeting = await Meeting.findById(meetingId);
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Meeting not found" });
+    }
+
+    const isOwner = meeting.uploadedBy.toString() === userId.toString();
+    const isParticipant = meeting.participants?.some(
+      (p) => p.user?.toString() === userId.toString(),
+    );
+
+    if (!isOwner && !isParticipant) {
+      return res.status(403).json({
+        success: false,
+        message: "Not authorized to view feedback for this meeting",
+      });
     }
 
     const feedback = await MeetingFeedback.find({ meetingId }).populate(

--- a/server/tests/meetingFeedback.test.js
+++ b/server/tests/meetingFeedback.test.js
@@ -2,6 +2,7 @@ import {
   submitFeedback,
   getAggregateFeedback,
   deleteFeedback,
+  getFeedbackForMeeting,
 } from "../controllers/meetingFeedbackController.js";
 import MeetingFeedback from "../models/meetingFeedbackModel.js";
 import Meeting from "../models/meetingModel.js";
@@ -122,6 +123,61 @@ describe("Meeting Feedback Controller", () => {
             },
           ],
         }),
+      );
+    });
+  });
+
+  describe("getFeedbackForMeeting", () => {
+    it("returns 403 when the user is neither owner nor participant", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        participants: [],
+      });
+      const findSpy = jest.spyOn(MeetingFeedback, "find");
+
+      await getFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false }),
+      );
+      // Must not query/leak feedback for an unauthorized user.
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the meeting does not exist", async () => {
+      req.params.meetingId = new mongoose.Types.ObjectId().toString();
+      jest.spyOn(Meeting, "findById").mockResolvedValue(null);
+
+      await getFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("returns feedback for a participant", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        participants: [{ user: req.user._id }],
+      });
+      jest.spyOn(MeetingFeedback, "find").mockReturnValue({
+        populate: jest
+          .fn()
+          .mockResolvedValue([{ _id: "f1", overallRating: 5 }]),
+      });
+
+      await getFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
       );
     });
   });


### PR DESCRIPTION
## Description

`getFeedbackForMeeting` had **no authorization check**, so any authenticated user could `GET /api/feedback/meeting/<meetingId>` for a meeting in **any other organization** and read every feedback entry — including each submitter's name and email (IDOR / broken access control). The route only mounts `userAuth` and validated that `meetingId` was a valid ObjectId.

This was the lone unguarded reader on this data model — `submitFeedback` and `getAggregateFeedback` in the same file already check org/participant, and the sibling reaction routes use `requireOrgAccess(Meeting)`.

## Fix

Load the meeting and authorize before returning any feedback, mirroring `submitFeedback` in this same controller:
- `404` if the meeting doesn't exist,
- `403` unless the caller is the meeting owner (`uploadedBy`) or a participant,
- only then run the feedback query.

The unauthorized path now returns before `MeetingFeedback.find` is ever called, so no feedback or submitter PII is leaked cross-org.

## Tests

Added to `server/tests/meetingFeedback.test.js`:
- returns 403 for a non-owner/non-participant (and asserts `MeetingFeedback.find` is never called),
- returns 404 when the meeting doesn't exist,
- returns 200 with feedback for a participant.

Closes #933

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved meeting feedback access controls.
  - Meeting owners and participants can view feedback, while unauthorized viewers are denied access.
  - Requests for nonexistent meetings now return a clear not-found response.
  - Unauthorized requests are rejected before feedback data is accessed, improving privacy and security.
- **Tests**
  - Added coverage for authorized access, unauthorized requests, and missing meetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->