### PR TITLE
fix: correct Automation Rules RBAC permission mapping

### DIFF
--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -167,7 +167,7 @@ const ProtectedRoutes = (
     <Route
       path="/automation-rules"
       element={
-        <ProtectedRoute resource="organization" action="manage">
+        <ProtectedRoute resource="automation_rules" action="view">
           <AutomationRules />
         </ProtectedRoute>
       }

--- a/client/src/utils/__tests__/rbacPermissions.test.js
+++ b/client/src/utils/__tests__/rbacPermissions.test.js
@@ -112,6 +112,21 @@ describe("RBAC Permissions Utils", () => {
       );
       expect(hasPermission("admin", "audit_logs", "view")).toBe(true);
       expect(hasPermission("member", "audit_logs", "view")).toBe(false);
+      expect(hasPermission("admin", "automation_rules", "view")).toBe(true);
+      expect(hasPermission("owner", "automation_rules", "create")).toBe(true);
+      expect(hasPermission("member", "automation_rules", "view")).toBe(false);
+      expect(hasPermission("moderator", "automation_rules", "edit")).toBe(
+        false,
+      );
+    });
+
+    it("rejects the previous invalid Automation Rules mapping (#1126)", () => {
+      // resource was singular "organization" and action "manage" — neither exists
+      expect(hasPermission("admin", "organization", "manage")).toBe(false);
+      expect(hasPermission("owner", "organization", "manage")).toBe(false);
+      expect(PERMISSIONS.organization).toBeUndefined();
+      expect(PERMISSIONS.organizations.manage).toBeUndefined();
+      expect(PERMISSIONS.automation_rules).toBeDefined();
     });
 
     it("allows viewer search/view but blocks meeting mutation", () => {

--- a/client/src/utils/rbacPermissions.js
+++ b/client/src/utils/rbacPermissions.js
@@ -77,6 +77,12 @@ export const PERMISSIONS = {
     view: ["owner", "admin", "moderator", "member"],
     export: ["owner", "admin", "moderator"],
   },
+  // Analytics permissions (including attendance analytics)
+  analytics: {
+    view: ["owner", "admin", "moderator"],
+    export: ["owner", "admin"],
+    manage: ["owner", "admin"],
+  },
   // Admin Panel permissions
   admin_panel: {
     view: ["owner", "admin"],
@@ -101,6 +107,13 @@ export const PERMISSIONS = {
   // Audit Logs permissions
   audit_logs: {
     view: ["owner", "admin"],
+  },
+  // Automation Rules permissions (org admins / owners only)
+  automation_rules: {
+    view: ["owner", "admin"],
+    create: ["owner", "admin"],
+    edit: ["owner", "admin"],
+    delete: ["owner", "admin"],
   },
 };
 

--- a/server/routes/automationRuleRoutes.js
+++ b/server/routes/automationRuleRoutes.js
@@ -1,6 +1,6 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
-import { requireAdminOrOwner } from "../middleware/rbac.js";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
 import {
   createRule,
   getRules,
@@ -12,15 +12,23 @@ import {
 
 const router = express.Router();
 
-// All routes require authentication and admin/owner role
+// Authenticated org members only; action checks use the shared RBAC map.
 router.use(userAuth);
-router.use(requireAdminOrOwner);
+router.use(requireOrgMembership);
 
-router.post("/", createRule);
-router.get("/", getRules);
-router.get("/:id", getRuleById);
-router.put("/:id", updateRule);
-router.patch("/:id/toggle", toggleRuleStatus);
-router.delete("/:id", deleteRule);
+router.post("/", requirePermission("automation_rules", "create"), createRule);
+router.get("/", requirePermission("automation_rules", "view"), getRules);
+router.get("/:id", requirePermission("automation_rules", "view"), getRuleById);
+router.put("/:id", requirePermission("automation_rules", "edit"), updateRule);
+router.patch(
+  "/:id/toggle",
+  requirePermission("automation_rules", "edit"),
+  toggleRuleStatus,
+);
+router.delete(
+  "/:id",
+  requirePermission("automation_rules", "delete"),
+  deleteRule,
+);
 
 export default router;

--- a/server/tests/automationRulesRbac.test.js
+++ b/server/tests/automationRulesRbac.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { hasPermission } from "../utils/rbacPermissions.js";
+import { requirePermission } from "../middleware/rbac.js";
+
+describe("Automation Rules RBAC mapping (#1126)", () => {
+  let res;
+  let next;
+
+  beforeEach(() => {
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    next = vi.fn();
+  });
+
+  it("grants owner and admin every automation_rules action", () => {
+    for (const role of ["owner", "admin"]) {
+      for (const action of ["view", "create", "edit", "delete"]) {
+        expect(hasPermission(role, "automation_rules", action)).toBe(true);
+      }
+    }
+  });
+
+  it("denies non-admin roles automation_rules access", () => {
+    for (const role of ["moderator", "member", "viewer", "guest"]) {
+      expect(hasPermission(role, "automation_rules", "view")).toBe(false);
+      expect(hasPermission(role, "automation_rules", "create")).toBe(false);
+    }
+  });
+
+  it("rejects the previous invalid organization/manage mapping", () => {
+    expect(hasPermission("admin", "organization", "manage")).toBe(false);
+    expect(hasPermission("owner", "organizations", "manage")).toBe(false);
+  });
+
+  it("requirePermission allows an admin to view automation rules", () => {
+    const middleware = requirePermission("automation_rules", "view");
+    middleware({ user: { role: "admin", organization: "org1" } }, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("requirePermission blocks a member from creating automation rules", () => {
+    const middleware = requirePermission("automation_rules", "create");
+    middleware({ user: { role: "member", organization: "org1" } }, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/server/utils/rbacPermissions.js
+++ b/server/utils/rbacPermissions.js
@@ -108,6 +108,13 @@ export const PERMISSIONS = {
   audit_logs: {
     view: ["owner", "admin"],
   },
+  // Automation Rules permissions (org admins / owners only)
+  automation_rules: {
+    view: ["owner", "admin"],
+    create: ["owner", "admin"],
+    edit: ["owner", "admin"],
+    delete: ["owner", "admin"],
+  },
 };
 
 /**


### PR DESCRIPTION
## Description

Automation Rules was gated with `resource=\"organization\" action=\"manage\"`. Neither that resource nor that action exists in the RBAC map, so `hasPermission` always failed and authorized admins/owners were denied in the UI.

This adds an `automation_rules` permission (view/create/edit/delete for owner and admin) on both client and server, points the route at `automation_rules`/`view`, and switches the API routes to `requirePermission` so they use the same model as the rest of the app. Existing admin/owner-only access is preserved; other roles remain blocked.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1126

## Testing

- Client RBAC tests (including client/server sync and rejection of the old mapping)
- Server `automationRulesRbac` tests for allow/deny via `requirePermission`
- Format/lint validation; client build succeeds

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access & Permissions**
  - Updated automation-rules access controls to use dedicated permissions for viewing, creating, editing, and deleting rules.
  - Organization members must now have the appropriate elevated role to perform each action.
  - Improved consistency between client and server authorization behavior.
  - Added analytics permission definitions for viewing, exporting, and managing analytics features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->