### PR TITLE
fix(agenda): use consistent Socket.IO meeting room names

### DIFF
--- a/server/controllers/agendaTimerController.js
+++ b/server/controllers/agendaTimerController.js
@@ -51,7 +51,7 @@ export const startAgendaItem = async (req, res) => {
 
     const io = req.app.get("io");
     if (io) {
-      io.to(`meeting_${meetingId}`).emit("agenda_timer_updated", {
+      io.to(meetingId.toString()).emit("agenda_timer_updated", {
         meetingId,
         item,
         action: "start",
@@ -116,7 +116,7 @@ export const stopAgendaItem = async (req, res) => {
 
     const io = req.app.get("io");
     if (io) {
-      io.to(`meeting_${meetingId}`).emit("agenda_timer_updated", {
+      io.to(meetingId.toString()).emit("agenda_timer_updated", {
         meetingId,
         item,
         action: "stop",
@@ -176,7 +176,7 @@ export const skipAgendaItem = async (req, res) => {
 
     const io = req.app.get("io");
     if (io) {
-      io.to(`meeting_${meetingId}`).emit("agenda_timer_updated", {
+      io.to(meetingId.toString()).emit("agenda_timer_updated", {
         meetingId,
         item,
         action: "skip",


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a Socket.IO room name mismatch that prevented agenda timer updates from reaching connected clients.

### Changes made

- Updated agenda timer event emissions to use the same meeting room naming convention as the Socket.IO meeting handler.
- Replaced `meeting_${meetingId}` room names with `meetingId.toString()` for:
  - Start agenda item events
  - Stop agenda item events
  - Skip agenda item events
- Preserved existing event names and payloads.
- Standardized room naming with the rest of the real-time meeting features.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #815

## Testing

Verified the changes locally.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (backend Socket.IO fix).

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review