### PR TITLE
fix(routing): register conflict resolution route in application routing

### DIFF
--- a/client/src/pages/__tests__/ConflictResolutionRoute.test.jsx
+++ b/client/src/pages/__tests__/ConflictResolutionRoute.test.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import AppContent from "../../context/AppContent.js";
+import ProtectedRoute from "../../components/ProtectedRoute.jsx";
+import ConflictResolution from "../ConflictResolution.jsx";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../ConflictResolution.jsx", () => ({
+  default: () => (
+    <div data-testid="conflict-resolution-page">Conflict Resolution Page</div>
+  ),
+}));
+
+describe("Conflict Resolution Route Registration (#1128)", () => {
+  it("resolves /knowledge/conflicts route correctly to ConflictResolution component", () => {
+    const mockContext = {
+      isLoggedin: true,
+      userData: { name: "Test User", hasCompletedOnboarding: true },
+      loading: false,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/knowledge/conflicts"]}>
+        <AppContent.Provider value={mockContext}>
+          <Routes>
+            <Route
+              path="/knowledge/conflicts"
+              element={
+                <ProtectedRoute resource="knowledge" action="view">
+                  <ConflictResolution />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/knowledge/:decisionId"
+              element={<div>Dynamic Decision Page</div>}
+            />
+          </Routes>
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("conflict-resolution-page")).toBeInTheDocument();
+    expect(screen.queryByText("Dynamic Decision Page")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -56,6 +56,7 @@ import RecapScheduleDashboard from "../pages/RecapScheduleDashboard.jsx";
 import MeetingHealthDashboard from "../pages/MeetingHealthDashboard.jsx";
 import AutomationRules from "../pages/AutomationRules.jsx";
 import TopicExplorer from "../pages/TopicExplorer.jsx";
+import ConflictResolution from "../pages/ConflictResolution.jsx";
 
 const ProtectedRoutes = (
   <React.Fragment>
@@ -84,10 +85,10 @@ const ProtectedRoutes = (
       }
     />
     <Route
-      path="/knowledge/:decisionId"
+      path="/knowledge/conflicts"
       element={
-        <ProtectedRoute>
-          <KnowledgeTimeline />
+        <ProtectedRoute resource="knowledge" action="view">
+          <ConflictResolution />
         </ProtectedRoute>
       }
     />
@@ -120,6 +121,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="knowledge" action="view">
           <GraphSnapshots />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/knowledge/:decisionId"
+      element={
+        <ProtectedRoute>
+          <KnowledgeTimeline />
         </ProtectedRoute>
       }
     />


### PR DESCRIPTION
Fixes #1128

## Description
This PR registers the ConflictResolution.jsx page within ProtectedRoutes.jsx under /knowledge/conflicts and ensures static routes under /knowledge/ take precedence over dynamic decision routes.

## Proposed Changes
- **Route Registration**: Added <Route path="/knowledge/conflicts" element={<ProtectedRoute resource="knowledge" action="view"><ConflictResolution /></ProtectedRoute>} /> in ProtectedRoutes.jsx.
- **Precedence Hierarchy**: Ordered static knowledge routes (/knowledge/conflicts, /knowledge/consolidate, /knowledge/lifecycle, /knowledge/archive, /knowledge/graph-history) before dynamic parameterized route /knowledge/:decisionId.
- **Unit Test Coverage**: Added Vitest test suite (ConflictResolutionRoute.test.jsx) verifying route resolution and component rendering.

## Checklist
- [x] Related Issue is linked (Fixes #1128).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.