### PR TITLE
fix(digest): validate tag ownership in digest preferences (#832)

### DIFF
--- a/server/controllers/digestPreferenceController.js
+++ b/server/controllers/digestPreferenceController.js
@@ -1,7 +1,9 @@
 // server/controllers/digestPreferenceController.js
 
+import mongoose from "mongoose";
 import DigestPreference from "../models/digestPreferenceModel.js";
 import User from "../models/userModel.js";
+import Tag from "../models/tagModel.js";
 import transporter from "../config/nodeMailer.js";
 import MeetingDigestService from "../services/MeetingDigestService.js";
 
@@ -13,7 +15,9 @@ import MeetingDigestService from "../services/MeetingDigestService.js";
 export const getPreferences = async (req, res) => {
   try {
     const userId = req.user._id;
-    const preferences = await DigestPreference.findOne({ userId });
+    const preferences = await DigestPreference.findOne({
+      $or: [{ user: userId }, { userId }],
+    });
 
     if (!preferences) {
       return res.status(200).json({
@@ -22,6 +26,7 @@ export const getPreferences = async (req, res) => {
           frequency: "weekly",
           includeSections: ["decisions", "action-items"],
           enabled: true,
+          filterByTags: [],
         },
       });
     }
@@ -47,11 +52,72 @@ export const getPreferences = async (req, res) => {
 export const updatePreferences = async (req, res) => {
   try {
     const userId = req.user._id;
-    const { frequency, includeSections, enabled } = req.body;
+    const {
+      frequency,
+      includeSections,
+      enabled,
+      filterByTags,
+      deliveryDay,
+      deliveryHour,
+      maxItems,
+    } = req.body;
+
+    const userOrgId = req.user.organization;
+
+    let validTagIds = [];
+    if (
+      filterByTags &&
+      Array.isArray(filterByTags) &&
+      filterByTags.length > 0
+    ) {
+      if (!userOrgId) {
+        return res.status(400).json({
+          success: false,
+          message: "User must belong to an organization to filter by tags.",
+        });
+      }
+
+      // Check format of tag IDs
+      for (const tagId of filterByTags) {
+        if (!mongoose.Types.ObjectId.isValid(tagId)) {
+          return res.status(400).json({
+            success: false,
+            message: `Invalid tag ID format: ${tagId}`,
+          });
+        }
+      }
+
+      // Find organization-owned tags matching all passed IDs
+      const foundTags = await Tag.find({
+        _id: { $in: filterByTags },
+        organization: userOrgId,
+      }).select("_id");
+
+      if (foundTags.length !== filterByTags.length) {
+        return res.status(400).json({
+          success: false,
+          message:
+            "One or more tag IDs are invalid or do not belong to your organization.",
+        });
+      }
+
+      validTagIds = foundTags.map((t) => t._id);
+    }
+
+    const updateFields = {
+      user: userId,
+      ...(frequency !== undefined && { frequency }),
+      ...(includeSections !== undefined && { includeSections }),
+      ...(enabled !== undefined && { enabled }),
+      ...(deliveryDay !== undefined && { deliveryDay }),
+      ...(deliveryHour !== undefined && { deliveryHour }),
+      ...(maxItems !== undefined && { maxItems }),
+      ...(filterByTags !== undefined && { filterByTags: validTagIds }),
+    };
 
     const preferences = await DigestPreference.findOneAndUpdate(
-      { userId },
-      { frequency, includeSections, enabled },
+      { $or: [{ user: userId }, { userId }] },
+      updateFields,
       { new: true, upsert: true, runValidators: true },
     );
 

--- a/server/tests/digestPreferenceTagValidation.test.js
+++ b/server/tests/digestPreferenceTagValidation.test.js
@@ -1,0 +1,126 @@
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+import Tag from "../models/tagModel.js";
+import DigestPreference from "../models/digestPreferenceModel.js";
+import {
+  getPreferences,
+  updatePreferences,
+} from "../controllers/digestPreferenceController.js";
+
+describe("Digest Preferences Controller - Tag Ownership Validation", () => {
+  let app;
+  let mockUser;
+  let mockOrgId;
+
+  beforeAll(() => {
+    mockOrgId = new mongoose.Types.ObjectId();
+    mockUser = {
+      _id: new mongoose.Types.ObjectId(),
+      name: "Test User",
+      email: "test@example.com",
+      organization: mockOrgId,
+    };
+
+    app = express();
+    app.use(express.json());
+
+    // Inject mock auth user
+    app.use((req, res, next) => {
+      req.user = mockUser;
+      next();
+    });
+
+    app.get("/api/digest-preferences", getPreferences);
+    app.put("/api/digest-preferences", updatePreferences);
+  });
+
+  beforeEach(async () => {
+    // Mock DB operations on Tag and DigestPreference
+    jest.restoreAllMocks();
+  });
+
+  describe("PUT /api/digest-preferences tag ownership validation", () => {
+    it("should accept tag IDs owned by the user's organization", async () => {
+      const validTagId = new mongoose.Types.ObjectId();
+
+      jest.spyOn(Tag, "find").mockImplementation(() => ({
+        select: jest.fn().mockResolvedValue([{ _id: validTagId }]),
+      }));
+
+      jest.spyOn(DigestPreference, "findOneAndUpdate").mockResolvedValue({
+        _id: new mongoose.Types.ObjectId(),
+        user: mockUser._id,
+        frequency: "weekly",
+        filterByTags: [validTagId],
+      });
+
+      const res = await request(app)
+        .put("/api/digest-preferences")
+        .send({
+          frequency: "weekly",
+          filterByTags: [validTagId.toString()],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.filterByTags).toHaveLength(1);
+    });
+
+    it("should reject tag IDs belonging to another organization", async () => {
+      const unauthorizedTagId = new mongoose.Types.ObjectId();
+
+      jest.spyOn(Tag, "find").mockImplementation(() => ({
+        select: jest.fn().mockResolvedValue([]), // No matching tags found for user's org
+      }));
+
+      const res = await request(app)
+        .put("/api/digest-preferences")
+        .send({
+          frequency: "weekly",
+          filterByTags: [unauthorizedTagId.toString()],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(
+        /invalid or do not belong to your organization/i,
+      );
+    });
+
+    it("should reject invalid tag ID format", async () => {
+      const res = await request(app)
+        .put("/api/digest-preferences")
+        .send({
+          frequency: "weekly",
+          filterByTags: ["invalid-object-id"],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/invalid tag id format/i);
+    });
+
+    it("should reject tag filtering if user has no organization", async () => {
+      const validTagId = new mongoose.Types.ObjectId();
+
+      // Temporarily clear user organization
+      const origOrg = mockUser.organization;
+      mockUser.organization = null;
+
+      const res = await request(app)
+        .put("/api/digest-preferences")
+        .send({
+          frequency: "weekly",
+          filterByTags: [validTagId.toString()],
+        });
+
+      mockUser.organization = origOrg;
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/must belong to an organization/i);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Validate tag ownership in digest preferences before saving. Any tag IDs included in `filterByTags` are checked against the user's organization (`req.user.organization`). Invalid ObjectId formats or tag IDs belonging to other organizations are rejected with a 400 Bad Request response.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #832

## Testing

Added comprehensive unit test suite in `server/tests/digestPreferenceTagValidation.test.js`.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Digest preferences now support delivery schedules, item limits, and tag-based filtering.
  * Tag filters are validated against the user’s organization before being saved.
  * Preference lookups support records associated with either user identifier format.
  * Responses include an empty tag filter list when no filters are configured.

* **Bug Fixes**
  * Updating preferences now preserves unspecified settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->