### PR TITLE
fix: improve shared link passcode accessibility

### DIFF
--- a/client/src/pages/PublicSharedView.jsx
+++ b/client/src/pages/PublicSharedView.jsx
@@ -100,32 +100,69 @@ const PublicSharedView = () => {
   }
 
   if (requiresPasscode) {
+    const passcodeHelpId = "shared-link-passcode-help";
+    const passcodeErrorId = "shared-link-passcode-error";
+    const describedBy = passcodeError
+      ? `${passcodeHelpId} ${passcodeErrorId}`
+      : passcodeHelpId;
+
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
         <div className="bg-white dark:bg-gray-800 p-8 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 max-w-md w-full">
           <div className="text-center mb-6">
             <div className="w-16 h-16 bg-indigo-100 dark:bg-indigo-900/40 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Lock className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
+              <Lock
+                className="w-8 h-8 text-indigo-600 dark:text-indigo-400"
+                aria-hidden="true"
+              />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+            <h1
+              id="shared-link-passcode-heading"
+              className="text-xl font-semibold text-gray-900 dark:text-white mb-2"
+            >
               Protected Resource
-            </h2>
-            <p className="text-gray-600 dark:text-gray-300 text-sm">
+            </h1>
+            <p
+              id={passcodeHelpId}
+              className="text-gray-600 dark:text-gray-300 text-sm"
+            >
               Please enter the passcode to view this shared resource.
             </p>
           </div>
 
-          <form onSubmit={handleVerify} className="space-y-4">
+          <form
+            onSubmit={handleVerify}
+            className="space-y-4"
+            aria-labelledby="shared-link-passcode-heading"
+            noValidate
+          >
             <div>
+              <label
+                htmlFor="shared-link-passcode"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2"
+              >
+                Passcode
+              </label>
               <input
+                id="shared-link-passcode"
+                name="passcode"
                 type="password"
+                autoComplete="current-password"
+                inputMode="text"
                 placeholder="Enter passcode"
                 value={passcode}
                 onChange={(e) => setPasscode(e.target.value)}
+                aria-required="true"
+                aria-invalid={passcodeError ? "true" : "false"}
+                aria-describedby={describedBy}
                 className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 focus:border-indigo-500 dark:focus:border-indigo-400"
               />
               {passcodeError && (
-                <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                <p
+                  id={passcodeErrorId}
+                  role="alert"
+                  className="mt-2 text-sm text-red-600 dark:text-red-400"
+                >
                   {passcodeError}
                 </p>
               )}
@@ -133,6 +170,7 @@ const PublicSharedView = () => {
             <button
               type="submit"
               disabled={verifying}
+              aria-busy={verifying ? "true" : "false"}
               className="w-full bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-600 dark:hover:bg-indigo-500 text-white font-medium py-3 rounded-lg transition disabled:opacity-70"
             >
               {verifying ? "Verifying..." : "Access Resource"}

--- a/client/src/pages/__tests__/PublicSharedView.a11y.test.jsx
+++ b/client/src/pages/__tests__/PublicSharedView.a11y.test.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import PublicSharedView from "../PublicSharedView";
+
+vi.mock("../../services", () => ({
+  publicSharedApi: {
+    getPublicResource: vi.fn(),
+    verifyPasscode: vi.fn(),
+  },
+}));
+
+import { publicSharedApi } from "../../services";
+
+const renderPasscodeScreen = () =>
+  render(
+    <MemoryRouter initialEntries={["/shared/abc123"]}>
+      <Routes>
+        <Route path="/shared/:hash" element={<PublicSharedView />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("PublicSharedView passcode accessibility (#1136)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    publicSharedApi.getPublicResource.mockRejectedValue({
+      response: {
+        status: 401,
+        data: { requiresPasscode: true },
+      },
+    });
+  });
+
+  it("associates a visible label and help text with the passcode field", async () => {
+    renderPasscodeScreen();
+
+    const input = await screen.findByLabelText("Passcode");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("id", "shared-link-passcode");
+    expect(input).toHaveAttribute("name", "passcode");
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveAttribute("autoComplete", "current-password");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+
+    const help = screen.getByText(
+      /Please enter the passcode to view this shared resource/i,
+    );
+    expect(help).toHaveAttribute("id", "shared-link-passcode-help");
+    expect(input).toHaveAttribute(
+      "aria-describedby",
+      "shared-link-passcode-help",
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Protected Resource" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Access Resource/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("announces validation errors with aria-invalid and role=alert", async () => {
+    renderPasscodeScreen();
+
+    const submit = await screen.findByRole("button", {
+      name: /Access Resource/i,
+    });
+    fireEvent.click(submit);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Passcode is required");
+    expect(alert).toHaveAttribute("id", "shared-link-passcode-error");
+
+    const input = screen.getByLabelText("Passcode");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input.getAttribute("aria-describedby")).toContain(
+      "shared-link-passcode-help",
+    );
+    expect(input.getAttribute("aria-describedby")).toContain(
+      "shared-link-passcode-error",
+    );
+  });
+
+  it("keeps the verification submit flow working", async () => {
+    publicSharedApi.verifyPasscode.mockResolvedValue({
+      data: { success: true },
+    });
+    publicSharedApi.getPublicResource
+      .mockRejectedValueOnce({
+        response: {
+          status: 401,
+          data: { requiresPasscode: true },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          resourceType: "Meeting",
+          data: {
+            title: "Shared Standup",
+            description: "Weekly sync",
+            date: "2026-08-01T00:00:00.000Z",
+            participants: [],
+          },
+        },
+      });
+
+    renderPasscodeScreen();
+
+    const input = await screen.findByLabelText("Passcode");
+    fireEvent.change(input, { target: { value: "secret" } });
+    fireEvent.click(screen.getByRole("button", { name: /Access Resource/i }));
+
+    await waitFor(() => {
+      expect(publicSharedApi.verifyPasscode).toHaveBeenCalledWith("abc123", {
+        passcode: "secret",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Shared Standup")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

The shared-link passcode screen relied on placeholder text, so screen readers did not get a clear field name or description.

This adds a visible label, help text via \`aria-describedby\`, validation alerts (\`aria-invalid\` / \`role=\"alert\"\`), and \`autoComplete=\"current-password\"\`. The verification flow and layout are unchanged.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1136

## Testing

- New a11y tests for label association, error announcements, and successful verify flow
- \`npm run format:check:changed\` and client \`validate:pr\` pass

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
