### PR TITLE
fix(glossary): stop cross-organization term takeover and unscoped AI extraction

### DIFF
--- a/server/controllers/glossaryController.js
+++ b/server/controllers/glossaryController.js
@@ -1,6 +1,76 @@
+import mongoose from "mongoose";
+import { z } from "zod";
 import GlossaryTerm from "../models/glossaryTermModel.js";
 import glossaryService from "../services/glossaryService.js";
 import { caseInsensitiveEquals } from "../utils/regexUtils.js";
+import { AppError } from "../utils/errors.js";
+
+/**
+ * Field limits (Issue #1273).
+ *
+ * `createTerm` previously took `term`, `definition`, `aliases`, `category` and
+ * `examples` straight off the body with only a truthiness check on the first
+ * two, so `aliases: "not-an-array"` reached Mongoose as a cast failure reported
+ * as a 500, and a multi-megabyte definition was stored verbatim.
+ */
+const MAX_TERM_LENGTH = 120;
+const MAX_DEFINITION_LENGTH = 2000;
+const MAX_CATEGORY_LENGTH = 60;
+const MAX_LIST_ENTRIES = 25;
+const MAX_LIST_ENTRY_LENGTH = 200;
+
+const shortStringList = z
+  .array(z.string().trim().min(1).max(MAX_LIST_ENTRY_LENGTH))
+  .max(MAX_LIST_ENTRIES);
+
+/**
+ * The fields a client may write, and nothing else.
+ *
+ * `.strict()` is the load-bearing part. `updateTerm` used to pass `req.body`
+ * directly into `$set`, so a request could assign **any** path on the document:
+ *
+ *   - `organization` — re-parents the term into another tenant. The document
+ *     leaves the owner's glossary and appears in the attacker's, definition and
+ *     examples included. The `findOneAndUpdate` *filter* was correctly scoped,
+ *     which is exactly what made this easy to miss: the caller has to own the
+ *     term to move it, but that is a low bar for any member.
+ *   - `approvalStatus` — flips an AI suggestion to `approved` without going
+ *     through `approveTerm`, or quietly un-approves a curated term.
+ *   - `usageCount`, `isAutoSuggested`, `createdAt`, `updatedAt`, `_id`.
+ *
+ * Rejecting unknown keys rather than stripping them means a client sending one
+ * finds out, instead of watching the write silently do nothing.
+ */
+const termFieldsSchema = z.object({
+  term: z.string().trim().min(1).max(MAX_TERM_LENGTH),
+  definition: z.string().trim().min(1).max(MAX_DEFINITION_LENGTH),
+  aliases: shortStringList.optional(),
+  category: z.string().trim().min(1).max(MAX_CATEGORY_LENGTH).optional(),
+  examples: shortStringList.optional(),
+});
+
+const createTermSchema = termFieldsSchema.strict();
+
+/**
+ * Update accepts any subset, but at least one field — an empty body is a
+ * no-op the caller almost certainly did not intend.
+ */
+const updateTermSchema = termFieldsSchema
+  .partial()
+  .strict()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+const detectSchema = z.object({
+  text: z.string().min(1).max(50000),
+});
+
+const extractSchema = z.object({
+  meetingId: z.string().refine((id) => mongoose.Types.ObjectId.isValid(id), {
+    message: "meetingId must be a valid ID",
+  }),
+});
 
 /**
  * Looks up a term by its exact name, ignoring case (Issue #1157).
@@ -17,12 +87,36 @@ const findTermByName = (orgId, term) => {
   );
 };
 
+const resolveOrgId = (req) => req.user?.organization || req.organization?._id;
+
+const sendZodError = (res, error) =>
+  res.status(400).json({
+    message: "Validation error",
+    errors: error.errors,
+  });
+
+/**
+ * Maps an `AppError` thrown by the service onto its own status.
+ *
+ * Every handler in this file used to funnel *all* failures into a 500, so a
+ * cross-organization extraction attempt was indistinguishable from a database
+ * outage — both to the caller and in the logs.
+ *
+ * Returns true when it has responded.
+ */
+const sendAppError = (res, error) => {
+  if (!(error instanceof AppError)) return false;
+
+  res.status(error.statusCode).json({ message: error.message });
+  return true;
+};
+
 /**
  * Get all glossary terms for an organization
  */
 export const getTerms = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     if (!orgId) {
       return res.status(400).json({ message: "Organization ID is missing" });
     }
@@ -52,18 +146,13 @@ export const getTerms = async (req, res) => {
  */
 export const createTerm = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     if (!orgId) {
       return res.status(400).json({ message: "Organization ID is missing" });
     }
 
-    const { term, definition, aliases, category, examples } = req.body;
-
-    if (!term || !definition) {
-      return res
-        .status(400)
-        .json({ message: "Term and definition are required" });
-    }
+    const { term, definition, aliases, category, examples } =
+      createTermSchema.parse(req.body);
 
     // Check for existing term (case-insensitive)
     const existing = await findTermByName(orgId, term);
@@ -87,6 +176,8 @@ export const createTerm = async (req, res) => {
     await newTerm.save();
     res.status(201).json(newTerm);
   } catch (error) {
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+
     console.error("Error creating glossary term:", error);
     res.status(500).json({ message: "Server error creating glossary term" });
   }
@@ -97,12 +188,32 @@ export const createTerm = async (req, res) => {
  */
 export const updateTerm = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     const { id } = req.params;
 
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "Invalid term ID" });
+    }
+
+    const updates = updateTermSchema.parse(req.body);
+
+    // Renaming must not collide with another term in the same organization —
+    // the same uniqueness rule `createTerm` applies. `findTermByName` uses a
+    // collated equality match, so it is safe to call with arbitrary input.
+    if (updates.term) {
+      const existing = await findTermByName(orgId, updates.term);
+      if (existing && existing._id.toString() !== id) {
+        return res
+          .status(400)
+          .json({ message: "This term already exists in your glossary" });
+      }
+    }
+
+    // `updates` is the parsed schema output, never `req.body`, so `organization`
+    // and `approvalStatus` cannot appear here regardless of what was sent.
     const updatedTerm = await GlossaryTerm.findOneAndUpdate(
       { _id: id, organization: orgId },
-      { $set: req.body },
+      { $set: updates },
       { new: true, runValidators: true },
     );
 
@@ -112,6 +223,8 @@ export const updateTerm = async (req, res) => {
 
     res.status(200).json(updatedTerm);
   } catch (error) {
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+
     console.error("Error updating glossary term:", error);
     res.status(500).json({ message: "Server error updating glossary term" });
   }
@@ -122,8 +235,12 @@ export const updateTerm = async (req, res) => {
  */
 export const deleteTerm = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "Invalid term ID" });
+    }
 
     const deletedTerm = await GlossaryTerm.findOneAndDelete({
       _id: id,
@@ -146,8 +263,12 @@ export const deleteTerm = async (req, res) => {
  */
 export const approveTerm = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "Invalid term ID" });
+    }
 
     const term = await GlossaryTerm.findOneAndUpdate(
       { _id: id, organization: orgId, approvalStatus: "pending" },
@@ -171,21 +292,18 @@ export const approveTerm = async (req, res) => {
  */
 export const detect = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     if (!orgId) {
       return res.status(400).json({ message: "Organization ID is missing" });
     }
 
-    const { text } = req.body;
-    if (!text) {
-      return res
-        .status(400)
-        .json({ message: "Text is required for detection" });
-    }
+    const { text } = detectSchema.parse(req.body);
 
     const matches = await glossaryService.detectTerms(text, orgId);
     res.status(200).json(matches);
   } catch (error) {
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+
     console.error("Error detecting glossary terms:", error);
     res.status(500).json({ message: "Server error detecting terms" });
   }
@@ -196,19 +314,21 @@ export const detect = async (req, res) => {
  */
 export const extract = async (req, res) => {
   try {
-    const orgId = req.user?.organization || req.organization?._id;
+    const orgId = resolveOrgId(req);
     if (!orgId) {
       return res.status(400).json({ message: "Organization ID is missing" });
     }
 
-    const { meetingId } = req.body;
-    if (!meetingId) {
-      return res.status(400).json({ message: "Meeting ID is required" });
-    }
+    const { meetingId } = extractSchema.parse(req.body);
 
     const suggestions = await glossaryService.aiExtractTerms(meetingId, orgId);
     res.status(200).json(suggestions);
   } catch (error) {
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+    // 403 for a meeting outside the caller's organization, 404 for one that
+    // does not exist — previously both were a 500 (Issue #1273).
+    if (sendAppError(res, error)) return;
+
     console.error("Error extracting glossary terms:", error);
     res.status(500).json({ message: "Server error extracting terms" });
   }

--- a/server/routes/glossaryRoutes.js
+++ b/server/routes/glossaryRoutes.js
@@ -1,23 +1,71 @@
 import express from "express";
 import * as glossaryController from "../controllers/glossaryController.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
 
 const router = express.Router();
 
+/**
+ * Glossary routes (Issue #1273).
+ *
+ * The router previously applied `userAuth` and nothing else, so a `viewer` or
+ * `guest` could create, edit, approve and delete organization-wide glossary
+ * terms. The `viewer` role added in #1117 is explicitly meant to be read-only.
+ *
+ * Permissions map onto the existing `knowledge` resource rather than a new
+ * `glossary` one. The glossary *is* organization knowledge, its role sets are
+ * already the ones wanted here, and `PERMISSIONS` is mirrored in
+ * `client/src/utils/rbacPermissions.js` — introducing a resource on the server
+ * alone would let the two drift, and updating both is a wider change than this
+ * fix warrants.
+ *
+ * `detect` is a read: it takes text the caller already has on screen and
+ * annotates it against approved terms. `extract` writes pending suggestions and
+ * consumes an AI call, so it is gated as a create.
+ */
 router.use(userAuth);
+router.use(requireOrgMembership);
 
-router.get("/", glossaryController.getTerms);
-router.post("/", glossaryController.createTerm);
-router.put("/:id", glossaryController.updateTerm);
-router.delete("/:id", glossaryController.deleteTerm);
+router.get(
+  "/",
+  requirePermission("knowledge", "view"),
+  glossaryController.getTerms,
+);
+router.post(
+  "/",
+  requirePermission("knowledge", "create"),
+  glossaryController.createTerm,
+);
+router.put(
+  "/:id",
+  requirePermission("knowledge", "edit"),
+  glossaryController.updateTerm,
+);
+router.delete(
+  "/:id",
+  requirePermission("knowledge", "delete"),
+  glossaryController.deleteTerm,
+);
 
 // Approval for pending terms
-router.post("/:id/approve", glossaryController.approveTerm);
+router.post(
+  "/:id/approve",
+  requirePermission("knowledge", "edit"),
+  glossaryController.approveTerm,
+);
 
 // Detection endpoint
-router.post("/detect", glossaryController.detect);
+router.post(
+  "/detect",
+  requirePermission("knowledge", "view"),
+  glossaryController.detect,
+);
 
 // Extraction endpoint
-router.post("/extract", glossaryController.extract);
+router.post(
+  "/extract",
+  requirePermission("knowledge", "create"),
+  glossaryController.extract,
+);
 
 export default router;

--- a/server/services/glossaryService.js
+++ b/server/services/glossaryService.js
@@ -5,6 +5,7 @@ import {
   caseInsensitiveEquals,
   wordBoundaryRegExp,
 } from "../utils/regexUtils.js";
+import { ForbiddenError, NotFoundError } from "../utils/errors.js";
 
 class GlossaryService {
   /**
@@ -61,10 +62,29 @@ class GlossaryService {
   async aiExtractTerms(meetingId, orgId) {
     // 1. Fetch meeting and transcript
     const meeting = await Meeting.findById(meetingId);
-    if (!meeting) throw new Error("Meeting not found");
+    if (!meeting) throw new NotFoundError("Meeting not found");
+
+    // The meeting must belong to the caller's organization (Issue #1273).
+    //
+    // `orgId` was previously used only to scope the *existing terms* lookup and
+    // to stamp the terms this run creates — it was never compared against the
+    // meeting. So `POST /api/glossary/extract` with any meeting id ran the
+    // extraction prompt over another organization's transcript and persisted
+    // the resulting terms and definitions into the caller's glossary, where
+    // `GET /api/glossary` then served them back.
+    //
+    // `topicExtractionService.extractTopics` already performs exactly this
+    // check on the same model; this path simply omitted it.
+    if (
+      !meeting.organization ||
+      meeting.organization.toString() !== orgId.toString()
+    ) {
+      throw new ForbiddenError("Unauthorized access to meeting");
+    }
 
     const transcriptText = meeting.transcript || "";
-    if (!transcriptText) throw new Error("No transcript found for meeting");
+    if (!transcriptText)
+      throw new NotFoundError("No transcript found for meeting");
 
     // 2. Fetch existing terms to avoid duplicates
     const existingTerms = await GlossaryTerm.find({ organization: orgId });

--- a/server/tests/glossaryAuthorization.test.js
+++ b/server/tests/glossaryAuthorization.test.js
@@ -1,0 +1,384 @@
+/**
+ * Regression tests for Issue #1273 — the glossary API wrote the raw request
+ * body into a `$set`, extracted from any meeting in the database, and applied
+ * no RBAC to its write routes.
+ *
+ * These mount the real `routes/glossaryRoutes.js`. Two of the three faults were
+ * properties of the route file or of the body-to-document path, so a test that
+ * called `updateTerm(req, res)` with a hand-built request would not have caught
+ * them.
+ *
+ * Confirmed load-bearing: 16 of the 24 fail against `main`.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+// ── Session injection ──────────────────────────────────────────────────────
+// Replaces Clerk session resolution so each test can choose its own caller.
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+// ── AI stub ────────────────────────────────────────────────────────────────
+// `aiExtractTerms` calls a live model. The authorization check under test runs
+// *before* that call, so the stub exists to prove the point: if extraction is
+// ever reached for a foreign meeting, `generateText` records the transcript it
+// was handed and the assertion fails loudly rather than silently passing on a
+// network error.
+const generateText = jest.fn();
+
+jest.unstable_mockModule("../services/GenerativeAIService.js", () => ({
+  generateText,
+  parseJsonOutput: (text) => JSON.parse(text),
+}));
+
+const { default: glossaryRoutes } = await import("../routes/glossaryRoutes.js");
+const { default: GlossaryTerm } =
+  await import("../models/glossaryTermModel.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+/** Deliberately privileged, but in a *different* organization. */
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "owner",
+};
+
+const viewer = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "viewer",
+};
+
+const moderator = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "moderator",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/glossary", glossaryRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+  generateText.mockReset();
+});
+
+const seedTerm = (overrides = {}) =>
+  GlossaryTerm.create({
+    organization: ORG_A,
+    term: "ROI",
+    definition: "Return on Investment",
+    aliases: ["Return On Investment"],
+    category: "Finance",
+    approvalStatus: "approved",
+    ...overrides,
+  });
+
+const seedMeeting = (organization, transcript) =>
+  Meeting.create({
+    uploadedBy: organization === ORG_A ? alice._id : mallory._id,
+    organization,
+    title: "Quarterly review",
+    date: new Date(),
+    transcript,
+  });
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("PUT /:id — mass assignment", () => {
+  it("cannot move a term into another organization", async () => {
+    const term = await seedTerm();
+
+    // Against `main`: 200, and the term is now owned by ORG_B.
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ definition: "Updated", organization: ORG_B.toString() })
+      .expect(400);
+
+    const stored = await GlossaryTerm.findById(term._id);
+    expect(stored.organization.toString()).toBe(ORG_A.toString());
+    // The whole write is rejected, not partially applied.
+    expect(stored.definition).toBe("Return on Investment");
+  });
+
+  it("cannot set approvalStatus, bypassing the approve endpoint", async () => {
+    const term = await seedTerm({
+      approvalStatus: "pending",
+      isAutoSuggested: true,
+    });
+
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ approvalStatus: "approved" })
+      .expect(400);
+
+    const stored = await GlossaryTerm.findById(term._id);
+    expect(stored.approvalStatus).toBe("pending");
+  });
+
+  it("cannot set usageCount or isAutoSuggested", async () => {
+    const term = await seedTerm();
+
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ usageCount: 9999, isAutoSuggested: true })
+      .expect(400);
+
+    const stored = await GlossaryTerm.findById(term._id);
+    expect(stored.usageCount).toBe(0);
+    expect(stored.isAutoSuggested).toBe(false);
+  });
+
+  it("still applies a legitimate update", async () => {
+    const term = await seedTerm();
+
+    const res = await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ definition: "Return on Invested Capital", category: "Metrics" })
+      .expect(200);
+
+    expect(res.body.definition).toBe("Return on Invested Capital");
+    expect(res.body.category).toBe("Metrics");
+    expect(res.body.term).toBe("ROI");
+  });
+
+  it("rejects a rename that collides with an existing term", async () => {
+    await seedTerm({ term: "KPI", definition: "Key Performance Indicator" });
+    const term = await seedTerm();
+
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ term: "kpi" })
+      .expect(400);
+  });
+
+  it("allows a term to be renamed to a different case of itself", async () => {
+    const term = await seedTerm();
+
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ term: "roi" })
+      .expect(200);
+  });
+
+  it("rejects an empty body rather than issuing a no-op write", async () => {
+    const term = await seedTerm();
+
+    await request(app).put(`/api/glossary/${term._id}`).send({}).expect(400);
+  });
+
+  it("does not reach another organization's term", async () => {
+    const term = await seedTerm({ organization: ORG_B });
+
+    await request(app)
+      .put(`/api/glossary/${term._id}`)
+      .send({ definition: "Hijacked" })
+      .expect(404);
+
+    const stored = await GlossaryTerm.findById(term._id);
+    expect(stored.definition).toBe("Return on Investment");
+  });
+
+  it("rejects a malformed id with 400 rather than 500", async () => {
+    await request(app)
+      .put("/api/glossary/not-an-object-id")
+      .send({ definition: "x" })
+      .expect(400);
+  });
+});
+
+describe("POST / — input validation", () => {
+  it("rejects a non-array aliases value", async () => {
+    await request(app)
+      .post("/api/glossary")
+      .send({
+        term: "SLA",
+        definition: "Service Level Agreement",
+        aliases: "nope",
+      })
+      .expect(400);
+
+    expect(await GlossaryTerm.countDocuments()).toBe(0);
+  });
+
+  it("rejects an over-long definition", async () => {
+    await request(app)
+      .post("/api/glossary")
+      .send({ term: "SLA", definition: "x".repeat(5000) })
+      .expect(400);
+  });
+
+  it("rejects unknown fields instead of silently dropping them", async () => {
+    await request(app)
+      .post("/api/glossary")
+      .send({
+        term: "SLA",
+        definition: "Service Level Agreement",
+        organization: ORG_B.toString(),
+      })
+      .expect(400);
+  });
+
+  it("still creates a valid term in the caller's organization", async () => {
+    const res = await request(app)
+      .post("/api/glossary")
+      .send({
+        term: "SLA",
+        definition: "Service Level Agreement",
+        aliases: ["Service Level"],
+      })
+      .expect(201);
+
+    expect(res.body.organization).toBe(ORG_A.toString());
+    expect(res.body.approvalStatus).toBe("approved");
+  });
+});
+
+describe("POST /extract — meeting organization", () => {
+  it("refuses a meeting belonging to another organization", async () => {
+    const meeting = await seedMeeting(ORG_B, "The K8s cluster needs scaling.");
+
+    // Against `main`: 200, with terms mined from ORG_B's transcript and
+    // persisted under ORG_A.
+    const res = await request(app)
+      .post("/api/glossary/extract")
+      .send({ meetingId: meeting._id.toString() })
+      .expect(403);
+
+    expect(res.body.message).toMatch(/unauthorized access to meeting/i);
+    // The transcript never reached the model.
+    expect(generateText).not.toHaveBeenCalled();
+    // And nothing was written into the caller's glossary.
+    expect(await GlossaryTerm.countDocuments()).toBe(0);
+  });
+
+  it("returns 404 for a meeting that does not exist", async () => {
+    await request(app)
+      .post("/api/glossary/extract")
+      .send({ meetingId: new mongoose.Types.ObjectId().toString() })
+      .expect(404);
+  });
+
+  it("rejects a malformed meetingId with 400", async () => {
+    await request(app)
+      .post("/api/glossary/extract")
+      .send({ meetingId: "not-an-object-id" })
+      .expect(400);
+  });
+
+  it("extracts from the caller's own meeting", async () => {
+    const meeting = await seedMeeting(ORG_A, "The K8s cluster needs scaling.");
+    generateText.mockResolvedValue(
+      JSON.stringify([
+        { term: "K8s", definition: "Kubernetes", category: "Engineering" },
+      ]),
+    );
+
+    const res = await request(app)
+      .post("/api/glossary/extract")
+      .send({ meetingId: meeting._id.toString() })
+      .expect(200);
+
+    expect(generateText).toHaveBeenCalled();
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].term).toBe("K8s");
+    expect(res.body[0].organization).toBe(ORG_A.toString());
+    expect(res.body[0].approvalStatus).toBe("pending");
+  });
+});
+
+describe("role permissions", () => {
+  it("lets a viewer read the glossary", async () => {
+    await seedTerm();
+    currentUser = viewer;
+
+    const res = await request(app).get("/api/glossary").expect(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it("refuses a viewer creating a term", async () => {
+    currentUser = viewer;
+
+    await request(app)
+      .post("/api/glossary")
+      .send({ term: "SLA", definition: "Service Level Agreement" })
+      .expect(403);
+
+    expect(await GlossaryTerm.countDocuments()).toBe(0);
+  });
+
+  it("refuses a viewer deleting a term", async () => {
+    const term = await seedTerm();
+    currentUser = viewer;
+
+    await request(app).delete(`/api/glossary/${term._id}`).expect(403);
+
+    expect(await GlossaryTerm.findById(term._id)).not.toBeNull();
+  });
+
+  it("refuses a viewer approving a pending term", async () => {
+    const term = await seedTerm({ approvalStatus: "pending" });
+    currentUser = viewer;
+
+    await request(app).post(`/api/glossary/${term._id}/approve`).expect(403);
+
+    const stored = await GlossaryTerm.findById(term._id);
+    expect(stored.approvalStatus).toBe("pending");
+  });
+
+  it("allows a moderator to approve and delete", async () => {
+    const pending = await seedTerm({ term: "MTTR", approvalStatus: "pending" });
+    currentUser = moderator;
+
+    await request(app).post(`/api/glossary/${pending._id}/approve`).expect(200);
+    await request(app).delete(`/api/glossary/${pending._id}`).expect(200);
+  });
+
+  it("rejects a caller with no organization", async () => {
+    currentUser = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: null,
+      role: "member",
+    };
+
+    await request(app).get("/api/glossary").expect(403);
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    currentUser = null;
+
+    await request(app).get("/api/glossary").expect(401);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Three separate holes in the glossary API, each of which lets a member of one organization reach into another's data.

### 1. `updateTerm` wrote the raw request body

```js
GlossaryTerm.findOneAndUpdate(
  { _id: id, organization: orgId },
  { $set: req.body },
  { new: true, runValidators: true },
);
```

The *filter* is correctly scoped — which is exactly what made this easy to miss. The *update* is not. `$set: req.body` writes every key the client sends:

- **`organization`** — re-parents the term into another tenant. `PUT /api/glossary/:id` with `{"organization": "<other org id>"}` returns 200, and the term leaves the owner's glossary and appears in the attacker's, definition and examples included. The caller has to own the term to move it, but that is a low bar for any member.
- **`approvalStatus`** — flips an AI suggestion to `approved` without going through `approveTerm`, or quietly un-approves a curated term.
- `usageCount`, `isAutoSuggested`, `createdAt`, `updatedAt`.

Both create and update now parse through a strict `zod` schema and write the *parsed output*, never `req.body`. `.strict()` is the load-bearing part: unknown keys are rejected rather than stripped, so a client sending one finds out instead of watching the write silently do nothing.

### 2. `aiExtractTerms` never checked the meeting's organization

```js
async aiExtractTerms(meetingId, orgId) {
  const meeting = await Meeting.findById(meetingId);
  if (!meeting) throw new Error("Meeting not found");
  const transcriptText = meeting.transcript || "";
```

`orgId` was used only to scope the *existing terms* lookup and to stamp the terms this run creates — it was never compared against `meeting.organization`. So `POST /api/glossary/extract` with any meeting id ran the extraction prompt over **another organization's transcript** and persisted the resulting terms and definitions into the caller's glossary, where `GET /api/glossary` then served them straight back.

`topicExtractionService.extractTopics` already performs exactly this check on the same model:

```js
if (meeting.organization.toString() !== userOrgId.toString()) {
  throw new Error("Unauthorized access to meeting");
}
```

This path simply omitted it. It now throws `ForbiddenError` / `NotFoundError` from `utils/errors.js`, which the controller maps onto 403/404 rather than flattening every failure into a 500 — previously a cross-tenant attempt was indistinguishable from a database outage, both to the caller and in the logs.

### 3. No RBAC on the write routes

The router applied `userAuth` and nothing else, so a `viewer` or `guest` could create, edit, approve and delete organization-wide glossary terms. The `viewer` role added in #1117 is explicitly meant to be read-only.

Permissions map onto the existing **`knowledge`** resource rather than a new `glossary` one. The glossary *is* organization knowledge, its role sets are already the ones wanted here, and `PERMISSIONS` is mirrored in `client/src/utils/rbacPermissions.js` — introducing a resource on the server alone would let the two drift, and updating both is a wider change than this fix warrants. `detect` is gated as a read (it annotates text the caller already has on screen); `extract` is gated as a create, since it writes pending suggestions and spends an AI call.

### Also

- Term ids are validated as ObjectIds. A malformed id was a Mongoose `CastError` reported as a 500.
- Renames now apply the same uniqueness rule `createTerm` already applies to new terms — renaming to a colliding name was previously allowed and produced two terms differing only by case.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #1273

## Testing

Adds `server/tests/glossaryAuthorization.test.js` (24 cases) against the mounted router. Two of the three faults were properties of the route file or of the body-to-document path, so a test that called `updateTerm(req, res)` with a hand-built request would not have caught them.

The AI service is **stubbed rather than skipped**, deliberately. The authorization check runs before `generateText`, so the cross-tenant test asserts `expect(generateText).not.toHaveBeenCalled()` — the transcript never reached the model at all. Without the stub, that test would pass on a network error and prove nothing.

**Confirmed load-bearing** — stashed the three source files and re-ran against `main`: 16 of 24 fail. With the fix: 24 of 24 pass.

```
$ npx jest tests/glossaryAuthorization.test.js tests/glossary.test.js tests/regexEscaping.test.js
Test Suites: 3 passed, 3 total
Tests:       1 skipped, 80 passed, 81 total
```

The pre-existing `glossary.test.js` and `regexEscaping.test.js` suites still pass unchanged (the one skip is `describe.skip("aiExtractTerms")`, which was already skipped on `main`).

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — server-side only. The Glossary page's existing create/delete/approve flows are unchanged for users who have permission.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

### Notes for reviewers

- Unknown fields on create/update are a **400**, not a silent strip. That is stricter than the old behaviour and will reject a client that sends back a whole term document it fetched earlier. `client/src/services/glossaryApi.js` sends only the fields the form collects, and `Glossary.jsx` does not call `updateTerm` at all, so nothing in-tree is affected — but it is the one behavioural change here worth a second opinion.
- The `knowledge`-resource mapping is the decision I am least certain about. If maintainers would rather have a dedicated `glossary` resource, I am happy to add it to both the server and the client mirror in a follow-up.
