### PR TITLE
fix(auth): align settings page authorization with RBAC permission model

### DIFF
--- a/client/src/pages/__tests__/SettingsAuth.test.jsx
+++ b/client/src/pages/__tests__/SettingsAuth.test.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import AppContent from "../../context/AppContent.js";
+import ProtectedRoute from "../../components/ProtectedRoute.jsx";
+import Settings from "../Settings.jsx";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: (resource) => {
+      // User has no admin settings:view permission
+      if (resource === "settings") return false;
+      return true;
+    },
+  }),
+}));
+
+vi.mock("../Settings.jsx", () => ({
+  default: () => <div data-testid="settings-page">Personal Settings Page</div>,
+}));
+
+describe("Settings Page Authorization Alignment (#1129)", () => {
+  it("allows regular authenticated users to access personal /settings", () => {
+    const mockContext = {
+      isLoggedin: true,
+      userData: {
+        name: "Regular User",
+        role: "member",
+        hasCompletedOnboarding: true,
+      },
+      loading: false,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <AppContent.Provider value={mockContext}>
+          <Routes>
+            <Route
+              path="/settings"
+              element={
+                <ProtectedRoute>
+                  <Settings />
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("settings-page")).toBeInTheDocument();
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -384,7 +384,7 @@ const ProtectedRoutes = (
     <Route
       path="/settings"
       element={
-        <ProtectedRoute resource="settings" action="view">
+        <ProtectedRoute>
           <Settings />
         </ProtectedRoute>
       }


### PR DESCRIPTION
Fixes #1129

## Description
This PR aligns the Settings page authorization with the application's RBAC model, ensuring regular authenticated users can manage their personal settings while keeping organization-level settings strictly protected.

## Proposed Changes
- **RBAC Alignment**: Updated /settings route in ProtectedRoutes.jsx from requiring esource="settings" action="view" to standard <ProtectedRoute>, allowing users to manage personal settings.
- **Organization Settings Preservation**: Maintained RBAC permission enforcement (esource="organizations" action="view") for organization-level settings (/organization/settings, /organization-settings).
- **Unit Test Coverage**: Added Vitest test suite (SettingsAuth.test.jsx) verifying access to /settings for authenticated users.

## Checklist
- [x] Related Issue is linked (Fixes #1129).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.