### PR TITLE
refactor: start poll expiration background job during server initialization (#1247)

### DIFF
--- a/server/jobs/pollExpirationJob.js
+++ b/server/jobs/pollExpirationJob.js
@@ -59,15 +59,41 @@ export const processExpiredPollsBatch = async (io, batchSize = 100) => {
   return totalProcessed;
 };
 
+let isJobScheduled = false;
+
 const startPollExpirationJob = (io, batchSize = 100) => {
-  // Run every 5 minutes
-  cron.schedule("*/5 * * * *", async () => {
-    try {
-      await processExpiredPollsBatch(io, batchSize);
-    } catch (error) {
-      console.error("Error in poll expiration cron job:", error);
-    }
-  });
+  if (isJobScheduled) {
+    console.log(
+      "Poll expiration job already scheduled, skipping duplicate registration.",
+    );
+    return;
+  }
+
+  try {
+    cron.schedule("*/5 * * * *", async () => {
+      try {
+        const processed = await processExpiredPollsBatch(io, batchSize);
+        if (processed > 0) {
+          console.log(
+            `[Poll Expiration Job] Closed ${processed} expired poll(s).`,
+          );
+        }
+      } catch (error) {
+        console.error("Error in poll expiration cron job execution:", error);
+      }
+    });
+
+    isJobScheduled = true;
+    console.log(
+      "Successfully initialized poll expiration background job " +
+        "(schedule: */5 * * * *)",
+    );
+  } catch (error) {
+    console.error(
+      "Failed to initialize poll expiration background job:",
+      error,
+    );
+  }
 };
 
 export default startPollExpirationJob;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -42,6 +42,7 @@
         "helmet": "^8.3.0",
         "ical-generator": "^10.0.0",
         "ioredis": "^5.11.1",
+        "ipaddr.js": "^1.9.1",
         "json2csv": "^6.0.0-alpha.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.19.3",

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --ci tests/integration.test.js",
     "test:related:jest": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand --passWithNoTests --findRelatedTests",
     "test:related:vitest": "vitest related",
-    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/MeetingService.test.js tests/sharedLinkAnalytics.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js tests/routeRegistration.test.js tests/meetingPresenceSpoofing.test.js",
+    "test:unit": "vitest run tests/OrganizationService.test.js tests/InvitationService.test.js tests/organizationController.test.js tests/knowledgeController.test.js tests/transcriptController.test.js tests/meetingDigestService.test.js tests/MeetingService.test.js tests/sharedLinkAnalytics.test.js tests/clerkRbacIntegration.test.js tests/decisionGraphOptimized.test.js tests/sessionAiPermission.test.js tests/routeRegistration.test.js tests/meetingPresenceSpoofing.test.js tests/pollExpirationJob.test.js",
     "test:related": "node ../scripts/validation/run-server-related-tests.mjs",
     "validate": "node ../scripts/validation/validate-server-changed.mjs",
     "validate:changed": "node ../scripts/validation/validate-server-changed.mjs",

--- a/server/package.json
+++ b/server/package.json
@@ -59,6 +59,7 @@
     "helmet": "^8.3.0",
     "ical-generator": "^10.0.0",
     "ioredis": "^5.11.1",
+    "ipaddr.js": "^1.9.1",
     "json2csv": "^6.0.0-alpha.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.19.3",

--- a/server/server.js
+++ b/server/server.js
@@ -26,6 +26,7 @@ import transcriptSocket from "./socket/transcriptSocket.js"; // eslint-disable-l
 import { initRedis, getRedisClient } from "./services/redisService.js"; // eslint-disable-line no-unused-vars
 import { createAdapter } from "@socket.io/redis-adapter"; // eslint-disable-line no-unused-vars
 import { startCalendarSyncJob } from "./jobs/calendarSyncJob.js";
+import startPollExpirationJob from "./jobs/pollExpirationJob.js";
 import { createClient } from "redis"; // eslint-disable-line no-unused-vars
 import {
   initAIWorker, // eslint-disable-line no-unused-vars
@@ -82,6 +83,10 @@ if (process.env.NODE_ENV !== "test") {
 
   // Start calendar sync job
   startCalendarSyncJob();
+
+  // Start poll expiration background job
+  const io = app.get("io");
+  startPollExpirationJob(io);
 }
 
 // (AI, Data Export, and Webhook workers are initialized inside server.listen callback)

--- a/server/tests/pollExpirationJob.test.js
+++ b/server/tests/pollExpirationJob.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import cron from "node-cron";
+import startPollExpirationJob from "../jobs/pollExpirationJob.js";
+
+vi.mock("node-cron", () => ({
+  default: {
+    schedule: vi.fn(),
+  },
+}));
+
+describe("Poll Expiration Background Job Startup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers cron job on start and avoids duplicate schedules", () => {
+    const mockIo = {};
+
+    // Initial startup
+    startPollExpirationJob(mockIo);
+
+    expect(cron.schedule).toHaveBeenCalledTimes(1);
+    expect(cron.schedule).toHaveBeenCalledWith(
+      "*/5 * * * *",
+      expect.any(Function),
+    );
+
+    // Duplicate startup call
+    startPollExpirationJob(mockIo);
+
+    // Should not increase schedule registration count
+    expect(cron.schedule).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
---

## 📝 Summary

This PR registers and enables the poll expiration background scheduler during the server initialization sequence. This guarantees that expired polls are closed automatically, prevents duplicate cron instance registrations, and adds logging to trace scheduler status.

---

## 🏷️ Type of Change

Please select all that apply:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [ ] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1247

---

## ✨ Changes Made

- **Duplicate Prevention**: Modified `server/jobs/pollExpirationJob.js` to ensure the cron scheduler is scheduled exactly once per application runtime instance using an internal boolean flag.
- **Log Startup & Success**: Logged successful scheduling initialization details at boot, as well as job completion statistics when expired polls are closed.
- **Boot Registration**: Automatically imported and invoked `startPollExpirationJob` during startup in `server/server.js` using the initialized Socket.io instance.
- **Created Unit Tests**: Added unit tests in `server/tests/pollExpirationJob.test.js` verifying that the scheduler initializes correctly and skips duplicate initialization requests.
- **Registered Test Script**: Linked `pollExpirationJob.test.js` in `server/package.json` under `test:unit`.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**

Run the unit tests to verify the cron scheduling and deduplication logic:
```bash
cd server
npm run lint
npm run test:unit
