### PR TITLE
refactor: encrypt slack bot tokens before database storage (#1119)

### DIFF
--- a/server/controllers/slackController.js
+++ b/server/controllers/slackController.js
@@ -23,6 +23,7 @@ import {
   buildMeetingCreatedBlocks,
 } from "../services/slackService.js";
 import { sendError } from "../utils/responseHandler.js";
+import { encryptToken } from "../utils/crypto.js";
 
 // Helpers
 
@@ -181,7 +182,7 @@ export const slackOAuthRedirect = async (req, res, next) => {
     // slackData.team.id / slackData.team.name = the Slack workspace info
     await Organization.findByIdAndUpdate(organizationId, {
       $set: {
-        "slackIntegration.botToken": slackData.access_token,
+        "slackIntegration.botToken": encryptToken(slackData.access_token),
         "slackIntegration.channelId":
           slackData.incoming_webhook?.channel_id || "",
         "slackIntegration.teamId": slackData.team?.id || "",

--- a/server/models/organizationModel.js
+++ b/server/models/organizationModel.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { encryptToken, decryptToken } from "../utils/crypto.js";
 
 const organizationSchema = new mongoose.Schema(
   {
@@ -137,8 +138,24 @@ const organizationSchema = new mongoose.Schema(
       },
     },
   },
-  { timestamps: true },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  },
 );
+
+organizationSchema
+  .virtual("slackBotToken")
+  .get(function () {
+    return decryptToken(this.slackIntegration?.botToken);
+  })
+  .set(function (value) {
+    if (!this.slackIntegration) {
+      this.slackIntegration = {};
+    }
+    this.slackIntegration.botToken = encryptToken(value);
+  });
 
 // Indexes for performance
 

--- a/server/services/automationRuleService.js
+++ b/server/services/automationRuleService.js
@@ -87,7 +87,7 @@ export const evaluateRules = async (eventType, payload) => {
 
 const executeActions = async (rule, payload, meetingData) => {
   const org = await Organization.findById(rule.organization).select(
-    "+slackBotToken",
+    "+slackIntegration.botToken",
   );
 
   for (const action of rule.actions) {

--- a/server/services/slackService.js
+++ b/server/services/slackService.js
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import axios from "axios";
 import Organization from "../models/organizationModel.js";
 import eventBus from "./eventBus.js";
+import { decryptToken } from "../utils/crypto.js";
 
 // Slack Request Signature Verification
 
@@ -322,14 +323,15 @@ eventBus.on("mom.generated", async (meeting) => {
       .lean();
 
     const slack = org?.slackIntegration;
-    if (!slack?.botToken || !slack?.channelId) {
+    const decryptedToken = decryptToken(slack?.botToken);
+    if (!decryptedToken || !slack?.channelId) {
       // Slack not integrated for this org — silently skip
       return;
     }
 
     const blocks = buildMoMSummaryBlocks(meeting);
     await postBlockMessage(
-      slack.botToken,
+      decryptedToken,
       slack.channelId,
       blocks,
       `AI Meeting Summary ready for "${meeting.title}"`,

--- a/server/tests/slack.test.js
+++ b/server/tests/slack.test.js
@@ -57,6 +57,7 @@ const slackRoutes = (await import("../routes/slackRoutes.js")).default;
 const User = (await import("../models/userModel.js")).default;
 const Organization = (await import("../models/organizationModel.js")).default;
 const Membership = (await import("../models/membershipModel.js")).default;
+const { decryptToken } = await import("../utils/crypto.js");
 
 // Mirror production Slack mount order (see config/express.js) without booting
 // the full application graph from server.js.
@@ -419,14 +420,20 @@ describe("GET /api/slack/oauth_redirect", () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain("slackInstall=success");
 
-    // Verify the org was updated in the database
+    // Verify the org was updated in the database and the token is encrypted
     const updatedOrg = await Organization.findById(org._id)
       .select("+slackIntegration.botToken")
       .lean();
     expect(updatedOrg.slackIntegration.teamId).toBe("T12345TEST");
     expect(updatedOrg.slackIntegration.teamName).toBe("Test Workspace");
     expect(updatedOrg.slackIntegration.channelId).toBe("C12345TEST");
-    expect(updatedOrg.slackIntegration.botToken).toBe("xoxb-test-token");
+    // Verify it is not stored as plain text
+    expect(updatedOrg.slackIntegration.botToken).not.toBe("xoxb-test-token");
+    expect(updatedOrg.slackIntegration.botToken).toContain(":");
+    // Verify it decrypts back correctly
+    expect(decryptToken(updatedOrg.slackIntegration.botToken)).toBe(
+      "xoxb-test-token",
+    );
     expect(updatedOrg.slackIntegration.installedAt).toBeTruthy();
   });
 });

--- a/server/utils/crypto.js
+++ b/server/utils/crypto.js
@@ -1,0 +1,63 @@
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+
+const getEncryptionKey = () => {
+  const key =
+    process.env.TOKEN_ENCRYPTION_KEY || "default_dev_token_encryption_key_32";
+  // Always derive a 32-byte key via SHA-256 to prevent crashes
+  return crypto.createHash("sha256").update(key).digest();
+};
+
+/**
+ * Encrypts a token using AES-256-GCM
+ * @param {string} text Plaintext token
+ * @returns {string} Colon-separated ciphertext iv:encrypted:authTag
+ */
+export const encryptToken = (text) => {
+  if (!text) return "";
+  // If the token is already encrypted, return it
+  if (text.split(":").length === 3 && !text.startsWith("xoxb-")) {
+    return text;
+  }
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, getEncryptionKey(), iv);
+  let encrypted = cipher.update(text, "utf8", "hex");
+  encrypted += cipher.final("hex");
+  const authTag = cipher.getAuthTag().toString("hex");
+  return `${iv.toString("hex")}:${encrypted}:${authTag}`;
+};
+
+/**
+ * Decrypts a token using AES-256-GCM
+ * Supports plain-text fallback for legacy tokens (starts with xoxb-)
+ * @param {string} encryptedData Encrypted token string
+ * @returns {string} Decrypted token
+ */
+export const decryptToken = (encryptedData) => {
+  if (!encryptedData) return "";
+  // Check for legacy unencrypted tokens
+  if (encryptedData.startsWith("xoxb-")) {
+    return encryptedData;
+  }
+  const parts = encryptedData.split(":");
+  if (parts.length !== 3) {
+    return encryptedData;
+  }
+  try {
+    const [ivHex, encryptedText, authTagHex] = parts;
+    const key = getEncryptionKey();
+    const decipher = crypto.createDecipheriv(
+      ALGORITHM,
+      key,
+      Buffer.from(ivHex, "hex"),
+    );
+    decipher.setAuthTag(Buffer.from(authTagHex, "hex"));
+    let decrypted = decipher.update(encryptedText, "hex", "utf8");
+    decrypted += decipher.final("utf8");
+    return decrypted;
+  } catch (err) {
+    console.error("Failed to decrypt Slack token:", err.message);
+    return encryptedData;
+  }
+};


### PR DESCRIPTION
---

## 📝 Summary

This PR introduces at-rest encryption for Slack bot integration credentials using AES-256-GCM and the existing `TOKEN_ENCRYPTION_KEY` configuration. The tokens are encrypted before database persistence and decrypted only when required for API requests, with full backward compatibility for unencrypted legacy tokens.

---

## 🏷️ Type of Change

Please select all that apply:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1119

---

## ✨ Changes Made

- **Created Crypto Utility**: Implemented `encryptToken` and `decryptToken` inside `server/utils/crypto.js` using AES-256-GCM. Hashed the `TOKEN_ENCRYPTION_KEY` using SHA-256 to guarantee a robust 32-byte key. Added backward compatibility support for raw tokens (e.g. starting with `xoxb-`).
- **Added Schema Virtual Property**: Added `slackBotToken` virtual getter (automatically decrypts) and setter (automatically encrypts) to `Organization` schema in `server/models/organizationModel.js`. This resolves an existing bug in `automationRuleService.js` that was querying `+slackBotToken` (which was previously undefined in the schema).
- **OAuth Token Encryption**: Encrypted Slack tokens prior to database storage during OAuth redirect bindings inside `server/controllers/slackController.js`.
- **OAuth Token Decryption**: Decrypted bot tokens when executing Slack posts in the integration service (`server/services/slackService.js`).
- **Integrated Rules Engine**: Updated `executeActions` in `server/services/automationRuleService.js` to select `+slackIntegration.botToken` from database, which then resolves to the decrypted token via the `slackBotToken` virtual getter.
- **Updated Test Coverage**: Enhanced `server/tests/slack.test.js` to verify that the token stored in the database is encrypted (not a plaintext string) but successfully decrypts back to its original value.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally
- [ ] Screenshots attached (if applicable)

**Testing Details:**

Run the unit test suite locally to verify the encryption process:
```bash
cd server
npm run lint
npm run test:unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Slack bot access tokens are now encrypted when stored, helping protect integration credentials.
  * Tokens are securely decrypted only when needed for Slack activity.
  * Existing legacy Slack tokens remain supported during the transition.

* **Bug Fixes**
  * Improved handling of Slack integrations when credentials are missing or require initialization.
  * Slack-powered automation continues to use the configured bot credentials reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->