### PR TITLE
feat: enable transcript navigation from sentiment chart

### DIFF
--- a/client/src/components/MeetingSentimentChart.jsx
+++ b/client/src/components/MeetingSentimentChart.jsx
@@ -49,7 +49,7 @@ const CustomTooltip = ({ active, payload }) => {
   return null;
 };
 
-const MeetingSentimentChart = ({ transcript }) => {
+const MeetingSentimentChart = ({ transcript, onPointClick }) => {
   const chartData = useMemo(() => {
     if (!transcript || !transcript.segments) return [];
 
@@ -105,6 +105,17 @@ const MeetingSentimentChart = ({ transcript }) => {
           <AreaChart
             data={chartData}
             margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
+            onClick={(e) => {
+              if (
+                onPointClick &&
+                e &&
+                e.activePayload &&
+                e.activePayload.length > 0
+              ) {
+                onPointClick(e.activePayload[0].payload);
+              }
+            }}
+            style={{ cursor: onPointClick ? "pointer" : "default" }}
           >
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -139,7 +150,12 @@ const MeetingSentimentChart = ({ transcript }) => {
               strokeWidth={3}
               fillOpacity={1}
               fill={`url(#${gradientId})`}
-              activeDot={{ r: 6, strokeWidth: 0, fill: "#8b5cf6" }}
+              activeDot={{
+                r: 6,
+                strokeWidth: 0,
+                fill: "#8b5cf6",
+                style: { cursor: onPointClick ? "pointer" : "default" },
+              }}
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -321,7 +321,17 @@ const TranscriptViewer = () => {
           {/* Transcript Content */}
           <div className="lg:col-span-2 space-y-4">
             {/* Sentiment Chart */}
-            <MeetingSentimentChart transcript={transcript} />
+            <MeetingSentimentChart
+              transcript={transcript}
+              onPointClick={(segmentData) => {
+                const index = transcript.segments.findIndex(
+                  (s) => s.startTime === segmentData.startTime,
+                );
+                if (index !== -1) {
+                  scrollToSegment(index);
+                }
+              }}
+            />
 
             {transcript.segments?.length === 0 ? (
               <div className="bg-white dark:bg-slate-800 rounded-lg p-8 text-center">


### PR DESCRIPTION
# Pull Request

## Description

Implemented transcript navigation from the Meeting Sentiment Chart. Users can now click sentiment data points to automatically navigate to the corresponding transcript segment. The selected transcript section scrolls smoothly into view and is highlighted, while preserving existing transcript, playback, and sentiment analysis functionality.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

- Closes #917

## Testing

Verified that:

- Clicking any sentiment data point navigates to the correct transcript segment.
- The transcript scrolls smoothly to the selected segment.
- The selected transcript section is highlighted.
- Existing transcript navigation and sentiment analysis continue to work as expected.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart points in transcript sentiment visualizations are now clickable.
  * Selecting a point automatically scrolls to the corresponding transcript segment.
  * Clickable points display updated cursor styling for clearer interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->