### PR TITLE
fix(ui): restore dashboard navigation visibility for authorized users

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -389,7 +389,7 @@ const Navbar = () => {
       label: t("navbar.dashboard"),
       href: "/dashboard",
       icon: LayoutDashboard,
-      permission: { resource: "reports", action: "view" },
+      permission: null,
     },
     {
       label: t("navbar.meetings"),

--- a/client/src/components/__tests__/NavbarDashboardNav.test.jsx
+++ b/client/src/components/__tests__/NavbarDashboardNav.test.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import Navbar from "../Navbar.jsx";
+import AppContent from "../../context/AppContent.js";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: (resource, action) => {
+      // User has no reports:view permission
+      if (resource === "reports" && action === "view") return false;
+      return true;
+    },
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => {
+      if (key === "navbar.dashboard") return "Dashboard";
+      if (key === "navbar.meetings") return "Meetings";
+      return key;
+    },
+    i18n: {
+      language: "en",
+      changeLanguage: vi.fn(),
+    },
+  }),
+}));
+
+describe("Navbar Dashboard Navigation Visibility (#1127)", () => {
+  it("renders Dashboard navigation item for logged-in users regardless of reports:view permission", () => {
+    const mockContextValue = {
+      isLoggedin: true,
+      userData: {
+        name: "Test User",
+        email: "user@example.com",
+        role: "member",
+      },
+      setUserData: vi.fn(),
+      setIsLoggedin: vi.fn(),
+      backendUrl: "http://localhost:4000",
+    };
+
+    const mockThemeContext = {
+      theme: "light",
+      toggleTheme: vi.fn(),
+      setTheme: vi.fn(),
+      mounted: true,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <ThemeContext.Provider value={mockThemeContext}>
+          <AppContent.Provider value={mockContextValue}>
+            <Navbar />
+          </AppContent.Provider>
+        </ThemeContext.Provider>
+      </MemoryRouter>,
+    );
+
+    const dashboardElements = screen.getAllByText("Dashboard");
+    expect(dashboardElements.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #1127

## Description
This PR aligns the Dashboard navigation item visibility in Navbar.jsx with actual route accessibility, ensuring all authorized logged-in users can view and navigate to the Dashboard.

## Proposed Changes
- **Navbar Permissions Realignment**: Removed the overly restrictive esource: "reports", action: "view" requirement on the 	("navbar.dashboard") link in Navbar.jsx, aligning navigation visibility with the general <ProtectedRoute><Dashboard /></ProtectedRoute> route rule.
- **Unit Test Coverage**: Added Vitest test suite (NavbarDashboardNav.test.jsx) verifying that Dashboard navigation is visible to logged-in users regardless of eports:view permission.

## Checklist
- [x] Related Issue is linked (Fixes #1127).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard navigation is now visible to all authenticated users, regardless of `reports:view` permission.

* **Tests**
  * Added coverage confirming the Dashboard link appears for logged-in users without reporting permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->