### PR TITLE
feat(auth): display access denied page instead of silent permission redirects

### DIFF
--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { Navigate, useLocation } from "react-router-dom";
 import AppContent from "../context/AppContent";
 import { useRBAC } from "../hooks/useRBAC.js";
+import AccessDenied from "../pages/AccessDenied.jsx";
 
 const ProtectedRoute = ({
   children,
@@ -64,8 +65,7 @@ const ProtectedRoute = ({
   // RBAC: Check if user has required permission
   if (resource && action) {
     if (!hasPermission(resource, action)) {
-      if (forbiddenFallback) return forbiddenFallback;
-      return <Navigate to="/dashboard" state={{ from: location }} replace />;
+      return forbiddenFallback || <AccessDenied />;
     }
   } else if (requiredPermission) {
     const permResource =
@@ -77,8 +77,7 @@ const ProtectedRoute = ({
         ? requiredPermission.action
         : "view";
     if (!hasPermission(permResource, permAction)) {
-      if (forbiddenFallback) return forbiddenFallback;
-      return <Navigate to="/dashboard" state={{ from: location }} replace />;
+      return forbiddenFallback || <AccessDenied />;
     }
   }
 

--- a/client/src/components/__tests__/ProtectedRouteAccessDenied.test.jsx
+++ b/client/src/components/__tests__/ProtectedRouteAccessDenied.test.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AppContent from "../../context/AppContent.js";
+import ProtectedRoute from "../ProtectedRoute.jsx";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => false,
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+describe("ProtectedRoute Access Denied Display (#1130)", () => {
+  it("renders AccessDenied page instead of silent redirect when permission is denied", () => {
+    const mockContext = {
+      isLoggedin: true,
+      userData: { name: "Unauthorized User", hasCompletedOnboarding: true },
+      loading: false,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/admin/audit-logs"]}>
+        <AppContent.Provider value={mockContext}>
+          <ProtectedRoute resource="audit_logs" action="view">
+            <div data-testid="protected-content">Secret Content</div>
+          </ProtectedRoute>
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument();
+    expect(screen.getByText("accessDenied.title")).toBeInTheDocument();
+    expect(screen.getByText("accessDenied.description")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1130

## Description
This PR replaces silent authorization redirects in ProtectedRoute.jsx with a dedicated <AccessDenied /> page when authorization fails, providing a clear user explanation and safe navigation options.

## Proposed Changes
- **Access Denied Rendering**: Updated ProtectedRoute.jsx to render orbiddenFallback || <AccessDenied /> whenever hasPermission(...) checks fail instead of performing a silent redirect to /dashboard.
- **Navigation Options**: The <AccessDenied /> page displays a clear 403 authorization message along with "Go Back" and "Return to Dashboard" action buttons.
- **Unit Test Coverage**: Added Vitest test suite (ProtectedRouteAccessDenied.test.jsx) verifying that ProtectedRoute displays <AccessDenied /> when permissions are denied.

## Checklist
- [x] Related Issue is linked (Fixes #1130).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.