### PR TITLE
fix: paginate Knowledge Archive All view as one combined list

### DIFF
--- a/client/src/pages/KnowledgeArchive.jsx
+++ b/client/src/pages/KnowledgeArchive.jsx
@@ -54,74 +54,31 @@ const KnowledgeArchive = () => {
   const loadArchivedMemories = useCallback(async () => {
     setLoading(true);
     try {
-      let decisionList = [];
-      let actionList = [];
-      let totalDecisions = 0;
-      let totalActions = 0;
-      let dPages = 1;
-      let aPages = 1;
-
-      const queryOpts = {
-        includeArchived: true,
-        lifecycleState: "archived",
+      const res = await knowledgeApi.getArchivedMemories({
+        type: selectedType,
         page,
         limit,
         ...(searchQuery ? { search: searchQuery } : {}),
-      };
+      });
 
-      if (selectedType === "all" || selectedType === "decision") {
-        const dRes = await knowledgeApi.getDecisions(
-          "createdAt",
-          null,
-          queryOpts,
+      if (res.data?.success) {
+        setArchivedMemories(res.data.memories || []);
+        setTotalCount(res.data.pagination?.total || 0);
+        setTotalPages(Math.max(1, res.data.pagination?.totalPages || 1));
+      } else {
+        setArchivedMemories([]);
+        setTotalCount(0);
+        setTotalPages(1);
+        toast.error(
+          res.data?.message || "Failed to fetch archived knowledge items.",
         );
-        if (dRes.data?.success) {
-          decisionList = (dRes.data.decisions || []).map((d) => ({
-            ...d,
-            type: "decision",
-          }));
-          totalDecisions = dRes.data.pagination?.total || decisionList.length;
-          dPages = dRes.data.pagination?.totalPages || 1;
-        }
       }
-
-      if (selectedType === "all" || selectedType === "action-item") {
-        const aRes = await knowledgeApi.getActionItems(
-          "all",
-          "createdAt",
-          queryOpts,
-        );
-        if (aRes.data?.success) {
-          actionList = (aRes.data.actionItems || []).map((a) => ({
-            ...a,
-            type: "action-item",
-          }));
-          totalActions = aRes.data.pagination?.total || actionList.length;
-          aPages = aRes.data.pagination?.totalPages || 1;
-        }
-      }
-
-      const combined = [...decisionList, ...actionList].sort(
-        (a, b) =>
-          new Date(b.archivedAt || b.updatedAt) -
-          new Date(a.archivedAt || a.updatedAt),
-      );
-
-      setArchivedMemories(combined);
-
-      const computedTotal =
-        selectedType === "decision"
-          ? totalDecisions
-          : selectedType === "action-item"
-            ? totalActions
-            : totalDecisions + totalActions;
-      setTotalCount(computedTotal);
-
-      const maxPages = Math.max(dPages, aPages);
-      setTotalPages(maxPages > 0 ? maxPages : 1);
     } catch (err) {
       console.error("Failed to load archived memories:", err);
       toast.error("Failed to fetch archived knowledge items.");
+      setArchivedMemories([]);
+      setTotalCount(0);
+      setTotalPages(1);
     } finally {
       setLoading(false);
     }
@@ -241,7 +198,10 @@ const KnowledgeArchive = () => {
                 type="text"
                 placeholder="Search archived decisions, action items, or keywords..."
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  setPage(1);
+                }}
                 className="w-full pl-9 pr-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs focus:ring-2 focus:ring-indigo-500 focus:outline-none"
               />
             </div>
@@ -251,7 +211,10 @@ const KnowledgeArchive = () => {
               <Filter className="w-4 h-4 text-slate-400" />
               <select
                 value={selectedType}
-                onChange={(e) => setSelectedType(e.target.value)}
+                onChange={(e) => {
+                  setSelectedType(e.target.value);
+                  setPage(1);
+                }}
                 className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-xs font-medium cursor-pointer"
               >
                 {TYPE_OPTIONS.map((t) => (
@@ -312,7 +275,7 @@ const KnowledgeArchive = () => {
             <div className="space-y-4">
               {filteredMemories.map((mem) => (
                 <div
-                  key={mem._id}
+                  key={`${mem.type}-${mem._id}`}
                   className="bg-white dark:bg-slate-900 border border-indigo-100 dark:border-slate-800/80 rounded-2xl p-5 shadow-xs hover:border-indigo-300 dark:hover:border-indigo-800 transition-all flex flex-col md:flex-row md:items-center justify-between gap-4"
                 >
                   <div className="space-y-2 flex-1">

--- a/client/src/services/__tests__/knowledgeArchive.test.js
+++ b/client/src/services/__tests__/knowledgeArchive.test.js
@@ -107,4 +107,37 @@ describe("knowledgeApi - Archive Browser queries", () => {
       expect.stringContaining("limit=10"),
     );
   });
+
+  it("should call the unified archive endpoint with type, search, and pagination (#901)", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        memories: [],
+        pagination: { total: 25, page: 2, limit: 10, totalPages: 3 },
+      },
+    });
+
+    await knowledgeApi.getArchivedMemories({
+      type: "all",
+      search: "budget review",
+      page: 2,
+      limit: 10,
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("/api/knowledge/archive?"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("type=all"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringMatching(/search=budget(\+|%20)review/),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("page=2"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("limit=10"),
+    );
+  });
 });

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -25,6 +25,18 @@ export const knowledgeApi = {
     if (options.limit) url += `&limit=${options.limit}`;
     return apiClient.get(url);
   },
+  /**
+   * Unified archived decisions + action items with correct combined pagination (#901).
+   */
+  getArchivedMemories: (options = {}) => {
+    const params = new URLSearchParams();
+    if (options.type) params.append("type", options.type);
+    if (options.search) params.append("search", options.search);
+    if (options.page) params.append("page", String(options.page));
+    if (options.limit) params.append("limit", String(options.limit));
+    const query = params.toString();
+    return apiClient.get(`/api/knowledge/archive${query ? `?${query}` : ""}`);
+  },
   getDecisionLineage: (decisionId) =>
     apiClient.get(`/api/knowledge/decisions/${decisionId}/lineage`),
   submitFeedback: (type, id, rating) =>

--- a/server/controllers/knowledgeController.js
+++ b/server/controllers/knowledgeController.js
@@ -18,6 +18,10 @@ import {
   restoreMemory,
   transitionLifecycleState,
 } from "../services/memoryLifecycleService.js";
+import {
+  ALLOWED_ARCHIVE_TYPES,
+  getArchivedMemoriesPage,
+} from "../services/archivedKnowledgeService.js";
 import AuditLog from "../models/auditLogModel.js";
 import eventBus from "../services/eventBus.js";
 
@@ -289,6 +293,53 @@ export const getDecisions = async (req, res) => {
   } catch (error) {
     console.error("getDecisions error:", error);
     sendError(res, 500, "Failed to fetch decisions");
+  }
+};
+
+/**
+ * Unified Knowledge Archive listing (#901).
+ *
+ * The archive browser previously fetched page N of decisions and page N of
+ * action items independently, then merged them on the client. That produced
+ * the wrong page size, wrong totalPages (max of the two), and could skip or
+ * duplicate records. This endpoint paginates the combined set once.
+ */
+export const getArchivedMemories = async (req, res) => {
+  try {
+    const { type = "all", search } = req.query || {};
+    const organization = sanitizeOrg(req.user?.organization);
+
+    if (!organization) {
+      return sendError(res, 400, "Organization required");
+    }
+
+    if (typeof type !== "string" || !ALLOWED_ARCHIVE_TYPES.includes(type)) {
+      return sendError(
+        res,
+        400,
+        `Invalid type. Allowed values: ${ALLOWED_ARCHIVE_TYPES.join(", ")}`,
+      );
+    }
+
+    if (search !== undefined && search !== null && typeof search !== "string") {
+      return sendError(res, 400, "Invalid search");
+    }
+
+    const result = await getArchivedMemoriesPage({
+      organization,
+      type,
+      search,
+      page: req.query.page,
+      limit: req.query.limit,
+    });
+
+    sendSuccess(res, result);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("getArchivedMemories error:", error);
+    sendError(res, 500, "Failed to fetch archived memories");
   }
 };
 

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -6,6 +6,7 @@ import {
   getDecisionLineageController,
   getOpenActionItems,
   getDecisions,
+  getArchivedMemories,
   submitMemoryFeedback,
   recalculateImportance,
   updateActionItemStatus,
@@ -73,6 +74,12 @@ router.get(
   requireOrgMembership,
   requirePermission("knowledge", "view"),
   getDecisions,
+);
+router.get(
+  "/archive",
+  requireOrgMembership,
+  requirePermission("knowledge", "view"),
+  getArchivedMemories,
 );
 router.get(
   "/decisions/:id/lineage",

--- a/server/services/archivedKnowledgeService.js
+++ b/server/services/archivedKnowledgeService.js
@@ -1,0 +1,160 @@
+import mongoose from "mongoose";
+import ActionItem from "../models/actionItemModel.js";
+import Decision from "../models/decisionModel.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+
+const ALLOWED_ARCHIVE_TYPES = ["all", "decision", "action-item"];
+
+const toObjectId = (value) => {
+  if (!value) return null;
+  if (value instanceof mongoose.Types.ObjectId) return value;
+  const asString = String(value);
+  return mongoose.Types.ObjectId.isValid(asString)
+    ? new mongoose.Types.ObjectId(asString)
+    : value;
+};
+
+/**
+ * Builds the $match filter shared by both memory collections for the
+ * Knowledge Archive browser.
+ */
+export const buildArchiveMatch = ({ organization, search }) => {
+  const match = {
+    organization: toObjectId(organization),
+    lifecycleState: "archived",
+  };
+
+  if (typeof search === "string" && search.trim()) {
+    match.text = { $regex: search.trim(), $options: "i" };
+  }
+
+  return match;
+};
+
+const withTypeAndSortDate = (type) => ({
+  $addFields: {
+    type,
+    sortDate: { $ifNull: ["$archivedAt", "$updatedAt"] },
+  },
+});
+
+const meetingLookupStages = [
+  {
+    $lookup: {
+      from: "meetings",
+      localField: "sourceMeetingId",
+      foreignField: "_id",
+      as: "_sourceMeeting",
+      pipeline: [{ $project: { title: 1, date: 1 } }],
+    },
+  },
+  {
+    $addFields: {
+      sourceMeetingId: { $arrayElemAt: ["$_sourceMeeting", 0] },
+    },
+  },
+  { $project: { _sourceMeeting: 0, sortDate: 0, embedding: 0 } },
+];
+
+/**
+ * Builds the aggregation pipeline that returns one correctly paginated page
+ * of archived memories. When `type` is `"all"`, decisions and action items
+ * are unioned and sorted together before skip/limit so pages never skip or
+ * duplicate records the way client-side merging of two independent pages did.
+ */
+export const buildArchivePipeline = ({
+  type = "all",
+  organization,
+  search,
+  skip = 0,
+  limit = 10,
+}) => {
+  const match = buildArchiveMatch({ organization, search });
+  const actionItemCollection = ActionItem.collection?.name || "actionitems";
+
+  const decisionBranch = [{ $match: match }, withTypeAndSortDate("decision")];
+
+  let prefix;
+  if (type === "decision") {
+    prefix = decisionBranch;
+  } else if (type === "action-item") {
+    prefix = [{ $match: match }, withTypeAndSortDate("action-item")];
+  } else {
+    prefix = [
+      ...decisionBranch,
+      {
+        $unionWith: {
+          coll: actionItemCollection,
+          pipeline: [{ $match: match }, withTypeAndSortDate("action-item")],
+        },
+      },
+    ];
+  }
+
+  return [
+    ...prefix,
+    { $sort: { sortDate: -1, _id: -1 } },
+    {
+      $facet: {
+        metadata: [{ $count: "total" }],
+        data: [{ $skip: skip }, { $limit: limit }, ...meetingLookupStages],
+      },
+    },
+  ];
+};
+
+/**
+ * Fetches one page of archived knowledge items with unified pagination.
+ *
+ * @returns {{ memories: object[], pagination: object }}
+ */
+export const getArchivedMemoriesPage = async ({
+  organization,
+  type = "all",
+  search,
+  page,
+  limit,
+}) => {
+  if (!organization) {
+    const err = new Error("Organization required");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (!ALLOWED_ARCHIVE_TYPES.includes(type)) {
+    const err = new Error(
+      `Invalid type. Allowed values: ${ALLOWED_ARCHIVE_TYPES.join(", ")}`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const pagination = parsePagination(
+    { page, limit },
+    { defaultLimit: 10, maxLimit: 100 },
+  );
+
+  const pipeline = buildArchivePipeline({
+    type,
+    organization,
+    search,
+    skip: pagination.skip,
+    limit: pagination.limit,
+  });
+
+  const Model = type === "action-item" ? ActionItem : Decision;
+  const [facet] = await Model.aggregate(pipeline);
+  const memories = facet?.data || [];
+  const total = facet?.metadata?.[0]?.total || 0;
+
+  return {
+    memories,
+    pagination: buildPaginationMeta({
+      total,
+      page: pagination.page,
+      limit: pagination.limit,
+    }),
+  };
+};
+
+export { ALLOWED_ARCHIVE_TYPES };

--- a/server/tests/archivedKnowledgeService.test.js
+++ b/server/tests/archivedKnowledgeService.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+
+vi.mock("../models/decisionModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "decisions" },
+  },
+}));
+
+vi.mock("../models/actionItemModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "actionitems" },
+  },
+}));
+
+const Decision = (await import("../models/decisionModel.js")).default;
+const ActionItem = (await import("../models/actionItemModel.js")).default;
+const { buildArchiveMatch, buildArchivePipeline, getArchivedMemoriesPage } =
+  await import("../services/archivedKnowledgeService.js");
+
+describe("archivedKnowledgeService (#901)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("buildArchiveMatch", () => {
+    it("filters by organization and archived lifecycle state", () => {
+      const orgId = new mongoose.Types.ObjectId();
+      const match = buildArchiveMatch({ organization: orgId });
+
+      expect(match.lifecycleState).toBe("archived");
+      expect(String(match.organization)).toBe(String(orgId));
+      expect(match.text).toBeUndefined();
+    });
+
+    it("adds a case-insensitive text search when provided", () => {
+      const match = buildArchiveMatch({
+        organization: "507f1f77bcf86cd799439011",
+        search: "  budget  ",
+      });
+
+      expect(match.text).toEqual({ $regex: "budget", $options: "i" });
+    });
+  });
+
+  describe("buildArchivePipeline", () => {
+    it("unions decisions and action items for the All view", () => {
+      const pipeline = buildArchivePipeline({
+        type: "all",
+        organization: "507f1f77bcf86cd799439011",
+        skip: 10,
+        limit: 10,
+      });
+
+      expect(pipeline[0]).toEqual(
+        expect.objectContaining({ $match: expect.any(Object) }),
+      );
+      expect(pipeline).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            $unionWith: expect.objectContaining({
+              coll: "actionitems",
+            }),
+          }),
+        ]),
+      );
+
+      const facet = pipeline.find((stage) => stage.$facet);
+      expect(facet.$facet.data[0]).toEqual({ $skip: 10 });
+      expect(facet.$facet.data[1]).toEqual({ $limit: 10 });
+      expect(facet.$facet.metadata).toEqual([{ $count: "total" }]);
+    });
+
+    it("does not union when filtering to a single memory type", () => {
+      const decisionPipeline = buildArchivePipeline({
+        type: "decision",
+        organization: "507f1f77bcf86cd799439011",
+        skip: 0,
+        limit: 10,
+      });
+      const actionPipeline = buildArchivePipeline({
+        type: "action-item",
+        organization: "507f1f77bcf86cd799439011",
+        skip: 0,
+        limit: 10,
+      });
+
+      expect(decisionPipeline.some((stage) => stage.$unionWith)).toBe(false);
+      expect(actionPipeline.some((stage) => stage.$unionWith)).toBe(false);
+      expect(decisionPipeline[1].$addFields.type).toBe("decision");
+      expect(actionPipeline[1].$addFields.type).toBe("action-item");
+    });
+  });
+
+  describe("getArchivedMemoriesPage", () => {
+    it("returns a correctly paginated combined page", async () => {
+      Decision.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 25 }],
+          data: [
+            { _id: "d1", type: "decision", text: "Decide A" },
+            { _id: "a1", type: "action-item", text: "Do B" },
+          ],
+        },
+      ]);
+
+      const result = await getArchivedMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        type: "all",
+        page: 2,
+        limit: 10,
+      });
+
+      expect(Decision.aggregate).toHaveBeenCalledTimes(1);
+      const pipeline = Decision.aggregate.mock.calls[0][0];
+      const facet = pipeline.find((stage) => stage.$facet);
+      expect(facet.$facet.data[0]).toEqual({ $skip: 10 });
+      expect(facet.$facet.data[1]).toEqual({ $limit: 10 });
+
+      expect(result.memories).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        total: 25,
+        page: 2,
+        limit: 10,
+        totalPages: 3,
+        hasMore: true,
+      });
+    });
+
+    it("queries ActionItem when type is action-item", async () => {
+      ActionItem.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 2 }],
+          data: [{ _id: "a1", type: "action-item" }],
+        },
+      ]);
+
+      const result = await getArchivedMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        type: "action-item",
+        page: 1,
+        limit: 10,
+      });
+
+      expect(ActionItem.aggregate).toHaveBeenCalled();
+      expect(Decision.aggregate).not.toHaveBeenCalled();
+      expect(result.pagination.total).toBe(2);
+    });
+
+    it("rejects an invalid type", async () => {
+      await expect(
+        getArchivedMemoriesPage({
+          organization: "507f1f77bcf86cd799439011",
+          type: "notes",
+        }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("rejects a missing organization", async () => {
+      await expect(
+        getArchivedMemoriesPage({ type: "all" }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+  });
+});


### PR DESCRIPTION
## Description

The Knowledge Archive \"All\" view fetched page N of decisions and page N of action items independently, then merged them on the client. Page size, total pages (taken as the max of the two), and record ordering were wrong, so large archives could skip or duplicate items.

This adds `GET /api/knowledge/archive`, which unions archived decisions and action items, sorts them together, and applies a single skip/limit. The archive browser uses that endpoint for All, Decisions, and Action Items. Search and type filters behave as before; changing type or search resets to page 1.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #901

## Testing

- 8 unit tests for archive match/pipeline construction and paginated results (`server/tests/archivedKnowledgeService.test.js`).
- Client API test for the new archive query string.
- `npm run format:check:changed`, server `validate:pr`, and client `validate:pr` pass.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
