### PR TITLE
fix(meetings): persist agenda timer state (#1159)

### DIFF
--- a/client/src/components/meeting-details/AgendaTimer.jsx
+++ b/client/src/components/meeting-details/AgendaTimer.jsx
@@ -7,6 +7,7 @@ import { Play, Square, SkipForward, AlertTriangle } from "lucide-react";
 import {
   formatClock,
   getItemTiming,
+  readAgendaElapsedMs,
   summarizeAgendaTiming,
 } from "../../utils/agendaTiming";
 import { createClerkSocketOptions } from "../../services/apiClient.js";
@@ -26,24 +27,26 @@ const AgendaTimer = ({ meeting }) => {
     // Find active item
     const currentActive = agendaItems.find((item) => item.status === "active");
     setActiveItem(currentActive || null);
-
-    if (currentActive && currentActive.startedAt) {
-      const start = new Date(currentActive.startedAt).getTime();
-      const current = new Date().getTime();
-      setElapsedMs(current - start + (currentActive.actualDuration || 0));
-    } else {
-      setElapsedMs(0);
-    }
+    setElapsedMs(readAgendaElapsedMs(currentActive));
   }, [agendaItems]);
 
   useEffect(() => {
-    if (activeItem) {
-      timerRef.current = setInterval(() => {
-        setElapsedMs((prev) => prev + 1000);
-      }, 1000);
-    } else {
+    if (!activeItem) {
       clearInterval(timerRef.current);
+      return undefined;
     }
+
+    // Issue #1159 — this used to be `setElapsedMs((prev) => prev + 1000)`, so
+    // the displayed time was a count of ticks rather than a measurement.
+    // Browsers clamp `setInterval` to roughly once a minute in a backgrounded
+    // tab, which is exactly where a live meeting timer spends its time: the
+    // clock fell minutes behind and never caught up, and the overrun warning
+    // fired late or not at all. Recomputing from `startedAt` makes a dropped
+    // tick cost nothing but a late repaint.
+    const tick = () => setElapsedMs(readAgendaElapsedMs(activeItem));
+
+    tick();
+    timerRef.current = setInterval(tick, 1000);
 
     return () => clearInterval(timerRef.current);
   }, [activeItem]);

--- a/client/src/utils/__tests__/agendaTiming.test.js
+++ b/client/src/utils/__tests__/agendaTiming.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   formatClock,
   getItemTiming,
+  readAgendaElapsedMs,
   summarizeAgendaTiming,
 } from "../agendaTiming.js";
 
@@ -110,5 +111,80 @@ describe("summarizeAgendaTiming", () => {
       isOverrun: false,
       overrunMs: 0,
     });
+  });
+});
+
+describe("readAgendaElapsedMs (Issue #1159)", () => {
+  const T0 = new Date("2026-08-04T10:00:00.000Z").getTime();
+
+  it("returns zero for a missing item", () => {
+    expect(readAgendaElapsedMs(null, T0)).toBe(0);
+    expect(readAgendaElapsedMs(undefined, T0)).toBe(0);
+  });
+
+  it("returns only the banked total for a stopped item", () => {
+    const item = {
+      status: "completed",
+      actualDuration: 7 * MINUTE,
+      startedAt: new Date(T0 - 99 * MINUTE).toISOString(),
+    };
+
+    // `startedAt` is stale bookkeeping once the item is no longer running; it
+    // must not be added a second time.
+    expect(readAgendaElapsedMs(item, T0)).toBe(7 * MINUTE);
+  });
+
+  it("adds the time on the clock for a running item", () => {
+    const item = {
+      status: "active",
+      actualDuration: 4 * MINUTE,
+      startedAt: new Date(T0 - 3 * MINUTE).toISOString(),
+    };
+
+    // Banked plus live — the server only folds the current interval into
+    // `actualDuration` on stop, skip, or a switch to another item.
+    expect(readAgendaElapsedMs(item, T0)).toBe(7 * MINUTE);
+  });
+
+  it("does not drift when ticks are dropped", () => {
+    // This is the whole point of deriving rather than counting. A backgrounded
+    // tab is clamped to roughly one tick a minute, so a counter would be four
+    // minutes behind after four minutes hidden; a derived value is exact
+    // whenever it next runs.
+    const item = {
+      status: "active",
+      actualDuration: 0,
+      startedAt: new Date(T0).toISOString(),
+    };
+
+    expect(readAgendaElapsedMs(item, T0 + 1000)).toBe(1000);
+    // ...no ticks at all for the next four minutes...
+    expect(readAgendaElapsedMs(item, T0 + 4 * MINUTE)).toBe(4 * MINUTE);
+  });
+
+  it("treats an active item with no start marker as banked-only", () => {
+    expect(
+      readAgendaElapsedMs({ status: "active", actualDuration: 2 * MINUTE }, T0),
+    ).toBe(2 * MINUTE);
+  });
+
+  it("ignores an unparseable startedAt rather than reporting NaN", () => {
+    const elapsed = readAgendaElapsedMs(
+      { status: "active", actualDuration: 60_000, startedAt: "not a date" },
+      T0,
+    );
+
+    expect(elapsed).toBe(60_000);
+  });
+
+  it("never goes negative on a future startedAt", () => {
+    const item = {
+      status: "active",
+      actualDuration: 0,
+      startedAt: new Date(T0 + 5 * MINUTE).toISOString(),
+    };
+
+    // Clock skew between instances must not produce a negative clock.
+    expect(readAgendaElapsedMs(item, T0)).toBe(0);
   });
 });

--- a/client/src/utils/agendaTiming.js
+++ b/client/src/utils/agendaTiming.js
@@ -15,6 +15,35 @@ export const formatClock = (ms) => {
 };
 
 /**
+ * Total time an agenda item has used, in milliseconds, as of `now`.
+ *
+ * `actualDuration` is the time banked by previous sittings — the server only
+ * folds the current interval into it on stop, skip, or a switch to another
+ * item. So a *running* item's true elapsed time is that total plus whatever is
+ * on the clock since `startedAt`.
+ *
+ * Deriving this rather than counting up from a `setInterval` is the point
+ * (Issue #1159): browsers clamp timers to roughly once a minute in a
+ * backgrounded tab, and a live meeting timer is very often in one. A counter
+ * loses that time permanently; a derived value merely repaints late.
+ *
+ * @param {object|null|undefined} item
+ * @param {number} [now] epoch millis, injectable for tests
+ * @returns {number}
+ */
+export const readAgendaElapsedMs = (item, now = Date.now()) => {
+  if (!item) return 0;
+
+  const banked = Math.max(0, item.actualDuration || 0);
+  if (item.status !== "active" || !item.startedAt) return banked;
+
+  const startedAt = new Date(item.startedAt).getTime();
+  if (Number.isNaN(startedAt)) return banked;
+
+  return banked + Math.max(0, now - startedAt);
+};
+
+/**
  * Compares an agenda item's planned duration against the time it has actually
  * used. `liveElapsedMs` is the ticking value for the currently active item.
  *

--- a/server/controllers/agendaTimerController.js
+++ b/server/controllers/agendaTimerController.js
@@ -1,17 +1,72 @@
 import Meeting from "../models/meetingModel.js";
 
-// Utility to check permissions (Organizer or Admin)
-const hasPermission = (meeting, userId, userRole) => {
-  const isUploader = meeting.uploadedBy.toString() === userId;
-  const isOrgAdmin = userRole === "admin" || userRole === "owner";
+/**
+ * May this user drive the agenda timer for this meeting?
+ *
+ * Two things were wrong here (Issue #1159):
+ *
+ *   - `isOrgAdmin` was `userRole === "admin" || "owner"` with no reference to
+ *     the meeting at all. `userRole` is the caller's role in *their own*
+ *     organization, and `meeting` came from a bare `Meeting.findById` with no
+ *     org filter, so anyone who was an admin anywhere satisfied it for a
+ *     meeting in *any* organization. The route-level `requireOrgAccess` added
+ *     alongside this change is the primary fix; scoping the check here means
+ *     the handler is not relying on the router to be correct.
+ *   - `userId` came from `req.user.id`, the Mongoose virtual. It happens to
+ *     work, but it is the only place in the file reading it that way, so it
+ *     now takes `req.user` and normalizes internally.
+ */
+const canManageTimers = (meeting, user) => {
+  if (!meeting || !user) return false;
+
+  const userId = (user._id ?? user.id)?.toString();
+  if (!userId) return false;
+
+  const isUploader = meeting.uploadedBy?.toString() === userId;
+
+  const sameOrg = Boolean(
+    meeting.organization &&
+    user.organization &&
+    meeting.organization.toString() === user.organization.toString(),
+  );
+  const isOrgAdmin =
+    sameOrg && (user.role === "admin" || user.role === "owner");
 
   return isUploader || isOrgAdmin;
 };
 
+/**
+ * Folds a running item's elapsed time into its accumulated total and clears
+ * the start marker.
+ *
+ * `startAgendaItem` used to demote a running item to `pending` with no time
+ * accounting — the comment said so ("let's keep it simple for now"). Because a
+ * later restart overwrites `startedAt`, the first interval was unrecoverable.
+ * That was latent while nothing persisted; it becomes real data loss the moment
+ * the schema is fixed, so it is fixed here in the same change.
+ *
+ * Guards against a negative contribution: a `startedAt` in the future (clock
+ * skew across instances, or a hand-edited document) must not subtract from an
+ * accumulated total.
+ */
+const accumulateElapsed = (item, now) => {
+  if (!item.startedAt) return 0;
+
+  const elapsed = Math.max(0, now.getTime() - item.startedAt.getTime());
+  item.actualDuration = (item.actualDuration || 0) + elapsed;
+  item.startedAt = null;
+
+  return elapsed;
+};
+
+/** True once every item has reached a terminal state. */
+const allItemsFinished = (items) =>
+  items.length > 0 &&
+  items.every((ai) => ai.status === "completed" || ai.status === "skipped");
+
 export const startAgendaItem = async (req, res) => {
   try {
     const { meetingId, itemId } = req.params;
-    const userId = req.user.id;
 
     const meeting = await Meeting.findById(meetingId);
     if (!meeting) {
@@ -20,7 +75,7 @@ export const startAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId, req.user.role)) {
+    if (!canManageTimers(meeting, req.user)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });
@@ -33,19 +88,31 @@ export const startAgendaItem = async (req, res) => {
         .json({ success: false, message: "Agenda item not found" });
     }
 
-    // Set other items to pending if they were active
+    const now = new Date();
+
+    // Set other items to pending if they were active — banking their elapsed
+    // time on the way, rather than discarding it.
     meeting.agendaItems.forEach((ai) => {
-      if (ai.status === "active") {
+      if (ai._id.toString() !== itemId && ai.status === "active") {
+        accumulateElapsed(ai, now);
         ai.status = "pending";
-        // Optionally calculate duration for the interrupted item, but let's keep it simple for now
       }
     });
 
-    item.status = "active";
-    item.startedAt = new Date();
+    // Restarting the item that is already running would otherwise reset its
+    // clock and silently drop the interval so far.
+    if (item.status === "active") {
+      accumulateElapsed(item, now);
+    }
 
-    // Update meeting progress state
-    if (meeting.agendaProgress === "not_started") {
+    item.status = "active";
+    item.startedAt = now;
+    item.completedAt = null;
+
+    // Update meeting progress state. Resuming a skipped or completed item
+    // reopens the agenda, so `completed` is not a terminal state for the
+    // meeting either.
+    if (meeting.agendaProgress !== "in_progress") {
       meeting.agendaProgress = "in_progress";
     }
 
@@ -70,7 +137,6 @@ export const startAgendaItem = async (req, res) => {
 export const stopAgendaItem = async (req, res) => {
   try {
     const { meetingId, itemId } = req.params;
-    const userId = req.user.id;
 
     const meeting = await Meeting.findById(meetingId);
     if (!meeting) {
@@ -79,7 +145,7 @@ export const stopAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId, req.user.role)) {
+    if (!canManageTimers(meeting, req.user)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });
@@ -92,25 +158,26 @@ export const stopAgendaItem = async (req, res) => {
         .json({ success: false, message: "Agenda item not found" });
     }
 
+    // This guard is why `stop` returned 400 on every request: `status` was
+    // never persisted, so the reloaded item always had `undefined` here. The
+    // guard itself is correct and stays — it just has real state to read now.
     if (item.status !== "active") {
       return res
         .status(400)
         .json({ success: false, message: "Agenda item is not active" });
     }
 
+    const now = new Date();
+    // `accumulateElapsed` adds to `actualDuration` and clears `startedAt`. The
+    // old `item.actualDuration += elapsed` would have produced `NaN` on any
+    // item whose total had not been initialized — which, with the field absent
+    // from the schema, was all of them.
+    accumulateElapsed(item, now);
     item.status = "completed";
-    item.completedAt = new Date();
-
-    if (item.startedAt) {
-      const elapsed = item.completedAt.getTime() - item.startedAt.getTime();
-      item.actualDuration += elapsed;
-    }
+    item.completedAt = now;
 
     // Check if all items are completed/skipped
-    const allDone = meeting.agendaItems.every(
-      (ai) => ai.status === "completed" || ai.status === "skipped",
-    );
-    if (allDone) {
+    if (allItemsFinished(meeting.agendaItems)) {
       meeting.agendaProgress = "completed";
     }
 
@@ -135,7 +202,6 @@ export const stopAgendaItem = async (req, res) => {
 export const skipAgendaItem = async (req, res) => {
   try {
     const { meetingId, itemId } = req.params;
-    const userId = req.user.id;
 
     const meeting = await Meeting.findById(meetingId);
     if (!meeting) {
@@ -144,7 +210,7 @@ export const skipAgendaItem = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    if (!hasPermission(meeting, userId, req.user.role)) {
+    if (!canManageTimers(meeting, req.user)) {
       return res
         .status(403)
         .json({ success: false, message: "Not authorized to manage timers" });
@@ -157,20 +223,17 @@ export const skipAgendaItem = async (req, res) => {
         .json({ success: false, message: "Agenda item not found" });
     }
 
+    // Skipping a running item keeps whatever time it did use — the discussion
+    // happened, it just was not finished.
     if (item.status === "active") {
-      item.completedAt = new Date();
-      if (item.startedAt) {
-        const elapsed = item.completedAt.getTime() - item.startedAt.getTime();
-        item.actualDuration += elapsed;
-      }
+      const now = new Date();
+      accumulateElapsed(item, now);
+      item.completedAt = now;
     }
 
     item.status = "skipped";
 
-    const allDone = meeting.agendaItems.every(
-      (ai) => ai.status === "completed" || ai.status === "skipped",
-    );
-    if (allDone) {
+    if (allItemsFinished(meeting.agendaItems)) {
       meeting.agendaProgress = "completed";
     }
 
@@ -205,15 +268,33 @@ export const getAgendaPacingReport = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
-    const reportData = meeting.agendaItems.map((item) => ({
-      id: item._id,
-      text: item.text,
-      plannedDuration: item.duration || 0, // in minutes
-      actualDuration: item.actualDuration
-        ? Math.round(item.actualDuration / 60000)
-        : 0, // convert ms to minutes
-      status: item.status,
-    }));
+    const now = Date.now();
+
+    const reportData = meeting.agendaItems.map((item) => {
+      // An item that is running right now has time on the clock that is not
+      // yet in `actualDuration` — that is only banked on stop/skip/switch.
+      // Without this the currently-active item reports 0, which is the one row
+      // anybody watching a live meeting is looking at.
+      const liveElapsed =
+        item.status === "active" && item.startedAt
+          ? Math.max(0, now - new Date(item.startedAt).getTime())
+          : 0;
+
+      const actualMs = (item.actualDuration || 0) + liveElapsed;
+
+      return {
+        id: item._id,
+        text: item.text,
+        plannedDuration: item.duration || 0, // in minutes
+        actualDuration: Math.round(actualMs / 60000), // convert ms to minutes
+        // Rounding to whole minutes loses the difference between a 5-minute
+        // item that ran 5m00s and one that ran 5m50s, so the unrounded value
+        // is reported alongside it. `AgendaPacingReport.jsx` keeps charting
+        // `actualDuration`; this is for anything that needs the real figure.
+        actualDurationMs: actualMs,
+        status: item.status,
+      };
+    });
 
     const summaryStats = {
       totalPlanned: reportData.reduce(
@@ -225,8 +306,14 @@ export const getAgendaPacingReport = async (req, res) => {
         0,
       ),
       itemsSkipped: reportData.filter((i) => i.status === "skipped").length,
+      // Compared in milliseconds against the planned minutes, so an item that
+      // overruns by less than 30 seconds is still counted — rounding both
+      // sides to minutes first hid exactly the overruns worth reporting. An
+      // item with no planned duration cannot be over its plan.
       itemsOverTime: reportData.filter(
-        (i) => i.actualDuration > i.plannedDuration,
+        (i) =>
+          i.plannedDuration > 0 &&
+          i.actualDurationMs > i.plannedDuration * 60000,
       ).length,
     };
 

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -58,8 +58,36 @@ const meetingSchema = new mongoose.Schema(
       {
         text: { type: String, required: true },
         description: { type: String, default: "" },
+        // Planned length, in MINUTES. Named `duration` for backwards
+        // compatibility; see `actualDuration` below for the unit mismatch this
+        // creates and why it is deliberate.
         duration: { type: Number, default: null },
         position: { type: Number, min: 0, default: 0 },
+
+        // ── Live agenda timer (Issue #1159) ────────────────────────────────
+        // `agendaTimerController` has always written these four fields. None
+        // of them existed on the schema, and Mongoose is strict by default, so
+        // every assignment was discarded before the document was saved — the
+        // start/stop/skip endpoints returned 200 and persisted nothing, `stop`
+        // returned 400 unconditionally because `status` was always `undefined`
+        // on reload, and the pacing report was structurally all zeros.
+        status: {
+          type: String,
+          enum: ["pending", "active", "completed", "skipped"],
+          default: "pending",
+        },
+        startedAt: { type: Date, default: null },
+        completedAt: { type: Date, default: null },
+        // Accumulated elapsed time, in MILLISECONDS.
+        //
+        // The unit differs from `duration` above, which is minutes. That is not
+        // an oversight: `getAgendaPacingReport` already divides this by 60000
+        // to report minutes, and `client/src/utils/agendaTiming.js` already
+        // multiplies `duration` by 60 * 1000 to compare them. Both sides were
+        // written against milliseconds; storing minutes here would silently
+        // break both. It accumulates across start/stop cycles, so an item that
+        // is paused and resumed reports its total.
+        actualDuration: { type: Number, default: 0, min: 0 },
       },
     ],
     policyDetails: {
@@ -162,6 +190,18 @@ const meetingSchema = new mongoose.Schema(
     collaborativeNotes: {
       type: String, // Plain-text snapshot for read-only views and semantic search
       default: "",
+    },
+
+    // Overall progress through the agenda (Issue #1159).
+    //
+    // `agendaTimerController` set this on the document and
+    // `getAgendaPacingReport` selected and returned it, but it was never a
+    // schema path — so the write was dropped and the read was always
+    // `undefined`.
+    agendaProgress: {
+      type: String,
+      enum: ["not_started", "in_progress", "completed"],
+      default: "not_started",
     },
   },
   { timestamps: true },

--- a/server/routes/agendaTimerRoutes.js
+++ b/server/routes/agendaTimerRoutes.js
@@ -13,9 +13,35 @@ const router = express.Router();
 
 router.use(userAuth);
 
-router.put("/:meetingId/agenda/:itemId/start", startAgendaItem);
-router.put("/:meetingId/agenda/:itemId/stop", stopAgendaItem);
-router.put("/:meetingId/agenda/:itemId/skip", skipAgendaItem);
+// Issue #1159 — the read-only pacing route was given `requireOrgAccess` and
+// `requirePermission` (for #817); the three *mutating* routes were left with
+// `userAuth` alone. Their only check was the controller's `hasPermission`,
+// which treated "is an admin or owner" as sufficient without reference to the
+// meeting's organization — so an admin of any tenant could drive the timer on
+// any meeting, and the resulting `agenda_timer_updated` broadcast landed in the
+// victim's meeting room.
+//
+// Starting, stopping and skipping change the meeting document, so they require
+// `meetings:edit` rather than `meetings:view`.
+
+router.put(
+  "/:meetingId/agenda/:itemId/start",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  startAgendaItem,
+);
+router.put(
+  "/:meetingId/agenda/:itemId/stop",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  stopAgendaItem,
+);
+router.put(
+  "/:meetingId/agenda/:itemId/skip",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  skipAgendaItem,
+);
 router.get(
   "/:meetingId/pacing",
   requireOrgAccess(Meeting),

--- a/server/tests/agendaTimerPersistence.test.js
+++ b/server/tests/agendaTimerPersistence.test.js
@@ -1,0 +1,521 @@
+/**
+ * Regression tests for Issue #1159 — the agenda timer persisted nothing.
+ *
+ * `agendaTimerController` wrote `status`, `startedAt`, `completedAt` and
+ * `actualDuration` onto agenda subdocuments, and `agendaProgress` onto the
+ * meeting. None of those were schema paths, and Mongoose is strict by default,
+ * so every assignment was discarded before the save.
+ *
+ * The critical property of this suite is that **every assertion goes through a
+ * save/reload cycle**. `agendaPacingAuthorization.test.js` and
+ * `meetingHealth.test.js` both build agenda items as plain object literals and
+ * never persist them, which is exactly why a feature that saved nothing looked
+ * fine for as long as it did. A test that trusts an in-memory subdocument
+ * proves nothing here: `item.status = "active"` sets a plain JS property that
+ * reads back correctly and is dropped on `toObject()`.
+ *
+ * Confirmed load-bearing: against `main`'s model, controller, routes and
+ * ordering util, 23 of these 26 fail.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: agendaTimerRoutes } =
+  await import("../routes/agendaTimerRoutes.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { normalizeAgendaItems } = await import("../utils/agendaOrdering.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const organizer = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+const adminInOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+const viewerInOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "guest",
+};
+const adminInOrgB = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "owner", // privileged — in a different tenant
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/meetings/timer", agendaTimerRoutes);
+});
+
+beforeEach(() => {
+  currentUser = organizer;
+});
+
+const seedMeeting = async () =>
+  Meeting.create({
+    uploadedBy: organizer._id,
+    organization: ORG_A,
+    title: "Sprint review",
+    date: new Date(),
+    agendaItems: [
+      { text: "Opening", duration: 5 },
+      { text: "Demo", duration: 20 },
+      { text: "Retro", duration: 10 },
+    ],
+  });
+
+/** Reloads from the database — the only view of state this suite trusts. */
+const reload = (id) => Meeting.findById(id);
+
+const start = (meeting, item) =>
+  request(app).put(
+    `/api/meetings/timer/${meeting._id}/agenda/${item._id}/start`,
+  );
+const stop = (meeting, item) =>
+  request(app).put(
+    `/api/meetings/timer/${meeting._id}/agenda/${item._id}/stop`,
+  );
+const skip = (meeting, item) =>
+  request(app).put(
+    `/api/meetings/timer/${meeting._id}/agenda/${item._id}/skip`,
+  );
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("schema", () => {
+  it("declares every field the timer writes", () => {
+    const paths = Object.keys(Meeting.schema.path("agendaItems").schema.paths);
+
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        "status",
+        "startedAt",
+        "completedAt",
+        "actualDuration",
+      ]),
+    );
+    expect(Meeting.schema.path("agendaProgress")).toBeDefined();
+  });
+
+  it("defaults a new item to pending with a zeroed clock", async () => {
+    const meeting = await seedMeeting();
+    const reloaded = await reload(meeting._id);
+
+    expect(reloaded.agendaItems[0].status).toBe("pending");
+    expect(reloaded.agendaItems[0].actualDuration).toBe(0);
+    expect(reloaded.agendaItems[0].startedAt).toBeNull();
+    expect(reloaded.agendaProgress).toBe("not_started");
+  });
+
+  it("survives the pre-validate normalization hook", async () => {
+    // `meetingSchema.pre("validate")` rebuilds `agendaItems` through
+    // `normalizeAgendaItems` on every modification. If that ever stops
+    // preserving unknown fields, the timer state is stripped on save and this
+    // whole feature silently regresses to its previous behaviour.
+    const meeting = await seedMeeting();
+    const item = meeting.agendaItems[0];
+    item.status = "active";
+    item.actualDuration = 4321;
+    meeting.title = "Renamed, forcing another save";
+    await meeting.save();
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaItems[0].status).toBe("active");
+    expect(reloaded.agendaItems[0].actualDuration).toBe(4321);
+  });
+
+  it("normalizeAgendaItems preserves timer fields while reordering", () => {
+    const out = normalizeAgendaItems([
+      { text: "Second", position: 1, status: "completed", actualDuration: 900 },
+      { text: "First", position: 0, status: "active", actualDuration: 100 },
+    ]);
+
+    expect(out.map((i) => i.text)).toEqual(["First", "Second"]);
+    expect(out[0]).toMatchObject({ status: "active", actualDuration: 100 });
+    expect(out[1]).toMatchObject({ status: "completed", actualDuration: 900 });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("PUT .../start", () => {
+  it("persists active status and a start marker", async () => {
+    const meeting = await seedMeeting();
+
+    const res = await start(meeting, meeting.agendaItems[0]).expect(200);
+    expect(res.body.item.status).toBe("active");
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaItems[0].status).toBe("active");
+    expect(reloaded.agendaItems[0].startedAt).toBeInstanceOf(Date);
+    expect(reloaded.agendaProgress).toBe("in_progress");
+  });
+
+  it("banks the elapsed time of the item it interrupts", async () => {
+    const meeting = await seedMeeting();
+    const [first, second] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+
+    // Backdate the start so there is a measurable interval without sleeping.
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 90_000) } },
+    );
+
+    await start(meeting, second).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    const interrupted = reloaded.agendaItems.id(first._id);
+
+    expect(interrupted.status).toBe("pending");
+    // Against `main` this was 0 — the interrupted item's time was discarded
+    // with a comment saying so.
+    expect(interrupted.actualDuration).toBeGreaterThanOrEqual(89_000);
+    expect(interrupted.startedAt).toBeNull();
+    expect(reloaded.agendaItems.id(second._id).status).toBe("active");
+  });
+
+  it("does not reset the clock when restarting the running item", async () => {
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 60_000) } },
+    );
+    await start(meeting, first).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    const item = reloaded.agendaItems.id(first._id);
+
+    expect(item.status).toBe("active");
+    expect(item.actualDuration).toBeGreaterThanOrEqual(59_000);
+  });
+
+  it("404s for an unknown agenda item", async () => {
+    const meeting = await seedMeeting();
+
+    await request(app)
+      .put(
+        `/api/meetings/timer/${meeting._id}/agenda/${new mongoose.Types.ObjectId()}/start`,
+      )
+      .expect(404);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("PUT .../stop", () => {
+  it("completes an item that was started", async () => {
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+    // Against `main` this was a guaranteed 400: `status` never persisted, so
+    // the reloaded item was always `undefined` at the guard.
+    await stop(meeting, first).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    const item = reloaded.agendaItems.id(first._id);
+
+    expect(item.status).toBe("completed");
+    expect(item.completedAt).toBeInstanceOf(Date);
+    expect(item.startedAt).toBeNull();
+    expect(Number.isFinite(item.actualDuration)).toBe(true);
+  });
+
+  it("accumulates across a stop / restart / stop cycle", async () => {
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 30_000) } },
+    );
+    await stop(meeting, first).expect(200);
+
+    await start(meeting, first).expect(200);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 20_000) } },
+    );
+    await stop(meeting, first).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    // ~50s total, not ~20s — the point of accumulating rather than assigning.
+    expect(reloaded.agendaItems.id(first._id).actualDuration).toBeGreaterThan(
+      45_000,
+    );
+  });
+
+  it("still rejects stopping an item that is not running", async () => {
+    const meeting = await seedMeeting();
+
+    const res = await stop(meeting, meeting.agendaItems[0]).expect(400);
+    expect(res.body.message).toMatch(/not active/i);
+  });
+
+  it("marks the agenda completed once the last item finishes", async () => {
+    const meeting = await seedMeeting();
+
+    for (const item of meeting.agendaItems) {
+      await start(meeting, item).expect(200);
+      await stop(meeting, item).expect(200);
+    }
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaProgress).toBe("completed");
+  });
+
+  it("never produces NaN for actualDuration", async () => {
+    // `item.actualDuration += elapsed` on an undefined total yields NaN, which
+    // Mongoose would then have rejected — except the field did not exist, so
+    // this failure mode was invisible.
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+    await stop(meeting, first).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    expect(
+      Number.isNaN(reloaded.agendaItems.id(first._id).actualDuration),
+    ).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("PUT .../skip", () => {
+  it("persists skipped status", async () => {
+    const meeting = await seedMeeting();
+
+    await skip(meeting, meeting.agendaItems[1]).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaItems[1].status).toBe("skipped");
+  });
+
+  it("keeps the time a skipped item had already used", async () => {
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 45_000) } },
+    );
+    await skip(meeting, first).expect(200);
+
+    const reloaded = await reload(meeting._id);
+    const item = reloaded.agendaItems.id(first._id);
+
+    expect(item.status).toBe("skipped");
+    expect(item.actualDuration).toBeGreaterThanOrEqual(44_000);
+  });
+
+  it("completes the agenda when the last remaining item is skipped", async () => {
+    const meeting = await seedMeeting();
+
+    for (const item of meeting.agendaItems) {
+      await skip(meeting, item).expect(200);
+    }
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaProgress).toBe("completed");
+  });
+
+  it("reopens the agenda if a skipped item is started again", async () => {
+    const meeting = await seedMeeting();
+
+    for (const item of meeting.agendaItems) {
+      await skip(meeting, item).expect(200);
+    }
+    expect((await reload(meeting._id)).agendaProgress).toBe("completed");
+
+    await start(meeting, meeting.agendaItems[0]).expect(200);
+    expect((await reload(meeting._id)).agendaProgress).toBe("in_progress");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET .../pacing", () => {
+  const pacing = (meeting) =>
+    request(app).get(`/api/meetings/timer/${meeting._id}/pacing`);
+
+  it("reports real figures rather than structural zeros", async () => {
+    const meeting = await seedMeeting();
+    const [first, second] = meeting.agendaItems;
+
+    await start(meeting, first);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      {
+        $set: { "agendaItems.$.startedAt": new Date(Date.now() - 7 * 60_000) },
+      },
+    );
+    await stop(meeting, first).expect(200);
+    await skip(meeting, second).expect(200);
+
+    const res = await pacing(meeting).expect(200);
+
+    expect(res.body.reportData[0].actualDuration).toBe(7); // minutes
+    expect(res.body.reportData[0].status).toBe("completed");
+    expect(res.body.summaryStats.itemsSkipped).toBe(1);
+    // Planned 5, actual 7 → over time. Against `main` this was always 0,
+    // because `undefined > undefined` is false.
+    expect(res.body.summaryStats.itemsOverTime).toBe(1);
+    expect(res.body.agendaProgress).toBe("in_progress");
+  });
+
+  it("includes the time on the clock for a running item", async () => {
+    const meeting = await seedMeeting();
+    const [first] = meeting.agendaItems;
+
+    await start(meeting, first).expect(200);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": first._id },
+      {
+        $set: { "agendaItems.$.startedAt": new Date(Date.now() - 3 * 60_000) },
+      },
+    );
+
+    const res = await pacing(meeting).expect(200);
+    // `actualDuration` is only banked on stop/skip/switch, so without the live
+    // adjustment the currently-running row — the one anyone watching a live
+    // meeting is looking at — reads 0.
+    expect(res.body.reportData[0].actualDurationMs).toBeGreaterThanOrEqual(
+      179_000,
+    );
+  });
+
+  it("does not count an item with no planned duration as over time", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: organizer._id,
+      organization: ORG_A,
+      title: "Unplanned",
+      date: new Date(),
+      agendaItems: [{ text: "Open floor" }], // no `duration`
+    });
+    const [item] = meeting.agendaItems;
+
+    await start(meeting, item);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": item._id },
+      { $set: { "agendaItems.$.startedAt": new Date(Date.now() - 60_000) } },
+    );
+    await stop(meeting, item).expect(200);
+
+    const res = await pacing(meeting).expect(200);
+    expect(res.body.summaryStats.itemsOverTime).toBe(0);
+  });
+
+  it("counts an overrun of under thirty seconds", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: organizer._id,
+      organization: ORG_A,
+      title: "Tight",
+      date: new Date(),
+      agendaItems: [{ text: "Standup", duration: 5 }],
+    });
+    const [item] = meeting.agendaItems;
+
+    await start(meeting, item);
+    await Meeting.updateOne(
+      { _id: meeting._id, "agendaItems._id": item._id },
+      {
+        $set: {
+          "agendaItems.$.startedAt": new Date(
+            Date.now() - (5 * 60_000 + 10_000),
+          ),
+        },
+      },
+    );
+    await stop(meeting, item).expect(200);
+
+    const res = await pacing(meeting).expect(200);
+    // Rounds to 5 minutes, so a minute-granularity comparison would miss it.
+    expect(res.body.reportData[0].actualDuration).toBe(5);
+    expect(res.body.summaryStats.itemsOverTime).toBe(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("authorization", () => {
+  it("refuses a privileged caller from another organization", async () => {
+    const meeting = await seedMeeting();
+    currentUser = adminInOrgB;
+
+    // Against `main`: 200. `hasPermission` accepted any admin or owner without
+    // reference to the meeting's organization, and the route had no guard.
+    await start(meeting, meeting.agendaItems[0]).expect(403);
+    await stop(meeting, meeting.agendaItems[0]).expect(403);
+    await skip(meeting, meeting.agendaItems[0]).expect(403);
+
+    const reloaded = await reload(meeting._id);
+    expect(reloaded.agendaItems[0].status).toBe("pending");
+    expect(reloaded.agendaProgress).toBe("not_started");
+  });
+
+  it("allows an admin of the meeting's own organization", async () => {
+    const meeting = await seedMeeting();
+    currentUser = adminInOrgA;
+
+    await start(meeting, meeting.agendaItems[0]).expect(200);
+    expect((await reload(meeting._id)).agendaItems[0].status).toBe("active");
+  });
+
+  it("refuses a member who may view but not edit", async () => {
+    const meeting = await seedMeeting();
+    currentUser = viewerInOrgA;
+
+    await start(meeting, meeting.agendaItems[0]).expect(403);
+    // ...but the read-only pacing report is still available to them.
+    await request(app)
+      .get(`/api/meetings/timer/${meeting._id}/pacing`)
+      .expect(200);
+  });
+
+  it("refuses an unauthenticated caller", async () => {
+    const meeting = await seedMeeting();
+    currentUser = null;
+
+    await start(meeting, meeting.agendaItems[0]).expect(401);
+  });
+
+  it("rejects a malformed meeting id with 400, not 500", async () => {
+    await request(app)
+      .put(
+        `/api/meetings/timer/not-an-objectid/agenda/${new mongoose.Types.ObjectId()}/start`,
+      )
+      .expect(400);
+  });
+});

--- a/server/utils/agendaOrdering.js
+++ b/server/utils/agendaOrdering.js
@@ -5,6 +5,17 @@ const getAgendaText = (item) =>
       ? item.title.trim()
       : "";
 
+/**
+ * Reorders agenda items and assigns contiguous `position` values.
+ *
+ * This runs from `meetingSchema.pre("validate")` on every modification, so it
+ * sees the live subdocuments — including the timer fields added for
+ * Issue #1159 (`status`, `startedAt`, `completedAt`, `actualDuration`). It must
+ * therefore preserve every field it does not own. The `...item` spread below is
+ * what guarantees that; replacing it with an explicit field list would strip
+ * the timer state on every save, reproducing the original bug from the other
+ * direction.
+ */
 export const normalizeAgendaItems = (items = []) => {
   if (!Array.isArray(items)) return [];
 


### PR DESCRIPTION
# Pull Request

## Description

`agendaTimerController` writes five fields. None of them existed on the schema.

```js
agendaItems: [
  {
    text:        { type: String, required: true },
    description: { type: String, default: "" },
    duration:    { type: Number, default: null },
    position:    { type: Number, min: 0, default: 0 },
  },
],
```

No `status`, no `startedAt`, no `completedAt`, no `actualDuration`. `meetingSchema` had no `agendaProgress` either. Mongoose is strict by default, so every assignment was silently discarded before the save:

```js
const item = m.agendaItems[0];
item.status = "active";
item.startedAt = new Date();

JSON.stringify(m.toObject().agendaItems);
// [{"text":"Item A","description":"","duration":10,"position":0,"_id":"..."}]

Object.keys(Meeting.schema.path("agendaItems").schema.paths);
// [ 'text', 'description', 'duration', 'position', '_id' ]

!!Meeting.schema.path("agendaProgress");
// false
```

The live agenda timer has never worked.

- **Start** returned `200` and persisted nothing. The response body did not contain `status` either, since `toJSON()` drops the ad-hoc properties — and `AgendaTimer.jsx` does `if (ai._id === item._id) return item`, *replacing* its optimistic state with that stripped object, so the row visibly reverted to idle for the clicker and never moved for anyone else in the room.
- **Stop** was a guaranteed `400`. `if (item.status !== "active")` reads a field that was never written, so it was `undefined` on every reload — including immediately after a `200` from start. There was no sequence of API calls that could complete an agenda item.
- **Skip** did nothing, same reason.
- **The pacing report** was structurally all zeros: `actualDuration` always `undefined`, `itemsSkipped` always `0`, and `itemsOverTime` comparing `undefined > undefined`, which is `false`.
- **`meetingHealthService.js:32`** sums `item.actualDuration || 0` across agenda items to derive a health signal. That sum is zero for every meeting in the database, and no error is ever raised.

### The fix

The four item fields and `agendaProgress` are declared, with defaults (`pending`, `0`, `null`, `not_started`) so existing documents read sensibly without a migration.

`actualDuration` stays in **milliseconds**, which does differ from `duration` above it in minutes. That is deliberate and now documented on the schema: `getAgendaPacingReport` already divides by `60000`, and `client/src/utils/agendaTiming.js` already multiplies `duration` by `60 * 1000` to compare them. Both sides were written against milliseconds all along; storing minutes would have quietly broken both.

`normalizeAgendaItems` — which `meetingSchema.pre("validate")` runs on every modification — already preserved unknown fields via its `...item` spread. That is load-bearing now, so it says so, and there is a test pinning it.

### Three things fixed alongside

These only become reachable once state persists, so leaving them would have shipped a feature that saves the wrong numbers.

**Interrupted items lost their time.** `startAgendaItem` demoted a running item to `pending` with no accounting — the comment said as much ("let's keep it simple for now"). A later restart overwrites `startedAt`, so the first interval was unrecoverable. Switching items now banks the elapsed time, and restarting the item that is already running accumulates rather than resetting.

**Start, stop and skip had no route-level authorization.** The pacing route was given `requireOrgAccess` + `requirePermission` (for #817); the three mutating routes were left with `userAuth` alone. Their only check was:

```js
const isOrgAdmin = userRole === "admin" || userRole === "owner";
```

`meeting` came from a bare `Meeting.findById` with no org filter and `userRole` is the caller's role in *their own* organization — so anyone who is an admin anywhere satisfied it for a meeting in **any** organization, and the resulting `agenda_timer_updated` broadcast landed in the victim's meeting room. The routes now carry `requireOrgAccess(Meeting)` + `meetings:edit`, and the controller's own check is scoped to the meeting's organization so it does not depend on the router being right.

**The pacing report under-reported.** It now includes the running item's live elapsed time — `actualDuration` is only banked on stop/skip/switch, so the currently-active row (the one anybody watching a live meeting is looking at) read `0`. It also reports an unrounded `actualDurationMs` and compares overruns in milliseconds, so a 5-minute item that ran 5m10s is flagged instead of rounding to exactly 5. An item with no planned duration is no longer counted as over time.

### Client

The live timer was `setElapsedMs((prev) => prev + 1000)` — a count of ticks, not a measurement. Browsers clamp `setInterval` to roughly once a minute in a backgrounded tab, which is exactly where a meeting timer spends its time: the clock fell minutes behind and never caught up, and the overrun toast fired late or not at all. It now derives elapsed time from `startedAt` via a new `readAgendaElapsedMs` in `agendaTiming.js`, so a dropped tick costs a late repaint and nothing else.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1159

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/agendaTimerPersistence.test.js` — 26 tests, `mongodb-memory-server` + `supertest` against the real router.

**Every assertion goes through a save/reload cycle.** That is the design constraint, not a stylistic choice: `item.status = "active"` sets a plain JS property that reads back correctly in-process and vanishes on `toObject()`. A test trusting an in-memory subdocument would have passed against the broken code — which is precisely how this survived. Both existing agenda suites (`agendaPacingAuthorization.test.js`, `meetingHealth.test.js`) build agenda items as object literals and never persist them.

**Schema** — every written field is a declared path; a new item defaults to `pending` / `0` / `null` / `not_started`; timer state survives a second save through the `pre("validate")` normalization hook; `normalizeAgendaItems` preserves timer fields while reordering.

**Start** — persists `active` and a start marker and flips `agendaProgress`; banks ~90s from the item it interrupts and clears its `startedAt`; restarting the running item does not reset its clock; unknown item id is `404`.

**Stop** — completes an item that was started (a guaranteed `400` before); accumulates across stop / restart / stop to ~50s rather than ~20s; still rejects stopping an idle item; completes the agenda when the last item finishes; `actualDuration` is never `NaN` (`+=` against an undefined total).

**Skip** — persists `skipped`; keeps the time a skipped item had used; completes the agenda when the last item is skipped; starting a skipped item reopens the agenda.

**Pacing** — real figures instead of structural zeros (7 minutes actual against 5 planned, 1 skipped, 1 over time); the running item's live time is included; an item with no planned duration is not over time; a 10-second overrun is counted even though it rounds to the same whole minute.

**Authorization** — an *owner of another organization* is refused on all three mutating routes and the meeting is asserted untouched afterwards; an admin of the meeting's own organization is allowed; a `guest` is refused on start but can still read the pacing report; unauthenticated is `401`; a malformed meeting id is `400` rather than `500`.

Elapsed intervals are produced by backdating `startedAt` with a direct `updateOne`, so there are no sleeps and no timing flakiness — the suite ran clean three times in a row.

`client/src/utils/__tests__/agendaTiming.test.js` — 7 tests added (17 total in that file, all passing under vitest): banked-only for a stopped item even with a stale `startedAt`; banked + live for a running one; **exact after four minutes with no ticks at all**, which is the backgrounded-tab case; active with no start marker; unparseable `startedAt` returns the banked total rather than `NaN`; a future `startedAt` (clock skew) never goes negative.

**Confirmed load-bearing.** Against `main`'s model, controller, routes and ordering util, **23 of the 26 server tests fail**.

**Full server suite:** unchanged against `main` — 5 pre-existing suite failures and 1 pre-existing test failure on both, with 26 additional tests passing here. Verified across two full runs.

> Two notes on pre-existing conditions I did not touch, both present on `main`:
> - `tests/agendaPacingAuthorization.test.js` is a **vitest** suite that is not in jest's `testPathIgnorePatterns`, so jest tries to collect it and the suite errors. It passes under `npx vitest run tests/agendaPacingAuthorization.test.js` — I ran it, 7/7 green, so the changes here do not regress it. Adding it to the ignore list is a one-line config fix but belongs to its own issue.
> - The declared `diff` dependency was not installed in my checkout; I installed it locally with `--no-save` so `package.json` is untouched, and took the `main` baseline in that same state.

## Screenshots

N/A — the visible change is a timer that persists; the server tests assert the state that drives it.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
