### PR TITLE
fix(security): insert the mapped speaker name literally, and trim the label

### DIFF
--- a/server/services/speakerIdentificationService.js
+++ b/server/services/speakerIdentificationService.js
@@ -27,10 +27,16 @@ class SpeakerIdentificationService {
    * @param {string} mappedName
    */
   async applyMapping(meetingId, originalLabel, mappedName) {
-    const label = String(originalLabel ?? "");
-    if (!label.trim()) {
+    // Trimmed, not merely checked for emptiness: the label is compared against
+    // stored values (`segment.speaker === label`), so `" #1 "` would otherwise
+    // pass validation, match nothing, and complete without applying the
+    // mapping the caller asked for.
+    const label = String(originalLabel ?? "").trim();
+    if (!label) {
       throw new Error("Speaker label must not be empty");
     }
+
+    const replacement = String(mappedName ?? "");
 
     // Built once and reused for both the summary and the action item pass.
     // `lastIndex` on a `/g` regex is per-object state, so sharing one instance
@@ -39,13 +45,28 @@ class SpeakerIdentificationService {
     // constant.
     const labelPattern = wordBoundaryRegExp(label, "g");
 
+    // The *replacement* string is the other half of this bug, and it is the
+    // half that escaping the pattern does not fix: `String.prototype.replace`
+    // expands `$&`, `` $` ``, `$'` and `$1`…`$9` inside the replacement.
+    //
+    //   "Speaker 1 opened the review.".replace(/\bSpeaker 1\b/g, "$`")
+    //   -> " opened the review."
+    //
+    //   ...replace(/\bSpeaker 1\b/g, "A$'B")
+    //   -> "A opened the review.B opened the review."
+    //
+    // `mappedName` is caller-supplied, so a mapped name of `` $` `` destroys
+    // the summary exactly as a wildcard label did. A function replacement is
+    // never interpreted, so this is literal by construction.
+    const insertLiteral = () => replacement;
+
     // 1. Update Transcript Segments
     const transcript = await Transcript.findOne({ meeting: meetingId });
     if (transcript) {
       let isTranscriptModified = false;
       for (const segment of transcript.segments) {
         if (segment.speaker === label) {
-          segment.speaker = mappedName;
+          segment.speaker = replacement;
           isTranscriptModified = true;
         }
       }
@@ -61,7 +82,7 @@ class SpeakerIdentificationService {
 
       if (meeting.summary && meeting.summary.includes(label)) {
         // Use regex for word boundary to avoid partial matches
-        const replaced = meeting.summary.replace(labelPattern, mappedName);
+        const replaced = meeting.summary.replace(labelPattern, insertLiteral);
         // `includes` finds the label as a substring; the boundary pattern may
         // still match nothing (e.g. the label appears only inside a longer
         // word). Only mark the document dirty if something actually changed,
@@ -80,9 +101,9 @@ class SpeakerIdentificationService {
         );
         if (index !== -1) {
           if (typeof attendees[index] === "string") {
-            attendees[index] = mappedName;
+            attendees[index] = replacement;
           } else if (attendees[index].name) {
-            attendees[index].name = mappedName;
+            attendees[index].name = replacement;
           }
           meeting.markModified("structuredMoM");
           isMeetingModified = true;
@@ -103,12 +124,12 @@ class SpeakerIdentificationService {
       let updateDoc = {};
 
       if (item.owner === label) {
-        updateDoc.owner = mappedName;
+        updateDoc.owner = replacement;
         isModified = true;
       }
 
       if (item.text && item.text.includes(label)) {
-        const replacedText = item.text.replace(labelPattern, mappedName);
+        const replacedText = item.text.replace(labelPattern, insertLiteral);
         if (replacedText !== item.text) {
           updateDoc.text = replacedText;
           isModified = true;

--- a/server/tests/regexEscaping.test.js
+++ b/server/tests/regexEscaping.test.js
@@ -13,6 +13,11 @@
  * only `utils/regexUtils.js` added, since the suite imports it), 16 of these
  * fail — the false-collision cases in tags and glossary, the `SyntaxError`
  * cases, glossary detection of `C++`, and every speaker-mapping case.
+ *
+ * Per-test isolation comes from the global `afterEach` in `tests/setup.js`,
+ * which wipes every collection between tests. The `countDocuments(...)`
+ * assertions below are load-bearing for that too: they would fail immediately
+ * if an earlier test's tags survived into a later one.
  */
 
 import mongoose from "mongoose";
@@ -590,6 +595,129 @@ describe("speaker mapping (Issue #1157)", () => {
 
     const after = await Meeting.findById(meeting._id);
     expect(after.summary).toBe("Then Ada asked about scope.");
+  });
+
+  // Raised in review of #1157: escaping the *pattern* fixes only half of this.
+  // `String.prototype.replace` expands `$&`, `` $` ``, `$'` and `$1`…`$9` in
+  // the *replacement* string, and `mappedName` is caller-supplied too.
+  describe("replacement string is inserted literally", () => {
+    it("does not let a `$`` mapped name swallow the summary", async () => {
+      const meeting = await seedMeeting();
+
+      await speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1",
+        "$`",
+      );
+
+      const after = await Meeting.findById(meeting._id);
+      // With a string replacement this becomes " opened. Speaker 2 raised…",
+      // i.e. the preceding text is duplicated and the label is lost.
+      expect(after.summary).toBe(
+        "$` opened. Speaker 2 raised the deploy risk.",
+      );
+    });
+
+    it("does not let a `$'` mapped name duplicate the trailing text", async () => {
+      const meeting = await seedMeeting();
+
+      await speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1",
+        "A$'B",
+      );
+
+      const after = await Meeting.findById(meeting._id);
+      expect(after.summary).toBe(
+        "A$'B opened. Speaker 2 raised the deploy risk.",
+      );
+    });
+
+    it("inserts `$&` verbatim rather than re-inserting the match", async () => {
+      const meeting = await seedMeeting();
+
+      await speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1",
+        "$&",
+      );
+
+      const after = await Meeting.findById(meeting._id);
+      expect(after.summary).toBe(
+        "$& opened. Speaker 2 raised the deploy risk.",
+      );
+    });
+
+    it("applies the same guard to action item text", async () => {
+      const meeting = await seedMeeting();
+
+      await ActionItem.create({
+        text: "Speaker 1 to confirm the rollout window",
+        owner: "Speaker 1",
+        organization: ORG_A,
+        sourceMeetingId: meeting._id,
+      });
+
+      await speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1",
+        "$`",
+      );
+
+      const item = await ActionItem.findOne({ sourceMeetingId: meeting._id });
+      expect(item.text).toBe("$` to confirm the rollout window");
+      expect(item.owner).toBe("$`");
+    });
+
+    it("still handles an ordinary name containing a dollar sign", async () => {
+      const meeting = await seedMeeting();
+
+      await speakerIdentificationService.applyMapping(
+        meeting._id,
+        "Speaker 1",
+        "A$B Consulting",
+      );
+
+      const after = await Meeting.findById(meeting._id);
+      expect(after.summary).toBe(
+        "A$B Consulting opened. Speaker 2 raised the deploy risk.",
+      );
+    });
+  });
+
+  // Also raised in review: the label is compared against stored values, so it
+  // has to be trimmed rather than merely checked for emptiness.
+  it("trims a padded label so the mapping still applies", async () => {
+    const meeting = await seedMeeting();
+
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      "  Speaker 1  ",
+      "Ada",
+    );
+
+    const after = await Meeting.findById(meeting._id);
+    expect(after.summary).toBe("Ada opened. Speaker 2 raised the deploy risk.");
+  });
+
+  it("trims a padded label when rewriting transcript segments", async () => {
+    const meeting = await seedMeeting();
+
+    await Transcript.create({
+      meeting: meeting._id,
+      segments: [
+        { speaker: "Speaker 1", text: "Morning", startTime: 0, endTime: 2 },
+      ],
+    });
+
+    await speakerIdentificationService.applyMapping(
+      meeting._id,
+      " Speaker 1 ",
+      "Ada",
+    );
+
+    const transcript = await Transcript.findOne({ meeting: meeting._id });
+    expect(transcript.segments[0].speaker).toBe("Ada");
   });
 
   it("refuses an empty label rather than rewriting the document", async () => {


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #1162, which was merged before this commit landed on the branch. It carries the two review findings CodeRabbit raised there, both in `applyMapping`.

### The mapped name is expanded as a replacement pattern

#1162 escaped the *search pattern* so a label like `.` could no longer match arbitrary text. It left the *replacement* alone — and `String.prototype.replace` expands `$&`, `` $` ``, `$'` and `$1`…`$9` inside a replacement string. `mappedName` is caller-supplied in the body of `POST /api/speaker-mappings/:meetingId`, so that is the same bug from the other side:

```js
"Speaker 1 opened the review.".replace(/\bSpeaker 1\b/g, "$`")
// -> " opened the review."

"Speaker 1 opened the review.".replace(/\bSpeaker 1\b/g, "A$'B")
// -> "A opened the review.B opened the review."
```

A mapped name of ``$` `` therefore destroys `meeting.summary` exactly the way a wildcard label did before #1162 — `applyMapping` calls `meeting.save()`, writes no `NoteVersion` snapshot, and `revertMapping` re-enters the same function with the arguments swapped, so the original text is not recoverable.

Both replacement sites — `meeting.summary` and `ActionItem.text` — now take a **function** replacement. A function's return value is never scanned for `$` patterns, so insertion is literal by construction rather than by escaping. `owner`, `structuredMoM.attendees` and transcript speakers take the same normalized value.

### The label needs trimming, not just an emptiness check

`applyMapping` rejected a whitespace-only label but kept surrounding whitespace on everything else. The label is compared against stored values (`segment.speaker === label`), so `" #1 "` passed validation, matched nothing, and returned success without applying the mapping the caller asked for.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Follow-up to #1157 / #1162.

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

Seven tests added to `server/tests/regexEscaping.test.js` (54 total in the file, all passing):

- ``$` ``, `$'` and `$&` as mapped names against the summary — each asserted to appear verbatim rather than expanding.
- The same guard on action item **text and owner**.
- An ordinary name containing a dollar sign (`A$B Consulting`) still round-trips, so the fix is not over-escaping.
- A padded label (`"  Speaker 1  "`) applies to the summary, and to transcript segments.

Each of the three expansion tests fails against the merged `#1162` code, with the summary corrupted in the way shown above.

## Screenshots

N/A — server-side.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speaker-name mapping by trimming labels and consistently applying normalized names across transcripts, summaries, attendees, and action items.
  * Prevented special replacement tokens and dollar signs in speaker names from being interpreted incorrectly.
* **Tests**
  * Added regression coverage for speaker-name formatting, replacement handling, and updates across related meeting content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->