### PR TITLE
fix(meetings): link series occurrences and honour the recurrence day (#1160)

### DIFF
--- a/server/controllers/meetingSeriesController.js
+++ b/server/controllers/meetingSeriesController.js
@@ -1,8 +1,14 @@
 import { z } from "zod";
 import MeetingSeries from "../models/meetingSeriesModel.js";
 import Meeting from "../models/meetingModel.js";
-import { parseISO, addDays, addWeeks, addMonths } from "date-fns";
+import { parseISO } from "date-fns";
 import { parsePagination } from "../utils/pagination.js";
+import { normalizeAgendaItems } from "../utils/agendaOrdering.js";
+import {
+  generateOccurrenceDates,
+  parseMeetingTime,
+  MAX_OCCURRENCES,
+} from "../utils/recurrence.js";
 
 /**
  * Hard ceiling for the `limit=0` / `limit=all` whole-series response
@@ -25,7 +31,16 @@ const createSeriesSchema = z.object({
     .string()
     .refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
   endDate: z.string().refine((val) => !isNaN(Date.parse(val)), "Invalid date"),
-  time: z.string().min(1, "Time is required"),
+  // Was `z.string().min(1)`, so `"lunchtime"` was accepted and stored
+  // (Issue #1160). Both formats already present in the codebase are allowed:
+  // 24-hour `"14:30"` and 12-hour `"10:00 AM"`.
+  time: z
+    .string()
+    .min(1, "Time is required")
+    .refine(
+      (val) => parseMeetingTime(val) !== null,
+      "Time must be HH:MM (e.g. 14:30) or h:MM AM/PM (e.g. 2:30 PM)",
+    ),
   duration: z.number().optional().default(60),
   location: z.string().optional(),
   venue: z.string().optional(),
@@ -81,13 +96,43 @@ export const createSeries = async (req, res) => {
       });
     }
 
+    // Generate the occurrence dates *before* saving the series, so the values
+    // actually used for `dayOfWeek` / `dayOfMonth` can be written onto the
+    // series document. Previously the request's values were stored and then
+    // ignored, leaving the stored series describing a schedule its own meetings
+    // did not follow (Issue #1160).
+    const {
+      dates,
+      totalPossible,
+      truncated,
+      skippedMonths,
+      dayOfWeek: resolvedDayOfWeek,
+      dayOfMonth: resolvedDayOfMonth,
+    } = generateOccurrenceDates({
+      recurrencePattern,
+      startDate: start,
+      endDate: end,
+      dayOfWeek,
+      dayOfMonth,
+      time,
+      maxOccurrences: MAX_OCCURRENCES,
+    });
+
+    if (dates.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message:
+          "The requested schedule produces no meetings in the given date range.",
+      });
+    }
+
     const series = new MeetingSeries({
       title,
       organization: req.user.organization,
       createdBy: req.user._id,
       recurrencePattern,
-      dayOfWeek,
-      dayOfMonth,
+      dayOfWeek: resolvedDayOfWeek,
+      dayOfMonth: resolvedDayOfMonth,
       startDate: start,
       endDate: end,
       time,
@@ -96,51 +141,47 @@ export const createSeries = async (req, res) => {
 
     await series.save();
 
-    // Generate occurrences
-    let currentDate = start;
-    let occurrence = 1;
-    const meetingsToCreate = [];
-
-    // Limit to max 50 occurrences to prevent infinite loops / memory issues
-    const MAX_OCCURRENCES = 50;
-
-    while (currentDate <= end && occurrence <= MAX_OCCURRENCES) {
-      meetingsToCreate.push({
-        uploadedBy: req.user._id,
-        organization: req.user.organization,
-        title,
-        description,
-        meetingType,
-        date: currentDate,
-        time,
-        duration,
-        location,
-        venue,
-        participants,
-        agendaItems,
-        series: series._id,
-        seriesOccurrence: occurrence,
-      });
-
-      if (recurrencePattern === "daily") {
-        currentDate = addDays(currentDate, 1);
-      } else if (recurrencePattern === "weekly") {
-        currentDate = addWeeks(currentDate, 1);
-      } else if (recurrencePattern === "biweekly") {
-        currentDate = addWeeks(currentDate, 2);
-      } else if (recurrencePattern === "monthly") {
-        currentDate = addMonths(currentDate, 1);
-      }
-
-      occurrence++;
-    }
+    const meetingsToCreate = dates.map((date, index) => ({
+      uploadedBy: req.user._id,
+      organization: req.user.organization,
+      title,
+      description,
+      meetingType,
+      date,
+      time,
+      duration,
+      location,
+      venue,
+      participants,
+      // `insertMany` bypasses the document `pre("validate")` hook that
+      // normally runs `normalizeAgendaItems`, so series-created meetings had
+      // un-normalized `position` values unlike every other meeting. Applying it
+      // here restores the invariant.
+      agendaItems: normalizeAgendaItems(agendaItems),
+      series: series._id,
+      seriesOccurrence: index + 1,
+    }));
 
     const createdMeetings = await Meeting.insertMany(meetingsToCreate);
+
+    if (truncated) {
+      console.warn(
+        `⚠️ Series ${series._id} implied ${totalPossible} occurrences; created ${createdMeetings.length} (cap ${MAX_OCCURRENCES}).`,
+      );
+    }
 
     res.status(201).json({
       success: true,
       series,
       meetingsCreated: createdMeetings.length,
+      // A 201 that quietly drops occurrences is the wrong answer. The caller
+      // now gets enough to say "we scheduled 520 of the 730 you asked for".
+      occurrencesRequested: totalPossible,
+      truncated,
+      maxOccurrences: MAX_OCCURRENCES,
+      // Non-zero only for a monthly series on a day some months lack (the 31st
+      // in February), which is skipped rather than clamped.
+      skippedMonths,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -253,12 +294,23 @@ export const cancelSeries = async (req, res) => {
         .json({ success: false, message: "Series not found" });
     }
 
-    // Delete future un-started meetings in the series
-    const result = await Meeting.deleteMany({
+    // Delete future un-started meetings in the series.
+    //
+    // Scoped to the caller's organization (Issue #1160). `series._id` is
+    // already confirmed to belong to them by the `findOneAndUpdate` above, so
+    // this is defence in depth rather than a live hole — but every other
+    // destructive query in this controller is org-scoped, and a `deleteMany`
+    // is the last place to rely on an inference from two statements earlier.
+    const deletionFilter = {
       series: series._id,
       date: { $gte: new Date() },
       status: "uploaded", // Only delete if they haven't been started/processed
-    });
+    };
+    if (req.user.organization) {
+      deletionFilter.organization = req.user.organization;
+    }
+
+    const result = await Meeting.deleteMany(deletionFilter);
 
     res.json({
       success: true,

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -163,6 +163,29 @@ const meetingSchema = new mongoose.Schema(
       type: String, // Plain-text snapshot for read-only views and semantic search
       default: "",
     },
+
+    // ── Meeting series membership (Issue #1160) ──────────────────────────────
+    // `createSeries` has always built its occurrences with `series` and
+    // `seriesOccurrence` set and handed them to `Meeting.insertMany`. Neither
+    // was a schema path, so Mongoose stripped both — the meetings were created
+    // and then orphaned.
+    //
+    // Everything downstream reads the link: `getSeriesMeetings` queries
+    // `{ series: id }` and returned zero rows for every series ever created,
+    // and `cancelSeries` ran a `deleteMany` on the same filter and deleted
+    // nothing while reporting success.
+    series: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "MeetingSeries",
+      default: null,
+    },
+    // 1-based index of this meeting within its series; the sort key for
+    // `getSeriesMeetings`.
+    seriesOccurrence: {
+      type: Number,
+      default: null,
+      min: 1,
+    },
   },
   { timestamps: true },
 );
@@ -184,6 +207,10 @@ meetingSchema.index({ organization: 1, deletedAt: 1, createdAt: -1 });
 meetingSchema.index({ uploadedBy: 1, createdAt: -1 });
 meetingSchema.index({ status: 1 });
 meetingSchema.index({ title: "text", summary: "text" });
+// `getSeriesMeetings` filters on `series` and sorts on `seriesOccurrence`
+// (Issue #1160); `sparse` keeps the index to the small minority of meetings
+// that actually belong to a series.
+meetingSchema.index({ series: 1, seriesOccurrence: 1 }, { sparse: true });
 
 const Meeting = mongoose.model("Meeting", meetingSchema);
 export default Meeting;

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -105,6 +105,29 @@ const meetingSchema = new mongoose.Schema(
       default: "uploaded",
     },
     tags: [String], // e.g., ["policy", "finance", "staff"]
+
+    // ── Meeting series membership (Issue #1160) ──────────────────────────────
+    // `createSeries` has always built its occurrences with `series` and
+    // `seriesOccurrence` set and handed them to `Meeting.insertMany`. Neither
+    // was a schema path, so Mongoose stripped both — the meetings were created
+    // and then orphaned.
+    //
+    // Everything downstream reads the link: `getSeriesMeetings` queries
+    // `{ series: id }` and returned zero rows for every series ever created,
+    // and `cancelSeries` ran a `deleteMany` on the same filter and deleted
+    // nothing while reporting success.
+    series: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "MeetingSeries",
+      default: null,
+    },
+    // 1-based index of this meeting within its series; the sort key for
+    // `getSeriesMeetings`.
+    seriesOccurrence: {
+      type: Number,
+      default: null,
+      min: 1,
+    },
     externalCalendarRefs: [
       {
         provider: { type: String, enum: ["google", "outlook"], required: true },
@@ -162,29 +185,6 @@ const meetingSchema = new mongoose.Schema(
     collaborativeNotes: {
       type: String, // Plain-text snapshot for read-only views and semantic search
       default: "",
-    },
-
-    // ── Meeting series membership (Issue #1160) ──────────────────────────────
-    // `createSeries` has always built its occurrences with `series` and
-    // `seriesOccurrence` set and handed them to `Meeting.insertMany`. Neither
-    // was a schema path, so Mongoose stripped both — the meetings were created
-    // and then orphaned.
-    //
-    // Everything downstream reads the link: `getSeriesMeetings` queries
-    // `{ series: id }` and returned zero rows for every series ever created,
-    // and `cancelSeries` ran a `deleteMany` on the same filter and deleted
-    // nothing while reporting success.
-    series: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "MeetingSeries",
-      default: null,
-    },
-    // 1-based index of this meeting within its series; the sort key for
-    // `getSeriesMeetings`.
-    seriesOccurrence: {
-      type: Number,
-      default: null,
-      min: 1,
     },
   },
   { timestamps: true },

--- a/server/tests/meetingSeriesRecurrence.test.js
+++ b/server/tests/meetingSeriesRecurrence.test.js
@@ -1,0 +1,749 @@
+/**
+ * Regression tests for Issue #1160 — meeting series recurrence.
+ *
+ * Three separate defects, in rough order of severity:
+ *
+ *   1. `Meeting` had no `series` / `seriesOccurrence` schema path, so
+ *      `insertMany` stripped both and every occurrence was orphaned. The
+ *      series-meetings endpoint returned zero rows for every series ever
+ *      created and `cancelSeries` deleted nothing.
+ *   2. `dayOfWeek` / `dayOfMonth` were accepted, validated, stored — and never
+ *      read. `monthly` drifted off its intended day after any short month.
+ *   3. The 50-occurrence cap truncated silently, and the stored `date` carried
+ *      midnight rather than the meeting's time.
+ *
+ * The recurrence maths is tested directly against `utils/recurrence.js`,
+ * because assertions about "the third Wednesday in a DST transition" are worth
+ * making without a database round trip. Persistence and the endpoint contract
+ * are tested through the controller.
+ *
+ * Confirmed load-bearing: against `main`'s model and controller (keeping the
+ * new `utils/recurrence.js`, which the suite imports), 14 of the 20
+ * controller-level tests fail. The 40 pure-unit tests exercise the new module
+ * and so have no `main` counterpart.
+ *
+ * This change also turns `tests/meetingSeriesController.test.js` — the suite
+ * added for #915, red on `main` — green, for the reason in defect 1.
+ */
+
+import mongoose from "mongoose";
+
+import {
+  generateOccurrenceDates,
+  parseMeetingTime,
+  MAX_OCCURRENCES,
+} from "../utils/recurrence.js";
+import Meeting from "../models/meetingModel.js";
+import MeetingSeries from "../models/meetingSeriesModel.js";
+import {
+  createSeries,
+  getSeriesMeetings,
+  cancelSeries,
+} from "../controllers/meetingSeriesController.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: undefined };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+};
+
+const asUser = (body = {}, params = {}, query = {}) => ({
+  body,
+  params,
+  query,
+  user: { _id: USER_A, organization: ORG_A },
+});
+
+const DOW = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const dowOf = (date) => DOW[new Date(date).getDay()];
+
+const baseSeriesBody = (overrides = {}) => ({
+  title: "Weekly Sync",
+  recurrencePattern: "weekly",
+  startDate: "2026-08-03", // a Monday
+  endDate: "2026-09-28",
+  time: "10:00",
+  ...overrides,
+});
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("parseMeetingTime", () => {
+  it.each([
+    ["14:30", 14, 30],
+    ["09:05", 9, 5],
+    ["9:05", 9, 5],
+    ["00:00", 0, 0],
+    ["23:59", 23, 59],
+  ])("parses 24-hour %p", (input, hours, minutes) => {
+    expect(parseMeetingTime(input)).toEqual({ hours, minutes });
+  });
+
+  it.each([
+    ["10:00 AM", 10, 0],
+    ["10:00 PM", 22, 0],
+    ["12:00 AM", 0, 0],
+    ["12:30 PM", 12, 30],
+    ["1:15 pm", 13, 15],
+  ])("parses 12-hour %p", (input, hours, minutes) => {
+    // `tests/meetingSeriesController.test.js` already stores "10:00 AM", so
+    // rejecting this format would break existing data.
+    expect(parseMeetingTime(input)).toEqual({ hours, minutes });
+  });
+
+  it.each(["lunchtime", "", "25:00", "10:60", "10", "abc:de", null, undefined])(
+    "rejects %p",
+    (input) => {
+      expect(parseMeetingTime(input)).toBeNull();
+    },
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("generateOccurrenceDates", () => {
+  const opts = (o) => ({
+    startDate: new Date(2026, 7, 3), // Mon 3 Aug 2026
+    endDate: new Date(2026, 8, 28), // Mon 28 Sep 2026
+    time: "10:00",
+    ...o,
+  });
+
+  describe("weekly", () => {
+    it("honours dayOfWeek instead of following startDate", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", dayOfWeek: 3 }),
+      );
+
+      expect(dates.length).toBeGreaterThan(0);
+      expect(dates.every((d) => d.getDay() === 3)).toBe(true);
+      // Start is a Monday; the first Wednesday on or after it is the 5th.
+      expect(dates[0].getDate()).toBe(5);
+    });
+
+    it("falls back to startDate's weekday when dayOfWeek is omitted", () => {
+      const { dates, dayOfWeek } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly" }),
+      );
+
+      expect(dayOfWeek).toBe(1); // Monday
+      expect(dates.every((d) => d.getDay() === 1)).toBe(true);
+      expect(dates[0].getDate()).toBe(3);
+    });
+
+    it("reports the weekday it resolved so the series can store it", () => {
+      const { dayOfWeek } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", dayOfWeek: 5 }),
+      );
+      expect(dayOfWeek).toBe(5);
+    });
+
+    it("steps exactly seven days", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", dayOfWeek: 3 }),
+      );
+
+      for (let i = 1; i < dates.length; i++) {
+        const gapDays = Math.round(
+          (dates[i] - dates[i - 1]) / (24 * 60 * 60 * 1000),
+        );
+        expect(gapDays).toBe(7);
+      }
+    });
+
+    it("never produces an occurrence after endDate", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", dayOfWeek: 3 }),
+      );
+      const end = new Date(2026, 8, 28, 23, 59, 59);
+      expect(dates.every((d) => d <= end)).toBe(true);
+    });
+  });
+
+  describe("biweekly", () => {
+    it("honours dayOfWeek and steps fourteen days", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "biweekly", dayOfWeek: 4 }),
+      );
+
+      expect(dates.every((d) => d.getDay() === 4)).toBe(true);
+      for (let i = 1; i < dates.length; i++) {
+        const gapDays = Math.round(
+          (dates[i] - dates[i - 1]) / (24 * 60 * 60 * 1000),
+        );
+        expect(gapDays).toBe(14);
+      }
+    });
+  });
+
+  describe("monthly", () => {
+    it("honours dayOfMonth instead of following startDate", () => {
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "monthly",
+        startDate: new Date(2026, 0, 3),
+        endDate: new Date(2026, 5, 30),
+        dayOfMonth: 15,
+        time: "10:00",
+      });
+
+      expect(dates.every((d) => d.getDate() === 15)).toBe(true);
+    });
+
+    it("does not drift after a short month", () => {
+      // `addMonths(31 Jan, 1)` clamps to 28 Feb, and the old loop fed that back
+      // in — so every subsequent occurrence landed on the 28th and the series
+      // never returned to the 31st.
+      const { dates, skippedMonths } = generateOccurrenceDates({
+        recurrencePattern: "monthly",
+        startDate: new Date(2026, 0, 31),
+        endDate: new Date(2026, 11, 31),
+        time: "10:00",
+      });
+
+      expect(dates.every((d) => d.getDate() === 31)).toBe(true);
+      // Feb, Apr, Jun, Sep, Nov have no 31st.
+      expect(skippedMonths).toBe(5);
+      expect(dates.map((d) => d.getMonth())).toEqual([0, 2, 4, 6, 7, 9, 11]);
+    });
+
+    it("skips a February that has no 30th", () => {
+      const { dates, skippedMonths } = generateOccurrenceDates({
+        recurrencePattern: "monthly",
+        startDate: new Date(2026, 0, 30),
+        endDate: new Date(2026, 2, 31),
+        time: "10:00",
+      });
+
+      expect(dates.map((d) => d.getMonth())).toEqual([0, 2]); // Jan, Mar
+      expect(skippedMonths).toBe(1);
+    });
+
+    it("does not emit an occurrence before startDate in the anchor month", () => {
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "monthly",
+        startDate: new Date(2026, 0, 20),
+        endDate: new Date(2026, 2, 31),
+        dayOfMonth: 5,
+        time: "10:00",
+      });
+
+      // The 5th of January is before the start, so the series begins in Feb.
+      expect(dates[0].getMonth()).toBe(1);
+      expect(dates.every((d) => d.getDate() === 5)).toBe(true);
+    });
+  });
+
+  describe("daily", () => {
+    it("produces one occurrence per day inclusive of both ends", () => {
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "daily",
+        startDate: new Date(2026, 7, 1),
+        endDate: new Date(2026, 7, 10),
+        time: "09:30",
+      });
+
+      expect(dates).toHaveLength(10);
+      expect(dates[0].getDate()).toBe(1);
+      expect(dates[9].getDate()).toBe(10);
+    });
+
+    it("stays on the right calendar days across a DST transition", () => {
+      // Adding 24h repeatedly slips an hour across a clock change and can land
+      // on the wrong day; day-count arithmetic cannot.
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "daily",
+        startDate: new Date(2026, 2, 27),
+        endDate: new Date(2026, 3, 2),
+        time: "09:30",
+      });
+
+      expect(dates.map((d) => d.getDate())).toEqual([27, 28, 29, 30, 31, 1, 2]);
+      expect(
+        dates.every((d) => d.getHours() === 9 && d.getMinutes() === 30),
+      ).toBe(true);
+    });
+  });
+
+  describe("time of day", () => {
+    it("stamps every occurrence with the meeting time", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", time: "14:30" }),
+      );
+
+      expect(
+        dates.every((d) => d.getHours() === 14 && d.getMinutes() === 30),
+      ).toBe(true);
+    });
+
+    it("handles a 12-hour time string", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", time: "2:30 PM" }),
+      );
+      expect(dates[0].getHours()).toBe(14);
+    });
+
+    it("leaves midnight when the time is unparseable", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", time: "lunchtime" }),
+      );
+      expect(dates[0].getHours()).toBe(0);
+    });
+  });
+
+  describe("bounds", () => {
+    it("reports truncation and how many the range implied", () => {
+      const { dates, totalPossible, truncated } = generateOccurrenceDates({
+        recurrencePattern: "daily",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 11, 31),
+        time: "09:30",
+        maxOccurrences: 50,
+      });
+
+      expect(dates).toHaveLength(50);
+      expect(totalPossible).toBe(365);
+      expect(truncated).toBe(true);
+    });
+
+    it("does not report truncation when everything fits", () => {
+      const { truncated, totalPossible, dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "weekly", dayOfWeek: 3 }),
+      );
+
+      expect(truncated).toBe(false);
+      expect(totalPossible).toBe(dates.length);
+    });
+
+    it("covers a full year of weekly meetings under the default cap", () => {
+      // The old cap of 50 truncated a one-year weekly series at week 50.
+      const { dates, truncated } = generateOccurrenceDates({
+        recurrencePattern: "weekly",
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 11, 31),
+        time: "10:00",
+        maxOccurrences: MAX_OCCURRENCES,
+      });
+
+      expect(dates.length).toBeGreaterThanOrEqual(52);
+      expect(truncated).toBe(false);
+    });
+
+    it("returns nothing for an inverted range", () => {
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "weekly",
+        startDate: new Date(2026, 8, 1),
+        endDate: new Date(2026, 7, 1),
+        time: "10:00",
+      });
+      expect(dates).toEqual([]);
+    });
+
+    it("returns nothing for an unknown pattern", () => {
+      const { dates } = generateOccurrenceDates(
+        opts({ recurrencePattern: "fortnightly-ish" }),
+      );
+      expect(dates).toEqual([]);
+    });
+
+    it("handles a single-day range", () => {
+      const { dates } = generateOccurrenceDates({
+        recurrencePattern: "daily",
+        startDate: new Date(2026, 7, 3),
+        endDate: new Date(2026, 7, 3),
+        time: "10:00",
+      });
+      expect(dates).toHaveLength(1);
+    });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("POST /api/meeting-series", () => {
+  it("links every created meeting to its series", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody()), res);
+
+    expect(res.statusCode).toBe(201);
+    const seriesId = res.body.series._id;
+
+    // Against `main` this is 0: `series` was not a schema path, so
+    // `insertMany` stripped it and every occurrence was orphaned.
+    const linked = await Meeting.countDocuments({ series: seriesId });
+    expect(linked).toBe(res.body.meetingsCreated);
+    expect(linked).toBeGreaterThan(0);
+  });
+
+  it("numbers occurrences contiguously from one", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody()), res);
+
+    const meetings = await Meeting.find({
+      series: res.body.series._id,
+    }).sort({ seriesOccurrence: 1 });
+
+    expect(meetings.map((m) => m.seriesOccurrence)).toEqual(
+      meetings.map((_, i) => i + 1),
+    );
+  });
+
+  it("honours dayOfWeek", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(baseSeriesBody({ dayOfWeek: 3 })), // Wednesday
+      res,
+    );
+
+    const meetings = await Meeting.find({ series: res.body.series._id });
+    expect(meetings.length).toBeGreaterThan(0);
+    // Against `main`: every one of these is a Monday.
+    expect(meetings.every((m) => dowOf(m.date) === "Wed")).toBe(true);
+  });
+
+  it("stores the resolved dayOfWeek on the series", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody({ dayOfWeek: 3 })), res);
+
+    const series = await MeetingSeries.findById(res.body.series._id);
+    expect(series.dayOfWeek).toBe(3);
+
+    const meetings = await Meeting.find({ series: series._id });
+    // The stored schedule and the generated data must agree.
+    expect(
+      meetings.every((m) => new Date(m.date).getDay() === series.dayOfWeek),
+    ).toBe(true);
+  });
+
+  it("back-fills dayOfWeek when the caller omits it", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody()), res);
+
+    const series = await MeetingSeries.findById(res.body.series._id);
+    expect(series.dayOfWeek).toBe(1); // Monday, derived from startDate
+  });
+
+  it("honours dayOfMonth for a monthly series", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          recurrencePattern: "monthly",
+          dayOfMonth: 15,
+          startDate: "2026-01-03",
+          endDate: "2026-06-30",
+        }),
+      ),
+      res,
+    );
+
+    const meetings = await Meeting.find({ series: res.body.series._id });
+    expect(meetings.every((m) => new Date(m.date).getDate() === 15)).toBe(true);
+  });
+
+  it("stamps the meeting time onto the stored date", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody({ time: "14:30" })), res);
+
+    const meeting = await Meeting.findOne({ series: res.body.series._id });
+    // Against `main` this is midnight: `date: currentDate` inherited its
+    // time-of-day from a date-only `startDate`, while `time` said 14:30.
+    expect(new Date(meeting.date).getHours()).toBe(14);
+    expect(new Date(meeting.date).getMinutes()).toBe(30);
+  });
+
+  it("reports truncation instead of silently dropping occurrences", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          recurrencePattern: "daily",
+          startDate: "2026-01-01",
+          endDate: "2027-12-31",
+        }),
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.truncated).toBe(true);
+    expect(res.body.occurrencesRequested).toBeGreaterThan(
+      res.body.meetingsCreated,
+    );
+    expect(res.body.maxOccurrences).toBe(MAX_OCCURRENCES);
+  });
+
+  it("creates a full year of weekly meetings without truncating", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({ startDate: "2026-01-01", endDate: "2026-12-31" }),
+      ),
+      res,
+    );
+
+    // The old cap stopped at 50.
+    expect(res.body.meetingsCreated).toBeGreaterThanOrEqual(52);
+    expect(res.body.truncated).toBe(false);
+  });
+
+  it("rejects an unparseable time", async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody({ time: "lunchtime" })), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(await MeetingSeries.countDocuments()).toBe(0);
+  });
+
+  it("still rejects an inverted date range", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({ startDate: "2026-09-28", endDate: "2026-08-03" }),
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("does not create an empty series", async () => {
+    const res = mockRes();
+    // A weekly Wednesday series in a range containing no Wednesday.
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          dayOfWeek: 3,
+          startDate: "2026-08-06", // Thursday
+          endDate: "2026-08-08", // Saturday
+        }),
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(await MeetingSeries.countDocuments()).toBe(0);
+  });
+
+  it("normalizes agenda item positions, as non-series meetings do", async () => {
+    const res = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          agendaItems: [
+            { text: "Second", duration: 5 },
+            { text: "First", duration: 5 },
+          ],
+        }),
+      ),
+      res,
+    );
+
+    const meeting = await Meeting.findOne({ series: res.body.series._id });
+    // `insertMany` bypasses the document pre-validate hook, so these used to
+    // arrive un-normalized unlike every other meeting in the system.
+    expect(meeting.agendaItems.map((i) => i.position)).toEqual([0, 1]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET /api/meeting-series/:id/meetings", () => {
+  const seed = async () => {
+    const res = mockRes();
+    await createSeries(asUser(baseSeriesBody()), res);
+    return res.body.series._id.toString();
+  };
+
+  it("returns the meetings in the series", async () => {
+    const seriesId = await seed();
+    const res = mockRes();
+
+    await getSeriesMeetings(asUser({}, { id: seriesId }, {}), res);
+
+    // Against `main` this is an empty list with `total: 0` for every series
+    // that has ever been created.
+    expect(res.body.meetings.length).toBeGreaterThan(0);
+    expect(res.body.pagination.total).toBe(res.body.meetings.length);
+  });
+
+  it("orders by occurrence", async () => {
+    const seriesId = await seed();
+    const res = mockRes();
+
+    await getSeriesMeetings(
+      asUser({}, { id: seriesId }, { limit: "all" }),
+      res,
+    );
+
+    const occurrences = res.body.meetings.map((m) => m.seriesOccurrence);
+    expect(occurrences).toEqual([...occurrences].sort((a, b) => a - b));
+    expect(occurrences[0]).toBe(1);
+  });
+
+  it("does not return another series' meetings", async () => {
+    const firstId = await seed();
+    const secondRes = mockRes();
+    await createSeries(
+      asUser(baseSeriesBody({ title: "Other series" })),
+      secondRes,
+    );
+
+    const res = mockRes();
+    await getSeriesMeetings(asUser({}, { id: firstId }, { limit: "all" }), res);
+
+    expect(
+      res.body.meetings.every((m) => m.series.toString() === firstId),
+    ).toBe(true);
+  });
+
+  it("paginates", async () => {
+    const seriesId = await seed();
+
+    const page1 = mockRes();
+    await getSeriesMeetings(
+      asUser({}, { id: seriesId }, { limit: "3", page: "1" }),
+      page1,
+    );
+    expect(page1.body.meetings).toHaveLength(3);
+
+    const page2 = mockRes();
+    await getSeriesMeetings(
+      asUser({}, { id: seriesId }, { limit: "3", page: "2" }),
+      page2,
+    );
+    expect(page2.body.meetings[0].seriesOccurrence).toBe(4);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("PATCH /api/meeting-series/:id/cancel", () => {
+  it("deletes the future un-started meetings it reports", async () => {
+    const created = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          recurrencePattern: "daily",
+          startDate: new Date(Date.now() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+          endDate: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+        }),
+      ),
+      created,
+    );
+
+    const seriesId = created.body.series._id.toString();
+    const before = await Meeting.countDocuments({ series: seriesId });
+    expect(before).toBeGreaterThan(0);
+
+    const res = mockRes();
+    await cancelSeries(asUser({}, { id: seriesId }), res);
+
+    // Against `main`: `meetingsDeleted: 0` alongside "Series cancelled
+    // successfully", because the filter could never match.
+    expect(res.body.meetingsDeleted).toBe(before);
+    expect(await Meeting.countDocuments({ series: seriesId })).toBe(0);
+
+    const series = await MeetingSeries.findById(seriesId);
+    expect(series.isActive).toBe(false);
+  });
+
+  it("leaves meetings that have already been processed", async () => {
+    const created = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          recurrencePattern: "daily",
+          startDate: new Date(Date.now() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+          endDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+        }),
+      ),
+      created,
+    );
+
+    const seriesId = created.body.series._id.toString();
+    const keep = await Meeting.findOne({ series: seriesId });
+    await Meeting.updateOne({ _id: keep._id }, { status: "completed" });
+
+    const res = mockRes();
+    await cancelSeries(asUser({}, { id: seriesId }), res);
+
+    expect(await Meeting.findById(keep._id)).not.toBeNull();
+    expect(res.body.meetingsDeleted).toBeGreaterThan(0);
+  });
+
+  it("does not touch another organization's meetings", async () => {
+    const created = mockRes();
+    await createSeries(
+      asUser(
+        baseSeriesBody({
+          recurrencePattern: "daily",
+          startDate: new Date(Date.now() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+          endDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10),
+        }),
+      ),
+      created,
+    );
+
+    const seriesId = created.body.series._id;
+
+    // A meeting carrying the same series id but belonging to another tenant.
+    const foreign = await Meeting.create({
+      uploadedBy: new mongoose.Types.ObjectId(),
+      organization: new mongoose.Types.ObjectId(),
+      title: "Someone else's meeting",
+      date: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+      series: seriesId,
+      seriesOccurrence: 1,
+      status: "uploaded",
+    });
+
+    const res = mockRes();
+    await cancelSeries(asUser({}, { id: seriesId.toString() }), res);
+
+    expect(await Meeting.findById(foreign._id)).not.toBeNull();
+  });
+
+  it("404s for a series in another organization", async () => {
+    const created = mockRes();
+    await createSeries(asUser(baseSeriesBody()), created);
+
+    const res = mockRes();
+    await cancelSeries(
+      {
+        body: {},
+        params: { id: created.body.series._id.toString() },
+        query: {},
+        user: {
+          _id: new mongoose.Types.ObjectId(),
+          organization: new mongoose.Types.ObjectId(),
+        },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/server/utils/recurrence.js
+++ b/server/utils/recurrence.js
@@ -1,0 +1,278 @@
+/**
+ * Occurrence generation for meeting series (Issue #1160).
+ *
+ * `createSeries` used to generate dates inline by repeatedly adding an interval
+ * to `startDate`:
+ *
+ *   while (currentDate <= end && occurrence <= 50) {
+ *     ...
+ *     if (pattern === "weekly") currentDate = addWeeks(currentDate, 1);
+ *     else if (pattern === "monthly") currentDate = addMonths(currentDate, 1);
+ *   }
+ *
+ * Three things were wrong with that, and all three are why this is a separate,
+ * directly testable module rather than a loop inside a controller:
+ *
+ *   1. **`dayOfWeek` and `dayOfMonth` were ignored.** They were accepted,
+ *      range-checked by Zod and stored on the series document — then never
+ *      read. "Every Wednesday" produced whatever weekday `startDate` happened
+ *      to fall on, and the stored series disagreed with the data it generated.
+ *
+ *   2. **`monthly` drifted.** `addMonths` clamps to the end of a short month
+ *      and the loop fed the clamped value back in, so 31 Jan -> 28 Feb ->
+ *      28 Mar and never the 31st again. One short month permanently shifted the
+ *      rest of the series. Every occurrence here is computed from the series
+ *      *anchor* instead of from its predecessor, which makes drift structurally
+ *      impossible rather than merely unlikely.
+ *
+ *   3. **Truncation was silent.** The 50-occurrence cap is a reasonable guard;
+ *      returning `201 { meetingsCreated: 50 }` for a request that implied 365
+ *      is not. This reports what the range implied so the caller can say so.
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Default ceiling on generated occurrences.
+ *
+ * The previous 50 was low for the patterns this endpoint supports: daily
+ * covered seven weeks, and weekly truncated a one-year series — the single most
+ * common recurring meeting there is — at week 50. 520 is weekly for ten years
+ * or daily for about seventeen months, and is still far below anything that
+ * could exhaust memory (each occurrence is one small document).
+ */
+export const MAX_OCCURRENCES = 520;
+
+/**
+ * Absolute bound on the counting loop, so a pathological range (a hand-crafted
+ * `endDate` centuries out) cannot spin. Occurrences beyond this are not counted
+ * individually; `totalPossible` is reported as at-least this many.
+ */
+const COUNT_CEILING = 10_000;
+
+/**
+ * Parses a meeting time into `{hours, minutes}`.
+ *
+ * Both formats already in the data are accepted: 24-hour `"14:30"`, and the
+ * 12-hour `"10:00 AM"` that `tests/meetingSeriesController.test.js` uses. The
+ * field was `z.string().min(1)`, so `"lunchtime"` was accepted and stored;
+ * anything unparseable is now rejected rather than silently ignored.
+ *
+ * @param {string} time
+ * @returns {{hours: number, minutes: number}|null} null if unparseable
+ */
+export const parseMeetingTime = (time) => {
+  if (typeof time !== "string") return null;
+
+  const match = time
+    .trim()
+    .match(/^(\d{1,2}):([0-5]\d)(?:\s*([AaPp])\.?[Mm]\.?)?$/);
+  if (!match) return null;
+
+  let hours = Number.parseInt(match[1], 10);
+  const minutes = Number.parseInt(match[2], 10);
+  const meridiem = match[3]?.toLowerCase();
+
+  if (meridiem) {
+    if (hours < 1 || hours > 12) return null;
+    if (meridiem === "a") hours = hours === 12 ? 0 : hours;
+    else hours = hours === 12 ? 12 : hours + 12;
+  } else if (hours > 23) {
+    return null;
+  }
+
+  return { hours, minutes };
+};
+
+/** A date at midnight local time, so day arithmetic is not perturbed by DST. */
+const atMidnight = (date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+/** Applies a parsed time to a date, or leaves midnight if there is no time. */
+const withTime = (date, parsedTime) => {
+  const out = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  if (parsedTime) out.setHours(parsedTime.hours, parsedTime.minutes, 0, 0);
+  return out;
+};
+
+/** Days from `date` forward to the next occurrence of `targetDow` (0 if same). */
+const daysUntilWeekday = (date, targetDow) =>
+  (targetDow - date.getDay() + 7) % 7;
+
+/** Number of days in a given month, so an invalid `dayOfMonth` is detectable. */
+const daysInMonth = (year, monthIndex) =>
+  new Date(year, monthIndex + 1, 0).getDate();
+
+/**
+ * Generates the dates for a meeting series.
+ *
+ * `dayOfWeek` applies to `weekly` and `biweekly`; `dayOfMonth` applies to
+ * `monthly`. Either being absent means "derive it from `startDate`", which is
+ * the previous behaviour and stays the documented default — the derived value
+ * is returned so the caller can write it back and keep the stored series
+ * consistent with the data it produced.
+ *
+ * Months that do not contain `dayOfMonth` (the 31st in February) are **skipped**
+ * rather than clamped. Clamping is the alternative and is what `addMonths` did
+ * accidentally; skipping is chosen deliberately because "the 31st" has no
+ * February instance, and because a skipped month cannot shift the rest of the
+ * series the way a clamped one did.
+ *
+ * @param {object} options
+ * @param {"daily"|"weekly"|"biweekly"|"monthly"} options.recurrencePattern
+ * @param {Date} options.startDate
+ * @param {Date} options.endDate
+ * @param {number} [options.dayOfWeek]  0 (Sunday) – 6 (Saturday)
+ * @param {number} [options.dayOfMonth] 1 – 31
+ * @param {string} [options.time]       "HH:MM" or "h:MM AM"
+ * @param {number} [options.maxOccurrences]
+ * @returns {{
+ *   dates: Date[],
+ *   totalPossible: number,
+ *   truncated: boolean,
+ *   skippedMonths: number,
+ *   dayOfWeek: number|null,
+ *   dayOfMonth: number|null,
+ * }}
+ */
+export const generateOccurrenceDates = ({
+  recurrencePattern,
+  startDate,
+  endDate,
+  dayOfWeek,
+  dayOfMonth,
+  time,
+  maxOccurrences = MAX_OCCURRENCES,
+} = {}) => {
+  const empty = {
+    dates: [],
+    totalPossible: 0,
+    truncated: false,
+    skippedMonths: 0,
+    dayOfWeek: null,
+    dayOfMonth: null,
+  };
+
+  if (!(startDate instanceof Date) || Number.isNaN(startDate.getTime())) {
+    return empty;
+  }
+  if (!(endDate instanceof Date) || Number.isNaN(endDate.getTime())) {
+    return empty;
+  }
+
+  const parsedTime = parseMeetingTime(time);
+  const start = atMidnight(startDate);
+  // Compared at end-of-day so an `endDate` given as a date-only string still
+  // includes an occurrence falling on that day.
+  const lastDay = atMidnight(endDate);
+  if (lastDay < start) return empty;
+
+  const dates = [];
+  let totalPossible = 0;
+  let skippedMonths = 0;
+
+  const push = (date) => {
+    totalPossible++;
+    if (dates.length < maxOccurrences) dates.push(withTime(date, parsedTime));
+  };
+
+  if (recurrencePattern === "daily") {
+    // Iterating by day count rather than by mutating a Date avoids the DST
+    // hazard of repeatedly adding 24h across a clock change.
+    const span = Math.floor((lastDay - start) / MS_PER_DAY);
+    for (let i = 0; i <= span && totalPossible < COUNT_CEILING; i++) {
+      push(
+        new Date(start.getFullYear(), start.getMonth(), start.getDate() + i),
+      );
+    }
+    return {
+      dates,
+      totalPossible,
+      truncated: totalPossible > dates.length,
+      skippedMonths,
+      dayOfWeek: null,
+      dayOfMonth: null,
+    };
+  }
+
+  if (recurrencePattern === "weekly" || recurrencePattern === "biweekly") {
+    const step = recurrencePattern === "weekly" ? 7 : 14;
+
+    const targetDow =
+      Number.isInteger(dayOfWeek) && dayOfWeek >= 0 && dayOfWeek <= 6
+        ? dayOfWeek
+        : start.getDay();
+
+    // The anchor is the first occurrence of the requested weekday on or after
+    // `startDate`. Starting a "every Wednesday" series on a Monday now yields
+    // Wednesdays, not Mondays.
+    const anchor = new Date(
+      start.getFullYear(),
+      start.getMonth(),
+      start.getDate() + daysUntilWeekday(start, targetDow),
+    );
+
+    for (let i = 0; totalPossible < COUNT_CEILING; i++) {
+      const occurrence = new Date(
+        anchor.getFullYear(),
+        anchor.getMonth(),
+        anchor.getDate() + i * step,
+      );
+      if (occurrence > lastDay) break;
+      push(occurrence);
+    }
+
+    return {
+      dates,
+      totalPossible,
+      truncated: totalPossible > dates.length,
+      skippedMonths,
+      dayOfWeek: targetDow,
+      dayOfMonth: null,
+    };
+  }
+
+  if (recurrencePattern === "monthly") {
+    const targetDom =
+      Number.isInteger(dayOfMonth) && dayOfMonth >= 1 && dayOfMonth <= 31
+        ? dayOfMonth
+        : start.getDate();
+
+    for (let i = 0; totalPossible < COUNT_CEILING; i++) {
+      const year = start.getFullYear();
+      const monthIndex = start.getMonth() + i;
+
+      // Normalized so the month/year rollover is handled by Date itself.
+      const probe = new Date(year, monthIndex, 1);
+      if (probe > lastDay) break;
+
+      if (targetDom > daysInMonth(probe.getFullYear(), probe.getMonth())) {
+        skippedMonths++;
+        continue;
+      }
+
+      const occurrence = new Date(
+        probe.getFullYear(),
+        probe.getMonth(),
+        targetDom,
+      );
+      if (occurrence > lastDay) break;
+      if (occurrence < start) continue; // the anchor month, before startDate
+
+      push(occurrence);
+    }
+
+    return {
+      dates,
+      totalPossible,
+      truncated: totalPossible > dates.length,
+      skippedMonths,
+      dayOfWeek: null,
+      dayOfMonth: targetDom,
+    };
+  }
+
+  return empty;
+};
+
+export default { generateOccurrenceDates, parseMeetingTime, MAX_OCCURRENCES };


### PR DESCRIPTION
# Pull Request

## Description

Three defects, in order of severity. The first was found while writing the tests and [added to the issue](https://github.com/imuniqueshiv/MeetOnMemory/issues/1160#issuecomment-5181179997); it subsumes most of the symptoms originally reported.

### 1. Series occurrences were never linked to their series

`Meeting` has no `series` or `seriesOccurrence` schema path.

```js
const m = new Meeting({
  uploadedBy: oid, title: "Weekly Sync #1", date: new Date(),
  series: seriesId, seriesOccurrence: 1,
});

Meeting.schema.path("series");            // undefined
Meeting.schema.path("seriesOccurrence");  // undefined
m.toObject().series;                      // undefined
```

`createSeries` builds every occurrence with both fields set and hands the array to `Meeting.insertMany`. Mongoose is strict by default, so both are dropped. The meetings are created and immediately orphaned.

Everything downstream reads that link:

- `getSeriesMeetings` queries `{ series: req.params.id }` → **zero rows for every series that has ever been created**. `pagination.total` is `0`.
- It then sorts on `seriesOccurrence`, a field that does not exist.
- `cancelSeries` runs `deleteMany` on the same filter → **deletes nothing**, and reports `meetingsDeleted: 0` next to `"Series cancelled successfully"`.

This is also why **`server/tests/meetingSeriesController.test.js` is red on `main`** — the suite added for #915:

```
● fetches all meetings in a series when limit=0 is requested
  Expected: 105
  Received: 0
```

The test is correct. It inserts 105 meetings with `series` set and gets none back. The `limit=0` escape hatch #915 added works fine; the query it runs could never match. **This PR turns that suite green.**

Same failure mode as #1159: a controller writing fields the schema does not declare, dropped silently, with the read side reporting the resulting emptiness as a normal answer.

### 2. The recurrence day was ignored, and monthly drifted

`dayOfWeek` and `dayOfMonth` were accepted, range-checked by Zod, stored on the series — and never read by the generation loop:

```js
if (recurrencePattern === "weekly")  currentDate = addWeeks(currentDate, 1);
else if (recurrencePattern === "monthly") currentDate = addMonths(currentDate, 1);
```

A weekly series starting Monday 3 Aug with `dayOfWeek: 3` produced Mondays. The stored series said Wednesday, so the document and the data it generated disagreed and no client could tell which was authoritative.

`monthly` drifted because `addMonths` clamps to the end of a short month and the loop fed the clamped value back in:

```
31 Jan -> 28 Feb -> 28 Mar -> 28 Apr …   // never the 31st again
```

Occurrence generation moves to `utils/recurrence.js`. Each occurrence is computed from the series **anchor** rather than from its predecessor, so drift is structurally impossible rather than merely unlikely. Months that do not contain the requested day (the 31st in February) are **skipped** rather than clamped — a deliberate choice, documented, and the skipped count is returned. The resolved `dayOfWeek`/`dayOfMonth` is written back onto the series, so the stored schedule always matches the generated data.

Daily iterates by day count rather than by mutating a `Date`, which is what keeps it on the right calendar days across a DST transition.

### 3. Silent truncation, and the wrong time of day

The 50-occurrence cap is a reasonable guard; `201 { meetingsCreated: 50 }` for a request that implied 365 is not. The response now carries `occurrencesRequested`, `truncated` and `maxOccurrences`, so a client can say "we scheduled 520 of the 730 you asked for". The cap itself goes to 520 — 50 covered seven weeks of daily, and truncated a one-year weekly series (the single most common recurring meeting there is) at week 50.

`date: currentDate` inherited its time-of-day from `parseISO(startDate)` — midnight for a date-only string — while `time` said `"14:30"`. Every occurrence was stored at midnight, so anything sorting, filtering or rendering by `date` alone saw the wrong hour. The time is now applied to the stored date.

### Smaller things in the same handlers

- **`time` is validated.** It was `z.string().min(1)`, so `"lunchtime"` was accepted and stored. Both formats already present in the codebase are accepted — 24-hour `"14:30"` and the 12-hour `"10:00 AM"` that the existing #915 test uses — so this does not invalidate existing data.
- **A schedule producing no meetings is a `400`** rather than an empty series document with no occurrences.
- **Agenda normalization.** `insertMany` bypasses the document `pre("validate")` hook that runs `normalizeAgendaItems`, so series-created meetings had un-normalized `position` values unlike every other meeting in the system. It is applied explicitly.
- **`cancelSeries` scopes its `deleteMany` to the caller's organization.** The preceding `findOneAndUpdate` already establishes ownership, so this is defence in depth — but every other destructive query in the controller is scoped, and a `deleteMany` is the last place to rely on an inference from two statements earlier.
- A `{ series: 1, seriesOccurrence: 1 }` sparse index, since that is exactly what `getSeriesMeetings` filters and sorts on.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1160

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/meetingSeriesRecurrence.test.js` — 60 tests. The recurrence maths is asserted directly against `utils/recurrence.js` (40 tests), because claims about "the 31st across a year" and "a daily series through a DST transition" are worth making without a database round trip; persistence and the endpoint contract go through the controller against `mongodb-memory-server` (20 tests).

**`parseMeetingTime`** — 24-hour and 12-hour forms including the `12:00 AM` / `12:30 PM` edge cases; rejects `"lunchtime"`, `"25:00"`, `"10:60"`, `"10"`, `null`, `undefined`.

**Weekly / biweekly** — honours `dayOfWeek` and starts on the first matching weekday on or after `startDate`; falls back to `startDate`'s weekday when omitted and reports which it resolved; steps exactly 7 / 14 days; never passes `endDate`.

**Monthly** — honours `dayOfMonth`; **does not drift** (a Jan-31 series produces months `[0,2,4,6,7,9,11]`, all on the 31st, with `skippedMonths: 5`); skips a February with no 30th; does not emit an occurrence before `startDate` in the anchor month.

**Daily** — inclusive of both ends; stays on the right calendar days *and* the right clock time across a DST transition.

**Bounds** — reports `totalPossible: 365` while returning 50 under an explicit cap; reports `truncated: false` when everything fits; covers a full year of weekly under the default cap; returns nothing for an inverted range or an unknown pattern; handles a single-day range.

**`createSeries`** — every created meeting is linked to its series and the count matches `meetingsCreated`; occurrences are numbered contiguously from 1; `dayOfWeek: 3` yields Wednesdays (Mondays against `main`); the resolved day is stored on the series *and* asserted to agree with the generated meetings; `dayOfWeek` is back-filled when omitted; `dayOfMonth` is honoured; the stored `date` carries 14:30 rather than midnight; truncation is reported; a full year of weekly is created without truncating; `"lunchtime"` is a 400 with no series persisted; an inverted range is still a 400; a schedule with no matching day is a 400 with no series persisted; agenda positions are normalized.

**`getSeriesMeetings`** — returns the series' meetings (empty against `main`); orders by occurrence; does not return another series' meetings; paginates.

**`cancelSeries`** — deletes the meetings it reports and leaves the series inactive (`meetingsDeleted: 0` against `main`); leaves an already-processed meeting alone; does not delete a meeting belonging to another organization that carries the same series id; 404s for a series in another organization.

**Confirmed load-bearing.** Against `main`'s model and controller — keeping `utils/recurrence.js`, which the suite imports — **14 of the 20 controller-level tests fail**. The 40 unit tests exercise the new module and have no `main` counterpart.

**Full server suite:** **4 failing suites and 0 failing tests**, against a `main` baseline of 5 failing suites and 1 failing test. The improvement is `tests/meetingSeriesController.test.js`, which goes from red to green for the reason in defect 1 — nothing was skipped or deleted to achieve that. 870 tests pass, against 809 on `main`.

> As with the other PRs in this batch: the declared `diff` dependency was not installed in my checkout, so I installed it locally with `--no-save` (`package.json` untouched) and took the `main` baseline in that same state.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
