### PR TITLE
fix(shared-links): make the resource ownership check reachable (#1070)

### DIFF
--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -4,7 +4,58 @@ import Policy from "../models/policyModel.js";
 import crypto from "crypto";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
 import { hasPermission } from "../utils/rbacPermissions.js";
+
+/**
+ * The shareable resource types and the model each one resolves against.
+ *
+ * A single map, rather than an `includes()` check in one place and an
+ * `if/else` on the same string in another. The version this replaces had those
+ * two drift apart: inside the type guard, the `resourceType === "Meeting"` arm
+ * was unreachable — the enclosing condition had already excluded `"Meeting"` —
+ * so an unknown type was looked up as a Policy and reported as
+ * `"<type> not found"` instead of "invalid resource type", which also told the
+ * caller whether an arbitrary ObjectId existed as a Policy. Keeping the
+ * type→model relationship in one place removes that class of mismatch.
+ *
+ * Keys must stay in sync with the `resourceModel` enum on sharedLinkModel.
+ */
+export const SHARE_MODELS_BY_TYPE = Object.freeze({
+  Meeting,
+  Policy,
+});
+
+export const SHAREABLE_RESOURCE_TYPES = Object.freeze(
+  Object.keys(SHARE_MODELS_BY_TYPE),
+);
+
+/**
+ * Validates the optional `expirationDate`.
+ *
+ * `new Date(garbage)` yields `Invalid Date`, which Mongoose stores as null and
+ * silently turns a link the caller believed was time-boxed into one that never
+ * expires. A past date is rejected too — a link that is born expired is a
+ * request the caller got wrong, not a link worth creating.
+ *
+ * @returns {{ok: true, value: Date|null} | {ok: false, message: string}}
+ */
+export const parseExpirationDate = (raw) => {
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: true, value: null };
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return { ok: false, message: "Invalid expiration date" };
+  }
+
+  if (parsed.getTime() <= Date.now()) {
+    return { ok: false, message: "Expiration date must be in the future" };
+  }
+
+  return { ok: true, value: parsed };
+};
 
 const generateHash = () => {
   return crypto.randomBytes(16).toString("hex");
@@ -68,33 +119,63 @@ export const createLink = async (req, res) => {
         .json({ success: false, message: "Missing required fields" });
     }
 
-    if (!["Meeting", "Policy"].includes(resourceType)) {
-      let resource;
-
-      if (resourceType === "Meeting") {
-        resource = await Meeting.findById(resourceId);
-      } else {
-        resource = await Policy.findById(resourceId);
-      }
-
-      if (!resource) {
-        return res.status(404).json({
-          success: false,
-          message: `${resourceType} not found`,
-        });
-      }
-
-      if (
-        resource.organization.toString() !== req.user.organization.toString()
-      ) {
-        return res.status(403).json({
-          success: false,
-          message: "Forbidden: Resource does not belong to your organization",
-        });
-      }
+    // Issue #1070: the ownership check used to live inside
+    // `if (!["Meeting", "Policy"].includes(resourceType))` — the branch that is
+    // only entered when the type is *invalid*, and which then returned 400 a
+    // few lines later regardless. Every real request (`"Meeting"` / `"Policy"`)
+    // skipped it entirely, so any authenticated user could mint a public link
+    // for any resource in any organization given only its ObjectId. The guards
+    // below run on the path requests actually take.
+    if (!SHARE_MODELS_BY_TYPE[resourceType]) {
       return res
         .status(400)
         .json({ success: false, message: "Invalid resource type" });
+    }
+
+    if (!mongoose.isValidObjectId(resourceId)) {
+      // Previously a malformed id reached `findById` and surfaced as a CastError
+      // 500 rather than a validation error.
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid resource ID" });
+    }
+
+    const callerOrg = req.user?.organization;
+    if (!callerOrg) {
+      // A session with no organization used to blow up on `.toString()` of
+      // undefined; it cannot own a shareable resource either way.
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Resource does not belong to your organization",
+      });
+    }
+
+    const resource = await SHARE_MODELS_BY_TYPE[resourceType]
+      .findById(String(resourceId))
+      .select("organization");
+
+    if (!resource) {
+      return res.status(404).json({
+        success: false,
+        message: `${resourceType} not found`,
+      });
+    }
+
+    if (
+      !resource.organization ||
+      resource.organization.toString() !== callerOrg.toString()
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Resource does not belong to your organization",
+      });
+    }
+
+    const expiration = parseExpirationDate(expirationDate);
+    if (!expiration.ok) {
+      return res
+        .status(400)
+        .json({ success: false, message: expiration.message });
     }
 
     let hashedPasscode = null;
@@ -109,7 +190,7 @@ export const createLink = async (req, res) => {
       resourceId,
       resourceModel: resourceType,
       hash,
-      expirationDate: expirationDate ? new Date(expirationDate) : null,
+      expirationDate: expiration.value,
       passcode: hashedPasscode,
       createdBy: req.user._id,
       organizationId: req.user.organization,

--- a/server/tests/sharedLinkOwnership.test.js
+++ b/server/tests/sharedLinkOwnership.test.js
@@ -1,0 +1,435 @@
+/**
+ * Issue #1070 — shared-link ownership validation was unreachable.
+ *
+ * The check lived inside `if (!["Meeting", "Policy"].includes(resourceType))`,
+ * i.e. the branch entered only when the type is *invalid*, and that branch then
+ * returned 400 a few lines later regardless. Every real request — the ones with
+ * `resourceType` of `"Meeting"` or `"Policy"` — fell straight through to link
+ * creation with no existence check and no organization check, so any
+ * authenticated user could mint a public link for any resource in any
+ * organization given only its ObjectId.
+ *
+ * A second bug hid in the same block: the `resourceType === "Meeting"` arm was
+ * unreachable (the enclosing condition already excluded `"Meeting"`), so an
+ * unknown type was looked up as a Policy and answered `"<type> not found"` —
+ * leaking whether an arbitrary id exists as a Policy — instead of
+ * "Invalid resource type".
+ *
+ * `createLink` had no test coverage at all, which is why the guard shipped
+ * inverted.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import SharedLink from "../models/sharedLinkModel.js";
+import Meeting from "../models/meetingModel.js";
+import Policy from "../models/policyModel.js";
+import "../models/userModel.js";
+import {
+  createLink,
+  parseExpirationDate,
+  SHAREABLE_RESOURCE_TYPES,
+} from "../controllers/sharedLinkController.js";
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+const ORG_VICTIM = new mongoose.Types.ObjectId();
+const ORG_ATTACKER = new mongoose.Types.ObjectId();
+
+const victimUser = () => ({
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_VICTIM,
+  role: "member",
+});
+
+const attackerUser = (role = "owner") => ({
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_ATTACKER,
+  role,
+});
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const makeReq = (body, user) => ({ body, user });
+
+const seedMeeting = (organization = ORG_VICTIM) =>
+  Meeting.create({
+    title: "Board sync",
+    date: new Date("2026-08-01T09:00:00.000Z"),
+    organization,
+    uploadedBy: new mongoose.Types.ObjectId(),
+  });
+
+const seedPolicy = (organization = ORG_VICTIM) =>
+  Policy.create({
+    name: "Expenses",
+    fileUrl: "uploads/policies/expenses.pdf",
+    organization,
+    uploadedBy: new mongoose.Types.ObjectId(),
+  });
+
+describe("createLink resource ownership (#1070)", () => {
+  describe("cross-organization sharing", () => {
+    it("refuses to share another organization's meeting", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: meeting._id.toString(), resourceType: "Meeting" },
+          attackerUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.message).toMatch(/does not belong to your organization/i);
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+
+    it("refuses to share another organization's policy", async () => {
+      const policy = await seedPolicy(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: policy._id.toString(), resourceType: "Policy" },
+          attackerUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(403);
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+
+    it("is not bypassed by an elevated role in the caller's own organization", async () => {
+      // An owner is still an outsider to a resource they don't own.
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: meeting._id.toString(), resourceType: "Meeting" },
+          attackerUser("owner"),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("returns 403, not 500, when the caller has no organization", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: meeting._id.toString(), resourceType: "Meeting" },
+          { _id: new mongoose.Types.ObjectId(), role: "member" },
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(403);
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+  });
+
+  describe("resource existence", () => {
+    it("returns 404 for a well-formed id that matches no meeting", async () => {
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: new mongoose.Types.ObjectId().toString(),
+            resourceType: "Meeting",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toBe("Meeting not found");
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+
+    it("returns 404 for a well-formed id that matches no policy", async () => {
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: new mongoose.Types.ObjectId().toString(),
+            resourceType: "Policy",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toBe("Policy not found");
+    });
+
+    it("does not create a link for a meeting id passed as a Policy", async () => {
+      // The id resolves — as the wrong model. It must not be shareable.
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: meeting._id.toString(), resourceType: "Policy" },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(404);
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects an unknown resource type without querying any model", async () => {
+      const meetingSpy = jest.spyOn(Meeting, "findById");
+      const policySpy = jest.spyOn(Policy, "findById");
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: new mongoose.Types.ObjectId().toString(),
+            resourceType: "Report",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toBe("Invalid resource type");
+      // The old code queried Policy for an unknown type and answered
+      // "Report not found", telling the caller whether the id existed.
+      expect(meetingSpy).not.toHaveBeenCalled();
+      expect(policySpy).not.toHaveBeenCalled();
+
+      meetingSpy.mockRestore();
+      policySpy.mockRestore();
+    });
+
+    it("rejects a malformed resource id with 400 rather than a CastError 500", async () => {
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: "not-an-object-id", resourceType: "Meeting" },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toBe("Invalid resource ID");
+    });
+
+    it("still rejects missing fields", async () => {
+      for (const body of [
+        {},
+        { resourceId: new mongoose.Types.ObjectId().toString() },
+        { resourceType: "Meeting" },
+      ]) {
+        const res = makeRes();
+        await createLink(makeReq(body, victimUser()), res);
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toBe("Missing required fields");
+      }
+    });
+
+    it("exposes exactly the types the SharedLink model accepts", () => {
+      expect([...SHAREABLE_RESOURCE_TYPES].sort()).toEqual([
+        "Meeting",
+        "Policy",
+      ]);
+    });
+  });
+
+  describe("expiration date handling", () => {
+    it("accepts a future date", () => {
+      const future = new Date(Date.now() + 86400000).toISOString();
+      const parsed = parseExpirationDate(future);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.value.toISOString()).toBe(future);
+    });
+
+    it("treats an absent value as no expiry", () => {
+      for (const raw of [undefined, null, ""]) {
+        expect(parseExpirationDate(raw)).toEqual({ ok: true, value: null });
+      }
+    });
+
+    it("rejects an unparseable date instead of storing Invalid Date", () => {
+      const parsed = parseExpirationDate("next tuesday-ish");
+      expect(parsed.ok).toBe(false);
+      expect(parsed.message).toBe("Invalid expiration date");
+    });
+
+    it("rejects a date in the past", () => {
+      const parsed = parseExpirationDate(
+        new Date(Date.now() - 86400000).toISOString(),
+      );
+      expect(parsed.ok).toBe(false);
+      expect(parsed.message).toMatch(/must be in the future/i);
+    });
+
+    it("surfaces a bad expiration date as a 400 from createLink", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: meeting._id.toString(),
+            resourceType: "Meeting",
+            expirationDate: "whenever",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(await SharedLink.countDocuments({})).toBe(0);
+    });
+  });
+
+  describe("the legitimate path still works", () => {
+    it("creates a link for a meeting in the caller's own organization", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const user = victimUser();
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: meeting._id.toString(), resourceType: "Meeting" },
+          user,
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.link.hash).toMatch(/^[a-f0-9]{32}$/);
+
+      const stored = await SharedLink.findOne({ hash: res.body.link.hash });
+      expect(stored.resourceModel).toBe("Meeting");
+      expect(stored.resourceId.toString()).toBe(meeting._id.toString());
+      expect(stored.organizationId.toString()).toBe(ORG_VICTIM.toString());
+      expect(stored.createdBy.toString()).toBe(user._id.toString());
+      expect(stored.active).toBe(true);
+    });
+
+    it("creates a link for a policy in the caller's own organization", async () => {
+      const policy = await seedPolicy(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          { resourceId: policy._id.toString(), resourceType: "Policy" },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(201);
+      expect(
+        (await SharedLink.findOne({ hash: res.body.link.hash })).resourceModel,
+      ).toBe("Policy");
+    });
+
+    it("stores the passcode hashed, never in clear text", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: meeting._id.toString(),
+            resourceType: "Meeting",
+            passcode: "hunter2",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.link.hasPasscode).toBe(true);
+
+      const stored = await SharedLink.findOne({ hash: res.body.link.hash });
+      expect(stored.passcode).not.toBe("hunter2");
+      expect(stored.passcode.startsWith("$2")).toBe(true);
+    });
+
+    it("persists a valid future expiration date", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const expiresAt = new Date(Date.now() + 7 * 86400000);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: meeting._id.toString(),
+            resourceType: "Meeting",
+            expirationDate: expiresAt.toISOString(),
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.statusCode).toBe(201);
+      const stored = await SharedLink.findOne({ hash: res.body.link.hash });
+      expect(stored.expirationDate.toISOString()).toBe(expiresAt.toISOString());
+    });
+
+    it("never returns the passcode hash to the client", async () => {
+      const meeting = await seedMeeting(ORG_VICTIM);
+      const res = makeRes();
+
+      await createLink(
+        makeReq(
+          {
+            resourceId: meeting._id.toString(),
+            resourceType: "Meeting",
+            passcode: "hunter2",
+          },
+          victimUser(),
+        ),
+        res,
+      );
+
+      expect(res.body.link.passcode).toBeUndefined();
+      expect(JSON.stringify(res.body)).not.toContain("hunter2");
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The resource-ownership check in `createLink` sat inside the branch that is only entered when the resource type is **invalid**, and that branch then returned `400` a few lines later regardless:

```js
if (!["Meeting", "Policy"].includes(resourceType)) {   // only true for INVALID types
  let resource;
  if (resourceType === "Meeting") {                    // unreachable — excluded above
    resource = await Meeting.findById(resourceId);
  } else {
    resource = await Policy.findById(resourceId);
  }
  if (!resource) return res.status(404)...
  if (resource.organization.toString() !== req.user.organization.toString()) return res.status(403)...
  return res.status(400).json({ message: "Invalid resource type" });
}

// "Meeting" / "Policy" fall straight through here — unvalidated
```

So `POST /api/shared-links` with `{ resourceId: "<any meeting id>", resourceType: "Meeting" }` succeeded for any authenticated user, and the returned `hash` was a working public URL to a meeting in an organization the caller had never been a member of. The victim's organization had no way to see or revoke it either: the `SharedLink` belongs to the attacker (`createdBy`), and `getActiveLinksFixed` / `revokeLink` both filter by the caller's own org.

This is the vulnerability #814 was filed for. The fix that shipped in `d688dc4` added the right code in the wrong branch.

A second bug hid in the same block: inside a condition that had already excluded `"Meeting"`, the `resourceType === "Meeting"` arm was unreachable, so an unknown type was always looked up as a **Policy** and answered `"<type> not found"` instead of "Invalid resource type" — which also told the caller whether an arbitrary ObjectId exists as a Policy.

### What changed

The guards now run on the path requests actually take, in the order that lets each one do its job:

1. Unknown resource type → `400`, with **no database lookup at all**
2. Malformed `resourceId` → `400` (previously a `CastError` surfaced as a 500)
3. Caller with no organization → `403` (previously a `TypeError` on `undefined.toString()`, surfaced as a 500)
4. Resource does not exist → `404`
5. Resource belongs to another organization → `403`

The type→model relationship now lives in one frozen map (`SHARE_MODELS_BY_TYPE`) instead of an `includes()` check in one place and an `if/else` on the same string in another. Those two drifting apart is what produced the unreachable arm.

`expirationDate` is validated while here. `new Date("whenever")` yields `Invalid Date`, which Mongoose stores as null — silently turning a link the caller believed was time-boxed into one that never expires. Unparseable and past dates are now `400`s.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1070

Also closes the gap left open by #814 / #1064.

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`createLink` had **no test coverage**, which is why the inverted guard shipped. `server/tests/sharedLinkOwnership.test.js` — 21 tests:

- **Cross-org:** another org's meeting → 403; another org's policy → 403; not bypassed by an `owner` role in the caller's own org; orgless session → 403 not 500. Zero `SharedLink` documents created in every case.
- **Existence:** unknown meeting id → 404; unknown policy id → 404; a valid *meeting* id passed as `resourceType: "Policy"` → 404, no link created.
- **Validation:** unknown type → 400 with `Meeting.findById` and `Policy.findById` both asserted un-called; malformed id → 400 not 500; missing fields still 400; the exported type list matches the `resourceModel` enum on the model.
- **Expiration:** future date accepted; absent value means no expiry; unparseable → 400; past → 400; a bad date surfaces as a 400 from `createLink` with no link created.
- **Happy path:** meeting and policy links created with the right `resourceModel`, `organizationId`, `createdBy` and `active`; passcode stored bcrypt-hashed (`$2…`) and never echoed back in the response.

I confirmed the suite is actually load-bearing: re-inverting the type guard makes **14 of the 21 fail**.

Existing `sharedLinkAnalytics.test.js` (vitest) still passes. Full server suite unchanged against `main`.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
