### PR TITLE
Fix/restrict meeting upload file types

### DIFF
--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -151,6 +151,66 @@ const validatePath = (filePath) => {
   return resolved;
 };
 
+const ALLOWED_RECORDING_MIME_TYPES = [
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+  "audio/webm",
+  "audio/flac",
+  "audio/aac",
+  "audio/mp4",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-msvideo",
+  "video/x-matroska",
+  "application/octet-stream",
+];
+
+const ALLOWED_RECORDING_EXTENSIONS = [
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".ogg",
+  ".webm",
+  ".flac",
+  ".aac",
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+];
+
+const validateMeetingFileType = (file) => {
+  if (!file) return;
+  const ext = path.extname(file.originalname || "").toLowerCase();
+  const mimeType = file.mimetype;
+
+  const isExtAllowed = ALLOWED_RECORDING_EXTENSIONS.includes(ext);
+  const isMimeAllowed =
+    !mimeType || ALLOWED_RECORDING_MIME_TYPES.includes(mimeType);
+
+  if (!isExtAllowed || !isMimeAllowed) {
+    if (file.path) {
+      try {
+        const safePath = validatePath(file.path);
+        if (fs.existsSync(safePath)) {
+          fs.unlinkSync(safePath);
+        }
+      } catch {
+        // ignore cleanup error
+      }
+    }
+    throw new ValidationError(
+      `Invalid meeting recording file type: ${file.originalname || ext}. Allowed recording formats: MP3, WAV, M4A, OGG, WEBM, FLAC, AAC, MP4, MOV, AVI, MKV`,
+    );
+  }
+};
+
 // ── Helper: extract userId from the request ───────────────────
 const getUserId = (req) => {
   const id = req.user?.id || req.user?._id;
@@ -216,6 +276,7 @@ export const uploadMeeting = async (req, res, next) => {
     if (!req.file) {
       throw new ValidationError("No audio file uploaded.");
     }
+    validateMeetingFileType(req.file);
     const uploaderId = getUserId(req);
 
     let validated;
@@ -266,6 +327,7 @@ export const uploadAudioForMeeting = async (req, res, next) => {
     if (!req.file) {
       throw new ValidationError("No audio file uploaded.");
     }
+    validateMeetingFileType(req.file);
     const uploaderId = getUserId(req);
     const { meetingId } = req.body;
 

--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -191,6 +191,62 @@ export const uploadTranscriptAudio = async (req, res) => {
       });
     }
 
+    const ALLOWED_RECORDING_MIME_TYPES = [
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/wav",
+      "audio/x-wav",
+      "audio/m4a",
+      "audio/x-m4a",
+      "audio/ogg",
+      "audio/webm",
+      "audio/flac",
+      "audio/aac",
+      "audio/mp4",
+      "video/mp4",
+      "video/webm",
+      "video/quicktime",
+      "video/x-msvideo",
+      "video/x-matroska",
+      "application/octet-stream",
+    ];
+
+    const ALLOWED_RECORDING_EXTENSIONS = [
+      ".mp3",
+      ".wav",
+      ".m4a",
+      ".ogg",
+      ".webm",
+      ".flac",
+      ".aac",
+      ".mp4",
+      ".mov",
+      ".avi",
+      ".mkv",
+    ];
+
+    const ext = path.extname(req.file.originalname || "").toLowerCase();
+    const mimeType = req.file.mimetype;
+    const isExtAllowed = !ext || ALLOWED_RECORDING_EXTENSIONS.includes(ext);
+    const isMimeAllowed =
+      !mimeType ||
+      mimeType === "blob" ||
+      ALLOWED_RECORDING_MIME_TYPES.includes(mimeType);
+
+    if (!isExtAllowed || !isMimeAllowed) {
+      if (req.file.path && fs.existsSync(req.file.path)) {
+        try {
+          fs.unlinkSync(req.file.path);
+        } catch {
+          // ignore
+        }
+      }
+      return res.status(400).json({
+        success: false,
+        message: "Invalid file type or extension for meeting recording",
+      });
+    }
+
     // Verify meeting exists and user has access
     const meeting = await Meeting.findById(meetingId);
     if (!meeting) {

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -54,11 +54,74 @@ import {
   uploadTranscriptChunk,
 } from "../controllers/transcriptController.js";
 
+import path from "path";
+import { ValidationError } from "../utils/errors.js";
+
+const ALLOWED_RECORDING_MIME_TYPES = [
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+  "audio/webm",
+  "audio/flac",
+  "audio/aac",
+  "audio/mp4",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-msvideo",
+  "video/x-matroska",
+  "application/octet-stream",
+];
+
+const ALLOWED_RECORDING_EXTENSIONS = [
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".ogg",
+  ".webm",
+  ".flac",
+  ".aac",
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+];
+
+const meetingRecordingFilter = (req, file, cb) => {
+  if (!file) {
+    return cb(null, true);
+  }
+  const ext = path.extname(file.originalname || "").toLowerCase();
+  const mimeType = file.mimetype;
+
+  const isExtAllowed = ALLOWED_RECORDING_EXTENSIONS.includes(ext);
+  const isMimeAllowed =
+    !mimeType || ALLOWED_RECORDING_MIME_TYPES.includes(mimeType);
+
+  if (!isExtAllowed || !isMimeAllowed) {
+    return cb(
+      new ValidationError(
+        `Invalid meeting recording file type: ${file.originalname || ext}. Allowed recording formats: MP3, WAV, M4A, OGG, WEBM, FLAC, AAC, MP4, MOV, AVI, MKV`,
+      ),
+      false,
+    );
+  }
+  cb(null, true);
+};
+
 const router = express.Router();
-const upload = multer({ dest: "uploads/" }); // temporary upload directory
+const upload = multer({
+  dest: "uploads/",
+  fileFilter: meetingRecordingFilter,
+}); // temporary upload directory
 const transcriptUpload = multer({
   dest: "uploads/transcripts/",
   limits: { fileSize: 100 * 1024 * 1024 }, // 100MB limit
+  fileFilter: meetingRecordingFilter,
 });
 const transcriptChunkUpload = multer({
   storage: multer.memoryStorage(),


### PR DESCRIPTION
## Tagged Issue
Closes #1108

## Summary
Enforces strict server-side file type and extension validation for meeting recording uploads across Multer route configurations and meeting controllers to reject unsupported or unexpected file formats before storage.

## Changes Made
- Defined approved meeting recording MIME types (`audio/mpeg`, `audio/wav`, `audio/mp4`, `video/mp4`, `video/webm`, etc.) and approved extensions (`.mp3`, `.wav`, `.m4a`, `.ogg`, `.webm`, `.flac`, `.aac`, `.mp4`, `.mov`, `.avi`, `.mkv`).
- Added `meetingRecordingFilter` Multer file filter in `server/routes/meetingRoutes.js` for meeting audio/recording uploads.
- Created `validateMeetingFileType` helper in `server/controllers/meetingController.js` to inspect uploaded file extension and MIME type before processing.
- Added file format validation in `uploadMeeting`, `uploadAudioForMeeting`, and `uploadTranscriptAudio` (`server/controllers/transcriptController.js`), ensuring non-matching files are immediately removed with `fs.unlinkSync` and rejected with a `400 Bad Request` validation error.

## Security Considerations
- Restricts uploaded file types to safe and expected audio/video meeting formats.
- Prevents arbitrary file uploads (e.g. executables, scripts, or non-media files).
- Cleans up uploaded files from temporary disk storage upon validation failure.

## Verification Plan
### Automated Tests
- Ran server validation and unit test suites: `npm run validate:pr --prefix server`
- Verified rejection of non-audio/video file types.

### Manual Verification
- Uploaded valid meeting recordings (`.mp3`, `.wav`, `.mp4`, `.webm`) and confirmed successful upload and transcription.
- Attempted uploading invalid file types (`.exe`, `.sh`, `.html`) and verified immediate `400 Bad Request` responses and automatic file cleanup.

## Checklist
- [x] Server-side MIME type and extension validation implemented.
- [x] Unsupported uploads rejected with clear error messages.
- [x] Temporary files cleaned up on failure.
- [x] Pushed to branch `fix/restrict-meeting-upload-file-types`.
