### PR TITLE
fix(api): bound pagination on the list endpoints that had no ceiling (#1071)

### DIFF
--- a/server/controllers/attachmentController.js
+++ b/server/controllers/attachmentController.js
@@ -4,6 +4,7 @@ import { z } from "zod";
 import Attachment from "../models/attachmentModel.js";
 import Meeting from "../models/meetingModel.js";
 import { fileURLToPath } from "url";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -113,10 +114,9 @@ export const uploadAttachment = async (req, res) => {
 export const listAttachments = async (req, res) => {
   try {
     const { meetingId } = req.params;
-    const page = parseInt(req.query.page) || 1;
-    const limit = parseInt(req.query.limit) || 20;
-
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+    });
 
     const attachments = await Attachment.find({ meeting: meetingId })
       .populate("uploadedBy", "name email")
@@ -129,12 +129,7 @@ export const listAttachments = async (req, res) => {
     res.status(200).json({
       success: true,
       attachments,
-      pagination: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
+      pagination: buildPaginationMeta({ total, page, limit }),
     });
   } catch (error) {
     console.error("Error listing attachments:", error);

--- a/server/controllers/commentController.js
+++ b/server/controllers/commentController.js
@@ -2,6 +2,21 @@ import Comment from "../models/commentModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
 import mongoose from "mongoose";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+
+/**
+ * Ceiling on replies loaded alongside one page of top-level comments
+ * (Issue #1071).
+ *
+ * The reply query is a `$in` over every comment id on the page and had no
+ * limit of its own, so an unbounded `?limit=` did not just return N comments —
+ * it also pulled every reply belonging to all N and populated author and
+ * reaction refs across the whole set. Bounding the page bounds the fan-out,
+ * but only if the second query is bounded independently: a page of 50 comments
+ * where one thread has 10,000 replies is still one enormous response
+ * otherwise.
+ */
+const MAX_REPLIES_PER_PAGE = 500;
 
 // @desc    Create a new comment
 // @route   POST /api/comments
@@ -72,9 +87,9 @@ export const getCommentsByMeeting = async (req, res) => {
     if (!mongoose.isValidObjectId(meetingId)) {
       return res.status(400).json({ message: "Invalid meeting ID" });
     }
-    const page = parseInt(req.query.page) || 1;
-    const limit = parseInt(req.query.limit) || 50;
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 50,
+    });
 
     const meeting = await Meeting.findById(String(meetingId));
     if (!meeting) {
@@ -100,10 +115,13 @@ export const getCommentsByMeeting = async (req, res) => {
 
     // Fetch replies for these comments
     const commentIds = topLevelComments.map((c) => c._id);
-    const replies = await Comment.find({ parentComment: { $in: commentIds } })
-      .populate("author", "name email profilePicture")
-      .populate("reactions.user", "name")
-      .sort({ createdAt: 1 });
+    const replies = commentIds.length
+      ? await Comment.find({ parentComment: { $in: commentIds } })
+          .populate("author", "name email profilePicture")
+          .populate("reactions.user", "name")
+          .sort({ createdAt: 1 })
+          .limit(MAX_REPLIES_PER_PAGE)
+      : [];
 
     // Group replies
     const repliesMap = {};
@@ -125,11 +143,17 @@ export const getCommentsByMeeting = async (req, res) => {
       parentComment: null,
     });
 
+    const pagination = buildPaginationMeta({ total, page, limit });
+
     res.status(200).json({
       comments: commentsWithReplies,
-      currentPage: page,
-      totalPages: Math.ceil(total / limit),
-      totalComments: total,
+      // `currentPage` / `totalPages` / `totalComments` are kept so existing
+      // clients keep working; `pagination` is the shape new code should read,
+      // and it is the only one carrying `hasMore`.
+      currentPage: pagination.page,
+      totalPages: pagination.totalPages,
+      totalComments: pagination.total,
+      pagination,
     });
   } catch (error) {
     console.error("Error fetching comments:", error);

--- a/server/controllers/meetingSeriesController.js
+++ b/server/controllers/meetingSeriesController.js
@@ -2,6 +2,15 @@ import { z } from "zod";
 import MeetingSeries from "../models/meetingSeriesModel.js";
 import Meeting from "../models/meetingModel.js";
 import { parseISO, addDays, addWeeks, addMonths } from "date-fns";
+import { parsePagination } from "../utils/pagination.js";
+
+/**
+ * Hard ceiling for the `limit=0` / `limit=all` whole-series response
+ * (Issue #1071). Weekly for ~19 years — comfortably above any real recurrence
+ * schedule, and low enough that a corrupt or malicious series cannot exhaust
+ * the heap.
+ */
+const SERIES_MAX_UNPAGINATED = 1000;
 
 const createSeriesSchema = z.object({
   title: z.string().min(1, "Title is required"),
@@ -170,12 +179,14 @@ export const getSeriesById = async (req, res) => {
 
 export const getSeriesMeetings = async (req, res) => {
   try {
-    const page = parseInt(req.query.page) || 1;
-    let limit =
-      req.query.limit === "0" || req.query.limit === "all"
-        ? 0
-        : parseInt(req.query.limit);
-    if (isNaN(limit)) limit = 20;
+    // `limit=0` / `limit=all` is the deliberate "give me the whole series"
+    // escape hatch added for #915 — a series timeline is not useful a page at a
+    // time. It is kept, but it is no longer *unbounded*: a series with a
+    // runaway occurrence count would otherwise stream every document into
+    // memory. SERIES_MAX_UNPAGINATED is far above any real recurrence schedule
+    // (weekly for ~19 years), so nothing legitimate is truncated.
+    const wantsWholeSeries =
+      req.query.limit === "0" || req.query.limit === "all";
 
     const orgId = req.user?.organization || req.user?.organizationId || null;
     const query = { series: req.params.id };
@@ -185,13 +196,30 @@ export const getSeriesMeetings = async (req, res) => {
 
     const total = await Meeting.countDocuments(query);
 
-    let meetingsQuery = Meeting.find(query).sort({ seriesOccurrence: 1 });
-    if (limit > 0) {
-      const skip = (page - 1) * limit;
-      meetingsQuery = meetingsQuery.skip(skip).limit(limit);
-    }
+    let meetings;
+    let page = 1;
+    let limit = 0;
 
-    const meetings = await meetingsQuery;
+    if (wantsWholeSeries) {
+      meetings = await Meeting.find(query)
+        .sort({ seriesOccurrence: 1 })
+        .limit(SERIES_MAX_UNPAGINATED);
+
+      if (total > SERIES_MAX_UNPAGINATED) {
+        console.warn(
+          `⚠️ Series ${req.params.id} has ${total} meetings; truncating the unpaginated response at ${SERIES_MAX_UNPAGINATED}.`,
+        );
+      }
+    } else {
+      // `parseInt(req.query.limit)` used to be passed straight to `.limit()`,
+      // so `?limit=10000000` was honoured verbatim, and `?page=0` produced a
+      // negative skip that MongoDB rejected as a 500.
+      ({ page, limit } = parsePagination(req.query, { defaultLimit: 20 }));
+      meetings = await Meeting.find(query)
+        .sort({ seriesOccurrence: 1 })
+        .skip((page - 1) * limit)
+        .limit(limit);
+    }
 
     res.json({
       success: true,

--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -3,6 +3,7 @@ import Tag from "../models/tagModel.js";
 import Meeting from "../models/meetingModel.js";
 import { sendSuccess } from "../utils/responseHandler.js";
 import { ValidationError, NotFoundError } from "../utils/errors.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 // Validation schemas
 const createTagSchema = z.object({
@@ -153,9 +154,9 @@ export const getMeetingsByTag = async (req, res, next) => {
   try {
     const { name } = req.params;
     const orgId = req.user.organization;
-    const page = parseInt(req.query.page) || 1;
-    const limit = parseInt(req.query.limit) || 10;
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 10,
+    });
 
     const query = { organization: orgId, tags: name };
 
@@ -166,12 +167,14 @@ export const getMeetingsByTag = async (req, res, next) => {
       .populate("uploadedBy", "name email");
 
     const total = await Meeting.countDocuments(query);
+    const pagination = buildPaginationMeta({ total, page, limit });
 
     return sendSuccess(res, {
       meetings,
-      currentPage: page,
-      totalPages: Math.ceil(total / limit),
-      totalCount: total,
+      currentPage: pagination.page,
+      totalPages: pagination.totalPages,
+      totalCount: pagination.total,
+      pagination,
     });
   } catch (err) {
     next(err);

--- a/server/tests/pagination.test.js
+++ b/server/tests/pagination.test.js
@@ -1,0 +1,362 @@
+/**
+ * Issue #1071 — unbounded `?limit=` on list endpoints.
+ *
+ * `parseInt(req.query.limit) || <default>` was passed straight to `.limit()`,
+ * so `?limit=10000000` streamed millions of documents into the heap and
+ * `?page=0` produced a negative skip that MongoDB rejected as a 500.
+ *
+ * The clamping rule already existed in three places
+ * (`knowledgeController` → 100, `decisionGraphController` → 200,
+ * `notificationController` → 100) written three different ways, and was missed
+ * in four others. These suites pin the shared helper's contract and then check
+ * each previously-unbounded endpoint actually uses it.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import {
+  buildPaginationMeta,
+  parsePagination,
+  DEFAULT_MAX_LIMIT,
+  DEFAULT_PAGE_SIZE,
+} from "../utils/pagination.js";
+
+import Comment from "../models/commentModel.js";
+import Meeting from "../models/meetingModel.js";
+import Attachment from "../models/attachmentModel.js";
+import "../models/userModel.js";
+import { getCommentsByMeeting } from "../controllers/commentController.js";
+import { listAttachments } from "../controllers/attachmentController.js";
+import { getMeetingsByTag } from "../controllers/tagController.js";
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+describe("parsePagination (#1071)", () => {
+  describe("defaults", () => {
+    it("returns page 1 and the endpoint default when nothing is requested", () => {
+      expect(parsePagination({})).toEqual({
+        page: 1,
+        limit: DEFAULT_PAGE_SIZE,
+        skip: 0,
+        limitWasClamped: false,
+      });
+    });
+
+    it("honours a per-endpoint default limit", () => {
+      expect(parsePagination({}, { defaultLimit: 50 }).limit).toBe(50);
+    });
+
+    it("never lets a default exceed the endpoint ceiling", () => {
+      expect(
+        parsePagination({}, { defaultLimit: 500, maxLimit: 25 }).limit,
+      ).toBe(25);
+    });
+
+    it("tolerates a missing query object entirely", () => {
+      expect(parsePagination().page).toBe(1);
+      expect(parsePagination(undefined).limit).toBe(DEFAULT_PAGE_SIZE);
+    });
+  });
+
+  describe("the ceiling", () => {
+    it("clamps an absurd limit to the default maximum", () => {
+      const result = parsePagination({ limit: "10000000" });
+      expect(result.limit).toBe(DEFAULT_MAX_LIMIT);
+      expect(result.limitWasClamped).toBe(true);
+    });
+
+    it("clamps to a per-endpoint maximum", () => {
+      expect(parsePagination({ limit: "999" }, { maxLimit: 200 }).limit).toBe(
+        200,
+      );
+    });
+
+    it("does not clamp a limit inside the ceiling", () => {
+      const result = parsePagination({ limit: "35" });
+      expect(result.limit).toBe(35);
+      expect(result.limitWasClamped).toBe(false);
+    });
+
+    it("clamps rather than rejecting, so existing clients keep working", () => {
+      // A client that has always sent limit=500 gets a capped page, not a 400.
+      expect(() => parsePagination({ limit: "500" })).not.toThrow();
+      expect(parsePagination({ limit: "500" }).limit).toBe(DEFAULT_MAX_LIMIT);
+    });
+  });
+
+  describe("the floor", () => {
+    it("never produces a negative skip", () => {
+      for (const page of ["0", "-1", "-99999"]) {
+        const result = parsePagination({ page });
+        expect(result.page).toBe(1);
+        expect(result.skip).toBe(0);
+      }
+    });
+
+    it("never produces a limit below 1", () => {
+      for (const limit of ["0", "-5"]) {
+        expect(parsePagination({ limit }).limit).toBe(DEFAULT_PAGE_SIZE);
+      }
+    });
+
+    it("computes skip from the clamped values, not the requested ones", () => {
+      expect(parsePagination({ page: "3", limit: "10" }).skip).toBe(20);
+      expect(parsePagination({ page: "0", limit: "10" }).skip).toBe(0);
+    });
+  });
+
+  describe("parsing", () => {
+    it("falls back to the default for non-numeric input", () => {
+      for (const limit of ["abc", "  ", "null", "undefined", "{}"]) {
+        expect(parsePagination({ limit }).limit).toBe(DEFAULT_PAGE_SIZE);
+      }
+    });
+
+    it("rejects exponent notation instead of silently reading it as 1", () => {
+      // `parseInt("1e5", 10)` is 1 — the caller asked for 100000 and would
+      // have quietly received 1.
+      expect(parsePagination({ limit: "1e5" }).limit).toBe(DEFAULT_PAGE_SIZE);
+    });
+
+    it("rejects values with trailing junk", () => {
+      expect(parsePagination({ limit: "12abc" }).limit).toBe(DEFAULT_PAGE_SIZE);
+      expect(parsePagination({ page: "3xyz" }).page).toBe(1);
+    });
+
+    it("rejects floats", () => {
+      expect(parsePagination({ limit: "4.5" }).limit).toBe(DEFAULT_PAGE_SIZE);
+    });
+
+    it("accepts a genuine number, not only a string", () => {
+      expect(parsePagination({ page: 2, limit: 15 })).toEqual({
+        page: 2,
+        limit: 15,
+        skip: 15,
+        limitWasClamped: false,
+      });
+    });
+
+    it("takes the last value when a query key is repeated", () => {
+      // `?limit=5&limit=9` arrives as an array.
+      expect(parsePagination({ limit: ["5", "9"] }).limit).toBe(9);
+    });
+
+    it("falls back to defaults for values beyond the safe integer range", () => {
+      // Not clamped to the ceiling — treated as unusable input, because a value
+      // this large is a malformed request rather than an ambitious one.
+      expect(parsePagination({ limit: "999999999999999999999" }).limit).toBe(
+        DEFAULT_PAGE_SIZE,
+      );
+      expect(parsePagination({ page: "999999999999999999999" }).page).toBe(1);
+    });
+  });
+});
+
+describe("buildPaginationMeta (#1071)", () => {
+  it("reports hasMore while pages remain", () => {
+    expect(buildPaginationMeta({ total: 95, page: 1, limit: 20 })).toEqual({
+      total: 95,
+      page: 1,
+      limit: 20,
+      totalPages: 5,
+      hasMore: true,
+    });
+  });
+
+  it("reports hasMore false on the last page", () => {
+    expect(buildPaginationMeta({ total: 95, page: 5, limit: 20 }).hasMore).toBe(
+      false,
+    );
+  });
+
+  it("reports hasMore false on an exactly-full last page", () => {
+    expect(buildPaginationMeta({ total: 40, page: 2, limit: 20 }).hasMore).toBe(
+      false,
+    );
+  });
+
+  it("handles an empty result set", () => {
+    expect(buildPaginationMeta({ total: 0, page: 1, limit: 20 })).toEqual({
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+      hasMore: false,
+    });
+  });
+});
+
+// ─── Endpoint integration ──────────────────────────────────────────────────
+
+const ORG = new mongoose.Types.ObjectId();
+const AUTHOR = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const seedMeeting = () =>
+  Meeting.create({
+    title: "Retro",
+    date: new Date(),
+    organization: ORG,
+    uploadedBy: AUTHOR,
+    tags: ["retro"],
+  });
+
+describe("list endpoints respect the ceiling (#1071)", () => {
+  it("caps getCommentsByMeeting at the maximum page size", async () => {
+    const meeting = await seedMeeting();
+
+    await Comment.insertMany(
+      Array.from({ length: 130 }, (_, i) => ({
+        meeting: meeting._id,
+        author: AUTHOR,
+        organization: ORG,
+        body: `comment ${i}`,
+      })),
+    );
+
+    const res = makeRes();
+    await getCommentsByMeeting(
+      {
+        params: { meetingId: meeting._id.toString() },
+        query: { limit: "10000000" },
+        user: { id: AUTHOR, organization: ORG, role: "admin" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.comments.length).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.pagination.total).toBe(130);
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+
+  it("answers 200, not 500, for a zero or negative page", async () => {
+    const meeting = await seedMeeting();
+    await Comment.create({
+      meeting: meeting._id,
+      author: AUTHOR,
+      organization: ORG,
+      body: "only one",
+    });
+
+    for (const page of ["0", "-3"]) {
+      const res = makeRes();
+      await getCommentsByMeeting(
+        {
+          params: { meetingId: meeting._id.toString() },
+          query: { page },
+          user: { id: AUTHOR, organization: ORG, role: "admin" },
+        },
+        res,
+      );
+
+      // A negative skip used to reach MongoDB and come back as a 500.
+      expect(res.statusCode).toBe(200);
+      expect(res.body.comments.length).toBe(1);
+      expect(res.body.currentPage).toBe(1);
+    }
+  });
+
+  it("keeps the legacy comment response fields alongside the new envelope", async () => {
+    const meeting = await seedMeeting();
+    await Comment.create({
+      meeting: meeting._id,
+      author: AUTHOR,
+      organization: ORG,
+      body: "hi",
+    });
+
+    const res = makeRes();
+    await getCommentsByMeeting(
+      {
+        params: { meetingId: meeting._id.toString() },
+        query: {},
+        user: { id: AUTHOR, organization: ORG, role: "admin" },
+      },
+      res,
+    );
+
+    expect(res.body.currentPage).toBe(1);
+    expect(res.body.totalPages).toBe(1);
+    expect(res.body.totalComments).toBe(1);
+    expect(res.body.pagination.hasMore).toBe(false);
+  });
+
+  it("caps listAttachments at the maximum page size", async () => {
+    const meeting = await seedMeeting();
+
+    await Attachment.insertMany(
+      Array.from({ length: 120 }, (_, i) => ({
+        meeting: meeting._id,
+        fileName: `file-${i}.pdf`,
+        fileType: "pdf",
+        filePath: `uploads/attachments/file-${i}.pdf`,
+        fileSize: 100,
+        mimeType: "application/pdf",
+        uploadedBy: AUTHOR,
+      })),
+    );
+
+    const res = makeRes();
+    await listAttachments(
+      {
+        params: { meetingId: meeting._id.toString() },
+        query: { limit: "500000" },
+        user: { id: AUTHOR, organization: ORG, role: "admin" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.attachments.length).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.pagination.total).toBe(120);
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+
+  it("caps getMeetingsByTag at the maximum page size", async () => {
+    await Meeting.insertMany(
+      Array.from({ length: 115 }, (_, i) => ({
+        title: `Tagged ${i}`,
+        date: new Date(),
+        organization: ORG,
+        uploadedBy: AUTHOR,
+        tags: ["quarterly"],
+      })),
+    );
+
+    const res = makeRes();
+    await getMeetingsByTag(
+      {
+        params: { name: "quarterly" },
+        query: { limit: "9999999" },
+        user: { id: AUTHOR, organization: ORG, role: "admin" },
+      },
+      res,
+      jest.fn(),
+    );
+
+    // `sendSuccess` spreads the payload at the top level.
+    expect(res.body.meetings.length).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.pagination.total).toBe(115);
+    expect(res.body.totalCount).toBe(115);
+  });
+});

--- a/server/utils/pagination.js
+++ b/server/utils/pagination.js
@@ -1,0 +1,110 @@
+/**
+ * Shared pagination parsing (Issue #1071).
+ *
+ * Several list endpoints read `?page=` and `?limit=` with
+ * `parseInt(req.query.limit) || <default>` and passed the result straight to
+ * `.skip()` / `.limit()`. Three things went wrong with that:
+ *
+ *   - **No ceiling.** `?limit=10000000` streamed millions of documents into
+ *     the Node heap, ran `.populate()` over all of them and serialized the lot
+ *     to JSON. One request was enough to push a container past its memory
+ *     limit and take the API down for every tenant.
+ *   - **No floor.** `?page=0` produced `skip = -limit`; MongoDB rejects a
+ *     negative skip, and the controllers reported that validation problem as a
+ *     generic 500.
+ *   - **Accidental parsing.** `parseInt(x) || d` leans on NaN being falsy, so
+ *     it also swallows a deliberate `0`, and without a radix `"1e5"` parses as
+ *     `1` — quietly ignoring what the caller asked for.
+ *
+ * The rule already existed in the codebase — `knowledgeController` clamps to
+ * 100, `decisionGraphController` to 200, `notificationController` to 100 — but
+ * it was written three different ways and missed in four places. This is that
+ * rule, once.
+ *
+ * Out-of-range values are **clamped, not rejected**. Existing clients that ask
+ * for `limit=500` keep working and receive a capped page; turning that into a
+ * 400 would break them for no security benefit. Genuinely malformed input
+ * (`?limit=abc`) falls back to the endpoint's default, matching the previous
+ * behaviour.
+ */
+
+/** Ceiling applied when an endpoint does not specify its own. */
+export const DEFAULT_MAX_LIMIT = 100;
+
+/** Page size used when the caller does not ask for one. */
+export const DEFAULT_PAGE_SIZE = 20;
+
+/**
+ * Parses a value that should be a positive integer.
+ *
+ * Returns `null` for anything that is not one — including `NaN`, `Infinity`,
+ * floats, negatives and values with trailing junk — so the caller can tell
+ * "absent or unusable" apart from a real `0`.
+ */
+const parsePositiveInteger = (raw) => {
+  if (raw === undefined || raw === null || raw === "") return null;
+
+  // Arrays arrive when a query key is repeated (`?limit=5&limit=9`). Take the
+  // last one, which is what Express itself would surface for a scalar param.
+  const value = Array.isArray(raw) ? raw[raw.length - 1] : raw;
+
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  // Digits only: rejects "1e5", "12abc", "-3", " 4.5 " and hex/octal literals.
+  if (!/^\d+$/.test(trimmed)) return null;
+
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+/**
+ * Normalizes `?page=` and `?limit=` into values that are always safe to pass
+ * to Mongoose.
+ *
+ * @param {object} query                 `req.query`
+ * @param {object} [options]
+ * @param {number} [options.defaultLimit] page size when none is requested
+ * @param {number} [options.maxLimit]     hard ceiling for this endpoint
+ * @returns {{page: number, limit: number, skip: number, limitWasClamped: boolean}}
+ *   `page >= 1`, `1 <= limit <= maxLimit`, `skip >= 0` — always.
+ */
+export const parsePagination = (query = {}, options = {}) => {
+  const maxLimit = Math.max(1, options.maxLimit ?? DEFAULT_MAX_LIMIT);
+  const defaultLimit = Math.min(
+    Math.max(1, options.defaultLimit ?? DEFAULT_PAGE_SIZE),
+    maxLimit,
+  );
+
+  const page = parsePositiveInteger(query.page) ?? 1;
+
+  const requestedLimit = parsePositiveInteger(query.limit);
+  const limit =
+    requestedLimit === null ? defaultLimit : Math.min(requestedLimit, maxLimit);
+
+  return {
+    page,
+    limit,
+    skip: (page - 1) * limit,
+    limitWasClamped: requestedLimit !== null && requestedLimit > maxLimit,
+  };
+};
+
+/**
+ * Builds the response envelope that goes alongside a page of results.
+ *
+ * `hasMore` is the piece worth having: without it a client cannot distinguish
+ * a full page from the last page, and its only recourse is to keep asking for
+ * larger limits — the exact behaviour the ceiling is there to prevent.
+ */
+export const buildPaginationMeta = ({ total, page, limit }) => ({
+  total,
+  page,
+  limit,
+  totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+  hasMore: page * limit < total,
+});


### PR DESCRIPTION
# Pull Request

## Description

Four list endpoints read `?limit=` with `parseInt(req.query.limit) || <default>` and passed the result straight to `.limit()`. `?limit=10000000` therefore made MongoDB stream millions of documents into the Node heap, run `.populate()` over all of them, and serialize the result to JSON — enough for one request to push a container past its memory ceiling and take the API down for every tenant.

`?page=0` was the mirror image: `skip = -limit`, which MongoDB rejects, and the controllers reported that validation problem as a generic `500`.

The clamping rule already existed in this codebase — `knowledgeController` caps at 100, `decisionGraphController` at 200, `notificationController` at 100 — but written three different ways and missed in four places. `server/utils/pagination.js` is that rule, once.

### Parsing is tightened, not just clamped

`parseInt(x) || d` leans on `NaN` being falsy, which also swallows a deliberate `0`, and without a radix `"1e5"` parses as `1` — so a caller asking for 100000 quietly received 1. The shared helper uses an explicit radix, a digits-only check, and a safe-integer bound.

**Out-of-range values are clamped, not rejected.** A client that has always sent `limit=500` keeps working and receives a capped page; turning that into a 400 would break it for no security benefit.

### Applied to

| Endpoint | Default | Cap |
|---|---|---|
| `getCommentsByMeeting` | 50 | 100 |
| `listAttachments` | 20 | 100 |
| `getMeetingsByTag` | 10 | 100 |
| `getSeriesMeetings` | 20 | 100 |

`getCommentsByMeeting` needed a second fix. Its reply query is a `$in` over every comment id on the page and had **no limit of its own**, so bounding the page alone would not bound the response — a page of 50 comments where one thread has 10,000 replies is still one enormous payload. Replies are capped at 500 per page, and the query is skipped entirely when the page is empty.

`getSeriesMeetings` keeps the `limit=0` / `limit=all` whole-series escape hatch added for #915 — a series timeline is not useful a page at a time — but it is now capped at 1000 (weekly for ~19 years, comfortably above any real recurrence schedule) and logs when it truncates. Bounded without changing what any real caller sees.

### Response envelope

Responses now carry a `pagination` object with `hasMore`. Without it a client cannot distinguish a full page from the last page, and its only recourse is to keep asking for larger limits — the exact behaviour the ceiling is there to prevent. The existing `currentPage` / `totalPages` / `totalComments` / `totalCount` fields are kept alongside it so no client breaks.

### Scope correction

`organizationController.js` was in the original report but is **not** affected. `browsePublicOrganizations` and `searchOrganizations` already validate `page >= 1` and `1 <= limit <= 50` and reject out-of-range values with a 400. Rewriting them to clamp would change behaviour their callers rely on, so they are left alone. [Corrected on the issue.](https://github.com/imuniqueshiv/MeetOnMemory/issues/1071#issuecomment-5166375409)

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [x] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1071

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/pagination.test.js` — 27 tests.

**`parsePagination` contract:** defaults and per-endpoint defaults, a default that would exceed its own ceiling, a missing query object; clamping to the default and per-endpoint maximums, and *not* clamping a value inside the ceiling; `page=0` / `-1` / `-99999` never producing a negative skip; `limit=0` / `-5` never producing a limit below 1; skip computed from clamped values; non-numeric input, `"1e5"`, `"12abc"`, `"4.5"`, real numbers, repeated query keys (`?limit=5&limit=9`), and values beyond `Number.MAX_SAFE_INTEGER`.

**`buildPaginationMeta`:** `hasMore` true mid-way, false on the last page, false on an exactly-full last page, and an empty result set.

**Endpoint integration**, seeding past the ceiling and asserting the cap holds:

- 130 comments, `?limit=10000000` → 100 returned, `total: 130`, `hasMore: true`
- `?page=0` and `?page=-3` → **200 with the first page**, where a negative skip previously produced a 500
- legacy comment response fields still present alongside the new envelope
- 120 attachments, `?limit=500000` → 100 returned
- 115 tagged meetings, `?limit=9999999` → 100 returned

Full server suite: unchanged against `main` — same 17 pre-existing suite failures, same 1 pre-existing test failure. That failure is `meetingSeriesController`'s #915 test, which fails identically before and after this change; I left it alone rather than fold an unrelated fix into this PR.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
