### PR TITLE
fix: allow organization admins to control agenda timers

### DIFF
--- a/server/controllers/agendaTimerController.js
+++ b/server/controllers/agendaTimerController.js
@@ -1,9 +1,11 @@
 import Meeting from "../models/meetingModel.js";
 
 // Utility to check permissions (Organizer or Admin)
-const hasPermission = (meeting, userId) => {
-  return meeting.uploadedBy.toString() === userId;
-  // TODO: Add logic to check for Org Admin if required by the org structure.
+const hasPermission = (meeting, userId, userRole) => {
+  const isUploader = meeting.uploadedBy.toString() === userId;
+  const isOrgAdmin = userRole === "admin" || userRole === "owner";
+
+  return isUploader || isOrgAdmin;
 };
 
 export const startAgendaItem = async (req, res) => {
@@ -18,7 +20,7 @@ export const startAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId)) {
+    if (!hasPermission(meeting, userId, req.user.role)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });
@@ -77,7 +79,7 @@ export const stopAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId)) {
+    if (!hasPermission(meeting, userId, req.user.role)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });
@@ -142,7 +144,7 @@ export const skipAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId)) {
+    if (!hasPermission(meeting, userId, req.user.role)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });


### PR DESCRIPTION
## Summary

Fixes #818

This PR updates the agenda timer permission logic so that organization administrators can manage agenda timers in addition to the meeting uploader.

### Changes

- Allow `admin` and `owner` roles to control agenda timers.
- Preserve existing uploader permissions.
- Keep all timer functionality unchanged.
- Continue denying unauthorized users.

### Validation

- [x] Prettier passed
- [x] ESLint passed
- [x] PR validation passed
- [x] No UI changes
- [x] No behavior changes beyond authorization