### PR TITLE
fix(follow-up-threads): org/meeting authorization + validate mentions (#934)

### DIFF
--- a/server/controllers/followUpThreadController.js
+++ b/server/controllers/followUpThreadController.js
@@ -1,6 +1,45 @@
 import followUpThreadModel from "../models/followUpThreadModel.js";
 import threadReplyModel from "../models/threadReplyModel.js";
 import notificationModel from "../models/notificationModel.js";
+import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
+
+// Keep only the mentioned user IDs that belong to the same organization, so a
+// client-supplied mentions array can't spam notifications to arbitrary users.
+async function filterOrgMembers(mentions, organizationId) {
+  if (!Array.isArray(mentions) || mentions.length === 0 || !organizationId) {
+    return [];
+  }
+  const members = await User.find({
+    _id: { $in: mentions },
+    organization: organizationId,
+  }).select("_id");
+  return members.map((m) => m._id);
+}
+
+// Resolve a thread to its meeting and confirm the caller shares its org.
+// Returns { thread, meeting } on success or { error: { status, message } }.
+async function resolveThreadOrgAccess(threadId, user) {
+  const thread = await followUpThreadModel.findById(threadId);
+  if (!thread) {
+    return { error: { status: 404, message: "Thread not found" } };
+  }
+  const meeting = await Meeting.findById(thread.meetingId);
+  if (!meeting) {
+    return { error: { status: 404, message: "Meeting not found" } };
+  }
+  const isOwner = meeting.uploadedBy?.toString() === user._id.toString();
+  const isInSameOrg =
+    meeting.organization &&
+    user.organization &&
+    meeting.organization.toString() === user.organization.toString();
+  if (!isOwner && !isInSameOrg) {
+    return {
+      error: { status: 403, message: "You don't have access to this thread" },
+    };
+  }
+  return { thread, meeting };
+}
 
 export const createThread = async (req, res) => {
   try {
@@ -16,11 +55,17 @@ export const createThread = async (req, res) => {
       createdBy,
     });
 
+    // Only notify mentioned users who are members of the caller's org.
+    const validMentions = await filterOrgMembers(
+      mentions,
+      req.user.organization,
+    );
+
     const reply = await threadReplyModel.create({
       threadId: thread._id,
       author: createdBy,
       content,
-      mentions: mentions || [],
+      mentions: validMentions,
     });
 
     const populatedReply = await threadReplyModel
@@ -28,8 +73,8 @@ export const createThread = async (req, res) => {
       .populate("author", "name avatar");
 
     // Notifications for mentions
-    if (mentions && mentions.length > 0) {
-      const notifications = mentions.map((userId) => ({
+    if (validMentions.length > 0) {
+      const notifications = validMentions.map((userId) => ({
         user: userId,
         title: "You were mentioned in a thread",
         description: `${populatedReply.author.name} mentioned you in a follow-up thread.`,
@@ -87,14 +132,29 @@ export const getThreadsByMeetingId = async (req, res) => {
 export const createReply = async (req, res) => {
   try {
     const { threadId } = req.params;
-    const { content, mentions, meetingId } = req.body;
+    const { content, mentions } = req.body;
     const author = req.user._id;
+
+    const access = await resolveThreadOrgAccess(threadId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
+    // Derive the meeting from the thread instead of trusting req.body.meetingId.
+    const meetingId = access.thread.meetingId.toString();
+
+    // Only notify mentioned users who are members of the caller's org.
+    const validMentions = await filterOrgMembers(
+      mentions,
+      req.user.organization,
+    );
 
     const reply = await threadReplyModel.create({
       threadId,
       author,
       content,
-      mentions: mentions || [],
+      mentions: validMentions,
     });
 
     const populatedReply = await threadReplyModel
@@ -103,8 +163,8 @@ export const createReply = async (req, res) => {
       .populate("mentions", "name avatar");
 
     // Notifications for mentions
-    if (mentions && mentions.length > 0) {
-      const notifications = mentions.map((userId) => ({
+    if (validMentions.length > 0) {
+      const notifications = validMentions.map((userId) => ({
         user: userId,
         title: "You were mentioned in a reply",
         description: `${populatedReply.author.name} mentioned you in a follow-up thread reply.`,
@@ -214,12 +274,13 @@ export const resolveThread = async (req, res) => {
     const { threadId } = req.params;
     const resolvedBy = req.user._id;
 
-    const thread = await followUpThreadModel.findById(threadId);
-    if (!thread) {
+    const access = await resolveThreadOrgAccess(threadId, req.user);
+    if (access.error) {
       return res
-        .status(404)
-        .json({ success: false, message: "Thread not found" });
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
     }
+    const thread = access.thread;
 
     thread.status = "resolved";
     thread.resolvedBy = resolvedBy;

--- a/server/routes/followUpThreadRoutes.js
+++ b/server/routes/followUpThreadRoutes.js
@@ -1,5 +1,7 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgAccess } from "../middleware/rbac.js";
+import Meeting from "../models/meetingModel.js";
 import {
   createThread,
   getThreadsByMeetingId,
@@ -11,8 +13,18 @@ import {
 
 const router = express.Router();
 
-router.post("/meeting/:meetingId", userAuth, createThread);
-router.get("/meeting/:meetingId", userAuth, getThreadsByMeetingId);
+router.post(
+  "/meeting/:meetingId",
+  userAuth,
+  requireOrgAccess(Meeting),
+  createThread,
+);
+router.get(
+  "/meeting/:meetingId",
+  userAuth,
+  requireOrgAccess(Meeting),
+  getThreadsByMeetingId,
+);
 
 router.post("/:threadId/replies", userAuth, createReply);
 router.put("/replies/:replyId", userAuth, updateReply);

--- a/server/tests/followUpThread.test.js
+++ b/server/tests/followUpThread.test.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import request from "supertest";
 import { app } from "../server.js";
 import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
@@ -6,16 +7,24 @@ import ThreadReply from "../models/threadReplyModel.js";
 import Notification from "../models/notificationModel.js";
 import User from "../models/userModel.js";
 import Meeting from "../models/meetingModel.js";
+import Organization from "../models/organizationModel.js";
 
 describe("FollowUpThread API", () => {
-  let user1, user2, meeting, user1Token;
+  let user1, user2, meeting, user1Token, organization;
 
   beforeEach(async () => {
+    organization = await Organization.create({
+      name: "Test Org",
+      slug: "test-org-" + Math.random().toString(36).substring(7),
+      owner: new mongoose.Types.ObjectId(),
+    });
+
     user1 = await User.create({
       name: "Test User 1",
       email: "user1@test.com",
       password: "password",
       role: "member",
+      organization: organization._id,
     });
     user1.clerkUserId = `user_test_${user1._id}`;
     await user1.save();
@@ -25,6 +34,7 @@ describe("FollowUpThread API", () => {
       email: "user2@test.com",
       password: "password",
       role: "member",
+      organization: organization._id,
     });
     user2.clerkUserId = `user_test_${user2._id}`;
     await user2.save();
@@ -34,6 +44,7 @@ describe("FollowUpThread API", () => {
       date: new Date(),
       uploadedBy: user1._id,
       status: "completed",
+      organization: organization._id,
     });
 
     user1Token = createClerkTestToken({
@@ -148,6 +159,80 @@ describe("FollowUpThread API", () => {
       expect(res.body.thread.resolvedBy._id.toString()).toBe(
         user1._id.toString(),
       );
+    });
+  });
+
+  describe("authorization", () => {
+    // A meeting owned by another org that user1 must not be able to touch.
+    async function makeForeignMeeting() {
+      const otherOrg = await Organization.create({
+        name: "Other Org",
+        slug: "other-org-" + Math.random().toString(36).substring(7),
+        owner: new mongoose.Types.ObjectId(),
+      });
+      return Meeting.create({
+        title: "Foreign Meeting",
+        date: new Date(),
+        uploadedBy: new mongoose.Types.ObjectId(),
+        status: "completed",
+        organization: otherOrg._id,
+      });
+    }
+
+    it("returns 403 reading threads for a meeting in another org", async () => {
+      const foreign = await makeForeignMeeting();
+
+      const res = await request(app)
+        .get(`/api/follow-up-threads/meeting/${foreign._id}`)
+        .set(authHeader(user1Token));
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("returns 403 resolving a thread on a meeting in another org", async () => {
+      const foreign = await makeForeignMeeting();
+      const thread = await FollowUpThread.create({
+        meetingId: foreign._id,
+        anchorType: "general",
+        createdBy: new mongoose.Types.ObjectId(),
+      });
+
+      const res = await request(app)
+        .put(`/api/follow-up-threads/${thread._id}/resolve`)
+        .set(authHeader(user1Token));
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("does not notify a mentioned user who is outside the org", async () => {
+      const outsider = await User.create({
+        name: "Outsider",
+        email: "outsider@test.com",
+        password: "password",
+        role: "member",
+        organization: (
+          await Organization.create({
+            name: "Outsider Org",
+            slug: "outsider-org-" + Math.random().toString(36).substring(7),
+            owner: new mongoose.Types.ObjectId(),
+          })
+        )._id,
+      });
+
+      const thread = await FollowUpThread.create({
+        meetingId: meeting._id,
+        anchorType: "general",
+        createdBy: user1._id,
+      });
+
+      const res = await request(app)
+        .post(`/api/follow-up-threads/${thread._id}/replies`)
+        .set(authHeader(user1Token))
+        .send({ content: "hi", mentions: [outsider._id] });
+
+      expect(res.statusCode).toBe(201);
+      const notifs = await Notification.find({ user: outsider._id });
+      expect(notifs.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Description

The entire Follow-up Threads feature was protected by `userAuth` only — no org/meeting authorization and no ownership check — and `mentions` was taken from the client and fed straight into notification creation. That added up to:

- **Read IDOR** — `GET /api/follow-up-threads/meeting/:meetingId` dumped any meeting's thread history + author identities.
- **Tamper** — `PUT /:threadId/resolve` let any user resolve any org's thread.
- **Notification spam** — `createThread`/`createReply` passed a client-supplied `mentions` array of arbitrary user IDs straight into `notificationModel.insertMany`. `createReply` also trusted `meetingId` from `req.body`.

## Fix

- **`/meeting/:meetingId` routes** (create + list): guarded with `requireOrgAccess(Meeting)`, matching the sibling reaction routes.
- **`:threadId` routes** (`createReply`, `resolveThread`): resolve the thread → its meeting and verify org membership (owner or same-org) before read/mutate. `createReply` now derives `meetingId` from the thread instead of trusting `req.body`.
- **Mentions**: `filterOrgMembers()` keeps only mentioned users who belong to the caller's org before creating notifications, so a mention array can't spam arbitrary users.

## Tests

`tests/followUpThread.test.js`:
- Gave the existing suite a shared `Organization` on the users + meeting (required now that `requireOrgAccess` gates the routes — the setup was previously unrealistic without an org).
- Added: `403` reading threads for a meeting in another org, `403` resolving a thread on a foreign meeting, and "a mentioned user outside the org receives no notification".

> Note: I couldn't boot the integration harness locally — `main` currently fails module resolution before any test runs due to an unrelated broken import (`digestPreferenceController.js` → `../models/DigestPreference.js`, actual file `digestPreferenceModel.js`). That's separate from this change. The three files are prettier-clean and the authz mirrors the existing `requireOrgAccess` middleware; CI will exercise the suite.

Closes #934

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted meeting thread creation, retrieval, replies, and resolution to authorized members of the meeting’s organization.
  * Prevented notifications from being sent to users outside the meeting’s organization.
  * Improved handling of missing meetings and unauthorized thread access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->