### PR TITLE
fix: restore authentication protection for meeting attachment routes 

### DIFF
--- a/server/routes/attachmentRoutes.js
+++ b/server/routes/attachmentRoutes.js
@@ -9,6 +9,7 @@ import {
   downloadAttachment,
   deleteAttachment,
 } from "../controllers/attachmentController.js";
+import userAuth from "../middleware/userAuth.js";
 import { requireOrgAccess } from "../middleware/rbac.js";
 import Meeting from "../models/meetingModel.js";
 
@@ -94,7 +95,8 @@ const upload = multer({
   },
 });
 
-// All routes require org access to the meeting
+// All routes require authentication and org access to the meeting
+router.use(userAuth);
 router.use(requireOrgAccess(Meeting));
 
 // Route: /api/meetings/:meetingId/attachments


### PR DESCRIPTION
## Tagged Issue
Closes #1107

## Summary
Restores the global `userAuth` authentication middleware across all meeting attachment endpoints so that attachment operations run strictly within an authenticated user context prior to RBAC and organization authorization checks.

## Changes Made
- Imported `userAuth` middleware in `server/routes/attachmentRoutes.js`.
- Applied `router.use(userAuth)` before `router.use(requireOrgAccess(Meeting))` in `server/routes/attachmentRoutes.js`.
- Guaranteed `req.user` context is populated for all attachment endpoints (`POST /`, `GET /`, `GET /:id/download`, `DELETE /:id`).

## Security Considerations
- Prevents unauthenticated access to meeting attachments.
- Ensures RBAC authorization (`requireOrgAccess`) receives valid user identity and organization metadata.
- Preserves existing file access permissions and upload/download behavior for authenticated users.

## Verification Plan
### Automated Tests
- Ran server route registration and attachment tests: `npm run test:related --prefix server`
- Verified 401 Unauthorized response on unauthenticated request attempts to attachment endpoints.

### Manual Verification
- Sent unauthenticated HTTP requests to `/api/meetings/:meetingId/attachments` and confirmed `401 Unauthorized` responses.
- Verified authenticated users with valid organization access can upload, list, download, and delete meeting attachments.

## Checklist
- [x] Code follows repository guidelines.
- [x] All attachment endpoints protected by `userAuth`.
- [x] Existing RBAC enforcement preserved.
- [x] Pushed to branch `fix/attachment-route-auth-protection`.
