### PR TITLE
fix(security): limit max request size on Slack events endpoints (#1118)

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -22,16 +22,24 @@ export function configureExpress(app) {
   app.use(requestContext);
   configureSecurity(app);
   app.use(cors(corsOptions));
+  app.use(cookieParser());
+
+  // Public Slack webhooks are parsed by Slack-specific body parsers BEFORE the
+  // global JSON/urlencoded parsers. This order is required so that:
+  //  1. req.rawBody is captured for Slack HMAC signature verification, and
+  //  2. the strict SLACK_PAYLOAD_LIMIT is enforced on these endpoints.
+  // If the global parsers ran first, they would consume the stream and both
+  // guarantees would be lost. (Issue #1118)
+  app.use("/api/slack", slackWebhookParser, slackRoutes);
+
   app.use(express.json({ limit: "2mb" }));
   app.use(express.urlencoded({ extended: true, limit: "2mb" }));
-  app.use(cookieParser());
 
   // Dependency-aware health probes must not be blocked by the global limiter
   // or CSRF middleware.
   configureHealthEndpoints(app);
 
   // External/public routes use their own authentication mechanisms.
-  app.use("/api/slack", slackWebhookParser, slackRoutes);
   app.use("/api/webhooks", webhookRoutes);
   app.use("/api/public/shared", publicSharedRoutes);
 

--- a/server/middleware/slackWebhookParser.js
+++ b/server/middleware/slackWebhookParser.js
@@ -11,11 +11,23 @@ const captureRawBody = (req, _res, buf) => {
 };
 
 /**
+ * Strict payload cap for the public Slack webhook endpoints (Issue #1118).
+ *
+ * These routes are publicly reachable, so accepting up to 50mb is an
+ * unnecessary resource-consumption and abuse vector. Slack event callbacks
+ * and slash-command payloads are typically a few KB, so 1mb gives generous
+ * headroom while rejecting oversized bodies early with a 413 (handled by the
+ * global error handler's `entity.too.large` branch).
+ */
+export const SLACK_PAYLOAD_LIMIT = "1mb";
+
+/**
  * Slack-specific body parsers.
  *
  * Must be mounted on `/api/slack` *before* the global `express.json` /
  * `express.urlencoded` middleware. Otherwise the global parsers consume the
- * stream first and `req.rawBody` is never set, breaking signature checks.
+ * stream first and `req.rawBody` is never set, breaking signature checks —
+ * and the strict `SLACK_PAYLOAD_LIMIT` below is never enforced.
  *
  * Slack sends:
  * - `application/json` for Events API payloads
@@ -23,12 +35,12 @@ const captureRawBody = (req, _res, buf) => {
  */
 export const slackWebhookParser = [
   express.json({
-    limit: "50mb",
+    limit: SLACK_PAYLOAD_LIMIT,
     verify: captureRawBody,
   }),
   express.urlencoded({
     extended: true,
-    limit: "50mb",
+    limit: SLACK_PAYLOAD_LIMIT,
     verify: captureRawBody,
   }),
 ];

--- a/server/tests/slackWebhookParser.test.js
+++ b/server/tests/slackWebhookParser.test.js
@@ -10,7 +10,11 @@
 import request from "supertest";
 import crypto from "crypto";
 import express from "express";
-import { slackWebhookParser } from "../middleware/slackWebhookParser.js";
+import {
+  slackWebhookParser,
+  SLACK_PAYLOAD_LIMIT,
+} from "../middleware/slackWebhookParser.js";
+import errorHandler from "../middleware/errorHandler.js";
 
 const SIGNING_SECRET = "test_signing_secret_parser";
 
@@ -120,5 +124,55 @@ describe("slackWebhookParser raw body capture (Issue #614)", () => {
     expect(res.status).toBe(200);
     expect(res.body.parsedType).toBe("url_verification");
     expect(res.body.hasRawBody).toBe(false);
+  });
+});
+
+describe("slackWebhookParser payload limit (Issue #1118)", () => {
+  const buildLimitedApp = () => {
+    const limitedApp = express();
+    // Match the production mount order (config/express.js): Slack parser first,
+    // then the global error handler to serialize body-parser errors.
+    limitedApp.use("/api/slack", slackWebhookParser, (req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    limitedApp.use(errorHandler);
+    return limitedApp;
+  };
+
+  it("defines a strict Slack payload limit (not the legacy 50mb)", () => {
+    expect(SLACK_PAYLOAD_LIMIT).toBe("1mb");
+  });
+
+  it("rejects an oversized JSON event payload with 413", async () => {
+    const bigString = "x".repeat(1024 * 1024 + 1024); // ~1MB+ — over the limit
+    const res = await request(buildLimitedApp())
+      .post("/api/slack/events")
+      .set("Content-Type", "application/json")
+      .send({ type: "event_callback", blob: bigString });
+
+    expect(res.status).toBe(413);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("rejects an oversized urlencoded slash-command payload with 413", async () => {
+    const bigText = "y".repeat(1024 * 1024 + 1024); // ~1MB+ — over the limit
+    const res = await request(buildLimitedApp())
+      .post("/api/slack/events")
+      .set("Content-Type", "application/x-www-form-urlencoded")
+      .send(`command=/mom-create&text=${encodeURIComponent(bigText)}`);
+
+    expect(res.status).toBe(413);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("still accepts a legitimate Slack payload under the limit", async () => {
+    const payload = { type: "url_verification", challenge: "challenge-token" };
+    const res = await request(buildLimitedApp())
+      .post("/api/slack/events")
+      .set("Content-Type", "application/json")
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
   });
 });


### PR DESCRIPTION
---

## 📝 Summary

Public Slack webhook endpoints (`POST /api/slack/events`) were accepting request bodies up to **50mb** — an unnecessary resource-consumption and abuse vector for a route Slack needs only for small event callbacks and slash-command payloads. This PR caps the Slack webhook body parsers at **1mb**, so oversized requests are rejected with a `413` before any handler or signature work runs.

It also fixes a middleware-ordering regression in `server/config/express.js`: the Slack-specific parsers were mounted *after* the global `express.json`/`express.urlencoded` parsers, which meant `req.rawBody` was never captured (breaking HMAC signature verification) and the Slack-specific limit could never take effect. The Slack mount now precedes the global parsers, matching the contract documented in `slackWebhookParser.js`.

---

## 🏷️ Type of Change

Please select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1118

---

## ✨ Changes Made

- **Added `SLACK_PAYLOAD_LIMIT`**: Defined `1mb` in `server/middleware/slackWebhookParser.js` and applied it to both the JSON and urlencoded Slack body parsers (previously `50mb`).
- **Fixed parser mount order**: In `server/config/express.js`, mounted `/api/slack` (Slack parsers + routes) *before* the global JSON/urlencoded parsers, so `rawBody` capture and the strict limit are both honored. Global parsers still apply everywhere else.
- **Added test coverage** in `server/tests/slackWebhookParser.test.js`:
  - Asserts `SLACK_PAYLOAD_LIMIT` is `1mb` (not the legacy `50mb`).
  - Oversized JSON event payload → `413` with `success: false`.
  - Oversized urlencoded slash-command payload → `413`.
  - Legitimate Slack payload under the limit still returns `200`.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally
- [ ] Screenshots attached (if applicable)

**Testing Details:**

```bash
cd server
npx eslint config/express.js middleware/slackWebhookParser.js tests/slackWebhookParser.test.js
npx prettier --check config/express.js middleware/slackWebhookParser.js tests/slackWebhookParser.test.js
node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand tests/slackWebhookParser.test.js
# Test Suites: 1 passed, 1 total — Tests: 7 passed, 7 total
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack webhook requests now enforce a strict 1 MB payload limit.
  * Oversized Slack requests receive a clear HTTP 413 failure response.
  * Slack webhook payloads are parsed correctly before general request parsing occurs.
  * Valid requests within the limit continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->