### PR TITLE
refactor: restrict sensitive meeting and policy data exposure through shared links (#1124)

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -6,6 +6,7 @@ import meetingSocket from "../socket/meetingSocket.js";
 import documentSync from "../socket/documentSync.js";
 import transcriptSocket from "../socket/transcriptSocket.js";
 import reactionSocket from "../socket/reactionSocket.js";
+import authenticateSocket from "../middleware/socketAuth.js";
 
 export function configureSocket(server, app) {
   // SOCKET.IO
@@ -18,6 +19,9 @@ export function configureSocket(server, app) {
   });
 
   app.set("io", io);
+
+  // Authenticate main namespace connections once centrally
+  io.use(authenticateSocket);
 
   // REDIS PUB/SUB ADAPTER (Horizontal Scaling)
   // Enables collaborative editing to work across multiple server instances.

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -487,7 +487,8 @@ export const getPublicResource = async (req, res) => {
     if (link.resourceModel === "Meeting") {
       const meeting = await Meeting.findById(link.resourceId)
         .select(
-          "title description meetingType date time duration location venue participants agendaItems policyDetails transcript summary structuredMoM aiNotes status tags",
+          "title description date time location " +
+            "participants summary structuredMoM",
         )
         .lean();
 
@@ -496,12 +497,22 @@ export const getPublicResource = async (req, res) => {
           .status(404)
           .json({ success: false, message: "Meeting not found" });
       }
-      resourceData = meeting;
+
+      resourceData = {
+        title: meeting.title,
+        description: meeting.description,
+        date: meeting.date,
+        time: meeting.time,
+        location: meeting.location,
+        summary: meeting.summary,
+        structuredMoM: meeting.structuredMoM,
+        participants: meeting.participants
+          ? Array(meeting.participants.length).fill({})
+          : [],
+      };
     } else if (link.resourceModel === "Policy") {
       const policy = await Policy.findById(link.resourceId)
-        .select(
-          "name version fileUrl summary key_changes keywords status isDraft",
-        )
+        .select("name version summary key_changes")
         .lean();
 
       if (!policy) {
@@ -509,7 +520,13 @@ export const getPublicResource = async (req, res) => {
           .status(404)
           .json({ success: false, message: "Policy not found" });
       }
-      resourceData = policy;
+
+      resourceData = {
+        name: policy.name,
+        version: policy.version,
+        summary: policy.summary,
+        key_changes: policy.key_changes,
+      };
     }
 
     // Record view only after successful access; never include analytics in public payload

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -10,13 +10,14 @@ try {
   // rate-limit-redis optional dependency fallback
 }
 
-// Create a shared store that uses Redis if available, otherwise falls back to in-memory
+// Create a shared store that uses Redis if available,
+// otherwise falls back to in-memory
 const createStore = (prefix) => {
   const redisClient = getRedisClient();
   if (redisClient && RedisStore) {
     return new RedisStore({
       sendCommand: (...args) => redisClient.sendCommand(...args),
-      prefix: prefix,
+      prefix,
     });
   }
   return undefined; // Falls back to default MemoryStore
@@ -72,8 +73,11 @@ export const uploadLimiter = rateLimit({
 // Rate limiter for login endpoint (protects against brute-force attacks)
 export const loginLimiter = rateLimit({
   ...baseOptions,
-  windowMs: parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes default
-  max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5, // 5 attempts per window default
+  // 15 minutes default
+  windowMs:
+    parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
+  // 5 attempts per window default
+  max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5,
   message: {
     success: false,
     message: "Too many login attempts, please try again later.",
@@ -82,12 +86,15 @@ export const loginLimiter = rateLimit({
   store: createStore("rl:login:"),
 });
 
-// Rate limiter for registration endpoint (protects against automated account creation)
+// Rate limiter for registration endpoint
+// (protects against automated account creation)
 export const registerLimiter = rateLimit({
   ...baseOptions,
+  // 1 hour default
   windowMs:
-    parseInt(process.env.RATE_LIMIT_REGISTER_WINDOW_MS) || 60 * 60 * 1000, // 1 hour default
-  max: parseInt(process.env.RATE_LIMIT_REGISTER_MAX) || 3, // 3 registrations per hour default
+    parseInt(process.env.RATE_LIMIT_REGISTER_WINDOW_MS) || 60 * 60 * 1000,
+  // 3 registrations per hour default
+  max: parseInt(process.env.RATE_LIMIT_REGISTER_MAX) || 3,
   message: {
     success: false,
     message: "Too many registration attempts, please try again later.",
@@ -99,8 +106,11 @@ export const registerLimiter = rateLimit({
 // Rate limiter for OTP endpoints (protects against OTP abuse and spam)
 export const otpLimiter = rateLimit({
   ...baseOptions,
-  windowMs: parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000, // 1 hour default
-  max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5, // 5 OTP requests per hour default
+  // 1 hour default
+  windowMs:
+    parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
+  // 5 OTP requests per hour default
+  max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5,
   message: {
     success: false,
     message: "Too many OTP requests, please try again later.",
@@ -147,7 +157,9 @@ export const assistantMessageLimiter = rateLimit({
   ...baseOptions,
   windowMs: 1 * 60 * 1000, // 1 minute
   max: 10, // Limit each user to 10 messages per minute
-  message: { error: "Too many messages sent. Please try again later." },
+  message: {
+    error: "Too many messages sent. Please try again later.",
+  },
   store: createStore("rl:assistant_message:"),
 });
 
@@ -182,7 +194,8 @@ export const policyAnalyzeLimiter = rateLimit({
   max: 20,
   message: {
     success: false,
-    message: "Too many re-analysis requests, please try again after 15 minutes.",
+    message:
+      "Too many re-analysis requests, please try again after 15 minutes.",
   },
   store: createStore("rl:policy_analyze:"),
 });

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -11,11 +11,12 @@ try {
 }
 
 // Create a shared store that uses Redis if available, otherwise falls back to in-memory
-const createStore = () => {
+const createStore = (prefix) => {
   const redisClient = getRedisClient();
   if (redisClient && RedisStore) {
     return new RedisStore({
       sendCommand: (...args) => redisClient.sendCommand(...args),
+      prefix: prefix,
     });
   }
   return undefined; // Falls back to default MemoryStore
@@ -37,7 +38,7 @@ export const apiLimiter = rateLimit({
     success: false,
     message: "Too many requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:api:"),
 });
 
 // Stricter rate limiter for write operations (create, update, delete)
@@ -49,7 +50,7 @@ export const writeLimiter = rateLimit({
     success: false,
     message: "Too many write requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:write:"),
 });
 
 // Rate limiter for file uploads (stricter due to resource usage)
@@ -61,7 +62,7 @@ export const uploadLimiter = rateLimit({
     success: false,
     message: "Too many upload requests from this IP, please try again later.",
   },
-  store: createStore(),
+  store: createStore("rl:upload:"),
 });
 
 // ================================
@@ -78,7 +79,7 @@ export const loginLimiter = rateLimit({
     message: "Too many login attempts, please try again later.",
   },
   skipSuccessfulRequests: true, // Don't count successful requests
-  store: createStore(),
+  store: createStore("rl:login:"),
 });
 
 // Rate limiter for registration endpoint (protects against automated account creation)
@@ -92,7 +93,7 @@ export const registerLimiter = rateLimit({
     message: "Too many registration attempts, please try again later.",
   },
   skipSuccessfulRequests: true,
-  store: createStore(),
+  store: createStore("rl:register:"),
 });
 
 // Rate limiter for OTP endpoints (protects against OTP abuse and spam)
@@ -105,7 +106,7 @@ export const otpLimiter = rateLimit({
     message: "Too many OTP requests, please try again later.",
   },
   skipSuccessfulRequests: true,
-  store: createStore(),
+  store: createStore("rl:otp:"),
 });
 
 // ================================
@@ -122,7 +123,7 @@ export const globalLimiter = rateLimit({
     message:
       "Too many requests from this IP, please try again after 15 minutes",
   },
-  store: createStore(),
+  store: createStore("rl:global:"),
 });
 
 // Rate limiter for data export requests (1 per 24 hours per IP)
@@ -134,5 +135,78 @@ export const dataExportLimiter = rateLimit({
     success: false,
     message: "You can only request a data export once every 24 hours.",
   },
-  store: createStore(),
+  store: createStore("rl:data_export:"),
+});
+
+// ================================
+// ASSISTANT & POLICY RATE LIMITERS
+// ================================
+
+// Rate limiter for RAG assistant message sending
+export const assistantMessageLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each user to 10 messages per minute
+  message: { error: "Too many messages sent. Please try again later." },
+  store: createStore("rl:assistant_message:"),
+});
+
+// General policy rate limiter (all policy routes)
+export const policyApiLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  message: {
+    success: false,
+    message: "Too many requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_api:"),
+});
+
+// Stricter policy upload rate limiter
+export const policyUploadLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  message: {
+    success: false,
+    message: "Too many upload requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_upload:"),
+});
+
+// Policy re-analysis rate limiter
+export const policyAnalyzeLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20,
+  message: {
+    success: false,
+    message: "Too many re-analysis requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_analyze:"),
+});
+
+// Policy download rate limiter
+export const policyDownloadLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 60,
+  message: {
+    success: false,
+    message: "Too many download requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_download:"),
+});
+
+// Policy delete rate limiter
+export const policyDeleteLimiter = rateLimit({
+  ...baseOptions,
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10,
+  message: {
+    success: false,
+    message: "Too many delete requests, please try again after 15 minutes.",
+  },
+  store: createStore("rl:policy_delete:"),
 });

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -74,8 +74,7 @@ export const uploadLimiter = rateLimit({
 export const loginLimiter = rateLimit({
   ...baseOptions,
   // 15 minutes default
-  windowMs:
-    parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
+  windowMs: parseInt(process.env.RATE_LIMIT_LOGIN_WINDOW_MS) || 15 * 60 * 1000,
   // 5 attempts per window default
   max: parseInt(process.env.RATE_LIMIT_LOGIN_MAX) || 5,
   message: {
@@ -107,8 +106,7 @@ export const registerLimiter = rateLimit({
 export const otpLimiter = rateLimit({
   ...baseOptions,
   // 1 hour default
-  windowMs:
-    parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
+  windowMs: parseInt(process.env.RATE_LIMIT_OTP_WINDOW_MS) || 60 * 60 * 1000,
   // 5 OTP requests per hour default
   max: parseInt(process.env.RATE_LIMIT_OTP_MAX) || 5,
   message: {

--- a/server/middleware/socketAuth.js
+++ b/server/middleware/socketAuth.js
@@ -11,6 +11,18 @@ import { verifyClerkSessionToken } from "../utils/authUtils.js";
  */
 export const authenticateSocket = async (socket, next) => {
   try {
+    // Check if this connection (across multiplexed namespaces)
+    // has already been authenticated
+    const sharedUser = socket.request?.user || socket.client?.user;
+    if (sharedUser) {
+      socket.user = sharedUser;
+      socket.userId = socket.request?.userId || socket.client?.userId;
+      socket.userRole = socket.request?.userRole || socket.client?.userRole;
+      socket.userOrganization =
+        socket.request?.userOrganization || socket.client?.userOrganization;
+      return next();
+    }
+
     const authHeader = socket.handshake?.headers?.authorization;
     const authObjectToken = socket.handshake?.auth?.token;
 
@@ -58,6 +70,22 @@ export const authenticateSocket = async (socket, next) => {
     socket.userId = user._id ? user._id.toString() : user.id;
     socket.userRole = user.role;
     socket.userOrganization = user.organization;
+
+    // Cache the authenticated context on the underlying connection
+    // (HTTP request & client) to share it across multiplexed namespaces
+    // (e.g. /sync) on the same connection.
+    if (socket.request) {
+      socket.request.user = user;
+      socket.request.userId = socket.userId;
+      socket.request.userRole = socket.userRole;
+      socket.request.userOrganization = socket.userOrganization;
+    }
+    if (socket.client) {
+      socket.client.user = user;
+      socket.client.userId = socket.userId;
+      socket.client.userRole = socket.userRole;
+      socket.client.userOrganization = socket.userOrganization;
+    }
 
     next();
   } catch (error) {

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --ci tests/integration.test.js",
     "test:related:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand --passWithNoTests --findRelatedTests",
     "test:related:vitest": "vitest related",
-    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/MeetingService.test.js tests/sharedLinkAnalytics.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js tests/routeRegistration.test.js",
+    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/MeetingService.test.js tests/sharedLinkAnalytics.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js tests/routeRegistration.test.js tests/meetingPresenceSpoofing.test.js",
     "test:related": "node ../scripts/validation/run-server-related-tests.mjs",
     "validate": "node ../scripts/validation/validate-server-changed.mjs",
     "validate:changed": "node ../scripts/validation/validate-server-changed.mjs",

--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -111,39 +111,43 @@ router.delete("/sessions/:id/pinned-context", async (req, res) => {
 });
 
 // Send a message
-router.post("/sessions/:id/message", assistantMessageLimiter, async (req, res) => {
-  try {
-    const { content } = req.body;
-    if (!content) {
-      return res.status(400).json({ error: "Message content is required" });
+router.post(
+  "/sessions/:id/message",
+  assistantMessageLimiter,
+  async (req, res) => {
+    try {
+      const { content } = req.body;
+      if (!content) {
+        return res.status(400).json({ error: "Message content is required" });
+      }
+
+      const sessionId = req.params.id;
+      const userId = req.user._id?.toString() || req.user.id?.toString();
+      const io = req.app.get("io");
+      const targetSocket = io
+        ? io.to(
+            [userId, `user:${userId}`, `session:${sessionId}`].filter(Boolean),
+          )
+        : null;
+
+      processMessage(sessionId, req.user._id, content, targetSocket).catch(
+        (err) => {
+          console.error("Error processing message:", err);
+          if (targetSocket) {
+            targetSocket.emit("assistant_error", {
+              sessionId,
+              error: "Failed to process message.",
+            });
+          }
+        },
+      );
+
+      res.status(202).json({ status: "Processing" });
+    } catch (error) {
+      console.error("Error in message route:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
-
-    const sessionId = req.params.id;
-    const userId = req.user._id?.toString() || req.user.id?.toString();
-    const io = req.app.get("io");
-    const targetSocket = io
-      ? io.to(
-          [userId, `user:${userId}`, `session:${sessionId}`].filter(Boolean),
-        )
-      : null;
-
-    processMessage(sessionId, req.user._id, content, targetSocket).catch(
-      (err) => {
-        console.error("Error processing message:", err);
-        if (targetSocket) {
-          targetSocket.emit("assistant_error", {
-            sessionId,
-            error: "Failed to process message.",
-          });
-        }
-      },
-    );
-
-    res.status(202).json({ status: "Processing" });
-  } catch (error) {
-    console.error("Error in message route:", error);
-    res.status(500).json({ error: "Internal server error" });
-  }
-});
+  },
+);
 
 export default router;

--- a/server/routes/assistantRoutes.js
+++ b/server/routes/assistantRoutes.js
@@ -9,17 +9,11 @@ import {
   clearPinnedContext,
 } from "../services/ragAssistantService.js";
 import userAuth from "../middleware/userAuth.js";
-import rateLimit from "express-rate-limit";
+import { assistantMessageLimiter } from "../middleware/rateLimiter.js";
 
 const router = express.Router();
 
 router.use(userAuth);
-
-const messageLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 10, // Limit each user to 10 messages per minute
-  message: { error: "Too many messages sent. Please try again later." },
-});
 
 // Create a new session
 router.post("/sessions", async (req, res) => {
@@ -117,7 +111,7 @@ router.delete("/sessions/:id/pinned-context", async (req, res) => {
 });
 
 // Send a message
-router.post("/sessions/:id/message", messageLimiter, async (req, res) => {
+router.post("/sessions/:id/message", assistantMessageLimiter, async (req, res) => {
   try {
     const { content } = req.body;
     if (!content) {

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -2,7 +2,6 @@ import express from "express";
 import multer from "multer";
 import path from "path";
 import crypto from "crypto";
-import rateLimit from "express-rate-limit";
 import userAuth from "../middleware/userAuth.js";
 import Policy from "../models/policyModel.js";
 import {
@@ -20,69 +19,17 @@ import {
   analyzePolicy,
   comparePolicyVersions,
 } from "../controllers/policyController.js";
+import {
+  policyApiLimiter,
+  policyUploadLimiter,
+  policyAnalyzeLimiter,
+  policyDownloadLimiter,
+  policyDeleteLimiter,
+} from "../middleware/rateLimiter.js";
 
 const router = express.Router();
 // Apply rate limiting to all routes
-router.use(
-  rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100,
-    message: {
-      success: false,
-      message: "Too many requests, please try again after 15 minutes.",
-    },
-    standardHeaders: true,
-    legacyHeaders: false,
-  }),
-);
-
-// ──────────────────────────────────────────────
-// Rate Limiters
-// ──────────────────────────────────────────────
-const uploadLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
-  message: {
-    success: false,
-    message: "Too many upload requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const analyzeLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20,
-  message: {
-    success: false,
-    message:
-      "Too many re-analysis requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const downloadLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 60,
-  message: {
-    success: false,
-    message: "Too many download requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const deleteLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 10,
-  message: {
-    success: false,
-    message: "Too many delete requests, please try again after 15 minutes.",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+router.use(policyApiLimiter);
 
 // ──────────────────────────────────────────────
 // Multer Config — disk storage with validation
@@ -155,7 +102,7 @@ router.get("/", userAuth, requirePermission("policies", "view"), getPolicies);
 // Protected — require authentication & rate limiting (admin only for upload)
 router.post(
   "/upload",
-  uploadLimiter,
+  policyUploadLimiter,
   userAuth,
   requireAdminOrOwner,
   requireOrgMembership,
@@ -165,7 +112,7 @@ router.post(
 );
 router.post(
   "/:id/analyze",
-  analyzeLimiter,
+  policyAnalyzeLimiter,
   userAuth,
   requireOwnerOrAdmin(Policy),
   requirePermission("policies", "approve"),
@@ -173,7 +120,7 @@ router.post(
 );
 router.get(
   "/download/:id",
-  downloadLimiter,
+  policyDownloadLimiter,
   userAuth,
   requireOrgAccess(Policy),
   requirePermission("policies", "view"),
@@ -188,7 +135,7 @@ router.get(
 );
 router.delete(
   "/:id",
-  deleteLimiter,
+  policyDeleteLimiter,
   userAuth,
   requireOwnerOrAdmin(Policy),
   requirePermission("policies", "delete"),

--- a/server/socket/meetingSocket.js
+++ b/server/socket/meetingSocket.js
@@ -1,7 +1,6 @@
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
 import streamingTranscriptionService from "../services/StreamingTranscriptionService.js";
-import authenticateSocket from "../middleware/socketAuth.js";
 import { getRedisClient } from "../services/redisService.js";
 
 /**
@@ -118,9 +117,6 @@ export default (io) => {
   const localUsersInRoom = new Map(); // roomId -> Array of users
   const localSocketToRoom = new Map(); // socketId -> roomId
   const roomTimers = {}; // roomId -> timer state (still local as timers are instance-specific)
-
-  // Authentication Middleware with Clerk & Dual Auth support
-  io.use(authenticateSocket);
 
   io.on("connection", (socket) => {
     /**

--- a/server/socket/meetingSocket.js
+++ b/server/socket/meetingSocket.js
@@ -195,8 +195,17 @@ export default (io) => {
           return;
         }
 
-        // Create user object with socket ID
-        const user = { socketId: socket.id, ...userInfo };
+        // Create user object with socket ID using server-side
+        // authenticated data to prevent spoofing
+        const user = {
+          socketId: socket.id,
+          id: socket.userId,
+          userId: socket.userId,
+          name: socket.user?.name || "Anonymous",
+          email: socket.user?.email || "",
+          profilePic: socket.user?.profilePic || "",
+          role: socket.userRole || "member",
+        };
 
         // Add user to room presence (distributed via Redis)
         const allUsersInRoom = await addUserToRoom(
@@ -259,7 +268,15 @@ export default (io) => {
       io.to(payload.userToSignal).emit("user-joined-signal", {
         signal: payload.signal,
         callerID: payload.callerID,
-        userInfo: payload.userInfo,
+        userInfo: {
+          socketId: socket.id,
+          id: socket.userId,
+          userId: socket.userId,
+          name: socket.user?.name || "Anonymous",
+          email: socket.user?.email || "",
+          profilePic: socket.user?.profilePic || "",
+          role: socket.userRole || "member",
+        },
       });
     });
 

--- a/server/socket/transcriptSocket.js
+++ b/server/socket/transcriptSocket.js
@@ -1,12 +1,8 @@
 import Transcript from "../models/transcriptModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
-import authenticateSocket from "../middleware/socketAuth.js";
 
 export default (io) => {
-  // Authentication Middleware with Clerk & Dual Auth support
-  io.use(authenticateSocket);
-
   io.on("connection", (socket) => {
     console.log("🟢 User connected to transcript socket:", socket.id);
 

--- a/server/tests/meetingPresenceSpoofing.test.js
+++ b/server/tests/meetingPresenceSpoofing.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import meetingSocket from "../socket/meetingSocket.js";
+
+// Mock the Meeting model globally for this test file
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findById: vi.fn().mockResolvedValue({
+      _id: "meeting_789",
+      uploadedBy: "user_456",
+    }),
+  },
+}));
+
+describe("Meeting Presence Spoofing Prevention", () => {
+  it("ignores client userInfo and uses auth context", async () => {
+    let connectionCallback;
+    const mockIo = {
+      on: (event, cb) => {
+        if (event === "connection") {
+          connectionCallback = cb;
+        }
+      },
+      to: vi.fn().mockReturnValue({ emit: vi.fn() }),
+    };
+
+    meetingSocket(mockIo);
+
+    // Create a mock socket representing authenticated client
+    const mockSocket = {
+      id: "socket_123",
+      userId: "user_456",
+      userRole: "admin",
+      user: {
+        name: "Legit User",
+        email: "legit@example.com",
+        profilePic: "https://example.com/pic.png",
+      },
+      join: vi.fn(),
+      emit: vi.fn(),
+      on: vi.fn(),
+      to: vi.fn().mockReturnValue({ emit: vi.fn() }),
+    };
+
+    // Trigger connection
+    connectionCallback(mockSocket);
+
+    // Find the join-meeting listener registered on socket
+    const joinMeetingCall = mockSocket.on.mock.calls.find(
+      (call) => call[0] === "join-meeting",
+    );
+    expect(joinMeetingCall).toBeDefined();
+    const joinMeetingListener = joinMeetingCall[1];
+
+    // Call join-meeting with a spoofed userInfo payload
+    const spoofedUserInfo = {
+      name: "Imposter Admin",
+      email: "imposter@example.com",
+      profilePic: "https://example.com/fake.png",
+      role: "owner",
+    };
+
+    await joinMeetingListener({
+      roomId: "meeting_789",
+      userInfo: spoofedUserInfo,
+    });
+
+    // Check that socket.to was called to broadcast the user joined event
+    expect(mockSocket.to).toHaveBeenCalledWith("meeting_789");
+
+    // Find the user-joined broadcast call
+    const toResult = mockSocket.to.mock.results[0].value;
+    const userJoinedCall = toResult.emit.mock.calls.find(
+      (call) => call[0] === "user-joined",
+    );
+    expect(userJoinedCall).toBeDefined();
+    const broadcastedUser = userJoinedCall[1];
+
+    // Assert that the spoofed fields were ignored and correct server-side fields were used
+    expect(broadcastedUser.name).toBe("Legit User");
+    expect(broadcastedUser.email).toBe("legit@example.com");
+    expect(broadcastedUser.profilePic).toBe("https://example.com/pic.png");
+    expect(broadcastedUser.role).toBe("admin");
+  });
+});

--- a/server/tests/realtimeClerkAuthPhase4.test.js
+++ b/server/tests/realtimeClerkAuthPhase4.test.js
@@ -123,4 +123,28 @@ describe("Phase 4: Realtime Services & Third-Party Integration Clerk Auth (#890)
       }),
     );
   });
+
+  it("reuses pre-existing authenticated user context", async () => {
+    const mockUser = {
+      _id: dummyUserId,
+      role: "member",
+      organization: dummyOrgId,
+      email: "cacheduser@example.com",
+    };
+
+    mockSocket.request.user = mockUser;
+    mockSocket.request.userId = dummyUserId.toString();
+    mockSocket.request.userRole = "member";
+    mockSocket.request.userOrganization = dummyOrgId;
+
+    await authenticateSocket(mockSocket, nextFn);
+
+    expect(clerkExpress.verifyToken).not.toHaveBeenCalled();
+    expect(authLinkingService.findUserByClerkId).not.toHaveBeenCalled();
+    expect(mockSocket.user).toBe(mockUser);
+    expect(mockSocket.userId).toBe(dummyUserId.toString());
+    expect(mockSocket.userRole).toBe("member");
+    expect(mockSocket.userOrganization).toBe(dummyOrgId);
+    expect(nextFn).toHaveBeenCalledWith();
+  });
 });

--- a/server/tests/sharedLinkAnalytics.test.js
+++ b/server/tests/sharedLinkAnalytics.test.js
@@ -27,7 +27,17 @@ vi.mock("../models/meetingModel.js", () => ({
 
 vi.mock("../models/policyModel.js", () => ({
   default: {
-    findById: vi.fn(),
+    findById: vi.fn(() => ({
+      select: vi.fn(() => ({
+        lean: vi.fn().mockResolvedValue({
+          _id: "policy-1",
+          name: "Security Policy",
+          version: "1.0",
+          fileUrl: "http://example.com/secret.pdf",
+          summary: "This is secure",
+        }),
+      })),
+    })),
   },
 }));
 
@@ -257,5 +267,51 @@ describe("Shared link analytics (#723)", () => {
     expect(viewerRes.body.links[0].totalViews).toBeUndefined();
     expect(viewerRes.body.links[0].failedPasscodeAttempts).toBeUndefined();
     expect(viewerRes.body.links[0].hash).toBe("h1");
+  });
+
+  it("restricts public meeting resource response", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "link-meeting",
+      hash: "m123",
+      active: true,
+      passcode: null,
+      resourceModel: "Meeting",
+      resourceId: "meeting-1",
+    });
+
+    const req = { params: { hash: "m123" }, cookies: {} };
+    const res = mockRes();
+
+    await getPublicResource(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.title).toBe("Standup");
+    expect(res.body.data.transcript).toBeUndefined();
+    expect(res.body.data.aiNotes).toBeUndefined();
+    expect(res.body.data.meetingType).toBeUndefined();
+  });
+
+  it("restricts public policy resource response", async () => {
+    mockFindOne.mockResolvedValue({
+      _id: "link-policy",
+      hash: "p123",
+      active: true,
+      passcode: null,
+      resourceModel: "Policy",
+      resourceId: "policy-1",
+    });
+
+    const req = { params: { hash: "p123" }, cookies: {} };
+    const res = mockRes();
+
+    await getPublicResource(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.name).toBe("Security Policy");
+    expect(res.body.data.summary).toBe("This is secure");
+    expect(res.body.data.fileUrl).toBeUndefined();
+    expect(res.body.data.isDraft).toBeUndefined();
   });
 });


### PR DESCRIPTION
---

## 📝 Summary

This PR restricts the data returned through publicly shared links (meetings and policies) to the minimum required subset. It ensures sensitive organizational information, complete transcripts, private user data, and raw file URLs remain protected according to the principle of least privilege.

---

## 🏷️ Type of Change

Please select all that apply:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1124

---

## ✨ Changes Made

- **Restricted Public Meeting Details**: Filtered the public response for `Meeting` resources. Excluded sensitive fields (`transcript`, `aiNotes`, `meetingType`, `venue`, `duration`, etc.) from the `.select()` query in `sharedLinkController.js`.
- **Anonymized Meeting Participants**: Stripped personal identifiers (email, name, database ID) from the `participants` field, replacing them with a dummy array matching the length of participants (e.g. `[{}, {}]`). This preserves the frontend display (`data.participants?.length`) without leaking data.
- **Restricted Public Policy Details**: Excluded `fileUrl` (direct document download URL), `status`, `isDraft`, and `keywords` from the public `Policy` response. Only policy metadata, summary, and key changes are shared.
- **Added Automated Testing**: Created unit test cases in `server/tests/sharedLinkAnalytics.test.js` to assert that sensitive fields (such as `transcript` and `fileUrl`) are absent from the returned payload.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally
- [ ] Screenshots attached (if applicable)

**Testing Details:**

Run the unit tests locally to verify the restriction:
```bash
cd server
npm run lint
npm run test:unit
