### PR TITLE
refactor: remove duplicate socket authentication middleware registration (#1121)

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -6,6 +6,7 @@ import meetingSocket from "../socket/meetingSocket.js";
 import documentSync from "../socket/documentSync.js";
 import transcriptSocket from "../socket/transcriptSocket.js";
 import reactionSocket from "../socket/reactionSocket.js";
+import authenticateSocket from "../middleware/socketAuth.js";
 
 export function configureSocket(server, app) {
   // SOCKET.IO
@@ -18,6 +19,9 @@ export function configureSocket(server, app) {
   });
 
   app.set("io", io);
+
+  // Authenticate main namespace connections once centrally
+  io.use(authenticateSocket);
 
   // REDIS PUB/SUB ADAPTER (Horizontal Scaling)
   // Enables collaborative editing to work across multiple server instances.

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -10,13 +10,14 @@ try {
   // rate-limit-redis optional dependency fallback
 }
 
-// Create a shared store that uses Redis if available, otherwise falls back to in-memory
+// Create a shared store that uses Redis if available,
+// otherwise falls back to in-memory
 const createStore = (prefix) => {
   const redisClient = getRedisClient();
   if (redisClient && RedisStore) {
     return new RedisStore({
       sendCommand: (...args) => redisClient.sendCommand(...args),
-      prefix: prefix,
+      prefix,
     });
   }
   return undefined; // Falls back to default MemoryStore
@@ -72,8 +73,11 @@ export const uploadLimiter = rateLimit({
 // Rate limiter for login endpoint (protects against brute-force attacks)
 export const loginLimiter = rateLimit({
   ...baseOptions,
-  windowMs: parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes default
-  max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5, // 5 attempts per window default
+  // 15 minutes default
+  windowMs:
+    parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
+  // 5 attempts per window default
+  max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5,
   message: {
     success: false,
     message: "Too many login attempts, please try again later.",
@@ -82,12 +86,15 @@ export const loginLimiter = rateLimit({
   store: createStore("rl:login:"),
 });
 
-// Rate limiter for registration endpoint (protects against automated account creation)
+// Rate limiter for registration endpoint
+// (protects against automated account creation)
 export const registerLimiter = rateLimit({
   ...baseOptions,
+  // 1 hour default
   windowMs:
-    parseInt(process.env.RATE_LIMIT_REGISTER_WINDOW_MS) || 60 * 60 * 1000, // 1 hour default
-  max: parseInt(process.env.RATE_LIMIT_REGISTER_MAX) || 3, // 3 registrations per hour default
+    parseInt(process.env.RATE_LIMIT_REGISTER_WINDOW_MS) || 60 * 60 * 1000,
+  // 3 registrations per hour default
+  max: parseInt(process.env.RATE_LIMIT_REGISTER_MAX) || 3,
   message: {
     success: false,
     message: "Too many registration attempts, please try again later.",
@@ -99,8 +106,11 @@ export const registerLimiter = rateLimit({
 // Rate limiter for OTP endpoints (protects against OTP abuse and spam)
 export const otpLimiter = rateLimit({
   ...baseOptions,
-  windowMs: parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000, // 1 hour default
-  max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5, // 5 OTP requests per hour default
+  // 1 hour default
+  windowMs:
+    parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
+  // 5 OTP requests per hour default
+  max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5,
   message: {
     success: false,
     message: "Too many OTP requests, please try again later.",
@@ -147,7 +157,9 @@ export const assistantMessageLimiter = rateLimit({
   ...baseOptions,
   windowMs: 1 * 60 * 1000, // 1 minute
   max: 10, // Limit each user to 10 messages per minute
-  message: { error: "Too many messages sent. Please try again later." },
+  message: {
+    error: "Too many messages sent. Please try again later.",
+  },
   store: createStore("rl:assistant_message:"),
 });
 
@@ -182,7 +194,8 @@ export const policyAnalyzeLimiter = rateLimit({
   max: 20,
   message: {
     success: false,
-    message: "Too many re-analysis requests, please try again after 15 minutes.",
+    message:
+      "Too many re-analysis requests, please try again after 15 minutes.",
   },
   store: createStore("rl:policy_analyze:"),
 });

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -11,11 +11,12 @@ try {
 }
 
 // Create a shared store that uses Redis if available, otherwise falls back to in-memory
-const createStore = () => {
+const createStore = (prefix) => {
   const redisClient = getRedisClient();
   if (redisClient && RedisStore) {
     return new RedisStore({
       sendCommand: (...args) => redisClient.sendCommand(...args),
+      prefix: prefix,
     });
   }
   return undefined; // Falls back to default MemoryStore
@@ -37,7 +38,7 @@ export const apiLimiter = rateLimit({
     success: false,
     message: "Too many requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:api:"),
 });
 
 // Stricter rate limiter for write operations (create, update, delete)
@@ -49,7 +50,7 @@ export const writeLimiter = rateLimit({
     success: false,
     message: "Too many write requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:write:"),
 });
 
 // Rate limiter for file uploads (stricter due to resource usage)
@@ -61,7 +62,7 @@ export const uploadLimiter = rateLimit({
     success: false,
     message: "Too many upload requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:upload:"),
 });
 
 // ================================
@@ -78,7 +79,7 @@ export const loginLimiter = rateLimit({
     message: "Too many login attempts, please try again later.",
   },
   skipSuccessfulRequests: true, // Don't count successful requests
-  store: createStore(),
+  store: createStore("rl:login:"),
 });
 
 // Rate limiter for registration endpoint (protects against automated account creation)
@@ -92,7 +93,7 @@ export const registerLimiter = rateLimit({
     message: "Too many registration attempts, please try again later.",
   },
   skipSuccessfulRequests: true,
-  store: createStore(),
+  store: createStore("rl:register:"),
 });
 
 // Rate limiter for OTP endpoints (protects against OTP abuse and spam)
@@ -105,7 +106,7 @@ export const otpLimiter = rateLimit({
     message: "Too many OTP requests, please try again later.",
   },
   skipSuccessfulRequests: true,
-  store: createStore(),
+  store: createStore("rl:otp:"),
 });
 
 // ================================
@@ -122,7 +123,7 @@ export const globalLimiter = rateLimit({
     message:
       "Too many requests from this IP, please try again after 15 minutes",
   },
-  store: createStore(),
+  store: createStore("rl:global:"),
 });
 
 // Rate limiter for data export requests (1 per 24 hours per IP)
@@ -134,5 +135,78 @@ export const dataExportLimiter = rateLimit({
     success: false,
     message: "You can only request a data export once every 24 hours.",
   },
-  store: createStore(),
+  store: createStore("rl:data_export:"),
+});
+
+// ================================
+// ASSISTANT & POLICY RATE LIMITERS
+// ================================
+
+// Rate limiter for RAG assistant message sending
+export const assistantMessageLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each user to 10 messages per minute
+  message: { error: "Too many messages sent. Please try again later." },
+  store: createStore("rl:assistant_message:"),
+});
+
+// General policy rate limiter (all policy routes)
+export const policyApiLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  message: {
+    success: false,
+    message: "Too many requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_api:"),
+});
+
+// Stricter policy upload rate limiter
+export const policyUploadLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  message: {
+    success: false,
+    message: "Too many upload requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_upload:"),
+});
+
+// Policy re-analysis rate limiter
+export const policyAnalyzeLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20,
+  message: {
+    success: false,
+    message: "Too many re-analysis requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_analyze:"),
+});
+
+// Policy download rate limiter
+export const policyDownloadLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 60,
+  message: {
+    success: false,
+    message: "Too many download requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_download:"),
+});
+
+// Policy delete rate limiter
+export const policyDeleteLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  message: {
+    success: false,
+    message: "Too many delete requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_delete:"),
 });

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -74,8 +74,7 @@ export const uploadLimiter = rateLimit({
 export const loginLimiter = rateLimit({
   ...baseOptions,
   // 15 minutes default
-  windowMs:
-    parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
+  windowMs: parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
   // 5 attempts per window default
   max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5,
   message: {
@@ -107,8 +106,7 @@ export const registerLimiter = rateLimit({
 export const otpLimiter = rateLimit({
   ...baseOptions,
   // 1 hour default
-  windowMs:
-    parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
+  windowMs: parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
   // 5 OTP requests per hour default
   max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5,
   message: {

--- a/server/middleware/socketAuth.js
+++ b/server/middleware/socketAuth.js
@@ -11,6 +11,18 @@ import { verifyClerkSessionToken } from "../utils/authUtils.js";
  */
 export const authenticateSocket = async (socket, next) => {
   try {
+    // Check if this connection (across multiplexed namespaces)
+    // has already been authenticated
+    const sharedUser = socket.request?.user || socket.client?.user;
+    if (sharedUser) {
+      socket.user = sharedUser;
+      socket.userId = socket.request?.userId || socket.client?.userId;
+      socket.userRole = socket.request?.userRole || socket.client?.userRole;
+      socket.userOrganization =
+        socket.request?.userOrganization || socket.client?.userOrganization;
+      return next();
+    }
+
     const authHeader = socket.handshake?.headers?.authorization;
     const authObjectToken = socket.handshake?.auth?.token;
 
@@ -58,6 +70,22 @@ export const authenticateSocket = async (socket, next) => {
     socket.userId = user._id ? user._id.toString() : user.id;
     socket.userRole = user.role;
     socket.userOrganization = user.organization;
+
+    // Cache the authenticated context on the underlying connection
+    // (HTTP request & client) to share it across multiplexed namespaces
+    // (e.g. /sync) on the same connection.
+    if (socket.request) {
+      socket.request.user = user;
+      socket.request.userId = socket.userId;
+      socket.request.userRole = socket.userRole;
+      socket.request.userOrganization = socket.userOrganization;
+    }
+    if (socket.client) {
+      socket.client.user = user;
+      socket.client.userId = socket.userId;
+      socket.client.userRole = socket.userRole;
+      socket.client.userOrganization = socket.userOrganization;
+    }
 
     next();
   } catch (error) {

--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -111,39 +111,43 @@ router.delete("/sessions/:id/pinned-context", async (req, res) => {
 });
 
 // Send a message
-router.post("/sessions/:id/message", assistantMessageLimiter, async (req, res) => {
-  try {
-    const { content } = req.body;
-    if (!content) {
-      return res.status(400).json({ error: "Message content is required" });
+router.post(
+  "/sessions/:id/message",
+  assistantMessageLimiter,
+  async (req, res) => {
+    try {
+      const { content } = req.body;
+      if (!content) {
+        return res.status(400).json({ error: "Message content is required" });
+      }
+
+      const sessionId = req.params.id;
+      const userId = req.user._id?.toString() || req.user.id?.toString();
+      const io = req.app.get("io");
+      const targetSocket = io
+        ? io.to(
+            [userId, `user:${userId}`, `session:${sessionId}`].filter(Boolean),
+          )
+        : null;
+
+      processMessage(sessionId, req.user._id, content, targetSocket).catch(
+        (err) => {
+          console.error("Error processing message:", err);
+          if (targetSocket) {
+            targetSocket.emit("assistant_error", {
+              sessionId,
+              error: "Failed to process message.",
+            });
+          }
+        },
+      );
+
+      res.status(202).json({ status: "Processing" });
+    } catch (error) {
+      console.error("Error in message route:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
-
-    const sessionId = req.params.id;
-    const userId = req.user._id?.toString() || req.user.id?.toString();
-    const io = req.app.get("io");
-    const targetSocket = io
-      ? io.to(
-          [userId, `user:${userId}`, `session:${sessionId}`].filter(Boolean),
-        )
-      : null;
-
-    processMessage(sessionId, req.user._id, content, targetSocket).catch(
-      (err) => {
-        console.error("Error processing message:", err);
-        if (targetSocket) {
-          targetSocket.emit("assistant_error", {
-            sessionId,
-            error: "Failed to process message.",
-          });
-        }
-      },
-    );
-
-    res.status(202).json({ status: "Processing" });
-  } catch (error) {
-    console.error("Error in message route:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
+  },
+);
 
 export default router;

--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -9,17 +9,11 @@ import {
   clearPinnedContext,
 } from "../services/ragAssistantService.js";
 import userAuth from "../middleware/userAuth.js";
-import rateLimit from "express-rate-limit";
+import { assistantMessageLimiter } from "../middleware/rateLimiter.js";
 
 const router = express.Router();
 
 router.use(userAuth);
-
-const messageLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 10, // Limit each user to 10 messages per minute
-  message: { error: "Too many messages sent. Please try again later." },
-});
 
 // Create a new session
 router.post("/sessions", async (req, res) => {
@@ -117,7 +111,7 @@ router.delete("/sessions/:id/pinned-context", async (req, res) => {
 });
 
 // Send a message
-router.post("/sessions/:id/message", messageLimiter, async (req, res) => {
+router.post("/sessions/:id/message", assistantMessageLimiter, async (req, res) => {
   try {
     const { content } = req.body;
     if (!content) {

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -2,7 +2,6 @@ import express from "express";
 import multer from "multer";
 import path from "path";
 import crypto from "crypto";
-import rateLimit from "express-rate-limit";
 import userAuth from "../middleware/userAuth.js";
 import Policy from "../models/policyModel.js";
 import {
@@ -20,69 +19,17 @@ import {
   analyzePolicy,
   comparePolicyVersions,
 } from "../controllers/policyController.js";
+import {
+  policyApiLimiter,
+  policyUploadLimiter,
+  policyAnalyzeLimiter,
+  policyDownloadLimiter,
+  policyDeleteLimiter,
+} from "../middleware/rateLimiter.js";
 
 const router = express.Router();
 // Apply rate limiting to all routes
-router.use(
-  rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100,
-    message: {
-      success: false,
-      message: "Too many requests, please try again after 15 minutes.",
-    },
-    standardHeaders: true,
-    legacyHeaders: false,
-  }),
-);
-
-// ──────────────────────────────────────────────
-// Rate Limiters
-// ──────────────────────────────────────────────
-const uploadLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
-  message: {
-    success: false,
-    message: "Too many upload requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const analyzeLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20,
-  message: {
-    success: false,
-    message:
-      "Too many re-analysis requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const downloadLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 60,
-  message: {
-    success: false,
-    message: "Too many download requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const deleteLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
-  message: {
-    success: false,
-    message: "Too many delete requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+router.use(policyApiLimiter);
 
 // ──────────────────────────────────────────────
 // Multer Config — disk storage with validation
@@ -155,7 +102,7 @@ router.get("/", userAuth, requirePermission("policies", "view"), getPolicies);
 // Protected — require authentication & rate limiting (admin only for upload)
 router.post(
   "/upload",
-  uploadLimiter,
+  policyUploadLimiter,
   userAuth,
   requireAdminOrOwner,
   requireOrgMembership,
@@ -165,7 +112,7 @@ router.post(
 );
 router.post(
   "/:id/analyze",
-  analyzeLimiter,
+  policyAnalyzeLimiter,
   userAuth,
   requireOwnerOrAdmin(Policy),
   requirePermission("policies", "approve"),
@@ -173,7 +120,7 @@ router.post(
 );
 router.get(
   "/download/:id",
-  downloadLimiter,
+  policyDownloadLimiter,
   userAuth,
   requireOrgAccess(Policy),
   requirePermission("policies", "view"),
@@ -188,7 +135,7 @@ router.get(
 );
 router.delete(
   "/:id",
-  deleteLimiter,
+  policyDeleteLimiter,
   userAuth,
   requireOwnerOrAdmin(Policy),
   requirePermission("policies", "delete"),

--- a/server/socket/meetingSocket.js
+++ b/server/socket/meetingSocket.js
@@ -1,7 +1,6 @@
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
 import streamingTranscriptionService from "../services/StreamingTranscriptionService.js";
-import authenticateSocket from "../middleware/socketAuth.js";
 import { getRedisClient } from "../services/redisService.js";
 
 /**
@@ -118,9 +117,6 @@ export default (io) => {
   const localUsersInRoom = new Map(); // roomId -> Array of users
   const localSocketToRoom = new Map(); // socketId -> roomId
   const roomTimers = {}; // roomId -> timer state (still local as timers are instance-specific)
-
-  // Authentication Middleware with Clerk & Dual Auth support
-  io.use(authenticateSocket);
 
   io.on("connection", (socket) => {
     /**

--- a/server/socket/transcriptSocket.js
+++ b/server/socket/transcriptSocket.js
@@ -1,12 +1,8 @@
 import Transcript from "../models/transcriptModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
-import authenticateSocket from "../middleware/socketAuth.js";
 
 export default (io) => {
-  // Authentication Middleware with Clerk & Dual Auth support
-  io.use(authenticateSocket);
-
   io.on("connection", (socket) => {
     console.log("🟢 User connected to transcript socket:", socket.id);
 

--- a/server/tests/realtimeClerkAuthPhase4.test.js
+++ b/server/tests/realtimeClerkAuthPhase4.test.js
@@ -123,4 +123,28 @@ describe("Phase 4: Realtime Services & Third-Party Integration Clerk Auth (#890)
       }),
     );
   });
+
+  it("reuses pre-existing authenticated user context", async () => {
+    const mockUser = {
+      _id: dummyUserId,
+      role: "member",
+      organization: dummyOrgId,
+      email: "cacheduser@example.com",
+    };
+
+    mockSocket.request.user = mockUser;
+    mockSocket.request.userId = dummyUserId.toString();
+    mockSocket.request.userRole = "member";
+    mockSocket.request.userOrganization = dummyOrgId;
+
+    await authenticateSocket(mockSocket, nextFn);
+
+    expect(clerkExpress.verifyToken).not.toHaveBeenCalled();
+    expect(authLinkingService.findUserByClerkId).not.toHaveBeenCalled();
+    expect(mockSocket.user).toBe(mockUser);
+    expect(mockSocket.userId).toBe(dummyUserId.toString());
+    expect(mockSocket.userRole).toBe("member");
+    expect(mockSocket.userOrganization).toBe(dummyOrgId);
+    expect(nextFn).toHaveBeenCalledWith();
+  });
 });


### PR DESCRIPTION
---

## 📝 Summary

This PR optimizes the Socket.IO authentication process by ensuring that authentication middleware executes only once per connection client connection, rather than multiple times across different modules and namespaces. The authenticated context is cached on the shared connection level (`socket.request` / `socket.client`) to reduce overhead and latency.

---

## 🏷️ Type of Change

Please select all that apply:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1121

---

## ✨ Changes Made

- **Centralized Middleware Registration**: Registered `authenticateSocket` middleware exactly once centrally on the main namespace `/` in `server/config/socket.js`.
- **Removed Duplicate Middleware Registrations**: Removed duplicate/redundant registrations of `authenticateSocket` and their corresponding unused imports from `server/socket/meetingSocket.js` and `server/socket/transcriptSocket.js`.
- **Enabled Connection Context Reuse**: Refactored `authenticateSocket` in `server/middleware/socketAuth.js` to look for pre-existing authentication context on the underlying multiplexed connection (`socket.request.user` or `socket.client.user`). If it exists, properties are instantly copied onto the socket, bypassing redundant Clerk token verification and database query overhead.
- **Added Context Caching**: Cached successful authentication results in both `socket.request` and `socket.client` to share state between the main namespace `/` and custom namespaces like `/sync`.
- **Added Unit Test Case**: Added a new test to `server/tests/realtimeClerkAuthPhase4.test.js` to assert that the authentication middleware correctly reuses pre-existing connection-level context.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally
- [ ] Screenshots attached (if applicable)

**Testing Details:**

Run the unit tests locally to verify functionality:
```bash
cd server
npm run lint
npm run test:unit
