### PR TITLE
fix(bookmarks): validate organization ownership before bookmark creation (#819)

### DIFF
--- a/server/controllers/bookmarkController.js
+++ b/server/controllers/bookmarkController.js
@@ -1,6 +1,7 @@
 import Bookmark from "../models/bookmarkModel.js";
 import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
+import { isSameOrganization } from "../utils/authUtils.js";
 
 // @desc    Toggle bookmark (add if missing, remove if exists)
 // @route   POST /api/bookmarks/toggle
@@ -25,10 +26,7 @@ export const toggleBookmark = async (req, res) => {
       return res.status(404).json({ message: "Meeting not found" });
     }
 
-    const userOrg = req.user.organization?.toString();
-    const meetingOrg = meeting.organization?.toString();
-
-    if (!userOrg || !meetingOrg || userOrg !== meetingOrg) {
+    if (!isSameOrganization(req.user, meeting)) {
       return res.status(403).json({
         message: "Meeting does not belong to your organization",
       });

--- a/server/controllers/bookmarkController.js
+++ b/server/controllers/bookmarkController.js
@@ -1,4 +1,5 @@
 import Bookmark from "../models/bookmarkModel.js";
+import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
 
 // @desc    Toggle bookmark (add if missing, remove if exists)
@@ -13,9 +14,29 @@ export const toggleBookmark = async (req, res) => {
       return res.status(400).json({ message: "meetingId is required" });
     }
 
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meetingId" });
+    }
+
+    // Validate meeting existence and organization ownership
+    const meeting =
+      await Meeting.findById(meetingId).select("organization _id");
+    if (!meeting) {
+      return res.status(404).json({ message: "Meeting not found" });
+    }
+
+    const userOrg = req.user.organization?.toString();
+    const meetingOrg = meeting.organization?.toString();
+
+    if (!userOrg || !meetingOrg || userOrg !== meetingOrg) {
+      return res.status(403).json({
+        message: "Meeting does not belong to your organization",
+      });
+    }
+
     const existingBookmark = await Bookmark.findOne({
       user: userId,
-      meeting: String(meetingId),
+      meeting: meetingId,
     });
 
     if (existingBookmark) {

--- a/server/tests/bookmarkOwnership.test.js
+++ b/server/tests/bookmarkOwnership.test.js
@@ -73,12 +73,6 @@ const userInOrgB = () => ({
   organization: ORG_B,
 });
 
-const meetingInOrgA = (id = new mongoose.Types.ObjectId()) => ({
-  _id: id,
-  organization: ORG_A,
-  select: vi.fn().mockReturnThis(),
-});
-
 describe("toggleBookmark — organization ownership (#819)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -98,6 +92,26 @@ describe("toggleBookmark — organization ownership (#819)", () => {
 
       expect(res.statusCode).toBe(403);
       expect(res.body.message).toMatch(/does not belong to your organization/i);
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 and does not remove an existing bookmark when caller's org does not match meeting's org", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const existingBookmark = { _id: new mongoose.Types.ObjectId() };
+
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+      mockBookmarkFindOne.mockResolvedValue(existingBookmark);
+
+      const res = makeRes();
+      await toggleBookmark(makeReq(meetingId.toString(), userInOrgB()), res);
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.message).toMatch(/does not belong to your organization/i);
+      expect(mockBookmarkDeleteOne).not.toHaveBeenCalled();
       expect(mockBookmarkCreate).not.toHaveBeenCalled();
     });
 

--- a/server/tests/bookmarkOwnership.test.js
+++ b/server/tests/bookmarkOwnership.test.js
@@ -1,0 +1,221 @@
+/**
+ * Issue #819 — Bookmark creation allowed cross-organization meeting IDs.
+ *
+ * The toggleBookmark handler created bookmarks without verifying that the
+ * target meeting belongs to the caller's organization. Any authenticated user
+ * could bookmark meetings from other organizations given only the meeting ID.
+ *
+ * Fix: validate meeting existence and assert meeting.organization matches
+ * req.user.organization before creating a bookmark. Returns 404 when the
+ * meeting does not exist and 403 when it belongs to a different organization.
+ */
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+
+// --- Mocks ---
+
+const mockBookmarkFindOne = vi.fn();
+const mockBookmarkDeleteOne = vi.fn();
+const mockBookmarkCreate = vi.fn();
+
+vi.mock("../models/bookmarkModel.js", () => ({
+  default: {
+    findOne: (...args) => mockBookmarkFindOne(...args),
+    deleteOne: (...args) => mockBookmarkDeleteOne(...args),
+    create: (...args) => mockBookmarkCreate(...args),
+  },
+}));
+
+const mockMeetingFindById = vi.fn();
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findById: (...args) => mockMeetingFindById(...args),
+  },
+}));
+
+import { toggleBookmark } from "../controllers/bookmarkController.js";
+
+// --- Helpers ---
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: vi.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const makeReq = (meetingId, user) => ({
+  body: { meetingId },
+  user,
+});
+
+const userInOrgA = () => ({
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+});
+
+const userInOrgB = () => ({
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+});
+
+const meetingInOrgA = (id = new mongoose.Types.ObjectId()) => ({
+  _id: id,
+  organization: ORG_A,
+  select: vi.fn().mockReturnThis(),
+});
+
+describe("toggleBookmark — organization ownership (#819)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("cross-organization bookmark prevention", () => {
+    it("returns 403 when caller's org does not match meeting's org", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+
+      const res = makeRes();
+      await toggleBookmark(makeReq(meetingId.toString(), userInOrgB()), res);
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.message).toMatch(/does not belong to your organization/i);
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the caller has no organization", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+
+      const res = makeRes();
+      await toggleBookmark(
+        makeReq(meetingId.toString(), { _id: new mongoose.Types.ObjectId() }),
+        res,
+      );
+
+      expect(res.statusCode).toBe(403);
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the meeting has no organization", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: null }),
+      });
+
+      const res = makeRes();
+      await toggleBookmark(makeReq(meetingId.toString(), userInOrgA()), res);
+
+      expect(res.statusCode).toBe(403);
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resource existence validation", () => {
+    it("returns 404 when the meeting does not exist", async () => {
+      mockMeetingFindById.mockReturnValue({
+        select: vi.fn().mockResolvedValue(null),
+      });
+
+      const res = makeRes();
+      await toggleBookmark(
+        makeReq(new mongoose.Types.ObjectId().toString(), userInOrgA()),
+        res,
+      );
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.message).toBe("Meeting not found");
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for a malformed meetingId", async () => {
+      const res = makeRes();
+      await toggleBookmark(makeReq("not-an-objectid", userInOrgA()), res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toBe("Invalid meetingId");
+      expect(mockMeetingFindById).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when meetingId is missing", async () => {
+      const res = makeRes();
+      await toggleBookmark({ body: {}, user: userInOrgA() }, res);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toBe("meetingId is required");
+    });
+  });
+
+  describe("authorized bookmark operations", () => {
+    it("creates a bookmark when meeting belongs to caller's org (toggle on)", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const user = userInOrgA();
+      const created = {
+        _id: new mongoose.Types.ObjectId(),
+        meeting: meetingId,
+        user: user._id,
+      };
+
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+      mockBookmarkFindOne.mockResolvedValue(null);
+      mockBookmarkCreate.mockResolvedValue(created);
+
+      const res = makeRes();
+      await toggleBookmark(makeReq(meetingId.toString(), user), res);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.bookmarked).toBe(true);
+      expect(mockBookmarkCreate).toHaveBeenCalledOnce();
+    });
+
+    it("removes a bookmark when meeting belongs to caller's org (toggle off)", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const user = userInOrgA();
+      const existing = { _id: new mongoose.Types.ObjectId() };
+
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+      mockBookmarkFindOne.mockResolvedValue(existing);
+      mockBookmarkDeleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const res = makeRes();
+      await toggleBookmark(makeReq(meetingId.toString(), user), res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.bookmarked).toBe(false);
+      expect(mockBookmarkDeleteOne).toHaveBeenCalledOnce();
+      expect(mockBookmarkCreate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/utils/authUtils.js
+++ b/server/utils/authUtils.js
@@ -45,3 +45,15 @@ export async function verifyClerkSessionToken(token) {
     secretKey: process.env.CLERK_SECRET_KEY,
   });
 }
+
+/**
+ * Check if a user and a resource belong to the same organization.
+ * @param {object} user - User object containing `organization`.
+ * @param {object} resource - Resource object containing `organization`.
+ * @returns {boolean} True if both have valid, matching organization IDs.
+ */
+export const isSameOrganization = (user, resource) => {
+  const userOrg = user?.organization?.toString();
+  const resourceOrg = resource?.organization?.toString();
+  return Boolean(userOrg && resourceOrg && userOrg === resourceOrg);
+};


### PR DESCRIPTION
# Pull Request

## Description

Bookmarks could previously be created using any meeting ID without verifying that the meeting belonged to the caller's organization. This allowed authenticated users to cross-organization bookmark meetings they should not have access to.

This PR adds three sequential guards to `toggleBookmark` in `bookmarkController.js`:

1. **ObjectId format validation** — returns `400 Invalid meetingId` for malformed IDs, preventing Mongoose CastError 500s.
2. **Meeting existence check** — returns `404 Meeting not found` when no meeting matches the given ID.
3. **Organization ownership check** — returns `403 Meeting does not belong to your organization` when `meeting.organization` does not match `req.user.organization`, blocking cross-org bookmarks.

A new vitest test suite (`server/tests/bookmarkOwnership.test.js`) covers all guard paths: cross-org rejection, missing org, meeting not found, malformed ID, missing field, and the two authorized toggle paths (on/off).

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #819

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

New test file: `server/tests/bookmarkOwnership.test.js`

```
✓ tests/bookmarkOwnership.test.js (8 tests) 5ms
Test Files  1 passed (1) | Tests  8 passed (8)
```

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bookmark validation for invalid, missing, or unavailable meetings.
  * Prevented users from bookmarking or removing bookmarks from meetings outside their organization.
  * Added safeguards for users or meetings without organization information.
  * Authorized users can continue to create and remove bookmarks normally.

* **Tests**
  * Added coverage for bookmark ownership, organization access, meeting validation, and successful bookmark updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->