### PR TITLE
fix: prevent unassigned-role users from receiving guest permissions

### DIFF
--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -73,11 +73,7 @@ const analyticsPermissionFor = (resourceModel) =>
   resourceModel === "Policy" ? "policies" : "meetings";
 
 const canViewAnalytics = (user, resourceModel) =>
-  hasPermission(
-    user?.role || "guest",
-    analyticsPermissionFor(resourceModel),
-    "edit",
-  );
+  hasPermission(user?.role, analyticsPermissionFor(resourceModel), "edit");
 
 const toPublicLink = (link, includeAnalytics) => {
   const base = {

--- a/server/controllers/slackController.js
+++ b/server/controllers/slackController.js
@@ -159,7 +159,7 @@ export const slackOAuthRedirect = async (req, res, next) => {
       return sendError(res, 403, "Unauthorized organization binding.");
     }
 
-    if (!hasPermission(user.role || "guest", "settings", "edit")) {
+    if (!hasPermission(user.role, "settings", "edit")) {
       return sendError(
         res,
         403,

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -43,7 +43,14 @@ export const requireRole = (roles) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const userRole = req.user.role || "guest";
+    if (!req.user.role) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: No role assigned",
+      });
+    }
+
+    const userRole = req.user.role;
     const allowedRoles = Array.isArray(roles) ? roles : [roles];
 
     if (!allowedRoles.includes(userRole)) {
@@ -92,7 +99,14 @@ export const requirePermission = (resource, action) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const userRole = req.user.role || "guest";
+    if (!req.user.role) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: No role assigned",
+      });
+    }
+
+    const userRole = req.user.role;
 
     if (!hasPermission(userRole, resource, action)) {
       return res.status(403).json({
@@ -111,7 +125,14 @@ export const requireAnyPermission = (resource, actions) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const userRole = req.user.role || "guest";
+    if (!req.user.role) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: No role assigned",
+      });
+    }
+
+    const userRole = req.user.role;
 
     const hasAny = actions.some((action) =>
       hasPermission(userRole, resource, action),

--- a/server/tests/rbacUnassignedRole.test.js
+++ b/server/tests/rbacUnassignedRole.test.js
@@ -1,0 +1,207 @@
+import { jest } from "@jest/globals";
+import {
+  requireAdminOrOwner,
+  requireAnyPermission,
+  requireMinimumRole,
+  requirePermission,
+  requireRole,
+} from "../middleware/rbac.js";
+
+/**
+ * Regression for Issue #1116:
+ * Users without an assigned role must not inherit guest-level permissions.
+ * Null/missing roles are denied as unauthorized until onboarding or role
+ * assignment completes, while the literal "guest" role keeps its behaviour.
+ */
+describe("RBAC unassigned-role enforcement (#1116)", () => {
+  const mockRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  describe("requireRole", () => {
+    it("denies a user with no role assigned", () => {
+      const middleware = requireRole(["admin", "owner"]);
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: null } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: No role assigned",
+        }),
+      );
+    });
+
+    it("still permits an allowed assigned role", () => {
+      const middleware = requireRole(["admin", "owner"]);
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "admin" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it("still denies a role outside the allowed set", () => {
+      const middleware = requireRole(["admin", "owner"]);
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "member" } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: Insufficient role",
+        }),
+      );
+    });
+  });
+
+  describe("requirePermission", () => {
+    it("denies a user with no role assigned", () => {
+      const middleware = requirePermission("meetings", "view");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: null } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: No role assigned",
+        }),
+      );
+    });
+
+    it("denies a user whose role property is missing entirely", () => {
+      const middleware = requirePermission("meetings", "view");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: {} }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it("still permits an assigned guest role on guest-permitted actions", () => {
+      const middleware = requirePermission("meetings", "view");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "guest" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it("still denies an assigned guest role on non-guest actions", () => {
+      const middleware = requirePermission("meetings", "edit");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "guest" } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it("still permits assigned member roles", () => {
+      const middleware = requirePermission("ai_search", "search");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "member" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("requireAnyPermission", () => {
+    it("denies a user with no role assigned", () => {
+      const middleware = requireAnyPermission("meetings", ["view", "edit"]);
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: null } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: No role assigned",
+        }),
+      );
+    });
+
+    it("still permits an assigned guest role on guest-permitted actions", () => {
+      const middleware = requireAnyPermission("meetings", ["view", "edit"]);
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "guest" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-regression for other RBAC middleware", () => {
+    it("requireMinimumRole still denies a user with no role", () => {
+      const middleware = requireMinimumRole("viewer");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: null } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it("requireMinimumRole still permits an assigned role at/above the minimum", () => {
+      const middleware = requireMinimumRole("viewer");
+      const res = mockRes();
+      const next = jest.fn();
+
+      middleware({ user: { role: "member" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it("requireAdminOrOwner still denies a user with no role", () => {
+      const res = mockRes();
+      const next = jest.fn();
+
+      requireAdminOrOwner({ user: { role: null } }, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it("requireAdminOrOwner still permits an owner", () => {
+      const res = mockRes();
+      const next = jest.fn();
+
+      requireAdminOrOwner({ user: { role: "owner" } }, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Summary

Strengthens RBAC so that users without an assigned role no longer inherit guest-level permissions. Previously `requireRole`, `requirePermission`, and `requireAnyPermission` fell back to `"guest"` when `req.user.role` was null/undefined, letting un-assigned (pre-onboarding) users pass guest-permitted authorization checks like `meetings.view`. Now a missing role is rejected with `403 Forbidden: No role assigned` until onboarding/role assignment completes.

## 🏷️ Type of Change

- [x] Security fix
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1116

## ✨ Changes Made

- **`server/middleware/rbac.js`**
  - `requireRole` – reject null/undefined roles with `403 "Forbidden: No role assigned"` instead of defaulting to `guest`.
  - `requirePermission` – same guard, applied before the `hasPermission` check.
  - `requireAnyPermission` – same guard, applied before the per-action check.
  - Literal `guest` role behavior is fully preserved wherever `PERMISSIONS` includes it (e.g. `meetings.view`).
- **`server/controllers/slackController.js`**
  - `slackOAuthRedirect` – removed the `user.role || "guest"` fallback; `hasPermission` already denies null roles, so no privilege is granted and the deny behavior is unchanged.
- **`server/controllers/sharedLinkController.js`**
  - `canViewAnalytics` – removed the `user?.role || "guest"` fallback for the same consistency reason.
- **`server/tests/rbacUnassignedRole.test.js`** (new)
  - Denies null/missing roles across all three middleware.
  - Confirms assigned roles (including literal `guest` on guest-permitted actions) still work.
  - Non-regression checks for `requireMinimumRole` and `requireAdminOrOwner`.

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

```bash
node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand tests/rbacUnassignedRole.test.js tests/rbacMeetingIdRegression.test.js
node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand tests/slack.test.js tests/userAuth.test.js tests/sharedLinkOwnership.test.js
npx vitest run tests/sessionAiPermission.test.js tests/clerkRbacIntegration.test.js tests/sharedLinkAnalytics.test.js
npm run lint:changed
npm run format:check:changed
```
