### PR TITLE
fix: support paginated decision graph loading

### DIFF
--- a/client/src/hooks/useDecisionGraph.js
+++ b/client/src/hooks/useDecisionGraph.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { getDecisionGraph } from "../services/decisionGraphApi";
+import { getAllDecisionGraphPages } from "../services/decisionGraphApi";
 
 const useDecisionGraph = () => {
   const [data, setData] = useState({ nodes: [], edges: [] });
@@ -10,18 +10,31 @@ const useDecisionGraph = () => {
   const [statusFilter, setStatusFilter] = useState("all");
 
   useEffect(() => {
+    let isCurrent = true;
+
     const fetchGraph = async () => {
       try {
         setLoading(true);
-        const graphData = await getDecisionGraph();
-        setData(graphData);
+        setError(null);
+        const graphData = await getAllDecisionGraphPages();
+        if (isCurrent) {
+          setData(graphData);
+        }
       } catch (err) {
-        setError(err.message || "Failed to fetch decision graph");
+        if (isCurrent) {
+          setError(err.message || "Failed to fetch decision graph");
+        }
       } finally {
-        setLoading(false);
+        if (isCurrent) {
+          setLoading(false);
+        }
       }
     };
     fetchGraph();
+
+    return () => {
+      isCurrent = false;
+    };
   }, []);
 
   // Filter logic: when filters change, we compute the visible subset of nodes and edges

--- a/client/src/services/decisionGraphApi.js
+++ b/client/src/services/decisionGraphApi.js
@@ -5,7 +5,8 @@ export const getDecisionGraph = async (params = {}) => {
   return response.data;
 };
 
-const edgeKey = ({ source, target, type }) => `${source}:${target}:${type}`;
+const edgeKey = ({ source, target, type }) =>
+  JSON.stringify([source, target, type]);
 
 // The graph endpoint returns a window of nodes, so collect every window before
 // handing data to the canvas. A larger page size keeps the number of requests

--- a/client/src/services/decisionGraphApi.js
+++ b/client/src/services/decisionGraphApi.js
@@ -5,6 +5,43 @@ export const getDecisionGraph = async (params = {}) => {
   return response.data;
 };
 
+const edgeKey = ({ source, target, type }) => `${source}:${target}:${type}`;
+
+// The graph endpoint returns a window of nodes, so collect every window before
+// handing data to the canvas. A larger page size keeps the number of requests
+// low while remaining within the API's supported limit.
+export const getAllDecisionGraphPages = async (params = {}) => {
+  const nodesById = new Map();
+  const edgesByKey = new Map();
+  let page = 1;
+  let pagination;
+
+  do {
+    const graphPage = await getDecisionGraph({
+      ...params,
+      page,
+      limit: params.limit ?? 200,
+    });
+
+    const nodes = Array.isArray(graphPage?.nodes) ? graphPage.nodes : [];
+    const edges = Array.isArray(graphPage?.edges) ? graphPage.edges : [];
+
+    nodes.forEach((node) => nodesById.set(node.id, node));
+    edges.forEach((edge) => edgesByKey.set(edgeKey(edge), edge));
+
+    pagination = graphPage?.pagination;
+    if (!pagination?.hasMore) break;
+
+    page = Number.isInteger(pagination.page) ? pagination.page + 1 : page + 1;
+  } while (pagination?.hasMore);
+
+  return {
+    nodes: [...nodesById.values()],
+    edges: [...edgesByKey.values()],
+    pagination,
+  };
+};
+
 export const getDecisionNeighbors = async (id) => {
   const response = await apiClient.get(`/api/decision-graph/${id}/neighbors`);
   return response.data;

--- a/client/src/services/decisionGraphApi.test.js
+++ b/client/src/services/decisionGraphApi.test.js
@@ -76,4 +76,19 @@ describe("getAllDecisionGraphPages", () => {
     });
     expect(apiClient.get).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves distinct edges when IDs contain colons", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        edges: [
+          { source: "decision:one", target: "two", type: "relatesTo" },
+          { source: "decision", target: "one:two", type: "relatesTo" },
+        ],
+      },
+    });
+
+    const graph = await getAllDecisionGraphPages();
+
+    expect(graph.edges).toHaveLength(2);
+  });
 });

--- a/client/src/services/decisionGraphApi.test.js
+++ b/client/src/services/decisionGraphApi.test.js
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import apiClient from "./apiClient";
+import { getAllDecisionGraphPages } from "./decisionGraphApi";
+
+vi.mock("./apiClient", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("getAllDecisionGraphPages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("collects every page and removes duplicate nodes and edges", async () => {
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          nodes: [{ id: "decision-1" }, { id: "decision-2" }],
+          edges: [
+            {
+              source: "decision-1",
+              target: "decision-2",
+              type: "relatesTo",
+              confidence: 100,
+            },
+          ],
+          pagination: { page: 1, hasMore: true },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          nodes: [{ id: "decision-2" }, { id: "decision-3" }],
+          edges: [
+            {
+              source: "decision-1",
+              target: "decision-2",
+              type: "relatesTo",
+              confidence: 100,
+            },
+          ],
+          pagination: { page: 2, hasMore: false },
+        },
+      });
+
+    const graph = await getAllDecisionGraphPages();
+
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, "/api/decision-graph", {
+      params: { page: 1, limit: 200 },
+    });
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, "/api/decision-graph", {
+      params: { page: 2, limit: 200 },
+    });
+    expect(graph.nodes).toEqual([
+      { id: "decision-1" },
+      { id: "decision-2" },
+      { id: "decision-3" },
+    ]);
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it("returns available graph data when optional response fields are missing", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        nodes: [{ id: "decision-1" }],
+      },
+    });
+
+    const graph = await getAllDecisionGraphPages();
+
+    expect(graph).toEqual({
+      nodes: [{ id: "decision-1" }],
+      edges: [],
+      pagination: undefined,
+    });
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Implemented client-side pagination support for the Decision Graph.

### Changes
- Fetch all paginated graph data before rendering.
- Merge paginated nodes and edges while removing duplicates.
- Handle missing optional response fields safely.
- Add regression tests for pagination and edge cases.

No backend changes were made.

## Type of Change

- [✅] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #899

## Testing

- [✅] Tested locally
- [✅] Existing functionality verified
- [✅] No new warnings or errors

## Screenshots

N/A (No UI changes)

## Checklist

- [✅] Code follows project conventions
- [ ] Documentation updated where required
- [✅] No unnecessary files included
- [✅] Changes have been tested
- [✅] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Decision graphs now load all available pages, ensuring complete graph data is displayed.
  * Duplicate nodes and connections are removed from combined results.
  * Improved handling of incomplete responses and prevented updates after leaving the page.

* **Tests**
  * Added coverage for multi-page loading, deduplication, and missing response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->