### PR TITLE
fix: cancel stale Meeting Repository fetches

### DIFF
--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -1,21 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { toast } from "react-toastify";
 import { meetingApi } from "../../services";
-import { Trash2, Download, Edit2, Eye, Search, Filter } from "lucide-react";
-import AppContent from "../../context/AppContent";
 import MeetingCard from "./MeetingCard.jsx";
 import MeetingSearch from "./MeetingSearch.jsx";
 import MeetingFilters from "./MeetingFilters.jsx";
 import Pagination from "./Pagination.jsx";
 import EmptyState from "./EmptyState.jsx";
 import { useNavigate } from "react-router-dom";
+import useApiRequest from "../../hooks/useApiRequest.js";
 
 const MeetingRepository = () => {
   const navigate = useNavigate();
-  const [meetings, setMeetings] = useState([]);
   const [filteredMeetings, setFilteredMeetings] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [filters, setFilters] = useState({
     status: "all",
@@ -28,33 +24,40 @@ const MeetingRepository = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 9;
 
-  // Fetch meetings
-  const fetchMeetings = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const response = await meetingApi.getAllMeetings();
+  // Abort in-flight loads when a newer refresh starts (#1131 / #978).
+  const loadMeetings = useCallback(async (signal) => {
+    const response = await meetingApi.getAllMeetings({}, { signal });
 
-      if (response.data?.success) {
-        setMeetings(response.data.meetings || []);
-      } else {
-        setError("Failed to fetch meetings");
-      }
-    } catch (err) {
-      console.error("Error fetching meetings:", err);
-      setError(err.response?.data?.message || "Failed to load meetings");
-    } finally {
-      setLoading(false);
+    if (!response.data?.success) {
+      const failure = new Error(
+        response.data?.message || "Failed to fetch meetings",
+      );
+      throw failure;
     }
-  };
+
+    return response.data.meetings || [];
+  }, []);
+
+  const {
+    data: meetings,
+    error: requestError,
+    loading,
+    execute: fetchMeetings,
+  } = useApiRequest(loadMeetings, { initialData: [] });
+
+  const error = requestError
+    ? requestError.response?.data?.message ||
+      requestError.message ||
+      "Failed to load meetings"
+    : null;
 
   useEffect(() => {
     fetchMeetings();
-  }, []);
+  }, [fetchMeetings]);
 
   // Apply filters and search
   useEffect(() => {
-    let filtered = [...meetings];
+    let filtered = [...(meetings || [])];
 
     // Apply search
     if (searchQuery.trim()) {
@@ -230,7 +233,7 @@ const MeetingRepository = () => {
           <div className="text-red-500 text-6xl mb-4">⚠️</div>
           <p className="text-gray-700 dark:text-gray-200 text-lg">{error}</p>
           <button
-            onClick={fetchMeetings}
+            onClick={() => fetchMeetings()}
             className="mt-4 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
           >
             Retry

--- a/client/src/components/meetings/__tests__/MeetingRepository.test.jsx
+++ b/client/src/components/meetings/__tests__/MeetingRepository.test.jsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import MeetingRepository from "../MeetingRepository";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services", () => ({
+  meetingApi: {
+    getAllMeetings: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+}));
+
+vi.mock("../MeetingCard.jsx", () => ({
+  default: ({ meeting }) => <div>{meeting.title}</div>,
+}));
+
+vi.mock("../MeetingSearch.jsx", () => ({
+  default: () => <div data-testid="meeting-search" />,
+}));
+
+vi.mock("../MeetingFilters.jsx", () => ({
+  default: () => <div data-testid="meeting-filters" />,
+}));
+
+vi.mock("../Pagination.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../EmptyState.jsx", () => ({
+  default: () => <div>Empty</div>,
+}));
+
+import { meetingApi } from "../../../services";
+
+const cancelError = () => {
+  const err = new Error("canceled");
+  err.code = "ERR_CANCELED";
+  return err;
+};
+
+describe("MeetingRepository race protection (#1131)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards an AbortSignal to getAllMeetings", async () => {
+    meetingApi.getAllMeetings.mockResolvedValue({
+      data: {
+        success: true,
+        meetings: [{ _id: "1", title: "Kickoff", createdAt: "2026-01-01" }],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingRepository />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Kickoff")).toBeInTheDocument();
+    });
+
+    expect(meetingApi.getAllMeetings).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("aborts an in-flight load so a late response cannot overwrite newer data", async () => {
+    let resolveSlow;
+    let slowSignal;
+
+    meetingApi.getAllMeetings
+      .mockImplementationOnce((_params, { signal } = {}) => {
+        slowSignal = signal;
+        return new Promise((resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(cancelError()));
+          resolveSlow = (meetings) => {
+            if (signal?.aborted) {
+              reject(cancelError());
+              return;
+            }
+            resolve({ data: { success: true, meetings } });
+          };
+        });
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          meetings: [
+            { _id: "new", title: "Fresh Meeting", createdAt: "2026-02-01" },
+          ],
+        },
+      });
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <MeetingRepository />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(meetingApi.getAllMeetings).toHaveBeenCalledTimes(1);
+    });
+
+    // Leaving the page aborts the outstanding request (#978 / #1131).
+    unmount();
+    expect(slowSignal?.aborted).toBe(true);
+
+    render(
+      <MemoryRouter>
+        <MeetingRepository />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Fresh Meeting")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveSlow?.([
+        { _id: "old", title: "Stale Meeting", createdAt: "2026-01-01" },
+      ]);
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(screen.queryByText("Stale Meeting")).not.toBeInTheDocument();
+    expect(screen.getByText("Fresh Meeting")).toBeInTheDocument();
+  });
+});

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -11,8 +11,8 @@ export const meetingApi = {
 
   summarizeMeeting: (data) => apiClient.post("/api/meetings/summarize", data),
 
-  getAllMeetings: (params = {}) =>
-    apiClient.get("/api/meetings/all", { params }),
+  getAllMeetings: (params = {}, config = {}) =>
+    apiClient.get("/api/meetings/all", { params, ...config }),
 
   getMeetingById: (id) => apiClient.get(`/api/meetings/${id}`),
 


### PR DESCRIPTION
## Description

Meeting Repository fetched meetings without cancelling in-flight requests. Rapid refresh, retry, or navigation could let an older response arrive after a newer one and replace the latest UI state.

This wires repository loads through the existing \`useApiRequest\` helper so each new fetch aborts the previous one, cancellations are not treated as errors, and only the latest successful response updates state. \`meetingApi.getAllMeetings\` now accepts an AbortSignal. Search, filters, pagination, and loading/error handling are unchanged.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1131

## Testing

- New \`MeetingRepository\` tests for AbortSignal forwarding and stale-response protection
- Existing \`useApiRequest\` cancellation tests still pass
- \`npm run format:check:changed\` and client \`validate:pr\` pass

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
