### PR TITLE
fix(cache): derive the search cache tenant from the session only (#1068)

### DIFF
--- a/server/middleware/cacheMiddleware.js
+++ b/server/middleware/cacheMiddleware.js
@@ -7,39 +7,167 @@ import {
 import crypto from "crypto";
 
 /**
- * Extract organization ID from request parameters, user token, or headers.
- * Defaults to "global" if unassigned.
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Search cache partitioning (Issue #1068)
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * The cache key is the *only* thing separating one tenant's search results from
+ * another's, so everything that feeds into it has to come from state the server
+ * established itself.
+ *
+ * The previous `getOrganizationIdFromReq` fell back to `x-organization-id`,
+ * `organization-id`, `req.body.organizationId` and `req.query.organizationId`
+ * when `req.user.organization` was missing. `requirePermission()` — the only
+ * guard in front of `cacheSearch` on the search routes — checks `req.user.role`
+ * and never requires an organization, so any authenticated caller without a
+ * resolved org reached this middleware and got to name its own cache partition
+ * with a header. That is both a read (serve the victim's cached payload before
+ * the controller ever runs) and a write (poison the victim's partition).
+ *
+ * Two rules follow, and they are the whole design:
+ *
+ *   1. Tenant identity comes from `req.user` only. Never from headers, body or
+ *      query — those are attacker-controlled on every request.
+ *   2. If the server cannot establish who the caller is, the request is simply
+ *      not cached. There is no shared "global" bucket to fall into, because a
+ *      bucket every unidentified caller shares is a cross-tenant channel by
+ *      construction.
+ *
+ * Rule 2 replaces the old `"global"` default. Skipping the cache costs a cache
+ * miss; sharing a partition costs a data leak.
  */
-export const getOrganizationIdFromReq = (req) => {
-  if (req?.user?.organization) {
-    if (
-      typeof req.user.organization === "object" &&
-      req.user.organization._id
-    ) {
-      return req.user.organization._id.toString();
+
+/** Sentinel returned when no trustworthy tenant identity exists on the request. */
+export const UNRESOLVED_TENANT = null;
+
+/**
+ * Normalizes an id that may arrive as an ObjectId, a populated document, or a
+ * string. Returns null for anything that isn't usable as key material.
+ */
+const normalizeId = (value) => {
+  if (value === null || value === undefined) return null;
+
+  // Populated ref — e.g. `req.user.organization` after `.populate()`.
+  if (typeof value === "object") {
+    if (value._id !== undefined && value._id !== null) {
+      return normalizeId(value._id);
     }
-    return req.user.organization.toString();
+    if (typeof value.toString === "function") {
+      const asString = value.toString();
+      // A plain object stringifies to "[object Object]" — not an id.
+      return asString === "[object Object]" ? null : asString.trim() || null;
+    }
+    return null;
   }
-  if (req?.user?.organizationId) {
-    return req.user.organizationId.toString();
-  }
-  if (req?.headers?.["x-organization-id"]) {
-    return req.headers["x-organization-id"].toString();
-  }
-  if (req?.headers?.["organization-id"]) {
-    return req.headers["organization-id"].toString();
-  }
-  if (req?.body?.organizationId) {
-    return req.body.organizationId.toString();
-  }
-  if (req?.query?.organizationId) {
-    return req.query.organizationId.toString();
-  }
-  return "global";
+
+  const asString = String(value).trim();
+  return asString.length > 0 ? asString : null;
 };
 
 /**
- * Multi-Tenant Search Caching Middleware with Tagging & Stale-While-Revalidate (SWR) Strategy
+ * Resolves the organization the *server* believes this request belongs to.
+ *
+ * Only `req.user` is consulted, because only `req.user` is populated by
+ * `userAuth` from a verified session. Returns `UNRESOLVED_TENANT` (null) when no
+ * organization is attached to the session — callers must treat that as
+ * "not cacheable", not as a default bucket.
+ */
+export const getOrganizationIdFromReq = (req) => {
+  if (!req || typeof req !== "object") return UNRESOLVED_TENANT;
+
+  const user = req.user;
+  if (!user || typeof user !== "object") return UNRESOLVED_TENANT;
+
+  return (
+    normalizeId(user.organization) ??
+    normalizeId(user.organizationId) ??
+    UNRESOLVED_TENANT
+  );
+};
+
+/**
+ * Resolves the authenticated principal — again from `req.user` only.
+ *
+ * The org alone is not a sufficient partition for these routes. `semanticSearch`
+ * filters its results through the caller's own `Membership` documents and
+ * `uploadedBy`, and `federatedSearch` scopes by `req.user._id`, so two members
+ * of the same organization legitimately see different rows for the same query.
+ * Keying only by org would serve one member's rows to another.
+ */
+export const getUserIdFromReq = (req) => {
+  if (!req || typeof req !== "object") return UNRESOLVED_TENANT;
+
+  const user = req.user;
+  if (!user || typeof user !== "object") return UNRESOLVED_TENANT;
+
+  return normalizeId(user._id) ?? normalizeId(user.id) ?? UNRESOLVED_TENANT;
+};
+
+/**
+ * Full cache-partition decision for a request.
+ *
+ * @returns {{organizationId: string|null, userId: string|null,
+ *            cacheable: boolean, reason: string|null}}
+ */
+export const resolveCacheTenant = (req) => {
+  const organizationId = getOrganizationIdFromReq(req);
+  const userId = getUserIdFromReq(req);
+
+  if (!userId) {
+    return {
+      organizationId,
+      userId,
+      cacheable: false,
+      reason: "unauthenticated-principal",
+    };
+  }
+
+  if (!organizationId) {
+    return {
+      organizationId,
+      userId,
+      cacheable: false,
+      reason: "unresolved-organization",
+    };
+  }
+
+  return { organizationId, userId, cacheable: true, reason: null };
+};
+
+/**
+ * Builds the Redis key for a search response.
+ *
+ * The org prefix stays first so `clearOrgSetAndKeys("org:<id>:search_keys")`
+ * invalidation keeps working unchanged; the principal is folded into the hash
+ * rather than the prefix for the same reason.
+ */
+export const buildSearchCacheKey = ({
+  organizationId,
+  userId,
+  route,
+  query,
+  options,
+}) => {
+  const cachePayload = JSON.stringify({
+    // Included in the hashed material as well as the prefix so a key can never
+    // be reinterpreted under a different tenant even if the prefix is stripped.
+    organizationId,
+    userId,
+    route,
+    query: String(query).toLowerCase().trim(),
+    options: options ?? {},
+  });
+
+  const hash = crypto.createHash("sha256").update(cachePayload).digest("hex");
+  return `org:${organizationId}:search:${hash}`;
+};
+
+/**
+ * Multi-tenant search caching middleware with tagging and a
+ * stale-while-revalidate (SWR) read path.
+ *
+ * Fails open: any Redis problem falls through to `next()` so a cache outage
+ * degrades latency rather than availability.
  */
 export const cacheSearch = async (req, res, next) => {
   try {
@@ -53,16 +181,27 @@ export const cacheSearch = async (req, res, next) => {
       return next();
     }
 
-    const organizationId = getOrganizationIdFromReq(req);
+    const { organizationId, userId, cacheable, reason } =
+      resolveCacheTenant(req);
 
-    // Include the route path, tenant org, and extra options in the cache key
-    const cachePayload = JSON.stringify({
-      route: req.baseUrl + req.path,
-      query: query.toLowerCase().trim(),
+    if (!cacheable) {
+      // Deliberately not cached — see the module header. Debug-level because a
+      // request from a user mid-org-switch is normal, not an incident.
+      if (process.env.NODE_ENV !== "production") {
+        console.debug(
+          `↩️ Search cache bypassed (${reason}) for ${req.method} ${req.originalUrl || req.url}`,
+        );
+      }
+      return next();
+    }
+
+    const cacheKey = buildSearchCacheKey({
+      organizationId,
+      userId,
+      route: (req.baseUrl || "") + (req.path || ""),
+      query,
       options,
     });
-    const hash = crypto.createHash("sha256").update(cachePayload).digest("hex");
-    const cacheKey = `org:${organizationId}:search:${hash}`;
     const lockKey = `lock:${cacheKey}`;
 
     req.cacheKey = cacheKey;
@@ -93,40 +232,59 @@ export const cacheSearch = async (req, res, next) => {
       const isStale = Date.now() - cachedAt > softTTL * 1000;
 
       if (!isStale) {
-        console.log(`⚡ Serving fresh Redis cache for query: "${query}"`);
         return res.status(200).json(payload);
       }
 
-      // Stale cache hit (SWR flow)
-      console.log(`⏳ Serving stale Redis cache (SWR) for query: "${query}"`);
+      // Stale cache hit (SWR flow).
       const lockToken = await acquireLock(lockKey, 5000);
 
       if (!lockToken) {
-        // Background revalidation is already in progress by another concurrent request
+        // Another request is already revalidating this key.
         return res.status(200).json(payload);
       }
 
-      // Return stale payload immediately to client
+      // Serve the stale payload immediately, then revalidate in the background.
       res.status(200).json(payload);
 
-      // Perform background revalidation asynchronously without writing duplicate HTTP headers
-      res.headersSent = true;
-      const originalJson = res.json;
-      const swrJsonHook = function (freshData) {
+      // The controller still runs and will call `res.json(freshData)`. Writing
+      // that to the socket a second time would corrupt the response, so swap in
+      // a hook that only refreshes the cache.
+      //
+      // The previous implementation additionally did `res.headersSent = true`.
+      // `headersSent` is a getter-only accessor on ServerResponse, so that
+      // assignment was silently discarded (and throws under strict mode) — it
+      // never suppressed anything. Replacing `res.json` is what actually does
+      // the job, so the bogus assignment is gone.
+      const revalidateOnly = function (freshData) {
         if (freshData && freshData.success !== false) {
-          setSearchCache(cacheKey, organizationId, freshData).finally(() => {
-            releaseLock(lockKey, lockToken);
-          });
+          setSearchCache(cacheKey, organizationId, freshData)
+            .catch((err) =>
+              console.error(
+                "⚠️ SWR revalidation write failed:",
+                cacheKey,
+                err.message,
+              ),
+            )
+            .finally(() => {
+              releaseLock(lockKey, lockToken);
+            });
         } else {
           releaseLock(lockKey, lockToken);
         }
         return this;
       };
-      if (originalJson && typeof originalJson === "function") {
-        Object.setPrototypeOf(swrJsonHook, originalJson);
-        Object.assign(swrJsonHook, originalJson);
+      res.json = revalidateOnly;
+
+      // Also release the lock if the controller errors out without ever calling
+      // `res.json`, so a failed revalidation can't block the next one for the
+      // full lock TTL.
+      if (typeof res.once === "function") {
+        res.once("close", () => {
+          if (res.json === revalidateOnly) {
+            releaseLock(lockKey, lockToken);
+          }
+        });
       }
-      res.json = swrJsonHook;
 
       (globalThis.setImmediate || setTimeout)(() => {
         next();
@@ -134,11 +292,11 @@ export const cacheSearch = async (req, res, next) => {
       return;
     }
 
-    // Cache Miss -> Lock acquisition for stampede protection
+    // Cache miss → acquire the lock for stampede protection.
     const lockToken = await acquireLock(lockKey, 5000);
 
     if (!lockToken) {
-      // Another request is executing the search query; poll Redis until cache is populated
+      // Another request is executing the same search; poll until it publishes.
       for (let i = 0; i < 50; i++) {
         await new Promise((resolve) => setTimeout(resolve, 50));
         const polledStr = await redisClient.get(cacheKey);
@@ -155,13 +313,21 @@ export const cacheSearch = async (req, res, next) => {
       }
     }
 
-    // Lock acquired (or polling timed out), hook res.json to populate Redis cache upon completion
+    // Lock acquired (or polling timed out) — populate the cache on the way out.
     const originalJson = res.json.bind(res);
     res.json = function (body) {
       if (req.cacheKey && body && body.success !== false) {
-        setSearchCache(cacheKey, organizationId, body).finally(() => {
-          if (lockToken) releaseLock(lockKey, lockToken);
-        });
+        setSearchCache(cacheKey, organizationId, body)
+          .catch((err) =>
+            console.error(
+              "⚠️ Search cache write failed:",
+              cacheKey,
+              err.message,
+            ),
+          )
+          .finally(() => {
+            if (lockToken) releaseLock(lockKey, lockToken);
+          });
       } else if (lockToken) {
         releaseLock(lockKey, lockToken);
       }

--- a/server/tests/cacheInvalidation.test.js
+++ b/server/tests/cacheInvalidation.test.js
@@ -3,9 +3,24 @@ import eventBus from "../services/eventBus.js";
 import * as redisService from "../services/redisService.js";
 import { invalidateOrgCache } from "../services/cacheInvalidationService.js";
 import {
+  buildSearchCacheKey,
   cacheSearch,
   getOrganizationIdFromReq,
 } from "../middleware/cacheMiddleware.js";
+
+/**
+ * Every request fixture here carries a `_id` as well as an `organization`.
+ *
+ * Before #1068 the middleware keyed on the organization alone, so a session
+ * without a user id still produced a cache key. It no longer does: the search
+ * controllers filter results per principal, so a request the server cannot
+ * attribute to a user is not cacheable at all. Fixtures have to look like real
+ * authenticated sessions.
+ */
+const sessionFor = (organization, id = "user_fixture") => ({
+  _id: id,
+  organization,
+});
 
 // Helper to construct an in-memory Redis client mock
 function createMockRedisClient() {
@@ -87,7 +102,7 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
   });
 
   describe("1. Organization Extraction & Key Isolation", () => {
-    it("should correctly extract organizationId from user object, headers, body, or fallback", () => {
+    it("should extract organizationId from the authenticated session only", () => {
       expect(
         getOrganizationIdFromReq({ user: { organization: "org_user_123" } }),
       ).toBe("org_user_123");
@@ -99,16 +114,11 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
       ).toBe("org_obj_456");
 
       expect(
-        getOrganizationIdFromReq({
-          headers: { "x-organization-id": "org_hdr_789" },
-        }),
-      ).toBe("org_hdr_789");
+        getOrganizationIdFromReq({ user: { organizationId: "org_alt_789" } }),
+      ).toBe("org_alt_789");
 
-      expect(
-        getOrganizationIdFromReq({ body: { organizationId: "org_body_101" } }),
-      ).toBe("org_body_101");
-
-      expect(getOrganizationIdFromReq({})).toBe("global");
+      // No session → no tenant. `null` means "not cacheable", not "global".
+      expect(getOrganizationIdFromReq({})).toBeNull();
     });
 
     it("should generate organization-scoped cache keys for identical search queries", async () => {
@@ -116,7 +126,7 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
         baseUrl: "/api",
         path: "/search",
         body: { query: "quarterly financial report" },
-        user: { organization: "org_alpha" },
+        user: sessionFor("org_alpha", "user_alpha"),
       };
       const res1 = { status: jest.fn().mockReturnThis(), json: jest.fn() };
       const next1 = jest.fn();
@@ -130,7 +140,7 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
         baseUrl: "/api",
         path: "/search",
         body: { query: "quarterly financial report" },
-        user: { organization: "org_beta" },
+        user: sessionFor("org_beta", "user_beta"),
       };
       const res2 = { status: jest.fn().mockReturnThis(), json: jest.fn() };
       const next2 = jest.fn();
@@ -220,7 +230,7 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
         baseUrl: "/api",
         path: "/search",
         body: { query: "security compliance policy" },
-        user: { organization: orgId },
+        user: sessionFor(orgId, "user_swr"),
       };
       const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
       const next = jest.fn();
@@ -251,20 +261,16 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
         baseUrl: "/api",
         path: "/search",
         body: { query: "engineering guidelines" },
-        user: { organization: orgId },
+        user: sessionFor(orgId, "user_swr_stale"),
       };
 
-      const crypto = await import("crypto");
-      const cachePayload = JSON.stringify({
+      const cacheKey = buildSearchCacheKey({
+        organizationId: orgId,
+        userId: req.user._id,
         route: req.baseUrl + req.path,
         query: req.body.query,
         options: {},
       });
-      const hash = crypto
-        .createHash("sha256")
-        .update(cachePayload)
-        .digest("hex");
-      const cacheKey = `org:${orgId}:search:${hash}`;
 
       const stalePayload = { success: true, results: ["old_guideline"] };
       // Save cache entry with an old timestamp (6 minutes ago, > softTTL of 300s)
@@ -277,13 +283,22 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
       await mockRedis.setEx(cacheKey, 3600, JSON.stringify(staleCacheValue));
       await mockRedis.sAdd(`org:${orgId}:search_keys`, cacheKey);
 
-      const resStale = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      // Record payloads out-of-band: on the SWR path the middleware replaces
+      // `res.json` with a revalidate-only hook once the stale payload has been
+      // written, so the original spy is no longer reachable through `res.json`
+      // by the time the assertions run.
+      const served = [];
+      const resStale = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn((body) => served.push(body)),
+        once: jest.fn(),
+      };
       const nextStale = jest.fn();
 
       await cacheSearch(req, resStale, nextStale);
 
       expect(resStale.status).toHaveBeenCalledWith(200);
-      expect(resStale.json).toHaveBeenCalledWith(stalePayload);
+      expect(served).toEqual([stalePayload]);
 
       // Lock should have been acquired for background revalidation
       const lockVal = await mockRedis.get(`lock:${cacheKey}`);
@@ -299,21 +314,17 @@ describe("Multi-Tenant Cache Invalidation & SWR System", () => {
         baseUrl: "/api",
         path: "/search",
         body: { query: "heavy concurrency search" },
-        user: { organization: orgId },
+        user: sessionFor(orgId, "user_stampede"),
       };
 
-      // Populate a stale cache payload
-      const cachePayload = JSON.stringify({
+      // Populate a stale cache payload under the key the middleware will build.
+      const cacheKey = buildSearchCacheKey({
+        organizationId: orgId,
+        userId: reqTemplate.user._id,
         route: reqTemplate.baseUrl + reqTemplate.path,
         query: reqTemplate.body.query,
         options: {},
       });
-      const crypto = await import("crypto");
-      const hash = crypto
-        .createHash("sha256")
-        .update(cachePayload)
-        .digest("hex");
-      const cacheKey = `org:${orgId}:search:${hash}`;
 
       const staleData = { success: true, results: ["heavy_result"] };
       await mockRedis.setEx(

--- a/server/tests/searchCacheTenantIsolation.test.js
+++ b/server/tests/searchCacheTenantIsolation.test.js
@@ -1,0 +1,426 @@
+/**
+ * Issue #1068 — the search cache tenant boundary.
+ *
+ * `getOrganizationIdFromReq` used to fall back to `x-organization-id`,
+ * `organization-id`, `req.body.organizationId` and `req.query.organizationId`
+ * when the session had no organization on it. That value became the Redis key
+ * prefix, so a caller could name the partition it read from and wrote to with a
+ * single request header.
+ *
+ * These suites pin down the two halves of the fix:
+ *
+ *   1. Nothing outside `req.user` can influence the cache key.
+ *   2. A request the server cannot attribute to an (organization, user) pair is
+ *      not cached at all — there is no shared bucket to land in.
+ *
+ * Plus the property that motivated adding the principal to the key material:
+ * the search controllers filter rows through the caller's own memberships, so
+ * two members of the same organization must not share a cache entry.
+ */
+
+import { jest } from "@jest/globals";
+import * as redisService from "../services/redisService.js";
+import {
+  buildSearchCacheKey,
+  cacheSearch,
+  getOrganizationIdFromReq,
+  getUserIdFromReq,
+  resolveCacheTenant,
+} from "../middleware/cacheMiddleware.js";
+
+function createMockRedisClient() {
+  const store = new Map();
+  const sets = new Map();
+
+  return {
+    isReady: true,
+    async get(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async setEx(key, _seconds, value) {
+      store.set(key, value);
+      return "OK";
+    },
+    async set(key, value, opts) {
+      if (opts && opts.NX) {
+        if (store.has(key)) return null;
+        store.set(key, value);
+        return "OK";
+      }
+      store.set(key, value);
+      return "OK";
+    },
+    async sAdd(key, member) {
+      if (!sets.has(key)) sets.set(key, new Set());
+      sets.get(key).add(member);
+      return 1;
+    },
+    async sMembers(key) {
+      return sets.has(key) ? Array.from(sets.get(key)) : [];
+    },
+    async del(key) {
+      const had = store.has(key) || sets.has(key);
+      store.delete(key);
+      sets.delete(key);
+      return had ? 1 : 0;
+    },
+    async expire() {
+      return 1;
+    },
+    _store: store,
+    _sets: sets,
+  };
+}
+
+/**
+ * Minimal express-ish response double.
+ *
+ * `served` is populated by the original `json` implementation only. The
+ * middleware legitimately replaces `res.json` (to populate the cache on a miss,
+ * or to swallow the revalidation write on the SWR path), so assertions have to
+ * read this array rather than the spy that `res.json` used to point at.
+ */
+const makeRes = () => {
+  const served = [];
+  const res = {
+    statusCode: null,
+    served,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      served.push(body);
+      return res;
+    }),
+    once: jest.fn(),
+  };
+  return res;
+};
+
+const VICTIM_ORG = "org_victim_acme";
+const ATTACKER_ORG = "org_attacker_evil";
+const SHARED_QUERY = "q4 revenue plan";
+
+describe("Search cache tenant isolation (#1068)", () => {
+  let mockRedis;
+
+  beforeEach(() => {
+    mockRedis = createMockRedisClient();
+    redisService.overrideRedisClientForTesting(mockRedis);
+  });
+
+  afterEach(() => {
+    redisService.overrideRedisClientForTesting(null);
+    jest.restoreAllMocks();
+  });
+
+  describe("tenant resolution ignores client-controlled input", () => {
+    it("never reads the organization from request headers", () => {
+      expect(
+        getOrganizationIdFromReq({
+          headers: { "x-organization-id": VICTIM_ORG },
+        }),
+      ).toBeNull();
+
+      expect(
+        getOrganizationIdFromReq({
+          headers: { "organization-id": VICTIM_ORG },
+        }),
+      ).toBeNull();
+    });
+
+    it("never reads the organization from the body or query string", () => {
+      expect(
+        getOrganizationIdFromReq({ body: { organizationId: VICTIM_ORG } }),
+      ).toBeNull();
+
+      expect(
+        getOrganizationIdFromReq({ query: { organizationId: VICTIM_ORG } }),
+      ).toBeNull();
+    });
+
+    it("prefers the session organization even when a header contradicts it", () => {
+      const req = {
+        user: { _id: "user_1", organization: ATTACKER_ORG },
+        headers: { "x-organization-id": VICTIM_ORG },
+        body: { organizationId: VICTIM_ORG },
+        query: { organizationId: VICTIM_ORG },
+      };
+
+      expect(getOrganizationIdFromReq(req)).toBe(ATTACKER_ORG);
+    });
+
+    it("accepts a populated organization document as well as a raw id", () => {
+      expect(
+        getOrganizationIdFromReq({
+          user: { organization: { _id: VICTIM_ORG, name: "Acme" } },
+        }),
+      ).toBe(VICTIM_ORG);
+
+      expect(
+        getOrganizationIdFromReq({ user: { organizationId: VICTIM_ORG } }),
+      ).toBe(VICTIM_ORG);
+    });
+
+    it("treats blank and non-string session values as unresolved", () => {
+      expect(
+        getOrganizationIdFromReq({ user: { organization: "" } }),
+      ).toBeNull();
+      expect(
+        getOrganizationIdFromReq({ user: { organization: "   " } }),
+      ).toBeNull();
+      expect(
+        getOrganizationIdFromReq({ user: { organization: {} } }),
+      ).toBeNull();
+      expect(getOrganizationIdFromReq(null)).toBeNull();
+      expect(getOrganizationIdFromReq(undefined)).toBeNull();
+    });
+
+    it("resolves the principal from _id or id, and nothing else", () => {
+      expect(getUserIdFromReq({ user: { _id: "user_a" } })).toBe("user_a");
+      expect(getUserIdFromReq({ user: { id: "user_b" } })).toBe("user_b");
+      expect(
+        getUserIdFromReq({ headers: { "x-user-id": "user_c" } }),
+      ).toBeNull();
+      expect(getUserIdFromReq({})).toBeNull();
+    });
+  });
+
+  describe("cacheability decision", () => {
+    it("is cacheable only when both organization and principal resolve", () => {
+      expect(
+        resolveCacheTenant({ user: { _id: "user_a", organization: "org_a" } }),
+      ).toEqual({
+        organizationId: "org_a",
+        userId: "user_a",
+        cacheable: true,
+        reason: null,
+      });
+    });
+
+    it("is not cacheable without a principal", () => {
+      const decision = resolveCacheTenant({ user: { organization: "org_a" } });
+      expect(decision.cacheable).toBe(false);
+      expect(decision.reason).toBe("unauthenticated-principal");
+    });
+
+    it("is not cacheable without an organization", () => {
+      const decision = resolveCacheTenant({ user: { _id: "user_a" } });
+      expect(decision.cacheable).toBe(false);
+      expect(decision.reason).toBe("unresolved-organization");
+    });
+
+    it("has no shared fallback bucket for unidentified callers", () => {
+      const decision = resolveCacheTenant({
+        headers: { "x-organization-id": "global" },
+      });
+      expect(decision.cacheable).toBe(false);
+      expect(decision.organizationId).toBeNull();
+    });
+  });
+
+  describe("middleware behaviour", () => {
+    it("passes through without caching when the tenant cannot be resolved", async () => {
+      const req = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        headers: { "x-organization-id": VICTIM_ORG },
+        user: { role: "member" }, // authenticated, but no org and no id
+      };
+      const res = makeRes();
+      const next = jest.fn();
+
+      await cacheSearch(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.served).toEqual([]);
+      expect(req.cacheKey).toBeUndefined();
+      // Nothing was written anywhere in Redis.
+      expect(mockRedis._store.size).toBe(0);
+    });
+
+    it("does not let a spoofed header read a victim's cached results", async () => {
+      // 1. The victim runs a search; the response lands in their partition.
+      const victimReq = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        user: { _id: "user_victim", organization: VICTIM_ORG },
+      };
+      const victimRes = makeRes();
+      await cacheSearch(victimReq, victimRes, jest.fn());
+
+      const victimPayload = {
+        success: true,
+        results: ["confidential-meeting"],
+      };
+      victimRes.json(victimPayload);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(await mockRedis.get(victimReq.cacheKey)).not.toBeNull();
+
+      // 2. The attacker replays the identical query, claiming the victim's org.
+      const attackerReq = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        headers: { "x-organization-id": VICTIM_ORG },
+        query: { organizationId: VICTIM_ORG },
+        user: { _id: "user_attacker", organization: ATTACKER_ORG },
+      };
+      const attackerRes = makeRes();
+      const attackerNext = jest.fn();
+
+      await cacheSearch(attackerReq, attackerRes, attackerNext);
+
+      // The attacker gets a miss and is forwarded to the controller, which will
+      // do its own org scoping. No cached payload is served.
+      expect(attackerNext).toHaveBeenCalledTimes(1);
+      expect(attackerRes.served).toEqual([]);
+      expect(attackerReq.cacheKey).not.toBe(victimReq.cacheKey);
+      expect(attackerReq.cacheKey.startsWith(`org:${ATTACKER_ORG}:`)).toBe(
+        true,
+      );
+    });
+
+    it("does not let a spoofed header poison a victim's partition", async () => {
+      const attackerReq = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        headers: { "x-organization-id": VICTIM_ORG },
+        user: { _id: "user_attacker", organization: ATTACKER_ORG },
+      };
+      const attackerRes = makeRes();
+
+      await cacheSearch(attackerReq, attackerRes, jest.fn());
+      attackerRes.json({ success: true, results: ["attacker-controlled"] });
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Everything written belongs to the attacker's own org, key and tag set.
+      const writtenKeys = Array.from(mockRedis._store.keys()).filter(
+        (k) => !k.startsWith("lock:"),
+      );
+      expect(writtenKeys.length).toBeGreaterThan(0);
+      writtenKeys.forEach((key) => {
+        expect(key.startsWith(`org:${ATTACKER_ORG}:`)).toBe(true);
+      });
+
+      expect(await redisService.getOrgKeys(VICTIM_ORG)).toEqual([]);
+      expect(await redisService.getOrgKeys(ATTACKER_ORG)).toEqual(writtenKeys);
+    });
+
+    it("separates two members of the same organization", async () => {
+      // `semanticSearch` filters through the caller's own Membership documents
+      // and `uploadedBy`, so an org-wide key would serve one member's rows to
+      // another.
+      const alice = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        user: { _id: "user_alice", organization: VICTIM_ORG },
+      };
+      const bob = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        user: { _id: "user_bob", organization: VICTIM_ORG },
+      };
+
+      await cacheSearch(alice, makeRes(), jest.fn());
+      await cacheSearch(bob, makeRes(), jest.fn());
+
+      expect(alice.cacheKey).not.toBe(bob.cacheKey);
+      // Both still live under the org prefix, so org-wide invalidation reaches
+      // them both.
+      expect(alice.cacheKey.startsWith(`org:${VICTIM_ORG}:`)).toBe(true);
+      expect(bob.cacheKey.startsWith(`org:${VICTIM_ORG}:`)).toBe(true);
+    });
+
+    it("keeps distinct routes and options in distinct entries", async () => {
+      const base = {
+        organizationId: VICTIM_ORG,
+        userId: "user_alice",
+        query: SHARED_QUERY,
+        options: {},
+      };
+
+      const search = buildSearchCacheKey({ ...base, route: "/api/search" });
+      const hybrid = buildSearchCacheKey({
+        ...base,
+        route: "/api/search/hybrid",
+      });
+      const weighted = buildSearchCacheKey({
+        ...base,
+        route: "/api/search",
+        options: { semanticWeight: 0.8 },
+      });
+
+      expect(new Set([search, hybrid, weighted]).size).toBe(3);
+    });
+
+    it("normalizes query casing and surrounding whitespace", async () => {
+      const base = {
+        organizationId: VICTIM_ORG,
+        userId: "user_alice",
+        route: "/api/search",
+        options: {},
+      };
+
+      expect(
+        buildSearchCacheKey({ ...base, query: "  Q4 Revenue Plan " }),
+      ).toBe(buildSearchCacheKey({ ...base, query: "q4 revenue plan" }));
+    });
+
+    it("fails open when Redis is unavailable", async () => {
+      redisService.overrideRedisClientForTesting({ isReady: false });
+
+      const req = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        user: { _id: "user_alice", organization: VICTIM_ORG },
+      };
+      const res = makeRes();
+      const next = jest.fn();
+
+      await cacheSearch(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.served).toEqual([]);
+    });
+
+    it("skips caching for a non-string or missing query", async () => {
+      for (const body of [{}, { query: 42 }, { query: null }]) {
+        const req = {
+          baseUrl: "/api",
+          path: "/search",
+          body,
+          user: { _id: "user_alice", organization: VICTIM_ORG },
+        };
+        const next = jest.fn();
+        await cacheSearch(req, makeRes(), next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(req.cacheKey).toBeUndefined();
+      }
+    });
+
+    it("does not cache an unsuccessful controller response", async () => {
+      const req = {
+        baseUrl: "/api",
+        path: "/search",
+        body: { query: SHARED_QUERY },
+        user: { _id: "user_alice", organization: VICTIM_ORG },
+      };
+      const res = makeRes();
+
+      await cacheSearch(req, res, jest.fn());
+      res.json({ success: false, message: "upstream failure" });
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(await mockRedis.get(req.cacheKey)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The Redis search cache key is the only thing separating one tenant's cached results from another's, and `getOrganizationIdFromReq` was willing to take that key material from the client:

```js
if (req?.headers?.["x-organization-id"]) return req.headers["x-organization-id"].toString();
if (req?.headers?.["organization-id"])   return req.headers["organization-id"].toString();
if (req?.body?.organizationId)           return req.body.organizationId.toString();
if (req?.query?.organizationId)          return req.query.organizationId.toString();
return "global";
```

`requirePermission()` is the only guard in front of `cacheSearch` on the search routes, and unlike `requireOrgMembership` it only checks `req.user.role` — it never requires an organization. So any authenticated caller whose session had no org resolved reached this middleware and could name its own cache partition with one header:

- **Read.** Replay a query the victim runs, with `x-organization-id: <victim org>`. The key collides and the middleware returns the cached payload with `res.status(200).json(payload)` **before the controller runs**, so the controller's own org scoping never gets a chance to filter anything.
- **Write.** On a miss, the attacker's results are stored under the victim's prefix and registered in `org:<victim>:search_keys`, serving them to victim users for the 3600s hard TTL.

### What changed

Tenant identity now comes from `req.user` and nothing else, and a request the server cannot attribute is not cached at all. The `"global"` fallback is gone with it — a bucket every unidentified caller shares is a cross-tenant channel by construction, and a cache miss is the cheaper trade.

The authenticated principal is now part of the key material too. That is not defence in depth, it is required for correctness:

- `semanticSearch` filters results through the caller's own `Membership` documents and `uploadedBy` (`searchController.js`, steps 4–5)
- `federatedSearch` scopes by `req.user._id`

Two members of one organization legitimately see different rows for the same query, so an org-wide key served one member's rows to the other. The org stays the key *prefix*, so `clearOrgSetAndKeys` invalidation is unaffected.

### Two SWR bugs fixed while in here

- `res.headersSent = true` was a no-op. `headersSent` is a getter-only accessor on `ServerResponse`, so the assignment was silently discarded (and throws under strict mode) — it never suppressed anything. Replacing `res.json` is what actually does the job, so the bogus assignment is gone.
- A revalidation that never reached `res.json` (a controller that threw) held the distributed lock until its 5s TTL expired. The lock is now released on response close as well.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1068

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

New suite `server/tests/searchCacheTenantIsolation.test.js` — 19 tests:

- headers / body / query are ignored for tenant resolution, individually and when they contradict the session
- populated org documents, raw ids, blank and non-string values
- the cacheability decision (`unauthenticated-principal`, `unresolved-organization`, no shared fallback)
- a spoofed header cannot read the victim's entry, and cannot write into their partition or tag set
- two members of one org get distinct keys, both still under the org prefix
- route and options separation, query normalization, fail-open on Redis down, no caching of `success: false`

Two changes to the existing `cacheInvalidation.test.js` are worth calling out explicitly, since both were passing tests:

1. The `getOrganizationIdFromReq` test asserted the header and body fallbacks as *intended* behaviour. It now asserts they are ignored.
2. The SWR test read `res.json` after the middleware had replaced it, and only passed because the old hook copied the spy's own properties across with `Object.assign`. It records served payloads out-of-band instead.

Full server suite: unchanged against `main` — same 17 pre-existing suite failures, same 1 pre-existing test failure (`meetingSeriesController` #915), 551 → 570 passing.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search-cache isolation by associating cached results with authenticated organization and user identities.
  * Prevented unauthenticated or incomplete requests from using shared cache partitions.
  * Blocked client-provided identity values from affecting cache access.
  * Improved stale-cache recovery and cache error handling.
  * Ensured cache locks are released when responses close or cache operations fail.

* **Tests**
  * Added coverage for tenant and user isolation, invalid requests, cache outages, and unsuccessful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->