### PR TITLE
fix(meeting): reuse device setup media stream during join

### DIFF
--- a/client/src/hooks/useDevicePermission.js
+++ b/client/src/hooks/useDevicePermission.js
@@ -70,6 +70,9 @@ export default function useDevicePermission() {
   const analyserRef = useRef(null);
   const sourceRef = useRef(null);
   const rafRef = useRef(null);
+  // Tracks ownership of the preview MediaStream so Device Setup can hand it
+  // off to Meeting Room without cleanup() stopping live tracks (#1210).
+  const streamRef = useRef(null);
 
   const stopAudioAnalyser = useCallback(() => {
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -168,11 +171,12 @@ export default function useDevicePermission() {
 
         const mediaStream =
           await navigator.mediaDevices.getUserMedia(constraints);
+        streamRef.current = mediaStream;
         setStream(mediaStream);
         setCameraStatus("granted");
         setMicStatus("granted");
 
-        if (video) startAudioAnalyser(mediaStream);
+        if (audio) startAudioAnalyser(mediaStream);
 
         await enumerateDevices();
         setLoading(false);
@@ -221,65 +225,87 @@ export default function useDevicePermission() {
     [selectedCamera, selectedMicrophone, enumerateDevices, startAudioAnalyser],
   );
 
-  const switchCamera = useCallback(
-    async (deviceId) => {
-      setSelectedCamera(deviceId);
-      if (stream) {
-        stream.getVideoTracks().forEach((t) => t.stop());
-        try {
-          const newStream = await navigator.mediaDevices.getUserMedia({
-            video: { deviceId: { exact: deviceId } },
-            audio: false,
-          });
-          const videoTrack = newStream.getVideoTracks()[0];
-          stream.addTrack(videoTrack);
-          setStream(newStream);
-        } catch {
-          // Fallback — will be refreshed on next requestMedia
-        }
+  const switchCamera = useCallback(async (deviceId) => {
+    setSelectedCamera(deviceId);
+    const current = streamRef.current;
+    if (current) {
+      current.getVideoTracks().forEach((t) => t.stop());
+      try {
+        const newStream = await navigator.mediaDevices.getUserMedia({
+          video: { deviceId: { exact: deviceId } },
+          audio: false,
+        });
+        const videoTrack = newStream.getVideoTracks()[0];
+        current.addTrack(videoTrack);
+        // Keep the same MediaStream instance so callers holding a reference
+        // (preview / pending join) continue to see updated tracks.
+        streamRef.current = current;
+        setStream(current);
+        newStream.getTracks().forEach((t) => {
+          if (t !== videoTrack) t.stop();
+        });
+      } catch {
+        // Fallback — will be refreshed on next requestMedia
       }
-    },
-    [stream],
-  );
+    }
+  }, []);
 
   const switchMicrophone = useCallback(
     async (deviceId) => {
       setSelectedMicrophone(deviceId);
-      if (stream) {
-        stream.getAudioTracks().forEach((t) => t.stop());
+      const current = streamRef.current;
+      if (current) {
+        current.getAudioTracks().forEach((t) => t.stop());
         try {
           const newStream = await navigator.mediaDevices.getUserMedia({
             audio: { deviceId: { exact: deviceId } },
             video: false,
           });
           const audioTrack = newStream.getAudioTracks()[0];
-          stream.addTrack(audioTrack);
-          setStream(newStream);
+          current.addTrack(audioTrack);
+          streamRef.current = current;
+          setStream(current);
+          startAudioAnalyser(current);
+          newStream.getTracks().forEach((t) => {
+            if (t !== audioTrack) t.stop();
+          });
         } catch {
           // Fallback
         }
       }
     },
-    [stream],
+    [startAudioAnalyser],
   );
 
   const retry = useCallback(async () => {
     stopAudioAnalyser();
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop());
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
       setStream(null);
     }
     const newStream = await requestMedia();
     return newStream;
-  }, [stream, requestMedia, stopAudioAnalyser]);
+  }, [requestMedia, stopAudioAnalyser]);
+
+  /**
+   * Relinquish ownership of the preview stream without stopping tracks.
+   * Call before unmounting Device Setup when handing the stream to Meeting Room.
+   */
+  const releaseStream = useCallback(() => {
+    stopAudioAnalyser();
+    streamRef.current = null;
+    setStream(null);
+  }, [stopAudioAnalyser]);
 
   const cleanup = useCallback(() => {
     stopAudioAnalyser();
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop());
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
       setStream(null);
     }
-  }, [stream, stopAudioAnalyser]);
+  }, [stopAudioAnalyser]);
 
   useEffect(() => {
     return () => cleanup();
@@ -318,6 +344,7 @@ export default function useDevicePermission() {
     switchCamera,
     switchMicrophone,
     retry,
+    releaseStream,
     cleanup,
     enumerateDevices,
     setSelectedCamera,

--- a/client/src/hooks/useWebRTC.js
+++ b/client/src/hooks/useWebRTC.js
@@ -5,6 +5,10 @@ import { toast } from "react-toastify";
 import { useNavigate } from "react-router-dom";
 import { getBackendUrl } from "../config/backendConfig.js";
 import { createClerkSocketOptions } from "../services/apiClient.js";
+import {
+  getTrackEnabledState,
+  resolveMeetingMediaStream,
+} from "../utils/mediaStream.js";
 
 export default function useWebRTC(roomId, callbacks) {
   const navigate = useNavigate();
@@ -26,18 +30,27 @@ export default function useWebRTC(roomId, callbacks) {
   const screenTrackRef = useRef(null);
   const peersRef = useRef([]);
 
-  const joinMeeting = async (providedStream = null) => {
+  const joinMeeting = async (providedStream = null, joinOptions = {}) => {
     try {
       setLoading(true);
 
-      const stream =
-        providedStream ||
-        (await navigator.mediaDevices.getUserMedia({
-          video: true,
-          audio: true,
-        }));
+      const {
+        mode = null,
+        videoDeviceId = "",
+        audioDeviceId = "",
+      } = joinOptions;
+
+      const stream = await resolveMeetingMediaStream({
+        providedStream,
+        mode,
+        videoDeviceId,
+        audioDeviceId,
+      });
 
       streamRef.current = stream;
+      const trackState = getTrackEnabledState(stream);
+      setMicOn(trackState.micOn);
+      setCameraOn(trackState.cameraOn);
       setJoined(true);
 
       setTimeout(() => {

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -31,6 +31,10 @@ import {
   getMeetingVideoGridClass,
   MEETING_VIDEO_TILE_CLASS,
 } from "../utils/meetingVideoGrid.js";
+import {
+  getTrackEnabledState,
+  resolveMeetingMediaStream,
+} from "../utils/mediaStream.js";
 
 const MeetingRoom = () => {
   const { roomId } = useParams();
@@ -123,16 +127,22 @@ const MeetingRoom = () => {
     return () => clearInterval(interval);
   }, [timerState.isRunning, meetingEnded]);
 
-  const joinMeeting = async () => {
+  const joinMeeting = async (providedStream = null, joinOptions = {}) => {
     try {
       setLoading(true);
 
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: true,
-        audio: true,
+      const { mode = null } = joinOptions;
+      const stream = await resolveMeetingMediaStream({
+        providedStream,
+        mode,
+        videoDeviceId: permission.selectedCamera,
+        audioDeviceId: permission.selectedMicrophone,
       });
 
       streamRef.current = stream;
+      const trackState = getTrackEnabledState(stream);
+      setMicOn(trackState.micOn);
+      setCameraOn(trackState.cameraOn);
       setJoined(true);
 
       setTimeout(() => {
@@ -265,6 +275,7 @@ const MeetingRoom = () => {
       setMediaError(errMsg);
       toast.error(errMsg);
       setLoading(false);
+      setDeviceSetupDone(false);
     }
   };
 
@@ -386,13 +397,16 @@ const MeetingRoom = () => {
   };
 
   const handleJoinWithStream = (stream) => {
+    // Hand off ownership so Device Setup unmount cleanup does not stop tracks.
+    permission.releaseStream();
     setDeviceSetupDone(true);
     joinMeeting(stream);
   };
 
-  const handleJoinWithout = () => {
+  const handleJoinWithout = (mode = "observer") => {
+    permission.releaseStream();
     setDeviceSetupDone(true);
-    joinMeeting(null);
+    joinMeeting(null, { mode });
   };
 
   return (

--- a/client/src/utils/mediaStream.js
+++ b/client/src/utils/mediaStream.js
@@ -1,0 +1,74 @@
+/**
+ * MediaStream helpers for meeting join / device-setup handoff (Issue #1210).
+ */
+
+/** True if the stream has at least one track still in the "live" state. */
+export function hasLiveTracks(stream) {
+  if (!stream || typeof stream.getTracks !== "function") return false;
+  return stream.getTracks().some((track) => track.readyState === "live");
+}
+
+/**
+ * Resolve the MediaStream used when joining a meeting.
+ * Reuses a still-valid Device Setup stream; otherwise acquires only what is needed.
+ *
+ * @param {object} options
+ * @param {MediaStream|null} [options.providedStream]
+ * @param {"mic-only"|"camera-only"|"observer"|null} [options.mode]
+ * @param {string} [options.videoDeviceId]
+ * @param {string} [options.audioDeviceId]
+ * @returns {Promise<MediaStream>}
+ */
+export async function resolveMeetingMediaStream({
+  providedStream = null,
+  mode = null,
+  videoDeviceId = "",
+  audioDeviceId = "",
+} = {}) {
+  if (hasLiveTracks(providedStream)) {
+    return providedStream;
+  }
+
+  if (mode === "observer") {
+    return new MediaStream();
+  }
+
+  const constraints = {};
+
+  if (mode === "mic-only") {
+    constraints.audio = audioDeviceId
+      ? { deviceId: { exact: audioDeviceId } }
+      : true;
+  } else if (mode === "camera-only") {
+    constraints.video = videoDeviceId
+      ? { deviceId: { exact: videoDeviceId } }
+      : true;
+  } else {
+    constraints.video = videoDeviceId
+      ? { deviceId: { exact: videoDeviceId } }
+      : true;
+    constraints.audio = audioDeviceId
+      ? { deviceId: { exact: audioDeviceId } }
+      : true;
+  }
+
+  if (!constraints.video && !constraints.audio) {
+    return new MediaStream();
+  }
+
+  return navigator.mediaDevices.getUserMedia(constraints);
+}
+
+/** Derive initial mic/camera UI state from an active stream. */
+export function getTrackEnabledState(stream) {
+  const audioTrack = stream?.getAudioTracks?.()[0];
+  const videoTrack = stream?.getVideoTracks?.()[0];
+  return {
+    micOn: Boolean(
+      audioTrack && audioTrack.enabled && audioTrack.readyState === "live",
+    ),
+    cameraOn: Boolean(
+      videoTrack && videoTrack.enabled && videoTrack.readyState === "live",
+    ),
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description

### Summary

This PR fixes the meeting join flow to reuse the MediaStream created during the Device Setup process instead of always requesting a new stream with `getUserMedia()`.

Previously, users could successfully preview their selected camera and microphone during Device Setup, but joining a meeting ignored that stream and acquired a new one. This resulted in duplicate permission prompts, unexpected device changes, and incorrect handling of "Continue without camera/microphone" selections.

The updated implementation reuses the existing valid MediaStream whenever possible while preserving the current meeting and WebRTC functionality.

### Changes Made

- Added shared MediaStream utility helpers to validate and reuse existing streams.
- Updated the Device Setup hook to safely transfer ownership of the preview stream without stopping tracks during handoff.
- Modified the Meeting Room join flow to reuse the existing MediaStream whenever it remains valid.
- Request a new MediaStream only when the existing stream is missing, invalid, or all tracks have ended.
- Preserved the user's selected camera and microphone devices when a new stream must be requested.
- Ensured "Continue without camera", "Continue without microphone", and observer join modes continue to work correctly.
- Kept existing signaling, Socket.IO communication, and meeting UI behavior unchanged.

### Benefits

- Eliminates unnecessary permission prompts.
- Reuses the Device Setup preview stream.
- Preserves the user's selected media devices.
- Prevents unexpected camera or microphone switching.
- Honors camera-disabled and microphone-disabled join choices.
- Avoids duplicate MediaStream creation.
- Maintains existing WebRTC and meeting functionality.

---

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

---

## Related Issue

Closes #1210

---

## Testing

Performed validation on the modified client files.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors introduced by this change

### Validation Performed

- ✅ Prettier formatting
- ✅ Formatting validation
- ✅ ESLint validation
- ✅ Related client test execution
- ✅ Client PR validation
- ✅ `git diff --check`

### Notes

If any unrelated client validation failures occur (for example missing project dependencies or existing repository issues), they are unrelated to the MediaStream reuse implementation introduced in this PR.

---

## Screenshots

Not applicable (meeting media flow improvement).

---

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review