### PR TITLE
fix(decision-graph): escape regex metacharacters in search (ReDoS) (#935)

### DIFF
--- a/server/controllers/decisionGraphController.js
+++ b/server/controllers/decisionGraphController.js
@@ -27,7 +27,10 @@ export const getDecisionGraph = async (req, res) => {
     }
 
     if (search && typeof search === "string") {
-      filter.text = { $regex: search, $options: "i" };
+      // Escape regex metacharacters so user input can't be compiled as a live
+      // regex (ReDoS / regex injection), matching tagController's escaping.
+      const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      filter.text = { $regex: escapedSearch, $options: "i" };
     }
 
     const total = await Decision.countDocuments(filter);

--- a/server/tests/decisionGraphOptimized.test.js
+++ b/server/tests/decisionGraphOptimized.test.js
@@ -84,4 +84,28 @@ describe("Decision Graph Optimization (#834)", () => {
       confidence: 90,
     });
   });
+
+  it("escapes regex metacharacters in search (ReDoS / regex injection)", async () => {
+    const req = {
+      user: { organization: "org123" },
+      query: { search: "(a+)+$" },
+    };
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    Decision.countDocuments.mockResolvedValue(0);
+    Decision.find.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      sort: vi.fn().mockReturnThis(),
+      skip: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue([]),
+    });
+
+    await getDecisionGraph(req, res);
+
+    const filterArg = Decision.countDocuments.mock.calls[0][0];
+    // Every metacharacter must be backslash-escaped — not the live pattern.
+    expect(filterArg.text.$regex).toBe("\\(a\\+\\)\\+\\$");
+    expect(filterArg.text.$options).toBe("i");
+  });
 });


### PR DESCRIPTION
## Description

The decision-graph search endpoint (`GET /api/decision-graph?search=...`) dropped raw user input straight into a Mongo `$regex`:

```js
filter.text = { $regex: search, $options: "i" };
```

A crafted pattern like `(a+)+$` causes catastrophic backtracking and pins a CPU core — a ReDoS / regex-injection DoS that any org member can trigger.

## Fix

Escape regex metacharacters before building the filter, using the same escaping `tagController` already applies to tag autocomplete:

```js
const escapedSearch = search.replace(/[.*+?^${}()|[\]\]/g, "\$&");
filter.text = { $regex: escapedSearch, $options: "i" };
```

## Tests

Added to `tests/decisionGraphOptimized.test.js`: a case asserting `search: "(a+)+$"` is stored as the escaped literal `\(a\+\)\+\$` (not a live pattern). Suite passes 2/2.

Closes #935

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decision graph search handling for special characters.
  * Prevented search patterns from being interpreted as unintended regular expressions, improving security and stability.

* **Tests**
  * Added regression coverage for searches containing regex metacharacters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->