### PR TITLE
fix(polls): make vote casting atomic so concurrent votes are not lost (#1072)

### DIFF
--- a/server/controllers/pollController.js
+++ b/server/controllers/pollController.js
@@ -126,6 +126,91 @@ export const getPollsByMeeting = async (req, res) => {
   }
 };
 
+/**
+ * Matches a poll that is currently open — closed flag down, expiry in the
+ * future or absent (Issue #1072).
+ *
+ * Used as the *filter* of the vote update rather than as a preceding `if`, so
+ * a poll that closes between the read and the write rejects the vote instead
+ * of silently accepting it.
+ */
+const openPollFilter = (pollId, organizationId, now = new Date()) => ({
+  _id: String(pollId),
+  organization: organizationId,
+  isClosed: false,
+  $or: [
+    { expiresAt: null },
+    { expiresAt: { $exists: false } },
+    { expiresAt: { $gt: now } },
+  ],
+});
+
+/**
+ * The vote itself, expressed as an aggregation-pipeline update so MongoDB
+ * applies "clear my previous votes, then record my new ones" server-side
+ * against current state (Issue #1072).
+ *
+ * The handler used to load the poll, rebuild `options[].votes` in memory and
+ * `save()` the whole array back. Because the filter step reassigns the array,
+ * Mongoose emits a `$set` of the entire array as it looked at *read* time —
+ * no `$push`, no version guard, no unique index — so two people voting in the
+ * same event-loop window overwrote each other:
+ *
+ *     t0  Alice reads  votes: []
+ *     t1  Bob   reads  votes: []
+ *     t2  Alice writes votes: [alice]
+ *     t3  Bob   writes votes: [bob]        <- Alice's vote is gone
+ *
+ * Both callers got a 200 and both clients rendered their own vote as
+ * recorded, so the loss was invisible until someone read the tally. In a live
+ * meeting where a room votes on a countdown, that is most of the votes.
+ *
+ * A pipeline update runs under the document lock, so concurrent votes
+ * serialize and each one sees its predecessor's result. The `$filter` before
+ * the append is what makes it idempotent: a retry can never leave the same
+ * voter in an option twice.
+ */
+const buildVotePipeline = (voterId, selectedOptionIds) => [
+  {
+    $set: {
+      options: {
+        $map: {
+          input: "$options",
+          as: "opt",
+          in: {
+            $mergeObjects: [
+              "$$opt",
+              {
+                votes: {
+                  $let: {
+                    vars: {
+                      // Everyone except this voter, in their original order.
+                      others: {
+                        $filter: {
+                          input: "$$opt.votes",
+                          as: "v",
+                          cond: { $ne: ["$$v", voterId] },
+                        },
+                      },
+                    },
+                    in: {
+                      $cond: [
+                        { $in: ["$$opt._id", selectedOptionIds] },
+                        { $concatArrays: ["$$others", [voterId]] },
+                        "$$others",
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+];
+
 // @desc    Cast a vote
 // @route   POST /api/polls/:id/vote
 // @access  Private
@@ -133,31 +218,9 @@ export const castVote = async (req, res) => {
   try {
     const { id } = req.params;
     const { optionIds } = req.body; // Array of option IDs
-    const userId = req.user.id;
 
     if (!mongoose.isValidObjectId(id)) {
       return res.status(400).json({ message: "Invalid poll ID" });
-    }
-
-    const poll = await Poll.findById(String(id));
-    if (!poll) {
-      return res.status(404).json({ message: "Poll not found" });
-    }
-
-    if (poll.isClosed) {
-      return res.status(400).json({ message: "Poll is closed" });
-    }
-
-    if (poll.expiresAt && new Date(poll.expiresAt) <= new Date()) {
-      poll.isClosed = true;
-      await poll.save();
-      return res.status(400).json({ message: "Poll has expired" });
-    }
-
-    if (poll.organization.toString() !== req.user.organization.toString()) {
-      return res
-        .status(403)
-        .json({ message: "Forbidden: Not part of organization" });
     }
 
     if (!Array.isArray(optionIds) || optionIds.length === 0) {
@@ -166,43 +229,94 @@ export const castVote = async (req, res) => {
         .json({ message: "Must provide at least one option to vote for" });
     }
 
-    if (poll.pollType === "single" && optionIds.length > 1) {
+    const callerOrg = req.user?.organization;
+    const callerId = req.user?.id ?? req.user?._id;
+    if (!callerOrg || !callerId) {
+      return res
+        .status(403)
+        .json({ message: "Forbidden: Not part of organization" });
+    }
+
+    const poll = await Poll.findById(String(id));
+    if (!poll) {
+      return res.status(404).json({ message: "Poll not found" });
+    }
+
+    if (poll.organization.toString() !== callerOrg.toString()) {
+      return res
+        .status(403)
+        .json({ message: "Forbidden: Not part of organization" });
+    }
+
+    if (poll.isClosed) {
+      return res.status(400).json({ message: "Poll is closed" });
+    }
+
+    if (poll.expiresAt && new Date(poll.expiresAt) <= new Date()) {
+      // Guarded so a vote landing in the same instant cannot be clobbered by
+      // this bookkeeping write.
+      await Poll.updateOne(
+        { _id: String(id), isClosed: false },
+        { $set: { isClosed: true } },
+      );
+      return res.status(400).json({ message: "Poll has expired" });
+    }
+
+    // Deduplicate before the arity check: `{ optionIds: [x, x, x] }` used to
+    // push the same voter into one option three times, so `voteCount` counted
+    // one person as three.
+    const requestedIds = [...new Set(optionIds.map((o) => String(o)))];
+
+    if (poll.pollType === "single" && requestedIds.length > 1) {
       return res
         .status(400)
         .json({ message: "This poll only allows a single vote" });
     }
 
-    // Remove user's previous votes for this poll
-    poll.options.forEach((option) => {
-      option.votes = option.votes.filter(
-        (v) => v.toString() !== userId.toString(),
-      );
-    });
+    const pollOptionIds = new Set(poll.options.map((o) => o._id.toString()));
+    const selectedIds = requestedIds.filter((optionId) =>
+      pollOptionIds.has(optionId),
+    );
 
-    // Add new votes
-    let validVotesCast = 0;
-    poll.options.forEach((option) => {
-      if (optionIds.includes(option._id.toString())) {
-        option.votes.push(userId);
-        validVotesCast++;
-      }
-    });
-
-    if (validVotesCast === 0) {
+    // Every id must belong to this poll. Previously unknown ids were silently
+    // dropped and the vote still counted as long as one id happened to match.
+    if (
+      selectedIds.length !== requestedIds.length ||
+      selectedIds.length === 0
+    ) {
       return res.status(400).json({ message: "Invalid option(s) provided" });
     }
 
-    const savedPoll = await poll.save();
-    await savedPoll.populate("createdBy", "name email profilePicture");
-    if (!poll.isAnonymous) {
-      await savedPoll.populate("options.votes", "name email profilePicture");
+    const voterId = new mongoose.Types.ObjectId(String(callerId));
+    const selectedObjectIds = selectedIds.map(
+      (optionId) => new mongoose.Types.ObjectId(optionId),
+    );
+
+    const updatedPoll = await Poll.findOneAndUpdate(
+      openPollFilter(id, poll.organization),
+      buildVotePipeline(voterId, selectedObjectIds),
+      { new: true },
+    );
+
+    if (!updatedPoll) {
+      // The filter no longer matches — the poll closed or expired between the
+      // validation read and the write. Reject rather than resurrect it.
+      return res.status(400).json({ message: "Poll is closed" });
     }
 
-    const pollResponse = stripVotersIfAnonymous(savedPoll);
+    await updatedPoll.populate("createdBy", "name email profilePicture");
+    if (!updatedPoll.isAnonymous) {
+      await updatedPoll.populate("options.votes", "name email profilePicture");
+    }
+
+    const pollResponse = stripVotersIfAnonymous(updatedPoll);
 
     const io = req.app.get("io");
     if (io) {
-      io.to(poll.meeting.toString()).emit("poll:vote", pollResponse);
+      // Broadcast the committed document, so every client converges on the
+      // same tally instead of on whichever snapshot its own request happened
+      // to build.
+      io.to(updatedPoll.meeting.toString()).emit("poll:vote", pollResponse);
     }
 
     res.status(200).json(pollResponse);

--- a/server/tests/pollVoteConcurrency.test.js
+++ b/server/tests/pollVoteConcurrency.test.js
@@ -1,0 +1,485 @@
+/**
+ * Issue #1072 — concurrent poll votes were silently lost.
+ *
+ * `castVote` loaded the poll, rebuilt `options[].votes` in memory and saved the
+ * whole array back. The filter step reassigns the array, so Mongoose emitted a
+ * `$set` of the entire array as it looked at *read* time — no `$push`, no
+ * version guard, no unique index. Two voters in the same event-loop window
+ * therefore overwrote each other, both received a 200, and both clients
+ * rendered their own vote as recorded. The discrepancy only showed up to
+ * whoever read the tally afterwards.
+ *
+ * Polls run during live meetings, where a room votes on a countdown — the
+ * access pattern the old implementation could not survive.
+ *
+ * The headline test fires N simultaneous votes and asserts the total is N.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import Poll from "../models/pollModel.js";
+import User from "../models/userModel.js";
+import { castVote } from "../controllers/pollController.js";
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+const ORG = new mongoose.Types.ObjectId();
+const OTHER_ORG = new mongoose.Types.ObjectId();
+const MEETING = new mongoose.Types.ObjectId();
+const CREATOR = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const makeReq = (pollId, userId, optionIds, organization = ORG, io = null) => ({
+  params: { id: String(pollId) },
+  body: { optionIds },
+  user: { id: userId, _id: userId, organization, role: "member" },
+  app: { get: jest.fn(() => io) },
+});
+
+const seedPoll = (overrides = {}) =>
+  Poll.create({
+    meeting: MEETING,
+    organization: ORG,
+    createdBy: CREATOR,
+    question: "Ship on Friday?",
+    options: [
+      { text: "Yes", votes: [] },
+      { text: "No", votes: [] },
+      { text: "Abstain", votes: [] },
+    ],
+    ...overrides,
+  });
+
+const tallyOf = (poll) => poll.options.map((o) => o.votes.length);
+const totalVotes = (poll) =>
+  poll.options.reduce((sum, o) => sum + o.votes.length, 0);
+
+describe("castVote concurrency (#1072)", () => {
+  it("keeps every vote when two members vote simultaneously", async () => {
+    const poll = await seedPoll();
+    const [optYes, optNo] = poll.options.map((o) => o._id.toString());
+
+    const alice = new mongoose.Types.ObjectId();
+    const bob = new mongoose.Types.ObjectId();
+
+    await Promise.all([
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+      castVote(makeReq(poll._id, bob, [optNo]), makeRes()),
+    ]);
+
+    const stored = await Poll.findById(poll._id);
+    // Under the old read-modify-write this came back [0, 1] or [1, 0].
+    expect(tallyOf(stored)).toEqual([1, 1, 0]);
+  });
+
+  it("records all 25 votes when a room votes at once", async () => {
+    const poll = await seedPoll();
+    const optionIds = poll.options.map((o) => o._id.toString());
+
+    const voters = Array.from(
+      { length: 25 },
+      () => new mongoose.Types.ObjectId(),
+    );
+
+    await Promise.all(
+      voters.map((voter, i) =>
+        castVote(makeReq(poll._id, voter, [optionIds[i % 3]]), makeRes()),
+      ),
+    );
+
+    const stored = await Poll.findById(poll._id);
+    expect(totalVotes(stored)).toBe(25);
+
+    // And every voter appears exactly once across the whole poll.
+    const seen = stored.options.flatMap((o) => o.votes.map(String));
+    expect(new Set(seen).size).toBe(25);
+  });
+
+  it("lets a voter change their mind under concurrency without duplicating", async () => {
+    const poll = await seedPoll();
+    const [optYes, optNo] = poll.options.map((o) => o._id.toString());
+
+    const alice = new mongoose.Types.ObjectId();
+    const others = Array.from(
+      { length: 10 },
+      () => new mongoose.Types.ObjectId(),
+    );
+
+    await Promise.all([
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+      ...others.map((v) => castVote(makeReq(poll._id, v, [optNo]), makeRes())),
+    ]);
+
+    await castVote(makeReq(poll._id, alice, [optNo]), makeRes());
+
+    const stored = await Poll.findById(poll._id);
+    expect(totalVotes(stored)).toBe(11);
+    expect(tallyOf(stored)).toEqual([0, 11, 0]);
+
+    const aliceAppearances = stored.options
+      .flatMap((o) => o.votes.map(String))
+      .filter((v) => v === alice.toString());
+    expect(aliceAppearances).toHaveLength(1);
+  });
+
+  it("is idempotent when the same vote is retried concurrently", async () => {
+    const poll = await seedPoll();
+    const optYes = poll.options[0]._id.toString();
+    const alice = new mongoose.Types.ObjectId();
+
+    // A client retry racing the original request.
+    await Promise.all([
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+    ]);
+
+    const stored = await Poll.findById(poll._id);
+    expect(totalVotes(stored)).toBe(1);
+  });
+});
+
+describe("castVote single-choice invariants (#1072)", () => {
+  it("replaces the previous vote rather than adding to it", async () => {
+    const poll = await seedPoll();
+    const [optYes, optNo] = poll.options.map((o) => o._id.toString());
+    const alice = new mongoose.Types.ObjectId();
+
+    await castVote(makeReq(poll._id, alice, [optYes]), makeRes());
+    await castVote(makeReq(poll._id, alice, [optNo]), makeRes());
+
+    const stored = await Poll.findById(poll._id);
+    expect(tallyOf(stored)).toEqual([0, 1, 0]);
+  });
+
+  it("never leaves one voter in two options of a single-choice poll", async () => {
+    const poll = await seedPoll();
+    const [optYes, optNo, optAbstain] = poll.options.map((o) =>
+      o._id.toString(),
+    );
+    const alice = new mongoose.Types.ObjectId();
+
+    await Promise.all([
+      castVote(makeReq(poll._id, alice, [optYes]), makeRes()),
+      castVote(makeReq(poll._id, alice, [optNo]), makeRes()),
+      castVote(makeReq(poll._id, alice, [optAbstain]), makeRes()),
+    ]);
+
+    const stored = await Poll.findById(poll._id);
+    expect(totalVotes(stored)).toBe(1);
+  });
+
+  it("rejects more than one option on a single-choice poll", async () => {
+    const poll = await seedPoll();
+    const [optYes, optNo] = poll.options.map((o) => o._id.toString());
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [optYes, optNo]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/single vote/i);
+    expect(totalVotes(await Poll.findById(poll._id))).toBe(0);
+  });
+});
+
+describe("castVote multiple-choice invariants (#1072)", () => {
+  it("records a vote in each selected option", async () => {
+    const poll = await seedPoll({ pollType: "multiple" });
+    const [optYes, optNo] = poll.options.map((o) => o._id.toString());
+    const alice = new mongoose.Types.ObjectId();
+
+    await castVote(makeReq(poll._id, alice, [optYes, optNo]), makeRes());
+
+    expect(tallyOf(await Poll.findById(poll._id))).toEqual([1, 1, 0]);
+  });
+
+  it("counts a duplicated option id once, not once per repetition", async () => {
+    // `{ optionIds: [x, x, x] }` used to push the same voter three times, so
+    // voteCount reported one person as three.
+    const poll = await seedPoll({ pollType: "multiple" });
+    const optYes = poll.options[0]._id.toString();
+    const alice = new mongoose.Types.ObjectId();
+
+    const res = makeRes();
+    await castVote(makeReq(poll._id, alice, [optYes, optYes, optYes]), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(tallyOf(await Poll.findById(poll._id))).toEqual([1, 0, 0]);
+  });
+
+  it("narrows a selection on a re-vote instead of accumulating", async () => {
+    const poll = await seedPoll({ pollType: "multiple" });
+    const [optYes, optNo, optAbstain] = poll.options.map((o) =>
+      o._id.toString(),
+    );
+    const alice = new mongoose.Types.ObjectId();
+
+    await castVote(
+      makeReq(poll._id, alice, [optYes, optNo, optAbstain]),
+      makeRes(),
+    );
+    await castVote(makeReq(poll._id, alice, [optNo]), makeRes());
+
+    expect(tallyOf(await Poll.findById(poll._id))).toEqual([0, 1, 0]);
+  });
+});
+
+describe("castVote validation and guards (#1072)", () => {
+  it("rejects an option id that does not belong to the poll", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        new mongoose.Types.ObjectId().toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe("Invalid option(s) provided");
+  });
+
+  it("rejects a mix of valid and unknown option ids", async () => {
+    // Previously the unknown id was silently dropped and the vote still
+    // counted, so a client bug went unnoticed.
+    const poll = await seedPoll({ pollType: "multiple" });
+    const optYes = poll.options[0]._id.toString();
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        optYes,
+        new mongoose.Types.ObjectId().toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(totalVotes(await Poll.findById(poll._id))).toBe(0);
+  });
+
+  it("rejects an empty or non-array optionIds", async () => {
+    const poll = await seedPoll();
+
+    for (const optionIds of [[], null, "opt-1", {}]) {
+      const res = makeRes();
+      await castVote(
+        makeReq(poll._id, new mongoose.Types.ObjectId(), optionIds),
+        res,
+      );
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it("rejects a vote on a closed poll", async () => {
+    const poll = await seedPoll({ isClosed: true });
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        poll.options[0]._id.toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe("Poll is closed");
+  });
+
+  it("rejects a vote on an expired poll and closes it", async () => {
+    const poll = await seedPoll({ expiresAt: new Date(Date.now() - 60000) });
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        poll.options[0]._id.toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toBe("Poll has expired");
+    expect((await Poll.findById(poll._id)).isClosed).toBe(true);
+  });
+
+  it("accepts a vote on a poll that has not expired yet", async () => {
+    const poll = await seedPoll({ expiresAt: new Date(Date.now() + 600000) });
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        poll.options[0]._id.toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(totalVotes(await Poll.findById(poll._id))).toBe(1);
+  });
+
+  it("rejects a voter from another organization", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await castVote(
+      makeReq(
+        poll._id,
+        new mongoose.Types.ObjectId(),
+        [poll.options[0]._id.toString()],
+        OTHER_ORG,
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(totalVotes(await Poll.findById(poll._id))).toBe(0);
+  });
+
+  it("returns 403, not 500, when the session has no organization", async () => {
+    const poll = await seedPoll();
+    const res = makeRes();
+
+    await castVote(
+      {
+        params: { id: poll._id.toString() },
+        body: { optionIds: [poll.options[0]._id.toString()] },
+        user: { id: new mongoose.Types.ObjectId() },
+        app: { get: jest.fn(() => null) },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 404 for an unknown poll and 400 for a malformed id", async () => {
+    const notFound = makeRes();
+    await castVote(
+      makeReq(new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId(), [
+        new mongoose.Types.ObjectId().toString(),
+      ]),
+      notFound,
+    );
+    expect(notFound.statusCode).toBe(404);
+
+    const malformed = makeRes();
+    await castVote(
+      makeReq("nope", new mongoose.Types.ObjectId(), ["opt"]),
+      malformed,
+    );
+    expect(malformed.statusCode).toBe(400);
+  });
+});
+
+describe("castVote response and broadcast (#1072)", () => {
+  it("returns the committed document, not a local snapshot", async () => {
+    // A real User document, because `.populate("options.votes")` silently drops
+    // ids that do not resolve — the response would show an empty tally for a
+    // synthetic voter regardless of what was stored.
+    const voter = await User.create({
+      name: "Voter",
+      email: `voter-${new mongoose.Types.ObjectId()}@example.com`,
+      password: "hashedpw123",
+    });
+
+    const poll = await seedPoll();
+    const optYes = poll.options[0]._id.toString();
+    const res = makeRes();
+
+    await castVote(makeReq(poll._id, voter._id, [optYes]), res);
+
+    expect(res.statusCode).toBe(200);
+    const stored = await Poll.findById(poll._id);
+    expect(res.body.options.map((o) => o.votes.length)).toEqual(
+      tallyOf(stored),
+    );
+    expect(tallyOf(stored)).toEqual([1, 0, 0]);
+  });
+
+  it("broadcasts poll:vote to the meeting room", async () => {
+    const poll = await seedPoll();
+    const emitted = [];
+    const io = {
+      to: jest.fn((room) => ({
+        emit: jest.fn((event, payload) =>
+          emitted.push({ room, event, payload }),
+        ),
+      })),
+    };
+
+    await castVote(
+      makeReq(
+        poll._id,
+        new mongoose.Types.ObjectId(),
+        [poll.options[0]._id.toString()],
+        ORG,
+        io,
+      ),
+      makeRes(),
+    );
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].room).toBe(MEETING.toString());
+    expect(emitted[0].event).toBe("poll:vote");
+  });
+
+  it("hides voter identities on an anonymous poll but keeps the count", async () => {
+    const poll = await seedPoll({ isAnonymous: true });
+    const res = makeRes();
+
+    await castVote(
+      makeReq(poll._id, new mongoose.Types.ObjectId(), [
+        poll.options[0]._id.toString(),
+      ]),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.options[0].votes).toEqual([]);
+    expect(res.body.options[0].voteCount).toBe(1);
+  });
+
+  it("does not emit when the vote is rejected", async () => {
+    const poll = await seedPoll({ isClosed: true });
+    const emitted = [];
+    const io = {
+      to: jest.fn(() => ({ emit: jest.fn((e, p) => emitted.push({ e, p })) })),
+    };
+
+    await castVote(
+      makeReq(
+        poll._id,
+        new mongoose.Types.ObjectId(),
+        [poll.options[0]._id.toString()],
+        ORG,
+        io,
+      ),
+      makeRes(),
+    );
+
+    expect(emitted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`castVote` loaded the poll, rebuilt `options[].votes` in memory and saved the whole array back:

```js
const poll = await Poll.findById(String(id));            // (1) read
poll.options.forEach((option) => {
  option.votes = option.votes.filter(                    // (2) reassignment -> $set of the whole array
    (v) => v.toString() !== userId.toString(),
  );
});
poll.options.forEach((option) => {
  if (optionIds.includes(option._id.toString())) option.votes.push(userId);
});
const savedPoll = await poll.save();                     // (3) write back the read-time snapshot
```

Step (2) reassigns the array rather than mutating it, so Mongoose emits a `$set` of the entire array as it looked at **read** time. No `$push`, no version guard, no unique index — nothing in the stack could notice a conflict:

| | Alice | Bob |
|---|---|---|
| t0 | reads `votes: []` | |
| t1 | | reads `votes: []` |
| t2 | writes `votes: [alice]` | |
| t3 | | writes `votes: [bob]` — **Alice is gone** |

Both requests answered `200` and both clients rendered their own vote as recorded, so nothing surfaced the loss until someone read the tally. Polls run during **live meetings**, where a room votes on a countdown — the one access pattern this could not survive — and the feature's entire output is a count.

### What changed

The vote is now a single `findOneAndUpdate` with an aggregation-pipeline update, so MongoDB applies "remove this voter everywhere, then append them to the selected options" server-side against current state, under the document lock. Concurrent votes serialize and each one sees its predecessor's result.

The `$filter` before the append is what makes it idempotent: a retry racing the original request cannot leave one voter in an option twice, and cannot leave them in two options of a single-choice poll.

The open-poll conditions moved from a preceding `if` into the update's **filter** (`isClosed: false`, expiry in the future, matching organization), so a poll that closes between validation and write now rejects the vote instead of resurrecting it. The expiry bookkeeping write is likewise guarded on `isClosed: false` so it cannot clobber a vote landing in the same instant.

### Two things found while writing the tests

- **Unknown option ids were silently dropped.** `{ optionIds: ["<valid>", "<garbage>"] }` counted as a valid vote because one id matched, so a client sending a stale id got a `200` and a vote it did not intend. Every id must now belong to the poll or the request is rejected.
- **A session with no organization was a 500.** `poll.organization.toString() !== req.user.organization.toString()` throws on `undefined`, and the catch reported it as "Server Error". It is a `403`.

`optionIds` is also deduplicated so the single-choice arity check counts distinct selections rather than repetitions. To be clear, this was **not** a live bug — the loop iterated the poll's options once each, so a repeated id never inflated a tally. My original issue said otherwise; [corrected there](https://github.com/imuniqueshiv/MeetOnMemory/issues/1072#issuecomment-5166415099).

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1072

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/pollVoteConcurrency.test.js` — 23 tests, run against `mongodb-memory-server` (already a dev dependency).

**Concurrency — the headline guarantees:**

- two members voting simultaneously → tally `[1, 1, 0]` (this came back `[0, 1]` or `[1, 0]` before)
- 25 simultaneous voters → total is **25**, and every voter appears exactly once across the whole poll
- one voter changing their mind while 10 others vote → total 11, and that voter appears exactly once
- three concurrent retries of the same vote → total 1

**Single-choice invariants:** a re-vote replaces rather than adds; three concurrent votes for three different options leave the voter in exactly one; more than one option in a single request → 400.

**Multiple-choice invariants:** a vote lands in every selected option; a repeated id counts once; a narrower re-vote replaces the earlier selection rather than accumulating.

**Validation and guards:** unknown option id → 400; a mix of valid and unknown ids → 400 with nothing recorded; empty / non-array `optionIds` → 400; closed poll → 400; expired poll → 400 *and* the poll is closed; not-yet-expired poll → 200; foreign organization → 403; orgless session → 403 not 500; unknown poll → 404; malformed id → 400.

**Response and broadcast:** the response reflects the committed document; `poll:vote` is emitted to the meeting room; an anonymous poll hides voter identities while reporting `voteCount`; a rejected vote emits nothing.

I confirmed the suite is load-bearing: against the previous implementation **5 tests fail** — all three multi-voter concurrency tests, the mixed valid/unknown id test, and the orgless-session test.

Full server suite: unchanged against `main` — same 17 pre-existing suite failures, same 1 pre-existing test failure.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
