### PR TITLE
fix(personal-notes): validate meeting access and cap content length (#937)

### DIFF
--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -1,4 +1,67 @@
+import mongoose from "mongoose";
+import { z } from "zod";
 import PersonalNote from "../models/personalNoteModel.js";
+import Meeting from "../models/meetingModel.js";
+
+const MAX_CONTENT_LENGTH = 50000;
+const MAX_ANNOTATION_LENGTH = 5000;
+
+const noteContentSchema = z.object({
+  content: z
+    .string()
+    .max(
+      MAX_CONTENT_LENGTH,
+      `Content must be at most ${MAX_CONTENT_LENGTH} characters`,
+    )
+    .optional(),
+});
+
+const annotationSchema = z.object({
+  annotationText: z
+    .string()
+    .max(
+      MAX_ANNOTATION_LENGTH,
+      `Annotation must be at most ${MAX_ANNOTATION_LENGTH} characters`,
+    )
+    .optional(),
+  sourceField: z.string().optional(),
+  offsets: z.any().optional(),
+  color: z.string().optional(),
+});
+
+// Verify the caller may attach personal notes to meetingId. Returns
+// { meeting } on success or { error: { status, message } } otherwise.
+async function resolveAccessibleMeeting(meetingId, user) {
+  if (!mongoose.isValidObjectId(meetingId)) {
+    return { error: { status: 400, message: "Invalid meeting ID" } };
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    return { error: { status: 404, message: "Meeting not found" } };
+  }
+
+  const userId = user._id.toString();
+  const isOwner = meeting.uploadedBy?.toString() === userId;
+  const isParticipant = meeting.participants?.some(
+    (p) => p.user?.toString() === userId,
+  );
+  const sameOrg =
+    meeting.organization &&
+    user.organization &&
+    meeting.organization.toString() === user.organization.toString();
+
+  if (!isOwner && !isParticipant && !sameOrg) {
+    return {
+      error: {
+        status: 403,
+        message: "Not authorized to add notes for this meeting",
+      },
+    };
+  }
+
+  return { meeting };
+}
 
 // @desc    Get personal note for a specific meeting
 // @route   GET /api/personal-notes/:meetingId
@@ -39,7 +102,21 @@ export const upsertNote = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const userId = req.user._id;
-    const { content } = req.body;
+
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
+
+    const parsed = noteContentSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ success: false, message: parsed.error.issues[0].message });
+    }
+    const content = parsed.data.content ?? "";
 
     let note = await PersonalNote.findOne({ userId, meetingId });
 
@@ -71,7 +148,21 @@ export const addAnnotation = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const userId = req.user._id;
-    const { annotationText, sourceField, offsets, color } = req.body;
+
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
+
+    const parsed = annotationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ success: false, message: parsed.error.issues[0].message });
+    }
+    const { annotationText, sourceField, offsets, color } = parsed.data;
 
     let note = await PersonalNote.findOne({ userId, meetingId });
 
@@ -142,6 +233,13 @@ export const togglePin = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
     const { isPinned } = req.body;
+
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
 
     let note = await PersonalNote.findOne({ userId, meetingId });
 

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -111,6 +111,59 @@ describe("PersonalNote API", () => {
     expect(res.body.notes[0].isPinned).toBe(true);
   });
 
+  it("rejects a non-ObjectId meetingId with 400 instead of 500", async () => {
+    const res = await request(app)
+      .post(`/api/personal-notes/not-an-object-id`)
+      .set(authHeader(token))
+      .send({ content: "x" });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("returns 404 for a meeting that does not exist", async () => {
+    const missingId = "5f9f1b9b9c9d440000000000";
+    const res = await request(app)
+      .post(`/api/personal-notes/${missingId}`)
+      .set(authHeader(token))
+      .send({ content: "x" });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 403 for a meeting the user cannot access", async () => {
+    const otherUser = await User.create({
+      name: "Other Org User",
+      email: "otherorg@test.com",
+      password: "password123",
+      role: "member",
+    });
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      uploadedBy: otherUser._id,
+      participants: [],
+    });
+
+    const res = await request(app)
+      .post(`/api/personal-notes/${foreignMeeting._id}`)
+      .set(authHeader(token))
+      .send({ content: "trying to attach to a foreign meeting" });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("rejects content over the max length with 400", async () => {
+    const res = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token))
+      .send({ content: "a".repeat(50001) });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
   it("should search notes", async () => {
     await PersonalNote.create({
       userId: user._id,


### PR DESCRIPTION
## Description

The Personal Notes create paths — `upsertNote`, `addAnnotation`, `togglePin` — created a `PersonalNote` against a client-supplied `req.params.meetingId` with **no** ObjectId validation, **no** check that the meeting exists or is accessible to the user, and **no** cap on `content` length. That allowed:

- notes attached to arbitrary/foreign meetings (cross-org write), whose `title`/`date` then leaked back through the populated `getPinnedNotes`;
- unbounded `content` (storage abuse);
- a 500 (uncaught CastError) on a non-ObjectId `meetingId`.

Unlike `tagController` / `meetingFeedbackController`, this controller used no Zod schema.

## Fix

- `resolveAccessibleMeeting(meetingId, user)` — `400` on an invalid ObjectId, `404` if the meeting doesn't exist, `403` unless the caller owns it (`uploadedBy`), participates in it, or shares its `organization` (mirrors `submitFeedback`).
- Zod schemas capping note `content` (50k) and `annotationText` (5k), mirroring the tag/feedback controllers.
- Applied to all three create paths. Blocking notes on inaccessible meetings also closes the `getPinnedNotes` metadata leak at the source (a user can no longer create a note pointing at a foreign meeting).

## Tests

Added to `tests/personalNote.test.js`: `400` for a non-ObjectId id, `404` for a missing meeting, `403` for a meeting the user can't access, and `400` for over-length content. (The existing happy-path tests use a user-owned meeting, so they stay green.)

> Note: I couldn't boot the integration harness locally — `main` currently has an unrelated broken import (`digestPreferenceController.js` imports `../models/DigestPreference.js`, but the file is `digestPreferenceModel.js`), which fails module resolution before any test runs. That's separate from this change; happy to file it separately. The controller change is `node --check`- and prettier-clean and follows the existing `submitFeedback` pattern.

Closes #937

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added access controls for creating notes, annotations, and pin changes based on meeting permissions.
  * Added clear handling for invalid, missing, or unauthorized meeting requests.
  * Enforced maximum lengths for note and annotation content while preserving optional metadata.

* **Tests**
  * Added coverage for invalid meeting IDs, missing meetings, unauthorized access, and oversized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->