### PR TITLE
fix: add complete dark mode support to public shared view

### DIFF
--- a/client/src/pages/PublicSharedView.jsx
+++ b/client/src/pages/PublicSharedView.jsx
@@ -79,21 +79,21 @@ const PublicSharedView = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 dark:border-indigo-400"></div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white p-8 rounded-xl shadow-sm border border-gray-200 max-w-md w-full text-center">
-          <Shield className="w-16 h-16 text-red-500 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+        <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 max-w-md w-full text-center">
+          <Shield className="w-16 h-16 text-red-500 dark:text-red-400 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
             Access Denied
           </h2>
-          <p className="text-gray-600 mb-6">{error}</p>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">{error}</p>
         </div>
       </div>
     );
@@ -101,16 +101,16 @@ const PublicSharedView = () => {
 
   if (requiresPasscode) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white p-8 rounded-xl shadow-sm border border-gray-200 max-w-md w-full">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+        <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 max-w-md w-full">
           <div className="text-center mb-6">
-            <div className="w-16 h-16 bg-indigo-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Lock className="w-8 h-8 text-indigo-600" />
+            <div className="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/40 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Lock className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
               Protected Resource
             </h2>
-            <p className="text-gray-600 text-sm">
+            <p className="text-gray-600 dark:text-gray-300 text-sm">
               Please enter the passcode to view this shared resource.
             </p>
           </div>
@@ -122,16 +122,18 @@ const PublicSharedView = () => {
                 placeholder="Enter passcode"
                 value={passcode}
                 onChange={(e) => setPasscode(e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 focus:border-indigo-500 dark:focus:border-indigo-400"
               />
               {passcodeError && (
-                <p className="mt-2 text-sm text-red-600">{passcodeError}</p>
+                <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                  {passcodeError}
+                </p>
               )}
             </div>
             <button
               type="submit"
               disabled={verifying}
-              className="w-full bg-indigo-600 text-white font-medium py-3 rounded-lg hover:bg-indigo-700 transition disabled:opacity-70"
+              className="w-full bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-600 dark:hover:bg-indigo-500 text-white font-medium py-3 rounded-lg transition disabled:opacity-70"
             >
               {verifying ? "Verifying..." : "Access Resource"}
             </button>
@@ -146,10 +148,10 @@ const PublicSharedView = () => {
   const { resourceType, data } = resource;
 
   return (
-    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
         {/* Header Bar */}
-        <div className="flex items-center gap-2 mb-8 text-indigo-600 bg-indigo-50 px-4 py-2 rounded-full inline-flex border border-indigo-100">
+        <div className="flex items-center gap-2 mb-8 text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-950/50 px-4 py-2 rounded-full inline-flex border border-indigo-100 dark:border-indigo-800/50">
           <Shield className="w-4 h-4" />
           <span className="text-sm font-medium">
             Shared via MeetOnMemory (Read-Only)
@@ -158,40 +160,42 @@ const PublicSharedView = () => {
 
         {resourceType === "Meeting" ? (
           <div className="space-y-6">
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
               <div className="flex items-start gap-4 mb-6">
-                <div className="p-3 bg-blue-100 text-blue-600 rounded-lg shrink-0">
+                <div className="p-3 bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 rounded-lg shrink-0">
                   <Video className="w-8 h-8" />
                 </div>
                 <div>
-                  <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                  <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
                     {data.title}
                   </h1>
-                  <p className="text-gray-600 text-lg">{data.description}</p>
+                  <p className="text-gray-600 dark:text-gray-300 text-lg">
+                    {data.description}
+                  </p>
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 py-6 border-y border-gray-100 my-6">
-                <div className="flex items-center gap-2 text-gray-600">
-                  <Calendar className="w-5 h-5 text-gray-400" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 py-6 border-y border-gray-100 dark:border-gray-700 my-6">
+                <div className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+                  <Calendar className="w-5 h-5 text-gray-400 dark:text-gray-400" />
                   <span className="text-sm">
                     {new Date(data.date).toLocaleDateString()}
                   </span>
                 </div>
                 {data.time && (
-                  <div className="flex items-center gap-2 text-gray-600">
-                    <Clock className="w-5 h-5 text-gray-400" />
+                  <div className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+                    <Clock className="w-5 h-5 text-gray-400 dark:text-gray-400" />
                     <span className="text-sm">{data.time}</span>
                   </div>
                 )}
                 {data.location && (
-                  <div className="flex items-center gap-2 text-gray-600">
-                    <MapPin className="w-5 h-5 text-gray-400" />
+                  <div className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+                    <MapPin className="w-5 h-5 text-gray-400 dark:text-gray-400" />
                     <span className="text-sm">{data.location}</span>
                   </div>
                 )}
-                <div className="flex items-center gap-2 text-gray-600">
-                  <Users className="w-5 h-5 text-gray-400" />
+                <div className="flex items-center gap-2 text-gray-600 dark:text-gray-300">
+                  <Users className="w-5 h-5 text-gray-400 dark:text-gray-400" />
                   <span className="text-sm">
                     {data.participants?.length || 0} Participants
                   </span>
@@ -200,10 +204,10 @@ const PublicSharedView = () => {
 
               {data.summary && (
                 <div className="mt-8">
-                  <h3 className="text-xl font-semibold text-gray-900 mb-4">
+                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
                     Meeting Summary
                   </h3>
-                  <div className="prose max-w-none text-gray-700">
+                  <div className="prose dark:prose-invert max-w-none text-gray-700 dark:text-gray-300">
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>
                       {data.summary}
                     </ReactMarkdown>
@@ -215,11 +219,11 @@ const PublicSharedView = () => {
                 <div className="mt-8 space-y-6">
                   {data.structuredMoM.decisions &&
                     data.structuredMoM.decisions.length > 0 && (
-                      <div className="bg-green-50 rounded-xl p-6 border border-green-100">
-                        <h3 className="text-lg font-semibold text-green-900 mb-4">
+                      <div className="bg-green-50 dark:bg-green-950/30 rounded-xl p-6 border border-green-100 dark:border-green-800/40">
+                        <h3 className="text-lg font-semibold text-green-900 dark:text-green-300 mb-4">
                           Key Decisions
                         </h3>
-                        <ul className="list-disc pl-5 space-y-2 text-green-800">
+                        <ul className="list-disc pl-5 space-y-2 text-green-800 dark:text-green-200">
                           {data.structuredMoM.decisions.map((desc, idx) => (
                             <li key={idx}>{desc}</li>
                           ))}
@@ -229,21 +233,21 @@ const PublicSharedView = () => {
 
                   {data.structuredMoM.action_items &&
                     data.structuredMoM.action_items.length > 0 && (
-                      <div className="bg-amber-50 rounded-xl p-6 border border-amber-100">
-                        <h3 className="text-lg font-semibold text-amber-900 mb-4">
+                      <div className="bg-amber-50 dark:bg-amber-950/30 rounded-xl p-6 border border-amber-100 dark:border-amber-800/40">
+                        <h3 className="text-lg font-semibold text-amber-900 dark:text-amber-300 mb-4">
                           Action Items
                         </h3>
                         <ul className="space-y-3">
                           {data.structuredMoM.action_items.map((item, idx) => (
                             <li
                               key={idx}
-                              className="flex items-start gap-3 bg-white p-3 rounded-lg border border-amber-200"
+                              className="flex items-start gap-3 bg-white dark:bg-gray-800 p-3 rounded-lg border border-amber-200 dark:border-amber-800/60"
                             >
-                              <div className="flex-1 text-gray-800">
+                              <div className="flex-1 text-gray-800 dark:text-gray-200">
                                 {item.task}
                               </div>
                               {item.assignee && (
-                                <div className="text-xs font-medium bg-amber-100 text-amber-800 px-2 py-1 rounded">
+                                <div className="text-xs font-medium bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-300 px-2 py-1 rounded">
                                   {item.assignee}
                                 </div>
                               )}
@@ -257,33 +261,33 @@ const PublicSharedView = () => {
             </div>
           </div>
         ) : (
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8">
             <div className="flex items-start gap-4 mb-6">
-              <div className="p-3 bg-purple-100 text-purple-600 rounded-lg shrink-0">
+              <div className="p-3 bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-400 rounded-lg shrink-0">
                 <FileText className="w-8 h-8" />
               </div>
               <div>
-                <h1 className="text-3xl font-bold text-gray-900 mb-1">
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-1">
                   {data.name}
                 </h1>
-                <p className="text-gray-500 font-medium">
+                <p className="text-gray-500 dark:text-gray-400 font-medium">
                   Version {data.version}
                 </p>
               </div>
             </div>
 
             <div className="mt-8">
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">
+              <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
                 Policy Summary
               </h3>
               {data.summary ? (
-                <div className="prose max-w-none text-gray-700 bg-gray-50 p-6 rounded-xl border border-gray-100">
+                <div className="prose dark:prose-invert max-w-none text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900/50 p-6 rounded-xl border border-gray-100 dark:border-gray-700">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>
                     {data.summary}
                   </ReactMarkdown>
                 </div>
               ) : (
-                <p className="text-gray-500 italic">
+                <p className="text-gray-500 dark:text-gray-400 italic">
                   No summary available for this policy.
                 </p>
               )}
@@ -291,10 +295,10 @@ const PublicSharedView = () => {
 
             {data.key_changes && data.key_changes.length > 0 && (
               <div className="mt-8">
-                <h3 className="text-xl font-semibold text-gray-900 mb-4">
+                <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
                   Key Elements
                 </h3>
-                <ul className="list-disc pl-5 space-y-2 text-gray-700">
+                <ul className="list-disc pl-5 space-y-2 text-gray-700 dark:text-gray-300">
                   {data.key_changes.map((change, idx) => (
                     <li key={idx}>{change}</li>
                   ))}


### PR DESCRIPTION
## 📌 Issue Reference
Closes #910

## 📝 Overview
This PR adds dark mode styling (`dark:` Tailwind classes) across all state containers and components of the Public Shared View (`PublicSharedView.jsx`).

## 🛠️ Changes Made
- **Public Shared View (`client/src/pages/PublicSharedView.jsx`)**:
  - Added dark mode classes (`dark:bg-gray-900`, `dark:bg-gray-800`, `dark:border-gray-700`, `dark:text-white`, `dark:text-gray-300`) to loading spinner container, error/access-denied cards, passcode input/form container, and shared meeting containers.
  - Added `dark:prose-invert` and dark text colors to Markdown summaries and policy summaries.
  - Updated key decisions box (`dark:bg-green-950/30 dark:border-green-800/40 dark:text-green-300`) and action items cards (`dark:bg-amber-950/30 dark:border-amber-800/40 dark:bg-gray-800`).
  - Added dark styling for header badge (`dark:bg-indigo-950/50 dark:border-indigo-800/50 dark:text-indigo-400`).

## 🧪 Verification Plan
- Tested UI with dark mode enabled across all public shared view states:
  1. Loading state (dark background & spinner)
  2. Access Denied / Error state (dark card & text contrast)
  3. Passcode prompt state (dark input & button contrast)
  4. Public Shared Meeting view (dark cards, detail metadata grid, key decisions, action items)
  5. Public Shared Policy view (dark policy summary & key elements)
- Ran `npm run lint` and `npx prettier . --check` (passed).
