### PR TITLE
feat(shared-links): add passcode lockout protection

### DIFF
--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -6,6 +6,14 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
 import { hasPermission } from "../utils/rbacPermissions.js";
+import logger from "../utils/logger.js";
+import {
+  SHARED_LINK_PASSCODE_AUTH_FAILURE_MESSAGE,
+  SHARED_LINK_PASSCODE_LOCKOUT_MS,
+  SHARED_LINK_PASSCODE_MAX_ATTEMPTS,
+  hasPasscodeLockExpired,
+  isPasscodeLocked,
+} from "../utils/sharedLinkSecurity.js";
 
 /**
  * The shareable resource types and the model each one resolves against.
@@ -101,13 +109,73 @@ const recordSuccessfulAccess = (linkId) => {
   );
 };
 
-const recordFailedPasscodeAttempt = (linkId) => {
+const clearPasscodeLockout = (linkId) =>
   SharedLink.findByIdAndUpdate(linkId, {
-    $inc: { failedPasscodeAttempts: 1 },
-  }).catch((err) =>
-    console.error("Failed to record failed passcode attempt:", err.message),
-  );
+    $set: {
+      failedPasscodeAttempts: 0,
+      passcodeLockUntil: null,
+    },
+  });
+
+/**
+ * Records a failed attempt and engages lockout once the threshold is reached.
+ * Returns the updated document (or null if the update failed).
+ */
+const recordFailedPasscodeAttempt = async (link) => {
+  try {
+    const updated = await SharedLink.findByIdAndUpdate(
+      link._id,
+      { $inc: { failedPasscodeAttempts: 1 } },
+      { new: true },
+    );
+
+    if (!updated) return null;
+
+    if (updated.failedPasscodeAttempts >= SHARED_LINK_PASSCODE_MAX_ATTEMPTS) {
+      const passcodeLockUntil = new Date(
+        Date.now() + SHARED_LINK_PASSCODE_LOCKOUT_MS,
+      );
+      await SharedLink.findByIdAndUpdate(link._id, {
+        $set: { passcodeLockUntil },
+      });
+
+      logger.warn("Shared link passcode lockout engaged", {
+        linkId: String(link._id),
+        organizationId: link.organizationId
+          ? String(link.organizationId)
+          : null,
+        resourceModel: link.resourceModel,
+        failedPasscodeAttempts: updated.failedPasscodeAttempts,
+        passcodeLockUntil: passcodeLockUntil.toISOString(),
+      });
+    } else if (
+      updated.failedPasscodeAttempts >=
+      Math.max(1, SHARED_LINK_PASSCODE_MAX_ATTEMPTS - 1)
+    ) {
+      // One attempt remaining before lockout — useful signal without leaking
+      // lockout details to the client.
+      logger.warn("Shared link passcode nearing lockout threshold", {
+        linkId: String(link._id),
+        organizationId: link.organizationId
+          ? String(link.organizationId)
+          : null,
+        failedPasscodeAttempts: updated.failedPasscodeAttempts,
+        maxAttempts: SHARED_LINK_PASSCODE_MAX_ATTEMPTS,
+      });
+    }
+
+    return updated;
+  } catch (err) {
+    console.error("Failed to record failed passcode attempt:", err.message);
+    return null;
+  }
 };
+
+const sendPasscodeAuthFailure = (res) =>
+  res.status(401).json({
+    success: false,
+    message: SHARED_LINK_PASSCODE_AUTH_FAILURE_MESSAGE,
+  });
 
 export const createLink = async (req, res) => {
   try {
@@ -318,6 +386,19 @@ export const verifyPasscode = async (req, res) => {
         .json({ success: true, message: "No passcode required" });
     }
 
+    // Active lockout: reject without running bcrypt (Issue #1111).
+    // Same generic message as a wrong passcode so callers cannot probe state.
+    if (isPasscodeLocked(link)) {
+      return sendPasscodeAuthFailure(res);
+    }
+
+    // Expired lockout clears automatically on the next verification attempt.
+    if (hasPasscodeLockExpired(link)) {
+      await clearPasscodeLockout(link._id);
+      link.failedPasscodeAttempts = 0;
+      link.passcodeLockUntil = null;
+    }
+
     if (!passcode) {
       return res
         .status(400)
@@ -326,11 +407,12 @@ export const verifyPasscode = async (req, res) => {
 
     const isMatch = await bcrypt.compare(passcode, link.passcode);
     if (!isMatch) {
-      recordFailedPasscodeAttempt(link._id);
-      return res
-        .status(401)
-        .json({ success: false, message: "Incorrect passcode" });
+      await recordFailedPasscodeAttempt(link);
+      return sendPasscodeAuthFailure(res);
     }
+
+    // Successful verification resets consecutive failures / lockout.
+    await clearPasscodeLockout(link._id);
 
     // Generate a short-lived token to access the resource
     const token = jwt.sign(

--- a/server/models/sharedLinkModel.js
+++ b/server/models/sharedLinkModel.js
@@ -53,6 +53,11 @@ const sharedLinkSchema = new mongoose.Schema(
       default: 0,
       min: 0,
     },
+    // Temporary lockout after consecutive failed passcode attempts (#1111)
+    passcodeLockUntil: {
+      type: Date,
+      default: null,
+    },
   },
   { timestamps: true },
 );

--- a/server/tests/sharedLinkAnalytics.test.js
+++ b/server/tests/sharedLinkAnalytics.test.js
@@ -137,6 +137,14 @@ describe("Shared link analytics (#723)", () => {
       active: true,
       passcode: "hashed-pass",
       expirationDate: null,
+      failedPasscodeAttempts: 0,
+      passcodeLockUntil: null,
+      organizationId: "org-1",
+      resourceModel: "Meeting",
+    });
+    mockFindByIdAndUpdate.mockResolvedValue({
+      _id: "link-3",
+      failedPasscodeAttempts: 1,
     });
     bcrypt.compare.mockResolvedValue(false);
 
@@ -150,11 +158,66 @@ describe("Shared link analytics (#723)", () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.body.message).toBe("Incorrect passcode");
+    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
+      "link-3",
+      { $inc: { failedPasscodeAttempts: 1 } },
+      { new: true },
+    );
+  });
 
-    await vi.waitFor(() => {
-      expect(mockFindByIdAndUpdate).toHaveBeenCalledWith("link-3", {
-        $inc: { failedPasscodeAttempts: 1 },
-      });
+  it("rejects verification while locked without running bcrypt", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "link-locked",
+      hash: "locked-hash",
+      active: true,
+      passcode: "hashed-pass",
+      expirationDate: null,
+      failedPasscodeAttempts: 5,
+      passcodeLockUntil: new Date(Date.now() + 60_000),
+    });
+
+    const req = {
+      params: { hash: "locked-hash" },
+      body: { passcode: "anything" },
+    };
+    const res = mockRes();
+
+    await verifyPasscode(req, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.message).toBe("Incorrect passcode");
+    expect(bcrypt.compare).not.toHaveBeenCalled();
+    expect(mockFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("clears expired lockout and resets counters on successful verify", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "link-expired-lock",
+      hash: "expired-lock",
+      active: true,
+      passcode: "hashed-pass",
+      expirationDate: null,
+      failedPasscodeAttempts: 5,
+      passcodeLockUntil: new Date(Date.now() - 1000),
+      organizationId: "org-1",
+    });
+    mockFindByIdAndUpdate.mockResolvedValue({});
+    bcrypt.compare.mockResolvedValue(true);
+
+    const req = {
+      params: { hash: "expired-lock" },
+      body: { passcode: "correct" },
+    };
+    const res = mockRes();
+
+    await verifyPasscode(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith("link-expired-lock", {
+      $set: {
+        failedPasscodeAttempts: 0,
+        passcodeLockUntil: null,
+      },
     });
   });
 

--- a/server/utils/sharedLinkSecurity.js
+++ b/server/utils/sharedLinkSecurity.js
@@ -1,0 +1,39 @@
+/**
+ * Shared-link passcode lockout (Issue #1111).
+ *
+ * Complements the HTTP `loginLimiter` on POST /api/public/shared/:hash/verify:
+ * the rate limiter caps requests per IP, while these settings lock a specific
+ * link after consecutive wrong passcodes — even across IPs or limiter windows.
+ *
+ * Defaults mirror the login limiter (5 failures / 15 minutes) so operators get
+ * a consistent brute-force posture. Override with env when needed.
+ */
+
+const parsePositiveInt = (raw, fallback) => {
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/** Consecutive failures before the link is temporarily locked. */
+export const SHARED_LINK_PASSCODE_MAX_ATTEMPTS = parsePositiveInt(
+  process.env.SHARED_LINK_PASSCODE_MAX_ATTEMPTS,
+  5,
+);
+
+/** How long a lockout lasts once the threshold is reached. */
+export const SHARED_LINK_PASSCODE_LOCKOUT_MS = parsePositiveInt(
+  process.env.SHARED_LINK_PASSCODE_LOCKOUT_MS,
+  15 * 60 * 1000,
+);
+
+/**
+ * Generic failure message for wrong passcodes *and* active lockouts.
+ * Intentionally identical so clients cannot distinguish the two cases.
+ */
+export const SHARED_LINK_PASSCODE_AUTH_FAILURE_MESSAGE = "Incorrect passcode";
+
+export const isPasscodeLocked = (link, now = new Date()) =>
+  Boolean(link?.passcodeLockUntil && new Date(link.passcodeLockUntil) > now);
+
+export const hasPasscodeLockExpired = (link, now = new Date()) =>
+  Boolean(link?.passcodeLockUntil && new Date(link.passcodeLockUntil) <= now);


### PR DESCRIPTION
# Pull Request

## Description

This PR improves the security of password-protected shared links by introducing a configurable account lockout mechanism for passcode verification.

After a configurable number of consecutive failed passcode attempts, verification is temporarily locked to mitigate brute-force attacks. The implementation preserves existing shared-link functionality while resetting failed attempts after a successful verification or when the lockout period expires.

## Type of Change

- [x] Security Improvement

## Related Issue

Closes #1111

## Testing

### Validation Performed

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Commands Executed

- `npx prettier --write`
- `npm run format:check:changed --prefix server`
- `npm run lint:changed --prefix server`

> **Note:** `npm run test:related --prefix server` still encounters existing repository-wide Jest/ESM issues (`module is already linked`, missing `helmet`, etc.), which are unrelated to this change.

## Screenshots

N/A (Backend security enhancement)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review