### PR TITLE
feat(tasks): optimize board data fetching with server-side pagination

### DIFF
--- a/client/src/hooks/useTasks.js
+++ b/client/src/hooks/useTasks.js
@@ -1,186 +1,172 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { toast } from "react-toastify";
 import { knowledgeApi } from "../services";
+
+const PAGE_SIZE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
+
+const mapActionItem = (item) => ({
+  id: item._id,
+  title: item.text,
+  owner: item.owner || "Unassigned",
+  dueDate: item.dueDate,
+  status: item.status || "open",
+  meetingId: item.sourceMeetingId?._id,
+  meetingTitle: item.sourceMeetingId?.title,
+  meetingDate: item.sourceMeetingId?.date,
+  priority: item.priority || "medium",
+  organization: item.sourceMeetingId?.organization?.name || "Personal",
+  description: item.description || item.text,
+  importanceScore: item.importanceScore ?? null,
+  remindersEnabled: item.remindersEnabled !== false,
+  reminderSent: item.reminderSent || {
+    upcoming: false,
+    overdue: false,
+  },
+});
 
 export default function useTasks() {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedTask, setSelectedTask] = useState(null);
 
-  // Filters
   const [statusFilter, setStatusFilter] = useState("all");
   const [priorityFilter, setPriorityFilter] = useState("all");
   const [organizationFilter, setOrganizationFilter] = useState("all");
   const [assignedFilter, setAssignedFilter] = useState("all");
 
-  // Sorting
   const [sortBy, setSortBy] = useState("dueDate");
   const [sortOrder, setSortOrder] = useState("asc");
 
-  // UI state
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [ownersFacet, setOwnersFacet] = useState([]);
+  const [organizationsFacet, setOrganizationsFacet] = useState([]);
+
   const [showFilters, setShowFilters] = useState(false);
+  const requestIdRef = useRef(0);
 
-  // Fetch action items
+  // Debounce search → server query; reset to first page on term change
   useEffect(() => {
-    const fetchTasks = async () => {
-      try {
-        setLoading(true);
-        setError(null);
+    const timer = setTimeout(() => {
+      const next = searchQuery.trim();
+      setDebouncedSearch((prev) => {
+        if (prev === next) return prev;
+        setPage(1);
+        return next;
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
-        const res = await knowledgeApi.getActionItems("all");
-
-        if (res.data?.success) {
-          const items = res.data.actionItems.map((item) => ({
-            id: item._id,
-            title: item.text,
-            owner: item.owner || "Unassigned",
-            dueDate: item.dueDate,
-            status: item.status || "open",
-
-            meetingId: item.sourceMeetingId?._id,
-            meetingTitle: item.sourceMeetingId?.title,
-            meetingDate: item.sourceMeetingId?.date,
-
-            priority: item.priority || "medium",
-            organization:
-              item.sourceMeetingId?.organization?.name || "Personal",
-            description: item.description || item.text,
-            importanceScore: item.importanceScore ?? null,
-            remindersEnabled: item.remindersEnabled !== false,
-            reminderSent: item.reminderSent || {
-              upcoming: false,
-              overdue: false,
-            },
-          }));
-          setTasks(items);
-        } else {
-          setError(res.data?.message || "Failed to load tasks");
-          toast.error(res.data?.message || "Failed to load tasks");
-        }
-      } catch (err) {
-        console.error("Error fetching tasks:", err);
-        setError("Unable to fetch tasks");
-        toast.error("Unable to fetch tasks");
-      } finally {
-        setLoading(false);
-      }
+  const resetToFirstPage = useCallback((updater) => {
+    return (value) => {
+      setPage(1);
+      updater(value);
     };
-
-    fetchTasks();
   }, []);
 
-  // Get unique values for filters
-  const organizations = useMemo(
-    () => [...new Set(tasks.map((t) => t.organization))],
-    [tasks],
+  const setStatusFilterAndReset = useMemo(
+    () => resetToFirstPage(setStatusFilter),
+    [resetToFirstPage],
   );
-  const assignedUsers = useMemo(
-    () => [...new Set(tasks.map((t) => t.owner))],
-    [tasks],
+  const setPriorityFilterAndReset = useMemo(
+    () => resetToFirstPage(setPriorityFilter),
+    [resetToFirstPage],
+  );
+  const setOrganizationFilterAndReset = useMemo(
+    () => resetToFirstPage(setOrganizationFilter),
+    [resetToFirstPage],
+  );
+  const setAssignedFilterAndReset = useMemo(
+    () => resetToFirstPage(setAssignedFilter),
+    [resetToFirstPage],
   );
 
-  // Filter tasks
-  const filteredTasks = useMemo(() => {
-    return tasks.filter((task) => {
-      // Search filter
-      const searchLower = searchQuery.toLowerCase();
-      const matchesSearch =
-        task.title?.toLowerCase().includes(searchLower) ||
-        task.meetingTitle?.toLowerCase().includes(searchLower) ||
-        task.owner?.toLowerCase().includes(searchLower) ||
-        task.description?.toLowerCase().includes(searchLower);
+  const fetchTasks = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    try {
+      setLoading(true);
+      setError(null);
 
-      // Status filter
-      const matchesStatus =
-        statusFilter === "all" || task.status === statusFilter;
+      const res = await knowledgeApi.getActionItems(statusFilter, sortBy, {
+        search: debouncedSearch || undefined,
+        owner: assignedFilter !== "all" ? assignedFilter : undefined,
+        priority: priorityFilter !== "all" ? priorityFilter : undefined,
+        organization:
+          organizationFilter !== "all" ? organizationFilter : undefined,
+        page,
+        limit: PAGE_SIZE,
+        sortOrder,
+      });
 
-      // Priority filter
-      const matchesPriority =
-        priorityFilter === "all" || task.priority === priorityFilter;
+      if (requestId !== requestIdRef.current) return;
 
-      // Organization filter
-      const matchesOrganization =
-        organizationFilter === "all" ||
-        task.organization === organizationFilter;
-
-      // Assigned user filter
-      const matchesAssigned =
-        assignedFilter === "all" || task.owner === assignedFilter;
-
-      return (
-        matchesSearch &&
-        matchesStatus &&
-        matchesPriority &&
-        matchesOrganization &&
-        matchesAssigned
-      );
-    });
+      if (res.data?.success) {
+        setTasks((res.data.actionItems || []).map(mapActionItem));
+        setTotalPages(res.data.pagination?.totalPages || 0);
+        setTotal(res.data.pagination?.total || 0);
+        setOwnersFacet(res.data.facets?.owners || []);
+        setOrganizationsFacet(res.data.facets?.organizations || []);
+      } else {
+        setError(res.data?.message || "Failed to load tasks");
+        toast.error(res.data?.message || "Failed to load tasks");
+      }
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      console.error("Error fetching tasks:", err);
+      setError("Unable to fetch tasks");
+      toast.error("Unable to fetch tasks");
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
   }, [
-    tasks,
-    searchQuery,
+    page,
     statusFilter,
     priorityFilter,
     organizationFilter,
     assignedFilter,
+    sortBy,
+    sortOrder,
+    debouncedSearch,
   ]);
 
-  // Sort tasks
-  const sortedTasks = useMemo(() => {
-    return [...filteredTasks].sort((a, b) => {
-      let comparison = 0;
+  useEffect(() => {
+    fetchTasks();
+  }, [fetchTasks]);
 
-      switch (sortBy) {
-        case "dueDate": {
-          if (!a.dueDate) comparison = 1;
-          else if (!b.dueDate) comparison = -1;
-          else comparison = new Date(a.dueDate) - new Date(b.dueDate);
-          break;
-        }
-        case "createdDate": {
-          comparison = new Date(a.meetingDate) - new Date(b.meetingDate);
-          break;
-        }
-        case "priority": {
-          const priorityOrder = { high: 0, medium: 1, low: 2 };
-          comparison = priorityOrder[a.priority] - priorityOrder[b.priority];
-          break;
-        }
-        case "status": {
-          const statusOrder = {
-            open: 0,
-            "in-progress": 1,
-            resolved: 2,
-            superseded: 3,
-          };
-          comparison = statusOrder[a.status] - statusOrder[b.status];
-          break;
-        }
-        case "alphabetical": {
-          comparison = a.title.localeCompare(b.title);
-          break;
-        }
-        case "importance": {
-          comparison = (b.importanceScore ?? 0) - (a.importanceScore ?? 0);
-          break;
-        }
-        default: {
-          comparison = 0;
-        }
-      }
+  const organizations = useMemo(() => {
+    if (organizationsFacet.length > 0) return organizationsFacet;
+    return [...new Set(tasks.map((t) => t.organization))];
+  }, [organizationsFacet, tasks]);
 
-      return sortOrder === "asc" ? comparison : -comparison;
-    });
-  }, [filteredTasks, sortBy, sortOrder]);
+  const assignedUsers = useMemo(() => {
+    if (ownersFacet.length > 0) return ownersFacet;
+    return [...new Set(tasks.map((t) => t.owner))];
+  }, [ownersFacet, tasks]);
+
+  // Server already filtered/sorted the current page
+  const sortedTasks = tasks;
 
   const handleSort = (field) => {
+    setPage(1);
     if (sortBy === field) {
       setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
       setSortBy(field);
-      setSortOrder("asc");
+      setSortOrder(field === "importance" ? "desc" : "asc");
     }
+  };
+
+  const handlePageChange = (nextPage) => {
+    setPage(nextPage);
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const updateTaskStatus = async (taskId, newStatus) => {
@@ -237,14 +223,16 @@ export default function useTasks() {
 
   const clearFilters = () => {
     setSearchQuery("");
+    setDebouncedSearch("");
     setStatusFilter("all");
     setPriorityFilter("all");
     setOrganizationFilter("all");
     setAssignedFilter("all");
+    setPage(1);
   };
 
   const hasActiveFilters =
-    searchQuery ||
+    Boolean(searchQuery.trim()) ||
     statusFilter !== "all" ||
     priorityFilter !== "all" ||
     organizationFilter !== "all" ||
@@ -259,13 +247,13 @@ export default function useTasks() {
     selectedTask,
     setSelectedTask,
     statusFilter,
-    setStatusFilter,
+    setStatusFilter: setStatusFilterAndReset,
     priorityFilter,
-    setPriorityFilter,
+    setPriorityFilter: setPriorityFilterAndReset,
     organizationFilter,
-    setOrganizationFilter,
+    setOrganizationFilter: setOrganizationFilterAndReset,
     assignedFilter,
-    setAssignedFilter,
+    setAssignedFilter: setAssignedFilterAndReset,
     sortBy,
     sortOrder,
     showFilters,
@@ -278,5 +266,11 @@ export default function useTasks() {
     toggleTaskReminder,
     clearFilters,
     hasActiveFilters,
+    page,
+    setPage: handlePageChange,
+    totalPages,
+    total,
+    limit: PAGE_SIZE,
+    refetch: fetchTasks,
   };
 }

--- a/client/src/pages/Tasks.jsx
+++ b/client/src/pages/Tasks.jsx
@@ -13,6 +13,7 @@ import TaskFilterPanel from "../components/tasks/TaskFilterPanel";
 import TaskSortBar from "../components/tasks/TaskSortBar";
 import TaskCard from "../components/tasks/TaskCard";
 import TaskDetailsModal from "../components/tasks/TaskDetailsModal";
+import Pagination from "../components/meetings/Pagination";
 
 const Tasks = () => {
   const navigate = useNavigate();
@@ -65,7 +66,7 @@ const Tasks = () => {
             </h3>
             <p className="text-red-700">{taskState.error}</p>
             <button
-              onClick={() => window.location.reload()}
+              onClick={() => taskState.refetch()}
               className="mt-4 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
             >
               Retry
@@ -97,18 +98,26 @@ const Tasks = () => {
             )}
           </div>
         ) : (
-          <div className="grid gap-4 fade-in-up stagger-3">
-            {taskState.sortedTasks.map((task) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                setSelectedTask={taskState.setSelectedTask}
-                navigate={navigate}
-                updateTaskStatus={taskState.updateTaskStatus}
-                toggleTaskReminder={taskState.toggleTaskReminder}
-              />
-            ))}
-          </div>
+          <>
+            <div className="grid gap-4 fade-in-up stagger-3">
+              {taskState.sortedTasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  setSelectedTask={taskState.setSelectedTask}
+                  navigate={navigate}
+                  updateTaskStatus={taskState.updateTaskStatus}
+                  toggleTaskReminder={taskState.toggleTaskReminder}
+                />
+              ))}
+            </div>
+
+            <Pagination
+              currentPage={taskState.page}
+              totalPages={taskState.totalPages}
+              onPageChange={taskState.setPage}
+            />
+          </>
         )}
 
         <TaskDetailsModal

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -9,6 +9,13 @@ export const knowledgeApi = {
     if (options.search) url += `&search=${encodeURIComponent(options.search)}`;
     if (options.page) url += `&page=${options.page}`;
     if (options.limit) url += `&limit=${options.limit}`;
+    if (options.owner) url += `&owner=${encodeURIComponent(options.owner)}`;
+    if (options.priority)
+      url += `&priority=${encodeURIComponent(options.priority)}`;
+    if (options.organization)
+      url += `&organization=${encodeURIComponent(options.organization)}`;
+    if (options.sortOrder)
+      url += `&sortOrder=${encodeURIComponent(options.sortOrder)}`;
     return apiClient.get(url);
   },
   updateActionItemStatus: (id, status) =>

--- a/server/controllers/knowledgeController.js
+++ b/server/controllers/knowledgeController.js
@@ -1,6 +1,8 @@
 import mongoose from "mongoose";
 import ActionItem from "../models/actionItemModel.js";
 import Decision from "../models/decisionModel.js";
+import Meeting from "../models/meetingModel.js";
+import Organization from "../models/organizationModel.js";
 import { getDecisionLineage } from "../services/knowledgeGraphService.js";
 import {
   recalculateAllImportanceScores,
@@ -24,11 +26,58 @@ import {
 } from "../services/archivedKnowledgeService.js";
 import AuditLog from "../models/auditLogModel.js";
 import eventBus from "../services/eventBus.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+import { escapeRegExp } from "../utils/regexUtils.js";
 
 const ALLOWED_SORT_FIELDS = {
   importance: { importanceScore: -1 },
   createdAt: { createdAt: -1 },
   dueDate: { dueDate: 1 },
+};
+
+/** Sort keys accepted by the Tasks board / action-items list (#903). */
+const ACTION_ITEM_SORT_FIELDS = new Set([
+  "dueDate",
+  "createdDate",
+  "createdAt",
+  "importance",
+  "alphabetical",
+  "status",
+  "priority",
+]);
+
+const STATUS_WEIGHT = {
+  open: 0,
+  "in-progress": 1,
+  resolved: 2,
+  superseded: 3,
+};
+
+const MEETING_POPULATE = {
+  path: "sourceMeetingId",
+  select: "title date organization",
+  populate: { path: "organization", select: "name" },
+};
+
+const resolveActionItemSort = (sortBy, sortOrder) => {
+  const direction = sortOrder === "desc" ? -1 : 1;
+
+  switch (sortBy) {
+    case "dueDate":
+      return { dueDate: direction, createdAt: -1 };
+    case "createdDate":
+    case "createdAt":
+      return { createdAt: direction };
+    case "importance":
+      return { importanceScore: direction, createdAt: -1 };
+    case "alphabetical":
+      return { text: direction, createdAt: -1 };
+    case "priority":
+      // Priority is not persisted on ActionItem; keep a stable secondary order.
+      return { createdAt: direction };
+    default:
+      return { createdAt: direction };
+  }
 };
 
 /**
@@ -89,9 +138,13 @@ export const getOpenActionItems = async (req, res) => {
     const {
       status = "open",
       sortBy = "createdAt",
+      sortOrder = "desc",
       includeArchived,
       lifecycleState,
       search,
+      owner,
+      priority,
+      organization: organizationName,
     } = req.query || {};
     const organization = sanitizeOrg(req.user?.organization);
 
@@ -107,79 +160,196 @@ export const getOpenActionItems = async (req, res) => {
       return sendError(res, 400, "Invalid status");
     }
 
+    if (typeof sortBy !== "string" || !ACTION_ITEM_SORT_FIELDS.has(sortBy)) {
+      return sendError(
+        res,
+        400,
+        `Invalid sortBy. Allowed values: ${[...ACTION_ITEM_SORT_FIELDS].join(", ")}`,
+      );
+    }
+
     if (
-      typeof sortBy !== "string" ||
-      !Object.prototype.hasOwnProperty.call(ALLOWED_SORT_FIELDS, sortBy)
+      sortOrder !== undefined &&
+      sortOrder !== null &&
+      sortOrder !== "" &&
+      sortOrder !== "asc" &&
+      sortOrder !== "desc"
     ) {
       return sendError(
         res,
         400,
-        `Invalid sortBy. Allowed values: ${Object.keys(ALLOWED_SORT_FIELDS).join(", ")}`,
+        "Invalid sortOrder. Allowed values: asc, desc",
       );
     }
 
-    let query;
-    if (status === "all") {
-      query = ActionItem.find({ organization });
-    } else if (status === "open") {
-      query = ActionItem.find({
-        organization,
-        status: "open",
-      });
-    } else if (status === "in-progress") {
-      query = ActionItem.find({
-        organization,
-        status: "in-progress",
-      });
-    } else if (status === "resolved") {
-      query = ActionItem.find({
-        organization,
-        status: "resolved",
-      });
-    } else if (status === "superseded") {
-      query = ActionItem.find({
-        organization,
-        status: "superseded",
-      });
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+      maxLimit: 100,
+    });
+
+    // Preserve legacy defaults when sortOrder is omitted (dueDate asc, others desc).
+    const effectiveSortOrder =
+      sortOrder === "asc" || sortOrder === "desc"
+        ? sortOrder
+        : sortBy === "dueDate"
+          ? "asc"
+          : "desc";
+
+    const filter = {};
+    if (organization) {
+      filter.organization = mongoose.Types.ObjectId.isValid(organization)
+        ? new mongoose.Types.ObjectId(organization)
+        : organization;
     }
 
-    if (search && typeof search === "string") {
-      query = query.where({ text: { $regex: search, $options: "i" } });
+    if (status !== "all") {
+      filter.status = status;
+    }
+
+    if (typeof owner === "string" && owner && owner !== "all") {
+      filter.owner = owner;
+    }
+
+    // Priority is not a persisted ActionItem field. Preserve prior client UX:
+    // "medium" matches everything (default), high/low match nothing.
+    if (priority === "high" || priority === "low") {
+      filter.priority = priority;
+    }
+
+    if (
+      typeof organizationName === "string" &&
+      organizationName &&
+      organizationName !== "all"
+    ) {
+      if (organizationName === "Personal") {
+        filter.organization = null;
+      } else {
+        const orgDoc = await Organization.findOne({
+          name: organizationName,
+        })
+          .select("_id")
+          .lean();
+        if (!orgDoc) {
+          return sendSuccess(res, {
+            actionItems: [],
+            pagination: buildPaginationMeta({ total: 0, page, limit }),
+            facets: { owners: [], organizations: [] },
+          });
+        }
+        filter.organization = orgDoc._id;
+      }
     }
 
     if (
       lifecycleState &&
       ["active", "dormant", "archived", "expired"].includes(lifecycleState)
     ) {
-      query = query.where({ lifecycleState });
+      filter.lifecycleState = lifecycleState;
     } else if (includeArchived !== "true") {
-      query = query.where({
-        lifecycleState: { $nin: ["archived", "expired"] },
-      });
+      filter.lifecycleState = { $nin: ["archived", "expired"] };
     }
 
-    const page = parseInt(req.query.page, 10) || 1;
-    const limit = Math.min(parseInt(req.query.limit, 10) || 10, 100);
-    const skip = (page - 1) * limit;
+    const searchTerm =
+      typeof search === "string" && search.trim() ? search.trim() : "";
+    if (searchTerm) {
+      const escaped = escapeRegExp(searchTerm);
+      const meetingTitleFilter = {
+        title: { $regex: escaped, $options: "i" },
+      };
+      if (filter.organization !== undefined) {
+        meetingTitleFilter.organization = filter.organization;
+      }
 
-    const total =
-      typeof ActionItem.countDocuments === "function" &&
-      typeof query.getFilter === "function"
-        ? await ActionItem.countDocuments(query.getFilter())
-        : 0;
+      const matchingMeetings = await Meeting.find(meetingTitleFilter)
+        .select("_id")
+        .lean();
 
-    let itemsQuery = query
-      .populate("sourceMeetingId", "title date")
-      .sort(ALLOWED_SORT_FIELDS[sortBy]);
-
-    if (typeof itemsQuery.skip === "function") {
-      itemsQuery = itemsQuery.skip(skip).limit(limit);
+      filter.$or = [
+        { text: { $regex: escaped, $options: "i" } },
+        { owner: { $regex: escaped, $options: "i" } },
+        {
+          sourceMeetingId: {
+            $in: matchingMeetings.map((meeting) => meeting._id),
+          },
+        },
+      ];
     }
 
-    const items = await itemsQuery;
+    // Facets for filter dropdowns (scoped to org + lifecycle, not page-local)
+    const facetFilter = {
+      ...(organization ? { organization } : {}),
+      ...(filter.lifecycleState
+        ? { lifecycleState: filter.lifecycleState }
+        : {}),
+    };
+    if (status !== "all") {
+      facetFilter.status = status;
+    }
 
-    // Retrieving this list counts as accessing each memory in it; refresh
-    // their importance scores in the background without blocking the response.
+    const [total, ownerFacets, organizationIds, hasPersonal] =
+      await Promise.all([
+        ActionItem.countDocuments(filter),
+        ActionItem.distinct("owner", facetFilter),
+        ActionItem.distinct("organization", {
+          ...facetFilter,
+          organization: { $ne: null },
+        }),
+        ActionItem.exists({ ...facetFilter, organization: null }),
+      ]);
+
+    let organizationFacets = [];
+    if (organizationIds.length > 0) {
+      const orgs = await Organization.find({
+        _id: { $in: organizationIds.filter(Boolean) },
+      })
+        .select("name")
+        .lean();
+      organizationFacets = orgs.map((org) => org.name).filter(Boolean);
+    }
+    if (hasPersonal) {
+      organizationFacets.push("Personal");
+    }
+    organizationFacets = [...new Set(organizationFacets)].sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    const direction = effectiveSortOrder === "desc" ? -1 : 1;
+    let items;
+
+    if (sortBy === "status") {
+      // Semantic status order (open → in-progress → resolved → superseded)
+      const pipeline = [
+        { $match: filter },
+        {
+          $addFields: {
+            statusWeight: {
+              $switch: {
+                branches: Object.entries(STATUS_WEIGHT).map(
+                  ([value, weight]) => ({
+                    case: { $eq: ["$status", value] },
+                    then: weight,
+                  }),
+                ),
+                default: 0,
+              },
+            },
+          },
+        },
+        { $sort: { statusWeight: direction, createdAt: -1 } },
+        { $skip: skip },
+        { $limit: limit },
+      ];
+
+      items = await ActionItem.aggregate(pipeline);
+      items = await ActionItem.populate(items, MEETING_POPULATE);
+    } else {
+      items = await ActionItem.find(filter)
+        .populate(MEETING_POPULATE)
+        .sort(resolveActionItemSort(sortBy, effectiveSortOrder))
+        .skip(skip)
+        .limit(limit);
+    }
+
     recordMemoryAccessBatch(
       "actionItem",
       items.map((item) => item._id),
@@ -187,11 +357,10 @@ export const getOpenActionItems = async (req, res) => {
 
     sendSuccess(res, {
       actionItems: items,
-      pagination: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
+      pagination: buildPaginationMeta({ total, page, limit }),
+      facets: {
+        owners: ownerFacets.filter(Boolean).sort((a, b) => a.localeCompare(b)),
+        organizations: organizationFacets,
       },
     });
   } catch (error) {

--- a/server/models/actionItemModel.js
+++ b/server/models/actionItemModel.js
@@ -177,6 +177,10 @@ const actionItemSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
+actionItemSchema.index({ organization: 1, status: 1, createdAt: -1 });
+actionItemSchema.index({ organization: 1, dueDate: 1 });
+actionItemSchema.index({ organization: 1, owner: 1 });
+
 const ActionItem =
   mongoose.models.ActionItem || mongoose.model("ActionItem", actionItemSchema);
 

--- a/server/tests/knowledgeController.test.js
+++ b/server/tests/knowledgeController.test.js
@@ -13,6 +13,24 @@ jest.mock("../models/actionItemModel.js", () => ({
     find: jest.fn(),
     findById: jest.fn(),
     findOne: jest.fn(),
+    countDocuments: jest.fn(),
+    distinct: jest.fn(),
+    exists: jest.fn(),
+    aggregate: jest.fn(),
+    populate: jest.fn(),
+  },
+}));
+
+jest.mock("../models/meetingModel.js", () => ({
+  default: {
+    find: jest.fn(),
+  },
+}));
+
+jest.mock("../models/organizationModel.js", () => ({
+  default: {
+    find: jest.fn(),
+    findOne: jest.fn(),
   },
 }));
 
@@ -38,6 +56,8 @@ const {
 } = await import("../controllers/knowledgeController.js");
 const Decision = (await import("../models/decisionModel.js")).default;
 const ActionItem = (await import("../models/actionItemModel.js")).default;
+const Meeting = (await import("../models/meetingModel.js")).default;
+const Organization = (await import("../models/organizationModel.js")).default;
 
 describe("knowledgeController - NoSQL Injection & Query Validation", () => {
   let req;
@@ -193,32 +213,119 @@ describe("knowledgeController - NoSQL Injection & Query Validation", () => {
   });
 
   describe("getOpenActionItems", () => {
+    const mockFindChain = (items = [{ _id: "item1" }]) => {
+      const chain = {
+        populate: jest.fn().mockReturnThis(),
+        sort: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockResolvedValue(items),
+      };
+      ActionItem.find.mockReturnValue(chain);
+      return chain;
+    };
+
+    beforeEach(() => {
+      ActionItem.countDocuments.mockResolvedValue(1);
+      ActionItem.distinct.mockResolvedValue([]);
+      ActionItem.exists.mockResolvedValue(null);
+      Organization.find.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([]),
+        }),
+      });
+      Meeting.find.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue([]),
+        }),
+      });
+    });
+
     it("should fetch action items with valid status and sortBy", async () => {
       req.query = { status: "in-progress", sortBy: "createdAt" };
-
-      const queryChain = {
-        where: jest.fn().mockReturnThis(),
-        getFilter: jest.fn().mockReturnValue({
-          organization: "org123",
-          status: "in-progress",
-          lifecycleState: { $nin: ["archived", "expired"] },
-        }),
-        populate: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue([{ _id: "item1" }]),
-      };
-      ActionItem.find.mockReturnValue(queryChain);
-      ActionItem.countDocuments = jest.fn().mockResolvedValue(1);
+      mockFindChain();
 
       await getOpenActionItems(req, res);
 
-      expect(ActionItem.find).toHaveBeenCalledWith({
-        organization: "org123",
-        status: "in-progress",
-      });
-      expect(queryChain.where).toHaveBeenCalledWith({
-        lifecycleState: { $nin: ["archived", "expired"] },
-      });
+      expect(ActionItem.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: expect.anything(),
+          status: "in-progress",
+          lifecycleState: { $nin: ["archived", "expired"] },
+        }),
+      );
+      expect(ActionItem.countDocuments).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          actionItems: [{ _id: "item1" }],
+          pagination: expect.objectContaining({
+            total: 1,
+            page: 1,
+            limit: 20,
+          }),
+          facets: expect.objectContaining({
+            owners: expect.any(Array),
+            organizations: expect.any(Array),
+          }),
+        }),
+      );
+    });
+
+    it("should apply owner filter and pagination on the server", async () => {
+      req.query = {
+        status: "all",
+        sortBy: "dueDate",
+        sortOrder: "asc",
+        owner: "Alex",
+        page: "2",
+        limit: "5",
+      };
+      ActionItem.countDocuments.mockResolvedValue(12);
+      const chain = mockFindChain([{ _id: "item2" }]);
+
+      await getOpenActionItems(req, res);
+
+      expect(ActionItem.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "Alex",
+          lifecycleState: { $nin: ["archived", "expired"] },
+        }),
+      );
+      expect(chain.skip).toHaveBeenCalledWith(5);
+      expect(chain.limit).toHaveBeenCalledWith(5);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pagination: expect.objectContaining({
+            total: 12,
+            page: 2,
+            limit: 5,
+            totalPages: 3,
+            hasMore: true,
+          }),
+        }),
+      );
+    });
+
+    it("should escape search input before building regex filters", async () => {
+      req.query = { status: "all", sortBy: "createdAt", search: "C++" };
+      mockFindChain();
+
+      await getOpenActionItems(req, res);
+
+      expect(Meeting.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: { $regex: "C\\+\\+", $options: "i" },
+        }),
+      );
+      expect(ActionItem.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            { text: { $regex: "C\\+\\+", $options: "i" } },
+            { owner: { $regex: "C\\+\\+", $options: "i" } },
+          ]),
+        }),
+      );
     });
 
     it("should reject NoSQL injection attack in status (object value)", async () => {


### PR DESCRIPTION
## Summary

Fixes #903

### What changed

- Moved Tasks Board filtering to the backend.
- Added server-side sorting and pagination.
- Reduced client-side processing and memory usage.
- Updated the client to request paginated task data from the API.
- Added backend support for additional query parameters and pagination metadata.
- Added database indexes to improve task query performance.
- Extended controller tests to cover filtering, sorting, and pagination.

### Benefits

- Scales efficiently for organizations with large numbers of action items.
- Reduces unnecessary network traffic.
- Improves Tasks Board responsiveness.
- Preserves existing functionality while enabling server-driven data loading.

### Validation

- Prettier formatting passed.
- ESLint passed.
- Client build completed successfully.
- Existing unrelated test failures were observed in the repository and are not caused by this change. :contentReference[oaicite:0]{index=0}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-powered task filtering, sorting, search, and pagination.
  * Added filter options for owners and organizations.
  * Added pagination controls with total result and page information.
  * Search now updates results as you type with improved responsiveness.

* **Bug Fixes**
  * Retry actions now refresh task data without reloading the entire page.
  * Improved handling of task searches, statuses, and sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->