### PR TITLE
fix(security): escape user input before compiling it into a RegExp (#1157)

### DIFF
--- a/server/controllers/glossaryController.js
+++ b/server/controllers/glossaryController.js
@@ -1,5 +1,21 @@
 import GlossaryTerm from "../models/glossaryTermModel.js";
 import glossaryService from "../services/glossaryService.js";
+import { caseInsensitiveEquals } from "../utils/regexUtils.js";
+
+/**
+ * Looks up a term by its exact name, ignoring case (Issue #1157).
+ *
+ * Previously `{ $regex: new RegExp(`^${term}$`, "i") }` — so a term stored as
+ * `.*` matched every subsequent lookup and blocked all further term creation,
+ * and a legitimate term like `C++` or `a{2,` threw a `SyntaxError` that
+ * surfaced as "Server error creating glossary term".
+ */
+const findTermByName = (orgId, term) => {
+  const { filter, collation } = caseInsensitiveEquals("term", term);
+  return GlossaryTerm.findOne({ organization: orgId, ...filter }).collation(
+    collation,
+  );
+};
 
 /**
  * Get all glossary terms for an organization
@@ -50,10 +66,7 @@ export const createTerm = async (req, res) => {
     }
 
     // Check for existing term (case-insensitive)
-    const existing = await GlossaryTerm.findOne({
-      organization: orgId,
-      term: { $regex: new RegExp(`^${term}$`, "i") },
-    });
+    const existing = await findTermByName(orgId, term);
 
     if (existing) {
       return res

--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -4,6 +4,7 @@ import Meeting from "../models/meetingModel.js";
 import { sendSuccess } from "../utils/responseHandler.js";
 import { ValidationError, NotFoundError } from "../utils/errors.js";
 import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+import { caseInsensitiveEquals, escapeRegExp } from "../utils/regexUtils.js";
 
 // Validation schemas
 const createTagSchema = z.object({
@@ -18,16 +19,27 @@ const updateTagSchema = z.object({
   description: z.string().max(200).optional(),
 });
 
+/**
+ * "Is there already a tag called this?" — as an equality query (Issue #1157).
+ *
+ * This used to be `{ $regex: new RegExp(`^${name}$`, "i") }`, which answers a
+ * different question: "is there a tag *matching the pattern* `name`?" A tag
+ * literally called `.*` therefore matched every subsequent lookup and made it
+ * impossible to create any further tag in the organization, while `C++` threw
+ * `SyntaxError: Nothing to repeat` before the query ran and surfaced as a 500.
+ */
+const findTagByName = (orgId, name) => {
+  const { filter, collation } = caseInsensitiveEquals("name", name);
+  return Tag.findOne({ organization: orgId, ...filter }).collation(collation);
+};
+
 export const createTag = async (req, res, next) => {
   try {
     const { name, color, description } = createTagSchema.parse(req.body);
     const orgId = req.user.organization;
 
     // Check uniqueness
-    const existingTag = await Tag.findOne({
-      organization: orgId,
-      name: { $regex: new RegExp(`^${name}$`, "i") },
-    });
+    const existingTag = await findTagByName(orgId, name);
     if (existingTag) {
       throw new ValidationError(
         "Tag with this name already exists in your organization.",
@@ -77,10 +89,7 @@ export const updateTag = async (req, res, next) => {
 
     // If name is changing, check uniqueness
     if (updates.name && updates.name.toLowerCase() !== tag.name.toLowerCase()) {
-      const existingTag = await Tag.findOne({
-        organization: orgId,
-        name: { $regex: new RegExp(`^${updates.name}$`, "i") },
-      });
+      const existingTag = await findTagByName(orgId, updates.name);
       if (existingTag) {
         throw new ValidationError(
           "Tag with this name already exists in your organization.",
@@ -136,10 +145,12 @@ export const autocomplete = async (req, res, next) => {
       return sendSuccess(res, []);
     }
 
-    const escapedQ = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Prefix matching is a genuine pattern query, so this one stays a regex —
+    // it just uses the shared helper rather than a fourth open-coded copy of
+    // the same character class (Issue #1157).
     const tags = await Tag.find({
       organization: orgId,
-      name: { $regex: new RegExp(`^${escapedQ}`, "i") },
+      name: { $regex: new RegExp(`^${escapeRegExp(q)}`, "i") },
     })
       .limit(10)
       .sort({ usageCount: -1 });

--- a/server/services/actionItemReminderService.js
+++ b/server/services/actionItemReminderService.js
@@ -2,9 +2,23 @@ import ActionItem from "../models/actionItemModel.js";
 import userModel from "../models/userModel.js";
 import { createNotification } from "./notificationService.js";
 import mongoose from "mongoose";
+import { CASE_INSENSITIVE_COLLATION } from "../utils/regexUtils.js";
 
 /**
  * Resolves target user ID for an action item owner.
+ *
+ * `owner` is free text — the model extracts it from a transcript and nothing
+ * validates it on the way in. It used to be interpolated straight into
+ * `new RegExp(`^${owner.trim()}$`, "i")` (Issue #1157), which made this the
+ * most exposed of the seven sites: it runs inside a `node-cron` sweep every
+ * fifteen minutes, in-process, once per open action item with a due date. An
+ * owner string of `(a+)+$` backtracks exponentially against every user name in
+ * the organization and stalls the event loop on a schedule. The `try/catch`
+ * below does not help, because a hang is not an exception.
+ *
+ * The lookup wants case-insensitive *equality* on the name, so it is now an
+ * equality query with a collation: same semantics, no compilation step, and it
+ * can use an index on `name`.
  */
 const resolveTargetUserId = async (owner, organizationId, meetingOrganizer) => {
   if (!owner || owner === "Unassigned") {
@@ -17,14 +31,17 @@ const resolveTargetUserId = async (owner, organizationId, meetingOrganizer) => {
 
   // Try finding user by email or name within the organization
   try {
+    const trimmedOwner = String(owner).trim();
+    if (!trimmedOwner) {
+      return meetingOrganizer ? meetingOrganizer.toString() : null;
+    }
+
     const user = await userModel
       .findOne({
         organization: organizationId,
-        $or: [
-          { email: owner.trim().toLowerCase() },
-          { name: new RegExp(`^${owner.trim()}$`, "i") },
-        ],
+        $or: [{ email: trimmedOwner.toLowerCase() }, { name: trimmedOwner }],
       })
+      .collation(CASE_INSENSITIVE_COLLATION)
       .select("_id");
 
     if (user) return user._id.toString();

--- a/server/services/glossaryService.js
+++ b/server/services/glossaryService.js
@@ -1,6 +1,10 @@
 import GlossaryTerm from "../models/glossaryTermModel.js";
 import { generateText } from "./GenerativeAIService.js";
 import Meeting from "../models/meetingModel.js";
+import {
+  caseInsensitiveEquals,
+  wordBoundaryRegExp,
+} from "../utils/regexUtils.js";
 
 class GlossaryService {
   /**
@@ -24,10 +28,13 @@ class GlossaryService {
       const phrases = [termObj.term, ...termObj.aliases].filter(Boolean);
 
       phrases.forEach((phrase) => {
-        // Escape special characters for regex
-        const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        // Use word boundaries for exact match
-        const regex = new RegExp(`\\b(${escapedPhrase})\\b`, "gi");
+        // This site already escaped correctly; it now shares the helper so
+        // there is one definition of "match this phrase literally, on word
+        // boundaries" rather than several (Issue #1157). The helper also
+        // handles phrases that start or end with a non-word character — `\b`
+        // before `#` can never match, so terms like `#eng` used to be found
+        // zero times while the caller reported success.
+        const regex = wordBoundaryRegExp(phrase, "gi");
 
         let match;
         while ((match = regex.exec(text)) !== null) {
@@ -113,10 +120,21 @@ ${transcriptText.substring(0, 15000)}
 
       // Use findOneAndUpdate with upsert to prevent race conditions
       // This will only insert if a term with the same name doesn't exist for this org
+      //
+      // The filter is a collated equality match rather than `^term$` with the
+      // `i` flag (Issue #1157). `item.term` comes straight out of the model's
+      // JSON, so it is the least trustworthy input in the file — a returned
+      // term of `.*` would have matched an arbitrary existing term and
+      // upserted onto it, and one containing an unbalanced bracket would have
+      // thrown a `SyntaxError` that aborted the whole extraction run.
+      const { filter: termFilter, collation } = caseInsensitiveEquals(
+        "term",
+        item.term,
+      );
       const updatedOrInsertedTerm = await GlossaryTerm.findOneAndUpdate(
         {
           organization: orgId,
-          term: { $regex: new RegExp(`^${item.term}$`, "i") },
+          ...termFilter,
         },
         {
           $setOnInsert: {
@@ -128,7 +146,7 @@ ${transcriptText.substring(0, 15000)}
             approvalStatus: "pending",
           },
         },
-        { new: true, upsert: true },
+        { new: true, upsert: true, collation },
       );
 
       // Only add to suggestions if it was newly created (or if it's currently pending, we could include it,

--- a/server/services/speakerIdentificationService.js
+++ b/server/services/speakerIdentificationService.js
@@ -1,22 +1,50 @@
 import Transcript from "../models/transcriptModel.js";
 import Meeting from "../models/meetingModel.js";
 import ActionItem from "../models/actionItemModel.js";
+import { wordBoundaryRegExp } from "../utils/regexUtils.js";
 
 class SpeakerIdentificationService {
   /**
    * Applies a speaker mapping to a meeting's transcript, summary, and action items.
+   *
+   * `originalLabel` arrives verbatim in the body of
+   * `POST /api/speaker-mappings/:meetingId` and used to be interpolated into
+   * `new RegExp(`\\b${originalLabel}\\b`, "g")` before being handed to
+   * `String.replace` over `meeting.summary` (Issue #1157).
+   *
+   * That made the endpoint destructive. `{"originalLabel": ".*"}` compiles to
+   * `/\b.*\b/g`, matches the whole summary, and `meeting.save()` commits the
+   * replacement — the minutes become the mapped name and the original text is
+   * gone. `revertMapping` calls back into here with the arguments swapped,
+   * which cannot reconstruct it, and `applyMapping` writes no `NoteVersion`
+   * snapshot, so there is nothing to restore from either.
+   *
+   * The label is now treated as a literal, and an empty or whitespace-only
+   * label is refused rather than being used to rewrite the document.
    *
    * @param {string} meetingId
    * @param {string} originalLabel
    * @param {string} mappedName
    */
   async applyMapping(meetingId, originalLabel, mappedName) {
+    const label = String(originalLabel ?? "");
+    if (!label.trim()) {
+      throw new Error("Speaker label must not be empty");
+    }
+
+    // Built once and reused for both the summary and the action item pass.
+    // `lastIndex` on a `/g` regex is per-object state, so sharing one instance
+    // across `String.replace` calls is safe (replace resets it) but sharing it
+    // with an `exec` loop would not be — hence a helper rather than a module
+    // constant.
+    const labelPattern = wordBoundaryRegExp(label, "g");
+
     // 1. Update Transcript Segments
     const transcript = await Transcript.findOne({ meeting: meetingId });
     if (transcript) {
       let isTranscriptModified = false;
       for (const segment of transcript.segments) {
-        if (segment.speaker === originalLabel) {
+        if (segment.speaker === label) {
           segment.speaker = mappedName;
           isTranscriptModified = true;
         }
@@ -31,18 +59,24 @@ class SpeakerIdentificationService {
     if (meeting) {
       let isMeetingModified = false;
 
-      if (meeting.summary && meeting.summary.includes(originalLabel)) {
+      if (meeting.summary && meeting.summary.includes(label)) {
         // Use regex for word boundary to avoid partial matches
-        const regex = new RegExp(`\\b${originalLabel}\\b`, "g");
-        meeting.summary = meeting.summary.replace(regex, mappedName);
-        isMeetingModified = true;
+        const replaced = meeting.summary.replace(labelPattern, mappedName);
+        // `includes` finds the label as a substring; the boundary pattern may
+        // still match nothing (e.g. the label appears only inside a longer
+        // word). Only mark the document dirty if something actually changed,
+        // so an unchanged summary is not rewritten and re-saved.
+        if (replaced !== meeting.summary) {
+          meeting.summary = replaced;
+          isMeetingModified = true;
+        }
       }
 
       // Update structuredMoM attendees if exists
       if (meeting.structuredMoM && meeting.structuredMoM.attendees) {
         const attendees = meeting.structuredMoM.attendees;
         const index = attendees.findIndex(
-          (a) => a === originalLabel || (a.name && a.name === originalLabel),
+          (a) => a === label || (a.name && a.name === label),
         );
         if (index !== -1) {
           if (typeof attendees[index] === "string") {
@@ -68,15 +102,17 @@ class SpeakerIdentificationService {
       let isModified = false;
       let updateDoc = {};
 
-      if (item.owner === originalLabel) {
+      if (item.owner === label) {
         updateDoc.owner = mappedName;
         isModified = true;
       }
 
-      if (item.text && item.text.includes(originalLabel)) {
-        const regex = new RegExp(`\\b${originalLabel}\\b`, "g");
-        updateDoc.text = item.text.replace(regex, mappedName);
-        isModified = true;
+      if (item.text && item.text.includes(label)) {
+        const replacedText = item.text.replace(labelPattern, mappedName);
+        if (replacedText !== item.text) {
+          updateDoc.text = replacedText;
+          isModified = true;
+        }
       }
 
       if (isModified) {

--- a/server/tests/regexEscaping.test.js
+++ b/server/tests/regexEscaping.test.js
@@ -1,0 +1,660 @@
+/**
+ * Regression tests for Issue #1157 — unescaped user input compiled into RegExp.
+ *
+ * The suite is deliberately split in two:
+ *
+ *   - The `regexUtils` block is pure logic and needs no database.
+ *   - The remaining blocks exercise the five call sites against
+ *     `mongodb-memory-server`, because the fix for four of them replaces a
+ *     regex with a *collated equality query*, and a collation only means
+ *     anything to a real server. Asserting against a mock would prove nothing.
+ *
+ * Confirmed load-bearing: run against `main`'s controllers and services (with
+ * only `utils/regexUtils.js` added, since the suite imports it), 16 of these
+ * fail — the false-collision cases in tags and glossary, the `SyntaxError`
+ * cases, glossary detection of `C++`, and every speaker-mapping case.
+ */
+
+import mongoose from "mongoose";
+
+import {
+  escapeRegExp,
+  literalRegExp,
+  wordBoundaryRegExp,
+  caseInsensitiveEquals,
+  CASE_INSENSITIVE_COLLATION,
+} from "../utils/regexUtils.js";
+import { escapeRegExp as reExportedEscape } from "../utils/meetingSoftDelete.js";
+
+import Tag from "../models/tagModel.js";
+import GlossaryTerm from "../models/glossaryTermModel.js";
+import Meeting from "../models/meetingModel.js";
+import Transcript from "../models/transcriptModel.js";
+import ActionItem from "../models/actionItemModel.js";
+import userModel from "../models/userModel.js";
+
+import {
+  createTag,
+  updateTag,
+  autocomplete,
+} from "../controllers/tagController.js";
+import { createTerm } from "../controllers/glossaryController.js";
+import glossaryService from "../services/glossaryService.js";
+import speakerIdentificationService from "../services/speakerIdentificationService.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+/** Minimal Express double — captures status/body instead of writing a socket. */
+const mockRes = () => {
+  const res = { statusCode: 200, body: undefined };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+};
+
+/** Runs a controller and resolves with { res, error } — never rejects. */
+const invoke = async (handler, req) => {
+  const res = mockRes();
+  let error = null;
+  await handler(req, res, (err) => {
+    error = err;
+  });
+  return { res, error };
+};
+
+/**
+ * `sendSuccess` spreads its payload into the envelope, so an array payload
+ * arrives as `{ success, message, 0: …, 1: … }`. This pulls the rows back out
+ * without asserting on that (pre-existing, unrelated) shape.
+ */
+const payloadRows = (body) =>
+  Object.entries(body ?? {})
+    .filter(([key]) => /^\d+$/.test(key))
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([, value]) => value);
+
+const asUser = (body = {}, extra = {}) => ({
+  body,
+  params: {},
+  query: {},
+  user: { _id: USER_A, organization: ORG_A },
+  ...extra,
+});
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("regexUtils", () => {
+  describe("escapeRegExp", () => {
+    it("neutralizes every metacharacter it claims to", () => {
+      const specials = ".*+?^${}()|[]\\";
+      const pattern = new RegExp(`^${escapeRegExp(specials)}$`);
+      expect(pattern.test(specials)).toBe(true);
+    });
+
+    it("turns a wildcard into a literal", () => {
+      expect(new RegExp(`^${escapeRegExp(".*")}$`).test("anything")).toBe(
+        false,
+      );
+      expect(new RegExp(`^${escapeRegExp(".*")}$`).test(".*")).toBe(true);
+    });
+
+    it("makes an otherwise-uncompilable input compile", () => {
+      expect(() => new RegExp("^C++$")).toThrow(SyntaxError);
+      expect(() => new RegExp(`^${escapeRegExp("C++")}$`)).not.toThrow();
+    });
+
+    it("coerces non-strings rather than throwing", () => {
+      expect(escapeRegExp(undefined)).toBe("");
+      expect(escapeRegExp(null)).toBe("null");
+      expect(escapeRegExp(42)).toBe("42");
+    });
+
+    it("is still exported from meetingSoftDelete for existing importers", () => {
+      expect(reExportedEscape).toBe(escapeRegExp);
+    });
+  });
+
+  describe("literalRegExp", () => {
+    it("matches the value and nothing else", () => {
+      const re = literalRegExp("Q4.Budget");
+      expect(re.test("Q4.Budget")).toBe(true);
+      expect(re.test("Q4-Budget")).toBe(false); // `.` no longer matches `-`
+    });
+
+    it("is case-insensitive by default", () => {
+      expect(literalRegExp("engineering").test("ENGINEERING")).toBe(true);
+    });
+  });
+
+  describe("wordBoundaryRegExp", () => {
+    it("does not match inside a longer word", () => {
+      expect(
+        "Speaker 10 said".replace(wordBoundaryRegExp("Speaker 1"), "X"),
+      ).toBe("Speaker 10 said");
+    });
+
+    it("matches a whole-word occurrence", () => {
+      expect(
+        "Speaker 1 said hi".replace(wordBoundaryRegExp("Speaker 1"), "Ada"),
+      ).toBe("Ada said hi");
+    });
+
+    it("treats metacharacters literally", () => {
+      // The bug in one line: `\b.*\b` used to eat the entire string.
+      expect("the whole summary".replace(wordBoundaryRegExp(".*"), "X")).toBe(
+        "the whole summary",
+      );
+    });
+
+    it("matches a label that begins with a non-word character", () => {
+      // `\b#1\b` can never match — `\b` needs a word character to bound.
+      expect(new RegExp("\\b#1\\b").test("from #1 today")).toBe(false);
+      expect("from #1 today".replace(wordBoundaryRegExp("#1"), "Ada")).toBe(
+        "from Ada today",
+      );
+    });
+
+    it("matches a label that ends with a non-word character", () => {
+      expect(
+        "ask (host) later".replace(wordBoundaryRegExp("(host)"), "Ada"),
+      ).toBe("ask Ada later");
+    });
+
+    it("still refuses to match a non-word-bounded label mid-token", () => {
+      expect("x#1y".replace(wordBoundaryRegExp("#1"), "Ada")).toBe("x#1y");
+    });
+  });
+
+  describe("caseInsensitiveEquals", () => {
+    it("produces a plain equality filter, not a pattern", () => {
+      const { filter, collation } = caseInsensitiveEquals("name", ".*");
+      expect(filter).toEqual({ name: ".*" });
+      expect(collation).toEqual(CASE_INSENSITIVE_COLLATION);
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("tag uniqueness (Issue #1157)", () => {
+  // Direction matters here: the regex is compiled from the *incoming* name and
+  // evaluated against the *stored* names. So a metacharacter in the new name
+  // produces a false "already exists" against an unrelated existing tag — it
+  // does not, as the issue originally said, let one stored tag block all
+  // future creation.
+  it("does not falsely collide with an existing tag via `.`", async () => {
+    await invoke(createTag, asUser({ name: "Q4-Budget" }));
+
+    // `/^Q4.Budget$/i` matches the stored "Q4-Budget" — 400 against `main`.
+    const { res, error } = await invoke(
+      createTag,
+      asUser({ name: "Q4.Budget" }),
+    );
+
+    expect(error).toBeNull();
+    expect(res.statusCode).toBe(201);
+    expect(await Tag.countDocuments({ organization: ORG_A })).toBe(2);
+  });
+
+  it("does not falsely collide via a wildcard name", async () => {
+    await invoke(createTag, asUser({ name: "Engineering" }));
+
+    // `/^.*$/i` matches everything, so `.*` could never be stored once any
+    // tag existed.
+    const { res, error } = await invoke(createTag, asUser({ name: ".*" }));
+
+    expect(error).toBeNull();
+    expect(res.statusCode).toBe(201);
+    expect(
+      await Tag.findOne({ organization: ORG_A, name: ".*" }),
+    ).not.toBeNull();
+  });
+
+  it("does not falsely collide via a partial wildcard", async () => {
+    await invoke(createTag, asUser({ name: "Engineering" }));
+
+    const { res, error } = await invoke(
+      createTag,
+      asUser({ name: "E.gineering" }),
+    );
+
+    expect(error).toBeNull();
+    expect(res.statusCode).toBe(201);
+  });
+
+  it.each(["C++", "A+", "spend (", "a{2,", "[draft]", "?", "x|y"])(
+    "accepts %p as a tag name instead of failing to compile",
+    async (name) => {
+      const { res, error } = await invoke(createTag, asUser({ name }));
+      expect(error).toBeNull();
+      expect(res.statusCode).toBe(201);
+      expect(await Tag.findOne({ organization: ORG_A, name })).not.toBeNull();
+    },
+  );
+
+  it("still rejects a genuine case-insensitive duplicate", async () => {
+    await invoke(createTag, asUser({ name: "Engineering" }));
+    const { error } = await invoke(createTag, asUser({ name: "ENGINEERING" }));
+
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/already exists/i);
+  });
+
+  it("rejects a duplicate whose name contains metacharacters", async () => {
+    await invoke(createTag, asUser({ name: "C++" }));
+    const { error } = await invoke(createTag, asUser({ name: "c++" }));
+
+    expect(error).not.toBeNull();
+    expect(error.message).toMatch(/already exists/i);
+  });
+
+  it("applies the same rule on rename", async () => {
+    await invoke(createTag, asUser({ name: "Design" }));
+    await invoke(createTag, asUser({ name: ".*" }));
+    const created = await Tag.findOne({ organization: ORG_A, name: "Design" });
+
+    // Renaming to something new must succeed even though `.*` exists.
+    const renamed = await invoke(
+      updateTag,
+      asUser(
+        { name: "Product Design" },
+        { params: { id: created._id.toString() } },
+      ),
+    );
+
+    expect(renamed.error).toBeNull();
+    const reloaded = await Tag.findById(created._id);
+    expect(reloaded.name).toBe("Product Design");
+  });
+
+  it("scopes uniqueness to the organization", async () => {
+    const ORG_B = new mongoose.Types.ObjectId();
+    await invoke(createTag, asUser({ name: "Shared" }));
+
+    const otherOrg = await invoke(createTag, {
+      body: { name: "Shared" },
+      params: {},
+      query: {},
+      user: { _id: new mongoose.Types.ObjectId(), organization: ORG_B },
+    });
+
+    expect(otherOrg.error).toBeNull();
+    expect(otherOrg.res.statusCode).toBe(201);
+  });
+});
+
+describe("tag autocomplete", () => {
+  it("prefix-matches literally rather than as a pattern", async () => {
+    await Tag.create([
+      { name: "Budget", organization: ORG_A, createdBy: USER_A },
+      { name: "B.dget", organization: ORG_A, createdBy: USER_A },
+    ]);
+
+    const { res, error } = await invoke(
+      autocomplete,
+      asUser({}, { query: { q: "B." } }),
+    );
+
+    expect(error).toBeNull();
+    expect(payloadRows(res.body).map((t) => t.name)).toEqual(["B.dget"]);
+  });
+
+  it("does not throw on a metacharacter query", async () => {
+    const { res, error } = await invoke(
+      autocomplete,
+      asUser({}, { query: { q: "C++" } }),
+    );
+
+    expect(error).toBeNull();
+    expect(payloadRows(res.body)).toEqual([]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("glossary term uniqueness (Issue #1157)", () => {
+  const glossaryReq = (body) => ({
+    body,
+    params: {},
+    query: {},
+    user: { _id: USER_A, organization: ORG_A },
+  });
+
+  it("does not falsely collide with an unrelated stored term", async () => {
+    await GlossaryTerm.create({
+      organization: ORG_A,
+      term: "SLO",
+      definition: "objective",
+    });
+
+    // `/^S.O$/i` matches the stored "SLO" — 400 "already exists" against `main`.
+    const res = mockRes();
+    await createTerm(
+      glossaryReq({ term: "S.O", definition: "unrelated" }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("allows a wildcard term to be stored", async () => {
+    await GlossaryTerm.create({
+      organization: ORG_A,
+      term: "SLO",
+      definition: "objective",
+    });
+
+    const res = mockRes();
+    await createTerm(glossaryReq({ term: ".*", definition: "catch-all" }), res);
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("accepts a term with unbalanced metacharacters", async () => {
+    const res = mockRes();
+    await createTerm(
+      glossaryReq({ term: "C++", definition: "a language" }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.term).toBe("C++");
+  });
+
+  it("still rejects a real case-insensitive duplicate", async () => {
+    await GlossaryTerm.create({
+      organization: ORG_A,
+      term: "SLO",
+      definition: "objective",
+    });
+
+    const res = mockRes();
+    await createTerm(glossaryReq({ term: "slo", definition: "again" }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/already exists/i);
+  });
+});
+
+describe("glossary detection", () => {
+  it("finds a term containing metacharacters", async () => {
+    await GlossaryTerm.create({
+      organization: ORG_A,
+      term: "C++",
+      definition: "a language",
+      approvalStatus: "approved",
+    });
+
+    const matches = await glossaryService.detectTerms(
+      "We are porting the C++ service.",
+      ORG_A,
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].matchedText).toBe("C++");
+  });
+
+  it("does not let one term match the entire text", async () => {
+    await GlossaryTerm.create({
+      organization: ORG_A,
+      term: ".*",
+      definition: "not a wildcard",
+      approvalStatus: "approved",
+    });
+
+    const matches = await glossaryService.detectTerms("nothing here", ORG_A);
+    expect(matches).toEqual([]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("action item owner resolution (Issue #1157)", () => {
+  it("resolves an owner by name without compiling it", async () => {
+    const user = await userModel.create({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      password: "not-used-under-clerk",
+      organization: ORG_A,
+      clerkUserId: "clerk_ada",
+    });
+
+    const { processActionItemReminders } =
+      await import("../services/actionItemReminderService.js");
+
+    const meeting = await Meeting.create({
+      uploadedBy: USER_A,
+      organization: ORG_A,
+      title: "Planning",
+      date: new Date(),
+    });
+
+    await ActionItem.create({
+      text: "Ship the thing",
+      owner: "ada lovelace", // different case — collation must still match
+      organization: ORG_A,
+      sourceMeetingId: meeting._id,
+      status: "open",
+      dueDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+
+    const summary = await processActionItemReminders({ organization: ORG_A });
+    expect(summary.upcomingCount).toBe(1);
+
+    const { default: Notification } =
+      await import("../models/notificationModel.js");
+    const notifications = await Notification.find({ user: user._id });
+    expect(notifications).toHaveLength(1);
+  });
+
+  it("completes promptly on an owner string that is a ReDoS pattern", async () => {
+    const { processActionItemReminders } =
+      await import("../services/actionItemReminderService.js");
+
+    await userModel.create({
+      name: "a".repeat(30),
+      email: "long@example.com",
+      password: "not-used-under-clerk",
+      organization: ORG_A,
+      clerkUserId: "clerk_long",
+    });
+
+    const meeting = await Meeting.create({
+      uploadedBy: USER_A,
+      organization: ORG_A,
+      title: "Planning",
+      date: new Date(),
+    });
+
+    await ActionItem.create({
+      text: "Poisoned owner",
+      owner: `(a+)+${"a".repeat(28)}b`,
+      organization: ORG_A,
+      sourceMeetingId: meeting._id,
+      status: "open",
+      dueDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+
+    const startedAt = Date.now();
+    await processActionItemReminders({ organization: ORG_A });
+    // Against `main` the regex engine backtracks for minutes on this input.
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("speaker mapping (Issue #1157)", () => {
+  const seedMeeting = async (overrides = {}) =>
+    Meeting.create({
+      uploadedBy: USER_A,
+      organization: ORG_A,
+      title: "Standup",
+      date: new Date(),
+      summary: "Speaker 1 opened. Speaker 2 raised the deploy risk.",
+      ...overrides,
+    });
+
+  // The destructive path needs the label to appear in the summary as a literal
+  // substring, because `applyMapping` guards the replace with
+  // `summary.includes(originalLabel)`. `"."` clears that guard on essentially
+  // every summary — sentences end with periods — and then `/\b.\b/g` matches
+  // every single-character word.
+  it("does not let a bare `.` shred the summary", async () => {
+    const meeting = await seedMeeting();
+    const before = meeting.summary;
+
+    await speakerIdentificationService.applyMapping(meeting._id, ".", "Priya");
+
+    const after = await Meeting.findById(meeting._id);
+    // Against `main`:
+    //   "SpeakerPriyaPriyaPriyaopened. SpeakerPriyaPriyaPriyaraised…"
+    expect(after.summary).toBe(before);
+  });
+
+  it("does not let a partial wildcard rewrite unrelated words", async () => {
+    const meeting = await seedMeeting({
+      summary: "Ada opened. Ben raised the deploy risk.",
+    });
+    const before = meeting.summary;
+
+    // `/\bA.a\b/g` matches "Ada"; the literal "A.a" does not appear.
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      "A.a",
+      "Priya",
+    );
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe(before);
+  });
+
+  it("still performs the mapping it is actually for", async () => {
+    const meeting = await seedMeeting();
+
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      "Speaker 1",
+      "Ada",
+    );
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe("Ada opened. Speaker 2 raised the deploy risk.");
+  });
+
+  it("does not rewrite a longer label that merely contains the mapped one", async () => {
+    const meeting = await seedMeeting({
+      summary: "Speaker 10 and Speaker 1 disagreed.",
+    });
+
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      "Speaker 1",
+      "Ada",
+    );
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe("Speaker 10 and Ada disagreed.");
+  });
+
+  it("handles a label containing metacharacters instead of throwing", async () => {
+    const meeting = await seedMeeting({
+      summary: "Speaker 1 (host) chaired the review.",
+    });
+
+    await expect(
+      speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1 (host)",
+        "Ada",
+      ),
+    ).resolves.not.toThrow();
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe("Ada chaired the review.");
+  });
+
+  it("maps a label that starts with a non-word character", async () => {
+    const meeting = await seedMeeting({
+      summary: "Then #1 asked about scope.",
+    });
+
+    await speakerIdentificationService.applyMapping(meeting._id, "#1", "Ada");
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe("Then Ada asked about scope.");
+  });
+
+  it("refuses an empty label rather than rewriting the document", async () => {
+    const meeting = await seedMeeting();
+    const before = meeting.summary;
+
+    await expect(
+      speakerIdentificationService.applyMapping(meeting._id, "   ", "Ada"),
+    ).rejects.toThrow(/must not be empty/i);
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe(before);
+  });
+
+  it("rewrites transcript segments and action items for a real label", async () => {
+    const meeting = await seedMeeting();
+
+    await Transcript.create({
+      meeting: meeting._id,
+      segments: [
+        { speaker: "Speaker 1", text: "Morning", startTime: 0, endTime: 2 },
+        { speaker: "Speaker 2", text: "Morning", startTime: 2, endTime: 4 },
+      ],
+    });
+
+    await ActionItem.create({
+      text: "Speaker 1 to confirm the rollout window",
+      owner: "Speaker 1",
+      organization: ORG_A,
+      sourceMeetingId: meeting._id,
+    });
+
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      "Speaker 1",
+      "Ada",
+    );
+
+    const transcript = await Transcript.findOne({ meeting: meeting._id });
+    expect(transcript.segments.map((s) => s.speaker)).toEqual([
+      "Ada",
+      "Speaker 2",
+    ]);
+
+    const item = await ActionItem.findOne({ sourceMeetingId: meeting._id });
+    expect(item.owner).toBe("Ada");
+    expect(item.text).toBe("Ada to confirm the rollout window");
+  });
+
+  it("leaves action item text untouched when a `.` label is supplied", async () => {
+    const meeting = await seedMeeting();
+
+    await ActionItem.create({
+      text: "Speaker 1 to confirm the rollout window. Owner: A.",
+      owner: "Speaker 1",
+      organization: ORG_A,
+      sourceMeetingId: meeting._id,
+    });
+
+    await speakerIdentificationService.applyMapping(meeting._id, ".", "Priya");
+
+    const item = await ActionItem.findOne({ sourceMeetingId: meeting._id });
+    expect(item.text).toBe(
+      "Speaker 1 to confirm the rollout window. Owner: A.",
+    );
+    expect(item.owner).toBe("Speaker 1");
+  });
+});

--- a/server/utils/meetingSoftDelete.js
+++ b/server/utils/meetingSoftDelete.js
@@ -11,5 +11,11 @@ export const deletedMeetingsFilter = (filter = {}) => ({
   deletedAt: { $ne: null },
 });
 
-export const escapeRegExp = (value = "") =>
-  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/**
+ * Re-exported for backwards compatibility (Issue #1157).
+ *
+ * `escapeRegExp` has nothing to do with soft deletion, and living here is a
+ * large part of why seven other call sites never found it. It now lives in
+ * `utils/regexUtils.js`; this re-export keeps existing importers working.
+ */
+export { escapeRegExp } from "./regexUtils.js";

--- a/server/utils/regexUtils.js
+++ b/server/utils/regexUtils.js
@@ -1,0 +1,116 @@
+/**
+ * Regex helpers (Issue #1157).
+ *
+ * Seven call sites built a `RegExp` by interpolating user-controlled text
+ * without escaping it. The helper to prevent that already existed — it just
+ * lived in `utils/meetingSoftDelete.js`, which is not somewhere you look when
+ * you are writing a tag uniqueness check.
+ *
+ * It lives here now, next to the other things that operate on patterns, and
+ * `meetingSoftDelete.js` re-exports it so existing importers are unaffected.
+ *
+ * Two rules for anything that reaches for this module:
+ *
+ *   1. Interpolating a value into a `RegExp` without `escapeRegExp` is a bug.
+ *      Not a style preference — the value decides whether the expression
+ *      compiles at all (`"C++"` throws `SyntaxError: Nothing to repeat`) and
+ *      what it matches if it does (`".*"` matches everything).
+ *
+ *   2. If what you actually want is case-insensitive *equality*, do not use a
+ *      regex at all. Use `caseInsensitiveEquals` below, which produces a plain
+ *      equality query plus a collation. It is index-friendly, it cannot be
+ *      given a pathological pattern, and it says what it means.
+ */
+
+/**
+ * Escapes every character that carries meaning inside a regular expression, so
+ * the result matches `value` literally.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export const escapeRegExp = (value = "") =>
+  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Builds an anchored, case-insensitive regex that matches `value` literally.
+ *
+ * Prefer `caseInsensitiveEquals` for database queries — this is for the cases
+ * where a `RegExp` object is genuinely required (string replacement, for
+ * instance), not for `{ $regex: ... }` filters.
+ *
+ * @param {string} value
+ * @param {string} [flags="i"]
+ * @returns {RegExp}
+ */
+export const literalRegExp = (value, flags = "i") =>
+  new RegExp(`^${escapeRegExp(value)}$`, flags);
+
+/**
+ * MongoDB collation for case- and diacritic-insensitive comparison.
+ *
+ * `strength: 2` compares base letters and accents but ignores case, which is
+ * what "does a tag with this name already exist?" means in practice.
+ */
+export const CASE_INSENSITIVE_COLLATION = { locale: "en", strength: 2 };
+
+/**
+ * Expresses "this field equals `value`, ignoring case" as a query fragment
+ * plus the collation it needs.
+ *
+ * Used as:
+ *
+ *   const { filter, collation } = caseInsensitiveEquals("name", name);
+ *   await Tag.findOne({ organization, ...filter }).collation(collation);
+ *
+ * A regex cannot do this safely: `^value$` with the `i` flag is only equality
+ * if `value` contains no metacharacters, which is precisely the assumption
+ * that failed.
+ *
+ * @param {string} field
+ * @param {string} value
+ * @returns {{filter: object, collation: object}}
+ */
+export const caseInsensitiveEquals = (field, value) => ({
+  filter: { [field]: String(value ?? "") },
+  collation: CASE_INSENSITIVE_COLLATION,
+});
+
+/**
+ * Builds a word-boundary replacement pattern for `value`.
+ *
+ * `\b` is a *boundary between* a word and a non-word character, so it does not
+ * match where there is no word character to bound. `new RegExp("\\b#1\\b")`
+ * matches nothing at all, because neither `#` nor the position before it is
+ * preceded by a word character.
+ *
+ * Speaker labels are free text (`"#1"`, `"(host)"`, `"— unknown —"`), so the
+ * boundary is applied only on the sides where it can actually mean something.
+ * A label that starts or ends with a non-word character gets a lookaround that
+ * asserts "not adjacent to a word character" instead, which is the same intent
+ * expressed in a way that can match.
+ *
+ * @param {string} value
+ * @param {string} [flags="g"]
+ * @returns {RegExp}
+ */
+export const wordBoundaryRegExp = (value, flags = "g") => {
+  const raw = String(value ?? "");
+  const escaped = escapeRegExp(raw);
+
+  const startsWithWordChar = /^\w/.test(raw);
+  const endsWithWordChar = /\w$/.test(raw);
+
+  const prefix = startsWithWordChar ? "\\b" : "(?<!\\w)";
+  const suffix = endsWithWordChar ? "\\b" : "(?!\\w)";
+
+  return new RegExp(`${prefix}${escaped}${suffix}`, flags);
+};
+
+export default {
+  escapeRegExp,
+  literalRegExp,
+  caseInsensitiveEquals,
+  wordBoundaryRegExp,
+  CASE_INSENSITIVE_COLLATION,
+};


### PR DESCRIPTION
# Pull Request

## Description

Seven call sites built a `RegExp` by interpolating user-controlled text without escaping it:

```js
name: { $regex: new RegExp(`^${name}$`, "i") }        // tagController ×2, glossaryController
{ name: new RegExp(`^${owner.trim()}$`, "i") }        // actionItemReminderService
new RegExp(`\\b${originalLabel}\\b`, "g")             // speakerIdentificationService ×2
```

The escape helper already existed — `escapeRegExp`, in `utils/meetingSoftDelete.js`. That is not a file you open while writing a tag uniqueness check, which is a large part of why three other sites (`tagController.autocomplete`, `glossaryService.detectTerms`, `OrganizationService`) each open-coded their own copy of the same character class and these seven had none at all.

### What changed

**`utils/regexUtils.js`** is the new home for the helper, plus two things the call sites actually needed:

- `caseInsensitiveEquals(field, value)` → `{ filter, collation }`. Four of the seven sites were asking "does a record with this exact name already exist, ignoring case?" A regex is the wrong tool for that question — it answers "does a record *match this pattern*?" instead. These are now equality queries with `collation({ locale: "en", strength: 2 })`: same semantics, index-friendly, and there is no pattern for a caller to control.
- `wordBoundaryRegExp(value, flags)` for the two sites that genuinely do string replacement.

`meetingSoftDelete.js` re-exports `escapeRegExp` so nothing that imports it today has to change.

### The correction

While writing the tests I found **two of my claims in the issue were wrong**, and the fix is shaped by the corrected version. [Detail here](https://github.com/imuniqueshiv/MeetOnMemory/issues/1157#issuecomment-5180666226); briefly:

**The uniqueness collision runs the opposite way.** The regex is compiled from the **incoming** name and evaluated against the **stored** names. So a stored `.*` does not block future creation, as I wrote. What happens is that a metacharacter in the *new* name produces a false `400 already exists` against an unrelated existing record — `Q4.Budget` collides with a stored `Q4-Budget`, `E.gineering` with `Engineering` — and `.*` itself can never be stored once any record exists.

**Speaker mapping needs the label as a literal substring**, because the replace is guarded by `summary.includes(originalLabel)`. So `.*` does not get through. A bare `.` does — almost every summary contains a period — and `/\b.\b/g` then matches every single-character word:

```
before: "Speaker 1 opened. Speaker 2 raised the deploy risk."
after:  "SpeakerPriyaPriyaPriyaopened. SpeakerPriyaPriyaPriyaraised…"
```

Same outcome, shorter input. `applyMapping` calls `meeting.save()`, writes no `NoteVersion` snapshot, and `revertMapping` re-enters the same function with the arguments swapped — so the original text is not recoverable.

### The rest of the damage, unchanged from the issue

- **`SyntaxError` → 500.** `new RegExp("^C++$")` throws *Nothing to repeat* before any query runs. `C++`, `spend (` and `?` are all reasonable tag names and all 500 today.
- **ReDoS on a cron.** `resolveTargetUserId` interpolates an action item's `owner` — free text the model extracted from a transcript. `processActionItemReminders` runs every 15 minutes, in-process, once per open action item. `(a+)+$` stalls the event loop on a schedule, and the surrounding `try/catch` cannot help because a hang is not an exception. This one has no `includes` guard in front of it.
- **`\b` against a non-word character never matches.** A diarization label like `#1` compiled to `/\b#1\b/`, which matches nothing — so the mapping silently did nothing while the endpoint returned success. `wordBoundaryRegExp` uses `(?<!\w)` / `(?!\w)` on the sides where `\b` cannot mean anything, and keeps `\b` where it can.

### Two smaller things in `applyMapping`

- An empty or whitespace-only label is now rejected rather than used to rewrite the document.
- The document is only marked dirty when the replacement actually changed something. `includes()` finding the label as a substring does not imply the boundary pattern matches it, so an unchanged summary was being re-saved.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1157

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/regexEscaping.test.js` — 47 tests against `mongodb-memory-server`. The DB is not optional here: four of the fixes replace a regex with a *collated* equality query, and a collation only means anything to a real server.

**`regexUtils`** — metacharacter coverage; `.*` as a literal; `C++` compiles after escaping; non-string coercion; the `meetingSoftDelete` re-export is the same function object; `wordBoundaryRegExp` matches whole words, refuses `Speaker 1` inside `Speaker 10`, treats `.*` literally, and matches `#1` / `(host)` where plain `\b` cannot — while still refusing `#1` inside `x#1y`.

**Tags** — no false collision via `.`, via `.*`, or via `E.gineering`; seven metacharacter names accepted (`C++`, `A+`, `spend (`, `a{2,`, `[draft]`, `?`, `x|y`); genuine case-insensitive duplicates still rejected, including one containing metacharacters; rename follows the same rule; uniqueness stays scoped to the organization. Autocomplete prefix-matches literally and no longer throws on `C++`.

**Glossary** — no false collision against a stored term; a wildcard term can be stored; `C++` accepted; real duplicates still rejected; `detectTerms` finds `C++` and does not let a `.*` term match arbitrary text.

**Reminders** — an owner resolves by name across a case difference (which is what the collation buys); a `(a+)+…b` owner completes in well under 5 s where the old regex backtracked for minutes.

**Speaker mapping** — a bare `.` leaves the summary byte-identical; `A.a` does not rewrite `Ada`; a real `Speaker 1 → Ada` mapping still works and does not touch `Speaker 10`; `Speaker 1 (host)` no longer throws; `#1` now maps; an empty label is refused and the document is untouched; transcript segments and action items are rewritten for a real label and left alone for a `.`.

**Confirmed load-bearing.** Running this suite against `main`'s controllers and services (adding only `utils/regexUtils.js`, which the suite imports) fails **16 tests** — every false-collision case, every `SyntaxError` case, glossary detection of `C++`, and all six speaker-mapping cases.

**Full server suite:** unchanged against `main` — 21 pre-existing suite failures and 1 pre-existing test failure on both, with 47 additional tests passing here. (One of those 21, `glossary.test.js`, fails because the declared `diff` dependency is not installed in this checkout; it fails identically on `main`.)

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for glossary terms, tags, owners, speakers, and transcript text containing special characters.
  * Prevented malformed or overly broad searches caused by regex metacharacters.
  * Improved case-insensitive matching, duplicate detection, and handling of labels with punctuation or whitespace.
  * Reduced unnecessary updates when speaker replacements do not change content.

* **Tests**
  * Added comprehensive coverage for special characters, wildcard inputs, duplicate detection, scoped matching, and related transcript updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->