### PR TITLE
fix(polls): repair DELETE /api/polls/:id and report failures in the UI (#1069)

### DIFF
--- a/client/src/components/meeting-details/PollSection.jsx
+++ b/client/src/components/meeting-details/PollSection.jsx
@@ -155,6 +155,35 @@ const PollSection = ({ meetingId }) => {
     }
   };
 
+  const handleClosePoll = async (pollId) => {
+    try {
+      await closePoll(pollId);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || "Error closing poll");
+    }
+  };
+
+  // `deletePoll` and `closePoll` were the only two actions in this component
+  // fired without a `.catch()`. While the server was answering 500 for every
+  // delete (#1069) that meant the button did nothing at all: no error, no
+  // removal, no console output — indistinguishable from an unresponsive UI.
+  // These now report failures the same way every other action here does.
+  const handleDeletePoll = async (pollId) => {
+    if (!window.confirm("Delete this poll?")) return;
+
+    try {
+      await deletePoll(pollId);
+      // The `poll:deleted` socket event normally removes it. Drop it locally
+      // too so the poll disappears even if the socket is down or the client
+      // never joined the room.
+      setPolls((prev) => prev.filter((p) => p._id !== pollId));
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || "Error deleting poll");
+    }
+  };
+
   // Multiple choice voting component
   const MultipleChoiceVoteForm = ({ poll }) => {
     const [selected, setSelected] = useState([]);
@@ -242,7 +271,7 @@ const PollSection = ({ meetingId }) => {
           <div className="flex gap-2">
             {!poll.isClosed && canManage && (
               <button
-                onClick={() => closePoll(poll._id)}
+                onClick={() => handleClosePoll(poll._id)}
                 className="text-xs text-orange-600 dark:text-orange-400 hover:underline"
               >
                 Close Poll
@@ -250,9 +279,7 @@ const PollSection = ({ meetingId }) => {
             )}
             {canManage && (
               <button
-                onClick={() => {
-                  if (window.confirm("Delete this poll?")) deletePoll(poll._id);
-                }}
+                onClick={() => handleDeletePoll(poll._id)}
                 className="text-xs text-red-600 dark:text-red-400 hover:underline"
               >
                 Delete

--- a/client/src/components/meeting-details/__tests__/PollSectionDelete.test.jsx
+++ b/client/src/components/meeting-details/__tests__/PollSectionDelete.test.jsx
@@ -1,0 +1,163 @@
+/**
+ * Issue #1069 — the client half of the broken poll delete.
+ *
+ * `deletePoll(poll._id)` and `closePoll(poll._id)` were fired as bare promises
+ * from their onClick handlers. While the server was answering 500 for every
+ * delete, the button therefore did nothing observable: the poll stayed on
+ * screen, no error surfaced, and the rejection went to an unhandled promise.
+ * Every other action in this component reports failures through the same
+ * try/catch + alert path; these two now do as well.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../../api/pollApi", () => ({
+  createPoll: vi.fn(),
+  getPollsByMeeting: vi.fn(),
+  castVote: vi.fn(),
+  closePoll: vi.fn(),
+  deletePoll: vi.fn(),
+}));
+
+import PollSection from "../PollSection";
+import AppContent from "../../../context/AppContent";
+import { closePoll, deletePoll, getPollsByMeeting } from "../../../api/pollApi";
+
+const ADMIN = {
+  _id: "user-admin",
+  name: "Ada",
+  role: "admin",
+};
+
+const POLL = {
+  _id: "poll-1",
+  question: "Ship on Friday?",
+  createdBy: { _id: "user-creator", name: "Bo" },
+  createdAt: "2026-08-01T10:00:00.000Z",
+  isAnonymous: false,
+  isClosed: false,
+  pollType: "single",
+  options: [
+    { _id: "opt-1", text: "Yes", votes: [] },
+    { _id: "opt-2", text: "No", votes: [] },
+  ],
+};
+
+const renderPollSection = () =>
+  render(
+    <AppContent.Provider
+      value={{ userData: ADMIN, backendUrl: "http://localhost:4000" }}
+    >
+      <PollSection meetingId="meeting-1" />
+    </AppContent.Provider>,
+  );
+
+describe("PollSection poll deletion (#1069)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPollsByMeeting.mockResolvedValue([POLL]);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("asks for confirmation before deleting", async () => {
+    window.confirm.mockReturnValue(false);
+    renderPollSection();
+
+    const button = await screen.findByRole("button", { name: /delete/i });
+    fireEvent.click(button);
+
+    expect(window.confirm).toHaveBeenCalledWith("Delete this poll?");
+    expect(deletePoll).not.toHaveBeenCalled();
+  });
+
+  it("calls the API with the poll id once confirmed", async () => {
+    deletePoll.mockResolvedValue({ message: "Poll deleted successfully" });
+    renderPollSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+    await waitFor(() => expect(deletePoll).toHaveBeenCalledWith("poll-1"));
+  });
+
+  it("removes the poll from the list on success without waiting for the socket", async () => {
+    deletePoll.mockResolvedValue({ message: "Poll deleted successfully" });
+    renderPollSection();
+
+    expect(await screen.findByText("Ship on Friday?")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Ship on Friday?")).toBeNull(),
+    );
+  });
+
+  it("surfaces the server message when the delete fails", async () => {
+    deletePoll.mockRejectedValue({
+      response: { data: { message: "Forbidden: Only creator or admin" } },
+    });
+    renderPollSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith(
+        "Forbidden: Only creator or admin",
+      ),
+    );
+  });
+
+  it("falls back to a generic message when the server sends none", async () => {
+    deletePoll.mockRejectedValue(new Error("Network Error"));
+    renderPollSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith("Error deleting poll"),
+    );
+  });
+
+  it("keeps the poll on screen when the delete fails", async () => {
+    deletePoll.mockRejectedValue(new Error("Server Error"));
+    renderPollSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /delete/i }));
+
+    await waitFor(() => expect(window.alert).toHaveBeenCalled());
+    expect(screen.getByText("Ship on Friday?")).toBeTruthy();
+  });
+
+  it("reports a failed close instead of swallowing it", async () => {
+    closePoll.mockRejectedValue({
+      response: { data: { message: "Poll already closed" } },
+    });
+    renderPollSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: /close poll/i }));
+
+    await waitFor(() =>
+      expect(window.alert).toHaveBeenCalledWith("Poll already closed"),
+    );
+  });
+});

--- a/server/controllers/pollController.js
+++ b/server/controllers/pollController.js
@@ -3,6 +3,55 @@ import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
 import mongoose from "mongoose";
 
+/**
+ * Loads a poll for a mutating request and runs the shared guards in the one
+ * order that works (Issue #1069).
+ *
+ * `deletePoll` dereferenced `poll` one statement above `const poll = await
+ * Poll.findById(...)`. Reading a `const` inside its temporal dead zone throws
+ * `ReferenceError: Cannot access 'poll' before initialization`, the catch block
+ * turned that into a generic 500, and so *every* `DELETE /api/polls/:id` failed
+ * — for the creator, for admins, for polls that did not exist. `closePoll`
+ * received the same organization guard in the same commit and got the ordering
+ * right, which is exactly why this is worth centralising rather than fixing in
+ * place: the guards can no longer be reordered independently per handler.
+ *
+ * @returns {{ok: true, poll: object} | {ok: false, status: number, message: string}}
+ */
+const loadPollForMutation = async (pollId, user) => {
+  if (!mongoose.isValidObjectId(pollId)) {
+    return { ok: false, status: 400, message: "Invalid poll ID" };
+  }
+
+  const poll = await Poll.findById(String(pollId));
+  if (!poll) {
+    return { ok: false, status: 404, message: "Poll not found" };
+  }
+
+  // A session with no organization used to blow up on `.toString()` of
+  // undefined and surface as a 500. It is a 403: the caller is not in the
+  // poll's organization, because they are not in one at all.
+  const callerOrg = user?.organization;
+  if (!callerOrg || poll.organization.toString() !== callerOrg.toString()) {
+    return {
+      ok: false,
+      status: 403,
+      message: "Forbidden: Not part of organization",
+    };
+  }
+
+  return { ok: true, poll };
+};
+
+/** Creator-or-admin check shared by close and delete. */
+const canManagePoll = (poll, user) => {
+  const callerId = user?.id ?? user?._id;
+  const isCreator =
+    Boolean(callerId) && poll.createdBy.toString() === callerId.toString();
+  const isAdmin = user?.role === "admin" || user?.role === "owner";
+  return isCreator || isAdmin;
+};
+
 // Helper function to strip voter IDs if poll is anonymous
 const stripVotersIfAnonymous = (poll) => {
   if (poll.isAnonymous) {
@@ -219,25 +268,13 @@ export const closePoll = async (req, res) => {
   try {
     const { id } = req.params;
 
-    if (!mongoose.isValidObjectId(id)) {
-      return res.status(400).json({ message: "Invalid poll ID" });
+    const loaded = await loadPollForMutation(id, req.user);
+    if (!loaded.ok) {
+      return res.status(loaded.status).json({ message: loaded.message });
     }
+    const { poll } = loaded;
 
-    const poll = await Poll.findById(String(id));
-    if (!poll) {
-      return res.status(404).json({ message: "Poll not found" });
-    }
-
-    if (poll.organization.toString() !== req.user.organization.toString()) {
-      return res.status(403).json({
-        message: "Forbidden: Not part of organization",
-      });
-    }
-
-    const isCreator = poll.createdBy.toString() === req.user.id.toString();
-    const isAdmin = req.user.role === "admin" || req.user.role === "owner";
-
-    if (!isCreator && !isAdmin) {
+    if (!canManagePoll(poll, req.user)) {
       return res
         .status(403)
         .json({ message: "Forbidden: Only creator or admin can close poll" });
@@ -271,35 +308,27 @@ export const deletePoll = async (req, res) => {
   try {
     const { id } = req.params;
 
-    if (!mongoose.isValidObjectId(id)) {
-      return res.status(400).json({ message: "Invalid poll ID" });
+    const loaded = await loadPollForMutation(id, req.user);
+    if (!loaded.ok) {
+      return res.status(loaded.status).json({ message: loaded.message });
     }
+    const { poll } = loaded;
 
-    if (poll.organization.toString() !== req.user.organization.toString()) {
-      return res.status(403).json({
-        message: "Forbidden: Not part of organization",
-      });
-    }
-
-    const poll = await Poll.findById(String(id));
-    if (!poll) {
-      return res.status(404).json({ message: "Poll not found" });
-    }
-
-    const isCreator = poll.createdBy.toString() === req.user.id.toString();
-    const isAdmin = req.user.role === "admin" || req.user.role === "owner";
-
-    if (!isCreator && !isAdmin) {
+    if (!canManagePoll(poll, req.user)) {
       return res
         .status(403)
         .json({ message: "Forbidden: Only creator or admin can delete poll" });
     }
 
+    // Read the room off the document before it goes away — after `deleteOne`
+    // there is nothing left to read `meeting` from.
+    const meetingRoom = poll.meeting.toString();
+
     await Poll.deleteOne({ _id: String(id) });
 
     const io = req.app.get("io");
     if (io) {
-      io.to(poll.meeting.toString()).emit("poll:deleted", { id });
+      io.to(meetingRoom).emit("poll:deleted", { id });
     }
 
     res.status(200).json({ message: "Poll deleted successfully", id });

--- a/server/tests/pollDeleteAuthorization.test.js
+++ b/server/tests/pollDeleteAuthorization.test.js
@@ -1,0 +1,347 @@
+/**
+ * Issue #1069 — `DELETE /api/polls/:id` returned 500 for everyone.
+ *
+ * `deletePoll` read `poll.organization` one statement above
+ * `const poll = await Poll.findById(...)`. Reading a `const` inside its
+ * temporal dead zone throws `ReferenceError: Cannot access 'poll' before
+ * initialization`; the handler's catch block reported that as a generic
+ * "Server Error", so the endpoint was unusable and looked like an outage.
+ *
+ * There was no test for `deletePoll` at all, which is why the reordering that
+ * introduced it went green. These suites cover the whole authorization matrix
+ * for both mutating handlers so the guards can't be reordered silently again.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import Poll from "../models/pollModel.js";
+// Registers the "User" schema that closePoll's `.populate("createdBy")` and
+// `.populate("options.votes")` resolve against.
+import "../models/userModel.js";
+import { closePoll, deletePoll } from "../controllers/pollController.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const MEETING = new mongoose.Types.ObjectId();
+
+const CREATOR = new mongoose.Types.ObjectId();
+const OTHER_MEMBER = new mongoose.Types.ObjectId();
+const ADMIN = new mongoose.Types.ObjectId();
+const OUTSIDER = new mongoose.Types.ObjectId();
+
+// Connect directly to the in-memory server from tests/setup.js. Importing the
+// app to get a connection would drag in the Pinecone/transformers module graph
+// for no benefit here.
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+/** Captures socket emissions so the broadcast can be asserted on. */
+const makeReq = (id, user, io = null) => ({
+  params: { id },
+  user,
+  app: { get: jest.fn(() => io) },
+});
+
+const makeIo = () => {
+  const emitted = [];
+  return {
+    emitted,
+    to: jest.fn((room) => ({
+      emit: jest.fn((event, payload) => emitted.push({ room, event, payload })),
+    })),
+  };
+};
+
+const session = (id, organization, role = "member") => ({
+  id,
+  _id: id,
+  organization,
+  role,
+});
+
+const seedPoll = async (overrides = {}) =>
+  Poll.create({
+    meeting: MEETING,
+    organization: ORG_A,
+    createdBy: CREATOR,
+    question: "Ship on Friday?",
+    options: [
+      { text: "Yes", votes: [] },
+      { text: "No", votes: [] },
+    ],
+    ...overrides,
+  });
+
+describe("deletePoll authorization (#1069)", () => {
+  it("deletes the poll for its creator instead of throwing a 500", async () => {
+    const poll = await seedPoll();
+    const io = makeIo();
+    const req = makeReq(poll._id.toString(), session(CREATOR, ORG_A), io);
+    const res = makeRes();
+
+    await deletePoll(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      message: "Poll deleted successfully",
+      id: poll._id.toString(),
+    });
+    expect(await Poll.findById(poll._id)).toBeNull();
+  });
+
+  it("does not report a ReferenceError to the client", async () => {
+    // The exact regression: the handler used to answer 500 with
+    // "Cannot access 'poll' before initialization" for a perfectly valid call.
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(CREATOR, ORG_A)),
+      res,
+    );
+
+    expect(res.statusCode).not.toBe(500);
+    expect(JSON.stringify(res.body)).not.toMatch(/before initialization/);
+  });
+
+  it("broadcasts poll:deleted to the meeting room", async () => {
+    const poll = await seedPoll();
+    const io = makeIo();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(CREATOR, ORG_A), io),
+      makeRes(),
+    );
+
+    expect(io.emitted).toHaveLength(1);
+    expect(io.emitted[0]).toEqual({
+      room: MEETING.toString(),
+      event: "poll:deleted",
+      payload: { id: poll._id.toString() },
+    });
+  });
+
+  it("still responds 200 when Socket.IO is not configured", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(CREATOR, ORG_A), null),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(await Poll.findById(poll._id)).toBeNull();
+  });
+
+  it("lets an organization admin delete someone else's poll", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(ADMIN, ORG_A, "admin")),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(await Poll.findById(poll._id)).toBeNull();
+  });
+
+  it("lets an organization owner delete someone else's poll", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(ADMIN, ORG_A, "owner")),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects a member of the same organization who did not create it", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(OTHER_MEMBER, ORG_A)),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/creator or admin/i);
+    expect(await Poll.findById(poll._id)).not.toBeNull();
+  });
+
+  it("rejects a caller from another organization before the creator check", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    // Admin elsewhere is still an outsider here — the org guard must win.
+    await deletePoll(
+      makeReq(poll._id.toString(), session(OUTSIDER, ORG_B, "admin")),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/Not part of organization/i);
+    expect(await Poll.findById(poll._id)).not.toBeNull();
+  });
+
+  it("returns 403, not 500, when the session has no organization", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), { id: OUTSIDER, _id: OUTSIDER }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(await Poll.findById(poll._id)).not.toBeNull();
+  });
+
+  it("returns 404 for a well-formed id that matches no poll", async () => {
+    const res = makeRes();
+
+    await deletePoll(
+      makeReq(new mongoose.Types.ObjectId().toString(), session(ADMIN, ORG_A)),
+      res,
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.message).toBe("Poll not found");
+  });
+
+  it("returns 400 for a malformed id without touching the database", async () => {
+    const findSpy = jest.spyOn(Poll, "findById");
+    const res = makeRes();
+
+    await deletePoll(makeReq("not-an-object-id", session(ADMIN, ORG_A)), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe("Invalid poll ID");
+    expect(findSpy).not.toHaveBeenCalled();
+    findSpy.mockRestore();
+  });
+
+  it("does not emit poll:deleted when the delete is rejected", async () => {
+    const poll = await seedPoll();
+    const io = makeIo();
+
+    await deletePoll(
+      makeReq(poll._id.toString(), session(OTHER_MEMBER, ORG_A), io),
+      makeRes(),
+    );
+
+    expect(io.emitted).toHaveLength(0);
+  });
+});
+
+describe("closePoll authorization (#1069)", () => {
+  it("closes the poll for its creator", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await closePoll(makeReq(poll._id.toString(), session(CREATOR, ORG_A)), res);
+
+    expect(res.statusCode).toBe(200);
+    expect((await Poll.findById(poll._id)).isClosed).toBe(true);
+  });
+
+  it("lets an admin close someone else's poll", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await closePoll(
+      makeReq(poll._id.toString(), session(ADMIN, ORG_A, "admin")),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect((await Poll.findById(poll._id)).isClosed).toBe(true);
+  });
+
+  it("rejects a non-creator member", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await closePoll(
+      makeReq(poll._id.toString(), session(OTHER_MEMBER, ORG_A)),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect((await Poll.findById(poll._id)).isClosed).toBe(false);
+  });
+
+  it("rejects a caller from another organization", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await closePoll(
+      makeReq(poll._id.toString(), session(OUTSIDER, ORG_B, "admin")),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/Not part of organization/i);
+  });
+
+  it("returns 403, not 500, when the session has no organization", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await closePoll(
+      makeReq(poll._id.toString(), { id: OUTSIDER, _id: OUTSIDER }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 404 for an unknown poll and 400 for a malformed id", async () => {
+    const notFound = makeRes();
+    await closePoll(
+      makeReq(new mongoose.Types.ObjectId().toString(), session(ADMIN, ORG_A)),
+      notFound,
+    );
+    expect(notFound.statusCode).toBe(404);
+
+    const malformed = makeRes();
+    await closePoll(makeReq("nope", session(ADMIN, ORG_A)), malformed);
+    expect(malformed.statusCode).toBe(400);
+  });
+
+  it("keeps voter identities hidden on an anonymous poll", async () => {
+    const poll = await seedPoll({ isAnonymous: true });
+    poll.options[0].votes.push(OTHER_MEMBER);
+    await poll.save();
+
+    const res = makeRes();
+    await closePoll(makeReq(poll._id.toString(), session(CREATOR, ORG_A)), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.options[0].votes).toEqual([]);
+    expect(res.body.options[0].voteCount).toBe(1);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`DELETE /api/polls/:id` returned `500` for everyone on `main`. `deletePoll` dereferenced `poll` on the line above its declaration:

```js
if (poll.organization.toString() !== req.user.organization.toString()) {   // line 278
  return res.status(403).json({ message: "Forbidden: Not part of organization" });
}

const poll = await Poll.findById(String(id));                              // line 284
```

Reading a `const` inside its temporal dead zone throws `ReferenceError: Cannot access 'poll' before initialization`, and the handler's catch turned that into a generic "Server Error". So polls could not be deleted at all — not by the creator, not by an admin — and the failure looked like an outage rather than a bug.

The organization guard came from `2d38ad3` (*fix(polls): validate organization ownership before close and delete*) and was inserted one statement too early. `closePoll` received the same guard in that commit and got the ordering right.

### What changed

Rather than move one statement, both mutating handlers now share `loadPollForMutation()` and `canManagePoll()`, so the guards cannot be reordered independently per handler again — which is exactly the failure mode here. `deletePoll` also reads `poll.meeting` into `meetingRoom` before `deleteOne`, since after the delete there is nothing left to read it from.

One behaviour change beyond the crash: a session with no organization used to reach `req.user.organization.toString()` and surface as a 500. That is a `403` — the caller is not in the poll's organization, because they are not in one at all.

### Client side

`deletePoll(poll._id)` and `closePoll(poll._id)` were the only two actions in `PollSection` fired as bare promises with no `.catch()`. With the server returning 500, the Delete button therefore did nothing observable: the poll stayed on screen, no error appeared, and the rejection became an unhandled promise. Both now use the same try/catch + alert path as every other action in the component (`handleCreatePoll`, `handleVote`, `submitMultipleVotes`), and a successful delete drops the poll locally so it disappears even when the socket is down.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1069

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

There was **no test for `deletePoll` at all**, which is why the reordering went green in CI. This adds the full authorization matrix for both mutating handlers.

`server/tests/pollDeleteAuthorization.test.js` — 19 tests:

| Case | Expected |
|---|---|
| creator deletes | 200, document gone, `poll:deleted` emitted |
| admin / owner deletes someone else's | 200 |
| same-org member who is not the creator | 403, poll intact |
| caller from another org (even as admin) | 403 — the org guard wins over the creator check |
| session with no organization | 403, not 500 |
| unknown poll id | 404 |
| malformed id | 400, and `Poll.findById` never called |
| Socket.IO not configured | still 200 |
| rejected delete | nothing emitted |

Plus the same matrix for `closePoll`, and that an anonymous poll's close response still hides voter identities while reporting `voteCount`.

`client/src/components/meeting-details/__tests__/PollSectionDelete.test.jsx` — 7 tests: confirmation gate, API called with the right id, optimistic removal, server message surfaced on failure, generic fallback message, poll stays on screen when the delete fails, and a failed close is reported rather than swallowed.

Full server suite: unchanged against `main` — same 17 pre-existing suite failures, same 1 pre-existing test failure. Client suite: 48 files, 286 tests, all passing.

## Screenshots

N/A — the visible change is that the Delete button now works, and reports a reason when it cannot.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
