### PR TITLE
fix(security): require meeting access for the note-version API (#1158)

### DIFF
--- a/server/controllers/noteVersionController.js
+++ b/server/controllers/noteVersionController.js
@@ -1,9 +1,19 @@
 import crypto from "crypto";
+import mongoose from "mongoose";
 import * as diff from "diff";
 import NoteVersion from "../models/noteVersionModel.js";
-import Meeting from "../models/meetingModel.js";
 import { sendSuccess } from "../utils/responseHandler.js";
-import { NotFoundError } from "../utils/errors.js";
+import { NotFoundError, ValidationError } from "../utils/errors.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+
+/**
+ * `socket/documentSync.js` is imported lazily, on the one code path that needs
+ * it, for two reasons: `documentService.js` already imports `snapshotNoteVersion`
+ * from this file (so a static import would close a cycle), and `documentSync`
+ * performs a top-level `await` on a Redis connection that no other handler in
+ * this controller should be made to wait for.
+ */
+const loadDocumentSync = () => import("../socket/documentSync.js");
 
 // Helper to hash content
 const hashContent = (content) => {
@@ -65,18 +75,45 @@ export const snapshotNoteVersion = async (
 
 // --- HTTP Routes ---
 
+/**
+ * Authorization for every handler below lives in the route definition
+ * (Issue #1158): `requireOrgAccess(Meeting)` for the `/:meetingId` route,
+ * `requireNoteVersionAccess` for the `/version/:versionId` routes. The latter
+ * attaches `req.noteVersion` and `req.meeting`, so these handlers no longer
+ * re-fetch either — and, more to the point, no longer read a document the
+ * caller has not been cleared for.
+ */
+
 export const getVersionHistory = async (req, res, next) => {
   try {
     const { meetingId, field } = req.params;
 
-    // Fetch all versions but exclude the actual content to keep response light
-    const versions = await NoteVersion.find({ meetingId, field })
-      .select("-content")
-      .populate("changedBy", "name email")
-      .sort({ version: -1 })
-      .exec();
+    // The history used to be unbounded. A long collaborative meeting writes a
+    // snapshot per edit burst — `saveDocumentState` calls `snapshotNoteVersion`
+    // on every debounced flush — so this list grows without limit for exactly
+    // the meetings anyone would want to inspect.
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 25,
+      maxLimit: 100,
+    });
 
-    return sendSuccess(res, { versions });
+    const filter = { meetingId, field };
+
+    const [versions, total] = await Promise.all([
+      NoteVersion.find(filter)
+        .select("-content")
+        .populate("changedBy", "name email")
+        .sort({ version: -1 })
+        .skip(skip)
+        .limit(limit)
+        .exec(),
+      NoteVersion.countDocuments(filter),
+    ]);
+
+    return sendSuccess(res, {
+      versions,
+      pagination: buildPaginationMeta({ total, page, limit }),
+    });
   } catch (err) {
     next(err);
   }
@@ -84,15 +121,8 @@ export const getVersionHistory = async (req, res, next) => {
 
 export const getVersionContent = async (req, res, next) => {
   try {
-    const { versionId } = req.params;
-    const version = await NoteVersion.findById(versionId).populate(
-      "changedBy",
-      "name email",
-    );
-
-    if (!version) {
-      throw new NotFoundError("Version not found");
-    }
+    // Loaded and access-checked by `requireNoteVersionAccess`.
+    const version = await req.noteVersion.populate("changedBy", "name email");
 
     return sendSuccess(res, { version });
   } catch (err) {
@@ -102,20 +132,33 @@ export const getVersionContent = async (req, res, next) => {
 
 export const getVersionDiff = async (req, res, next) => {
   try {
-    const { versionId, compareVersionId } = req.params;
+    const { compareVersionId } = req.params;
+    const v1 = req.noteVersion;
 
-    const v1 = await NoteVersion.findById(versionId);
-    const v2 = compareVersionId
-      ? await NoteVersion.findById(compareVersionId)
-      : null;
-
-    if (!v1) throw new NotFoundError("Base version not found");
-
-    // If compareVersionId is provided but not found, we throw error. If not provided, we compare with previous version.
-    let baseContent = v1.content;
     let compareContent = "";
 
-    if (v2) {
+    if (compareVersionId) {
+      if (!mongoose.Types.ObjectId.isValid(compareVersionId)) {
+        throw new ValidationError("Invalid comparison version ID format");
+      }
+
+      const v2 = await NoteVersion.findById(compareVersionId);
+      if (!v2) {
+        throw new NotFoundError("Comparison version not found");
+      }
+
+      // Only `versionId` passes through `requireNoteVersionAccess`, so without
+      // this the endpoint would happily diff one organization's content
+      // against another's — and the diff output contains both sides.
+      if (
+        v2.meetingId.toString() !== v1.meetingId.toString() ||
+        v2.field !== v1.field
+      ) {
+        throw new ValidationError(
+          "Versions must belong to the same meeting and field to be compared",
+        );
+      }
+
       compareContent = v2.content;
     } else {
       // Find the version right before v1
@@ -130,7 +173,7 @@ export const getVersionDiff = async (req, res, next) => {
     }
 
     // diffLines computes differences line by line
-    const diffResult = diff.diffLines(compareContent, baseContent);
+    const diffResult = diff.diffLines(compareContent, v1.content);
 
     return sendSuccess(res, { diff: diffResult });
   } catch (err) {
@@ -140,25 +183,26 @@ export const getVersionDiff = async (req, res, next) => {
 
 export const restoreVersion = async (req, res, next) => {
   try {
-    const { versionId } = req.params;
-    const userId = req.user?.id || req.user?._id;
+    const userId = req.user?._id || req.user?.id;
 
-    const versionToRestore = await NoteVersion.findById(versionId);
-    if (!versionToRestore) {
-      throw new NotFoundError("Version not found");
-    }
-
-    const meeting = await Meeting.findById(versionToRestore.meetingId);
-    if (!meeting) {
-      throw new NotFoundError("Meeting not found");
-    }
+    // Both loaded and access-checked by `requireNoteVersionAccess`.
+    const versionToRestore = req.noteVersion;
+    const meeting = req.meeting;
 
     // Restore content to the meeting
     if (versionToRestore.field === "collaborativeNotes") {
+      // Writing only the plain-text column is what made this restore revert:
+      // `getOrCreateDoc` rehydrates from `crdtState`, so the next client to
+      // open the notes reinstated the pre-restore text and the debounced save
+      // wrote it back. Rebuilding the CRDT is what makes the restore stick.
+      const { restoreCollaborativeNotes } = await loadDocumentSync();
+      const { state } = await restoreCollaborativeNotes(
+        meeting._id.toString(),
+        versionToRestore.content,
+      );
+
       meeting.collaborativeNotes = versionToRestore.content;
-      // Note: we are only updating the plain text here. If CRDT state exists,
-      // it might need to be reset or a new Yjs document created, but for simplicity
-      // and as a fallback we update the plain text.
+      meeting.crdtState = state;
     } else if (versionToRestore.field === "summary") {
       meeting.summary = versionToRestore.content;
     }

--- a/server/middleware/noteVersionAccess.js
+++ b/server/middleware/noteVersionAccess.js
@@ -1,0 +1,113 @@
+/**
+ * Authorization for the note-version API (Issue #1158).
+ *
+ * `noteVersionRoutes.js` applied `userAuth` and nothing else, and none of the
+ * five handlers checked anything themselves. Every id in the path was trusted,
+ * so any authenticated user could read any organization's collaborative notes
+ * and AI summaries — and, through `restoreVersion`, overwrite them.
+ *
+ * The `/:meetingId/...` route can use the existing `requireOrgAccess(Meeting)`,
+ * because the meeting id is right there in the path. The `/version/:versionId`
+ * routes cannot: `NoteVersion` carries no `organization` field, so the tenant
+ * boundary has to be resolved through `meetingId -> Meeting.organization`.
+ * That is what this module does.
+ *
+ * The access rule itself is deliberately *not* re-implemented here. It is
+ * imported from `rbac.js`, so "who may see this meeting" has one definition and
+ * these routes cannot drift away from the rest of the API.
+ */
+
+import mongoose from "mongoose";
+import NoteVersion from "../models/noteVersionModel.js";
+import Meeting from "../models/meetingModel.js";
+import { canAccessMeetingDoc } from "./rbac.js";
+
+/** The only two fields `NoteVersion.field` is allowed to hold. */
+export const VERSIONED_FIELDS = ["collaborativeNotes", "summary"];
+
+/**
+ * Rejects a `:field` path segment that is not one of the versioned fields.
+ *
+ * Without this, `GET /api/note-versions/<id>/crdtState/history` reaches the
+ * database with an arbitrary string and returns an empty list, which reads as
+ * "this meeting has no history" rather than "that is not a field".
+ */
+export const requireVersionedField = (req, res, next) => {
+  const { field } = req.params;
+
+  if (!VERSIONED_FIELDS.includes(field)) {
+    return res.status(400).json({
+      success: false,
+      message: `Unknown versioned field '${field}'. Expected one of: ${VERSIONED_FIELDS.join(", ")}.`,
+    });
+  }
+
+  next();
+};
+
+/**
+ * Loads the `NoteVersion` named by `:versionId`, resolves the meeting behind
+ * it, and applies the same access rule the rest of the API uses.
+ *
+ * On success attaches `req.noteVersion` and `req.meeting` so the handler does
+ * not repeat either lookup.
+ */
+export const requireNoteVersionAccess = async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    if (!req.user.organization) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    const { versionId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(versionId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid version ID format" });
+    }
+
+    const noteVersion = await NoteVersion.findById(versionId);
+    if (!noteVersion) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Version not found" });
+    }
+
+    const meeting = await Meeting.findById(noteVersion.meetingId);
+    if (!meeting) {
+      // A version whose meeting has been hard-deleted is unreachable content,
+      // not a 500. Reported as 404 so it is indistinguishable from a version
+      // id that never existed — a caller probing ids learns nothing either way.
+      return res
+        .status(404)
+        .json({ success: false, message: "Version not found" });
+    }
+
+    if (!canAccessMeetingDoc(meeting, req.user)) {
+      // Same message and status as an unknown id, for the same reason: the
+      // difference between "exists but is not yours" and "does not exist" is
+      // exactly what makes id enumeration worthwhile.
+      return res
+        .status(404)
+        .json({ success: false, message: "Version not found" });
+    }
+
+    req.noteVersion = noteVersion;
+    req.meeting = meeting;
+    next();
+  } catch (error) {
+    console.error("requireNoteVersionAccess error:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error during authorization check",
+    });
+  }
+};
+
+export default requireNoteVersionAccess;

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -6,6 +6,37 @@ import {
   isValidRole,
 } from "../utils/rbacPermissions.js";
 
+/**
+ * "May this user see this meeting-scoped document?" — the rule
+ * `requireOrgAccess` has always applied, extracted so it can be reused
+ * (Issue #1158).
+ *
+ * The note-version routes need the same rule but cannot use the middleware:
+ * their path carries a `NoteVersion` id, so the meeting has to be resolved
+ * first. Exporting the predicate keeps that from becoming a second, subtly
+ * different definition of who may read a meeting.
+ *
+ * @param {{organization?: any, uploadedBy?: any}} doc
+ * @param {{_id?: any, organization?: any}} user
+ * @returns {boolean}
+ */
+export const canAccessMeetingDoc = (doc, user) => {
+  if (!doc || !user) return false;
+
+  const isOwner =
+    Boolean(doc.uploadedBy) &&
+    Boolean(user._id) &&
+    doc.uploadedBy.toString() === user._id.toString();
+
+  const isInSameOrg = Boolean(
+    doc.organization &&
+    user.organization &&
+    doc.organization.toString() === user.organization.toString(),
+  );
+
+  return isOwner || isInSameOrg;
+};
+
 export const requireRole = (roles) => {
   return (req, res, next) => {
     if (!req.user) {
@@ -246,13 +277,7 @@ export const requireOrgAccess = (Model) => {
           .json({ success: false, message: "Resource not found" });
       }
 
-      const isOwner = doc.uploadedBy?.toString() === req.user._id.toString();
-      const isInSameOrg =
-        doc.organization &&
-        req.user.organization &&
-        doc.organization.toString() === req.user.organization.toString();
-
-      if (!isOwner && !isInSameOrg) {
+      if (!canAccessMeetingDoc(doc, req.user)) {
         return res.status(403).json({
           success: false,
           message: "Forbidden: You don't have access to this resource",

--- a/server/routes/noteVersionRoutes.js
+++ b/server/routes/noteVersionRoutes.js
@@ -1,23 +1,67 @@
 import express from "express";
 import * as noteVersionController from "../controllers/noteVersionController.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgAccess, requirePermission } from "../middleware/rbac.js";
+import {
+  requireNoteVersionAccess,
+  requireVersionedField,
+} from "../middleware/noteVersionAccess.js";
+import Meeting from "../models/meetingModel.js";
 
 const router = express.Router();
+
+// Issue #1158 — this file used to be `router.use(userAuth)` followed by five
+// bare routes. `userAuth` establishes *who* the caller is; nothing established
+// *what* they were allowed to reach, and the handlers did not check either.
+//
+// Every route below now resolves the meeting behind the requested resource
+// before the handler runs:
+//
+//   - `/:meetingId/...` has the meeting id in the path, so `requireOrgAccess`
+//     applies directly — the same guard `followUpThreadRoutes` and
+//     `agendaTimerRoutes` already use.
+//   - `/version/:versionId` does not, so `requireNoteVersionAccess` walks
+//     `NoteVersion -> Meeting` and applies the identical rule.
+//
+// Reads require `meetings:view`. `restoreVersion` mutates the meeting, so it
+// requires `meetings:edit` — the same view/edit split `meetingSeriesRoutes`
+// already draws.
 
 router.use(userAuth);
 
 router.get(
   "/:meetingId/:field/history",
+  requireVersionedField,
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
   noteVersionController.getVersionHistory,
 );
-router.get("/version/:versionId", noteVersionController.getVersionContent);
-router.get("/version/:versionId/diff", noteVersionController.getVersionDiff);
+
 router.get(
-  "/version/:versionId/diff/:compareVersionId",
+  "/version/:versionId",
+  requireNoteVersionAccess,
+  requirePermission("meetings", "view"),
+  noteVersionController.getVersionContent,
+);
+
+router.get(
+  "/version/:versionId/diff",
+  requireNoteVersionAccess,
+  requirePermission("meetings", "view"),
   noteVersionController.getVersionDiff,
 );
+
+router.get(
+  "/version/:versionId/diff/:compareVersionId",
+  requireNoteVersionAccess,
+  requirePermission("meetings", "view"),
+  noteVersionController.getVersionDiff,
+);
+
 router.post(
   "/version/:versionId/restore",
+  requireNoteVersionAccess,
+  requirePermission("meetings", "edit"),
   noteVersionController.restoreVersion,
 );
 

--- a/server/socket/documentSync.js
+++ b/server/socket/documentSync.js
@@ -163,6 +163,95 @@ const cleanupDoc = async (meetingId, syncNs) => {
   }
 };
 
+/**
+ * Replaces a meeting's collaborative notes with `text`, in the CRDT as well as
+ * the plain-text column (Issue #1158).
+ *
+ * `restoreVersion` used to write only `meeting.collaborativeNotes`. Because
+ * `getOrCreateDoc` rehydrates from `crdtState`, the next client to open the
+ * document reinstated the *pre-restore* text and the debounced save then wrote
+ * it back over the restored value. The restore looked correct in the REST
+ * response and in any read-only view, then silently reverted.
+ *
+ * Two cases, both handled here:
+ *
+ *   - **Live document.** Someone has the notes open, so the authoritative copy
+ *     is the in-memory `Y.Doc`, not the database. The replacement is applied
+ *     as a Yjs transaction and the resulting update is broadcast to the room
+ *     and published to Redis, so connected clients converge on the restored
+ *     text instead of overwriting it on their next keystroke.
+ *   - **Cold document.** Nobody is connected. A fresh `Y.Doc` seeded with the
+ *     text is encoded and returned, so the next `getOrCreateDoc` rehydrates
+ *     the restored content.
+ *
+ * @param {string} meetingId
+ * @param {string} text
+ * @returns {Promise<{state: Buffer, wasLive: boolean}>} `state` is the encoded
+ *   Yjs update the caller should store in `Meeting.crdtState`.
+ */
+export const restoreCollaborativeNotes = async (meetingId, text = "") => {
+  const key = String(meetingId);
+  const entry = docRegistry.get(key);
+
+  if (!entry) {
+    const ydoc = new Y.Doc();
+    if (text) ydoc.getText("notes").insert(0, text);
+    return { state: Buffer.from(Y.encodeStateAsUpdate(ydoc)), wasLive: false };
+  }
+
+  const { ydoc } = entry;
+  const yText = ydoc.getText("notes");
+
+  // Capture the update this transaction produces so it can be shipped to the
+  // clients that are already connected. Without it they keep rendering the old
+  // text until they reconnect, and their next edit re-applies it.
+  let restoreUpdate = null;
+  const captureUpdate = (update) => {
+    restoreUpdate = update;
+  };
+  ydoc.on("update", captureUpdate);
+
+  try {
+    ydoc.transact(() => {
+      if (yText.length > 0) yText.delete(0, yText.length);
+      if (text) yText.insert(0, text);
+    });
+  } finally {
+    ydoc.off("update", captureUpdate);
+  }
+
+  if (restoreUpdate) {
+    const payload = Array.from(restoreUpdate);
+    const roomName = `doc:${key}`;
+
+    if (syncNamespace) {
+      syncNamespace
+        .to(roomName)
+        .emit("sync-update", { meetingId: key, update: payload });
+    }
+
+    if (redisPub) {
+      redisPub
+        .publish(
+          "yjs-document-sync-updates",
+          JSON.stringify({ meetingId: key, update: payload, sender: serverId }),
+        )
+        .catch((err) =>
+          console.error("❌ Redis Publish Error (restore):", err.message),
+        );
+    }
+  }
+
+  // A pending debounced save would write the same state a few seconds later;
+  // the caller persists synchronously, so cancel it rather than racing it.
+  if (entry.saveTimer) {
+    clearTimeout(entry.saveTimer);
+    entry.saveTimer = null;
+  }
+
+  return { state: Buffer.from(Y.encodeStateAsUpdate(ydoc)), wasLive: true };
+};
+
 // Main export — registers /sync namespace on the Socket.io server
 export default (io) => {
   // Create a dedicated namespace for document synchronization

--- a/server/tests/noteVersionAuthorization.test.js
+++ b/server/tests/noteVersionAuthorization.test.js
@@ -1,0 +1,474 @@
+/**
+ * Regression tests for Issue #1158 — the note-version API had no authorization.
+ *
+ * These run the real Express router (`routes/noteVersionRoutes.js`) mounted on
+ * a bare app, rather than calling the handlers directly. That is the point: the
+ * bug was *in the route definitions* — the handlers were reachable by anyone
+ * because nothing stood in front of them. A test that invokes the controller
+ * directly would have passed on the vulnerable code.
+ *
+ * Confirmed load-bearing: against `main`'s route file and controller, 14 of
+ * these fail — every cross-tenant read, the cross-tenant restore, the
+ * view-but-not-edit case, both diff-across-boundary cases, the unknown-field
+ * and missing-meeting cases, pagination, and the CRDT persistence check.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+// ── Session injection ──────────────────────────────────────────────────────
+// `userAuth` resolves a Clerk session, which is not what is under test here.
+// It is replaced with a switch that injects whichever `req.user` the current
+// test wants, so the suite exercises the *authorization* layer in isolation.
+//
+// The mock has to be registered before the router is loaded, so the router and
+// everything downstream of it are imported dynamically below.
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: noteVersionRoutes } =
+  await import("../routes/noteVersionRoutes.js");
+const { default: NoteVersion } = await import("../models/noteVersionModel.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: errorHandler } = await import("../middleware/errorHandler.js");
+const { snapshotNoteVersion } =
+  await import("../controllers/noteVersionController.js");
+
+// `changedBy` is `ref: "User"`. `server.js` loads every model at boot, so the
+// schema is registered in production; this suite mounts one router, so it has
+// to register it explicitly or `populate` throws MissingSchemaError.
+await import("../models/userModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "owner", // deliberately privileged — in her *own* organization
+};
+const viewerInOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "guest",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/note-versions", noteVersionRoutes);
+  // The project's real error handler, so `ValidationError` and `NotFoundError`
+  // map to the same statuses and bodies they would in production.
+  app.use(errorHandler);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+});
+
+/** Creates an org-A meeting with two summary versions and one notes version. */
+const seed = async () => {
+  const meeting = await Meeting.create({
+    uploadedBy: alice._id,
+    organization: ORG_A,
+    title: "Q3 Planning",
+    date: new Date(),
+    summary: "v2 summary",
+    collaborativeNotes: "live notes",
+  });
+
+  const v1 = await snapshotNoteVersion(
+    meeting._id,
+    "summary",
+    "v1 summary",
+    "ai_processing",
+    alice._id,
+  );
+  const v2 = await snapshotNoteVersion(
+    meeting._id,
+    "summary",
+    "v2 summary",
+    "user_edit",
+    alice._id,
+  );
+  const n1 = await snapshotNoteVersion(
+    meeting._id,
+    "collaborativeNotes",
+    "notes as typed",
+    "user_edit",
+    alice._id,
+  );
+
+  return { meeting, v1, v2, n1 };
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET /:meetingId/:field/history", () => {
+  it("serves the history to a member of the owning organization", async () => {
+    const { meeting } = await seed();
+
+    const res = await request(app)
+      .get(`/api/note-versions/${meeting._id}/summary/history`)
+      .expect(200);
+
+    expect(res.body.versions).toHaveLength(2);
+    expect(res.body.versions[0].version).toBe(2);
+    // `-content` is still excluded, as before.
+    expect(res.body.versions[0].content).toBeUndefined();
+  });
+
+  it("refuses a caller from another organization", async () => {
+    const { meeting } = await seed();
+    currentUser = mallory;
+
+    // Against `main`: 200, with every version id and contributor email.
+    await request(app)
+      .get(`/api/note-versions/${meeting._id}/summary/history`)
+      .expect(403);
+  });
+
+  it("refuses an unauthenticated caller", async () => {
+    const { meeting } = await seed();
+    currentUser = null;
+
+    await request(app)
+      .get(`/api/note-versions/${meeting._id}/summary/history`)
+      .expect(401);
+  });
+
+  it("rejects an unknown field rather than reporting an empty history", async () => {
+    const { meeting } = await seed();
+
+    const res = await request(app)
+      .get(`/api/note-versions/${meeting._id}/crdtState/history`)
+      .expect(400);
+
+    expect(res.body.message).toMatch(/Unknown versioned field/i);
+  });
+
+  it("rejects a malformed meeting id with 400, not 500", async () => {
+    await request(app)
+      .get("/api/note-versions/not-an-objectid/summary/history")
+      .expect(400);
+  });
+
+  it("404s for a meeting that does not exist", async () => {
+    await request(app)
+      .get(
+        `/api/note-versions/${new mongoose.Types.ObjectId()}/summary/history`,
+      )
+      .expect(404);
+  });
+
+  it("paginates instead of returning every version", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: alice._id,
+      organization: ORG_A,
+      title: "Long meeting",
+      date: new Date(),
+    });
+
+    for (let i = 0; i < 30; i++) {
+      await snapshotNoteVersion(
+        meeting._id,
+        "summary",
+        `revision ${i}`,
+        "user_edit",
+        alice._id,
+      );
+    }
+
+    const firstPage = await request(app)
+      .get(`/api/note-versions/${meeting._id}/summary/history`)
+      .expect(200);
+
+    expect(firstPage.body.versions).toHaveLength(25); // default page size
+    expect(firstPage.body.pagination).toMatchObject({
+      total: 30,
+      page: 1,
+      limit: 25,
+      hasMore: true,
+    });
+
+    const secondPage = await request(app)
+      .get(`/api/note-versions/${meeting._id}/summary/history?page=2`)
+      .expect(200);
+
+    expect(secondPage.body.versions).toHaveLength(5);
+    expect(secondPage.body.pagination.hasMore).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET /version/:versionId", () => {
+  it("serves full content to a member of the owning organization", async () => {
+    const { v1 } = await seed();
+
+    const res = await request(app)
+      .get(`/api/note-versions/version/${v1._id}`)
+      .expect(200);
+
+    expect(res.body.version.content).toBe("v1 summary");
+  });
+
+  it("refuses a caller from another organization", async () => {
+    const { v1 } = await seed();
+    currentUser = mallory;
+
+    // Against `main`: 200 with the complete summary text.
+    await request(app).get(`/api/note-versions/version/${v1._id}`).expect(404);
+  });
+
+  it("does not distinguish 'not yours' from 'does not exist'", async () => {
+    const { v1 } = await seed();
+    currentUser = mallory;
+
+    const forbidden = await request(app).get(
+      `/api/note-versions/version/${v1._id}`,
+    );
+    const missing = await request(app).get(
+      `/api/note-versions/version/${new mongoose.Types.ObjectId()}`,
+    );
+
+    expect(forbidden.status).toBe(missing.status);
+    expect(forbidden.body.message).toBe(missing.body.message);
+  });
+
+  it("rejects a malformed version id with 400, not 500", async () => {
+    await request(app)
+      .get("/api/note-versions/version/not-an-objectid")
+      .expect(400);
+  });
+
+  it("refuses a caller with no organization on their session", async () => {
+    const { v1 } = await seed();
+    currentUser = { _id: new mongoose.Types.ObjectId(), role: "member" };
+
+    await request(app).get(`/api/note-versions/version/${v1._id}`).expect(403);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET /version/:versionId/diff", () => {
+  it("diffs against the preceding version by default", async () => {
+    const { v2 } = await seed();
+
+    const res = await request(app)
+      .get(`/api/note-versions/version/${v2._id}/diff`)
+      .expect(200);
+
+    const added = res.body.diff.find((part) => part.added);
+    expect(added.value).toContain("v2 summary");
+  });
+
+  it("refuses a caller from another organization", async () => {
+    const { v2 } = await seed();
+    currentUser = mallory;
+
+    await request(app)
+      .get(`/api/note-versions/version/${v2._id}/diff`)
+      .expect(404);
+  });
+
+  it("refuses to diff across two different meetings", async () => {
+    const { v1 } = await seed();
+
+    const otherMeeting = await Meeting.create({
+      uploadedBy: alice._id,
+      organization: ORG_A,
+      title: "Unrelated",
+      date: new Date(),
+    });
+    const otherVersion = await snapshotNoteVersion(
+      otherMeeting._id,
+      "summary",
+      "someone else's minutes",
+      "user_edit",
+      alice._id,
+    );
+
+    // Only `versionId` is access-checked, so without this guard the second id
+    // is a free read of any version in the database — including another
+    // organization's, since the diff output carries both sides.
+    const res = await request(app)
+      .get(`/api/note-versions/version/${v1._id}/diff/${otherVersion._id}`)
+      .expect(400);
+
+    expect(res.body.message).toMatch(/same meeting and field/i);
+  });
+
+  it("refuses to diff across two different fields of the same meeting", async () => {
+    const { v1, n1 } = await seed();
+
+    await request(app)
+      .get(`/api/note-versions/version/${v1._id}/diff/${n1._id}`)
+      .expect(400);
+  });
+
+  it("diffs two versions of the same meeting and field", async () => {
+    const { v1, v2 } = await seed();
+
+    const res = await request(app)
+      .get(`/api/note-versions/version/${v2._id}/diff/${v1._id}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body.diff)).toBe(true);
+  });
+
+  it("rejects a malformed comparison id with 400", async () => {
+    const { v1 } = await seed();
+
+    await request(app)
+      .get(`/api/note-versions/version/${v1._id}/diff/not-an-objectid`)
+      .expect(400);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("POST /version/:versionId/restore", () => {
+  it("restores a summary for an authorized caller", async () => {
+    const { meeting, v1 } = await seed();
+
+    await request(app)
+      .post(`/api/note-versions/version/${v1._id}/restore`)
+      .expect(200);
+
+    const reloaded = await Meeting.findById(meeting._id);
+    expect(reloaded.summary).toBe("v1 summary");
+  });
+
+  it("refuses a cross-tenant restore", async () => {
+    const { meeting, v1 } = await seed();
+    currentUser = mallory;
+
+    // Against `main`: 200, and org A's live summary silently reverts.
+    await request(app)
+      .post(`/api/note-versions/version/${v1._id}/restore`)
+      .expect(404);
+
+    const reloaded = await Meeting.findById(meeting._id);
+    expect(reloaded.summary).toBe("v2 summary"); // untouched
+  });
+
+  it("refuses a caller who may view but not edit", async () => {
+    const { meeting, v1 } = await seed();
+    currentUser = viewerInOrgA;
+
+    // Reading is fine for this role...
+    await request(app).get(`/api/note-versions/version/${v1._id}`).expect(200);
+    // ...restoring is not.
+    await request(app)
+      .post(`/api/note-versions/version/${v1._id}/restore`)
+      .expect(403);
+
+    const reloaded = await Meeting.findById(meeting._id);
+    expect(reloaded.summary).toBe("v2 summary");
+  });
+
+  it("rebuilds crdtState so a notes restore is not reverted by the next sync", async () => {
+    const { meeting, n1 } = await seed();
+
+    // Simulate a document that has been edited since — a stale CRDT blob that
+    // `getOrCreateDoc` would otherwise rehydrate over the restored text.
+    await Meeting.findByIdAndUpdate(meeting._id, {
+      crdtState: Buffer.from([1, 2, 3]),
+      collaborativeNotes: "text typed after the snapshot",
+    });
+
+    await request(app)
+      .post(`/api/note-versions/version/${n1._id}/restore`)
+      .expect(200);
+
+    const reloaded = await Meeting.findById(meeting._id);
+    expect(reloaded.collaborativeNotes).toBe("notes as typed");
+
+    // The blob must have been replaced, and must decode back to the restored
+    // text — asserting it merely changed would pass on any garbage write.
+    const Y = await import("yjs");
+    const ydoc = new Y.Doc();
+    Y.applyUpdate(ydoc, new Uint8Array(reloaded.crdtState));
+    expect(ydoc.getText("notes").toString()).toBe("notes as typed");
+  });
+
+  it("writes a new snapshot attributing the restore to the caller", async () => {
+    const { meeting, v1 } = await seed();
+
+    await request(app)
+      .post(`/api/note-versions/version/${v1._id}/restore`)
+      .expect(200);
+
+    const latest = await NoteVersion.findOne({
+      meetingId: meeting._id,
+      field: "summary",
+    }).sort({ version: -1 });
+
+    expect(latest.version).toBe(3);
+    expect(latest.content).toBe("v1 summary");
+    expect(latest.changedBy.toString()).toBe(alice._id.toString());
+  });
+
+  it("404s for an unknown version id", async () => {
+    await request(app)
+      .post(
+        `/api/note-versions/version/${new mongoose.Types.ObjectId()}/restore`,
+      )
+      .expect(404);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("meeting-owner access", () => {
+  it("lets the uploader through even without an organization match", async () => {
+    // `canAccessMeetingDoc` accepts owner *or* same-org, and this is the owner
+    // branch — a meeting created before the uploader joined an organization.
+    const meeting = await Meeting.create({
+      uploadedBy: mallory._id,
+      organization: null,
+      title: "Personal notes",
+      date: new Date(),
+    });
+
+    const version = await snapshotNoteVersion(
+      meeting._id,
+      "summary",
+      "mine",
+      "user_edit",
+      mallory._id,
+    );
+
+    currentUser = mallory;
+    const res = await request(app)
+      .get(`/api/note-versions/version/${version._id}`)
+      .expect(200);
+
+    expect(res.body.version.content).toBe("mine");
+
+    // ...and still refuses everyone else.
+    currentUser = alice;
+    await request(app)
+      .get(`/api/note-versions/version/${version._id}`)
+      .expect(404);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

`server/routes/noteVersionRoutes.js` was `router.use(userAuth)` followed by five bare routes:

```js
router.use(userAuth);                       // <- the only guard

router.get("/:meetingId/:field/history", noteVersionController.getVersionHistory);
router.get("/version/:versionId",        noteVersionController.getVersionContent);
router.get("/version/:versionId/diff",   noteVersionController.getVersionDiff);
router.get("/version/:versionId/diff/:compareVersionId", noteVersionController.getVersionDiff);
router.post("/version/:versionId/restore", noteVersionController.restoreVersion);
```

`userAuth` establishes *who* the caller is. Nothing established *what* they were allowed to reach, and none of the five handlers checked either — every id in the path went straight into a `findById`.

So any authenticated user of any organization could read the full text of any other organization's `collaborativeNotes` and AI-generated `summary`, and overwrite them.

`NoteVersion.content` is the whole field body, and `getVersionContent` returns it along with the name and email of whoever wrote it via the `changedBy` populate. `restoreVersion` is the one that writes: it loads the version, loads its meeting with no filter, assigns the content, and calls `meeting.save()`.

Version ids are `ObjectId`s and so not guessable at random — but `getVersionHistory` hands out every version id for a meeting to any caller who supplies the meeting id, and meeting ids appear in client URLs, share links, digest emails, socket room names and webhook payloads.

### The fix

The `/:meetingId/...` route has the meeting id in the path, so it uses the existing `requireOrgAccess(Meeting)` — the same guard `followUpThreadRoutes` and `agendaTimerRoutes` already use.

The `/version/:versionId` routes cannot: `NoteVersion` has no `organization` field, so the tenant boundary has to be resolved through `meetingId → Meeting.organization`. That is what `middleware/noteVersionAccess.js` does, and it deliberately does **not** re-implement the access rule. `requireOrgAccess`'s owner-or-same-org check is extracted into an exported `canAccessMeetingDoc` in `rbac.js` and both call it, so "who may read a meeting" has one definition.

Reads require `meetings:view`. `restoreVersion` mutates the meeting, so it requires `meetings:edit` — the same view/edit split `meetingSeriesRoutes` already draws. A `guest` can read history and refuse to restore.

Unauthorized version ids come back `404` with the same body as an id that does not exist. The difference between "exists but is not yours" and "does not exist" is exactly what makes id enumeration worth doing.

### The diff endpoint was a second read primitive

Only `versionId` passes through the access check. `compareVersionId` did not, and the diff output contains **both** sides:

```
GET /api/note-versions/version/<one I can read>/diff/<any version in the database>
```

Both versions must now belong to the same meeting *and* the same field.

### The restore was lossy in a way the API did not disclose

For `collaborativeNotes` the meeting also carries `crdtState`, the Yjs binary document. `restoreVersion` wrote only the plain-text column — the controller comment acknowledged this and left it. Because `getOrCreateDoc` rehydrates from `crdtState`, the next client to open the notes reinstated the *pre-restore* text, and `saveDocumentState`'s debounced flush wrote it back over the restored value. The restore returned `200`, looked correct in any read-only view, and then reverted.

`restoreCollaborativeNotes` in `socket/documentSync.js` handles both cases:

- **Cold document** — nobody connected. A fresh `Y.Doc` seeded with the restored text is encoded and stored, so the next `getOrCreateDoc` rehydrates the right content.
- **Live document** — someone has the notes open, so the authoritative copy is the in-memory `Y.Doc`. The replacement is applied as a Yjs transaction, and the resulting update is broadcast to the room and published to Redis, so connected clients converge on the restored text instead of overwriting it on their next edit. A pending debounced save is cancelled rather than raced.

`documentSync` is imported lazily on that one path: `documentService.js` already imports `snapshotNoteVersion` from this controller, so a static import would close a cycle, and `documentSync` top-level-awaits a Redis connection no other handler should wait on.

### Smaller things in the same handlers

- `getVersionHistory` is paginated (default 25, max 100). It returned every snapshot, and `saveDocumentState` writes one per debounced flush — so the list grows without limit for exactly the meetings anyone would want to inspect.
- A malformed id is a `400` rather than a `CastError` surfacing as `500`.
- An unknown `:field` is a `400`. `.../crdtState/history` used to reach the database and return `[]`, which reads as "this meeting has no history" rather than "that is not a field".

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1158

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/noteVersionAuthorization.test.js` — 25 tests, `mongodb-memory-server` + `supertest`.

These mount the **real router** on a bare app rather than calling handlers directly. That is the point: the bug was in the route definitions, so a test that invoked the controller would have passed on the vulnerable code. Only `userAuth` is stubbed — with a switch that injects whichever `req.user` the test wants — and the project's real `errorHandler` is mounted so statuses and bodies match production.

**Cross-tenant reads** — history, content and diff each refused for a caller in another organization, where `main` returns `200` with the full payload. The "not yours" response is byte-identical to the "does not exist" response. A session with no organization is refused. An unauthenticated caller is `401`.

**Cross-tenant write** — a restore from another organization is refused *and* the victim meeting's summary is asserted unchanged afterwards. A `guest` in the owning organization can read a version and cannot restore it, and the meeting is again asserted unchanged.

**Diff boundaries** — refuses to diff across two meetings (both in the same org, so this is the guard and not the org check doing the work), refuses to diff `summary` against `collaborativeNotes`, still diffs two versions of the same meeting and field, and rejects a malformed comparison id.

**CRDT restore** — a stale `crdtState` blob plus divergent `collaborativeNotes` is seeded, the notes version is restored, and the stored blob is decoded with Yjs and asserted to contain the restored text. Asserting only that it changed would pass on any garbage write.

**Preserved behaviour** — history still excludes `content` and still sorts newest-first; restore still writes a new snapshot attributing the change to the caller; the meeting *owner* is still admitted even with no organization match, and everyone else is still refused for that meeting.

**Pagination** — 30 snapshots return 25 on page 1 with `hasMore: true`, and 5 on page 2 with `hasMore: false`.

**Confirmed load-bearing.** Against `main`'s route file and controller, **14 of these 25 fail** — every cross-tenant read, the cross-tenant restore, the view-but-not-edit case, both diff-across-boundary cases, unknown-field, missing-meeting, pagination and the CRDT check.

**Full server suite:** unchanged against `main` — 5 pre-existing suite failures and 1 pre-existing test failure on both, with 25 additional tests passing here.

> One note on the environment: the declared `diff` dependency was not installed in my checkout, which made 16 suites fail to load on `main` for reasons unrelated to any of this. I installed it locally (`--no-save`, so `package.json` is untouched) and took the `main` baseline again afterwards; the 5-failure figures above are both from that state.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
