### PR TITLE
fix(transcript-annotations): authorize create, update, delete and resolve

### DIFF
--- a/server/controllers/transcriptAnnotationController.js
+++ b/server/controllers/transcriptAnnotationController.js
@@ -1,5 +1,74 @@
+import mongoose from "mongoose";
 import { transcriptAnnotationService } from "../services/transcriptAnnotationService.js";
 import TranscriptAnnotation from "../models/transcriptAnnotationModel.js";
+import Meeting from "../models/meetingModel.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+
+/**
+ * Roles that may moderate someone else's annotation *within their own
+ * organization* (Issue #1274).
+ *
+ * The previous check was:
+ *
+ *     annotation.author.toString() !== req.user._id.toString() &&
+ *     req.user.role !== "admin"
+ *
+ * `req.user.role` is the caller's role in *their* organization, not in the
+ * annotation's. Nothing established that the two were the same, so an `admin`
+ * of org B satisfied it for an annotation in org A. The list of roles was also
+ * wrong in the other direction: an org `owner` — strictly more privileged than
+ * an admin — could not moderate annotations in their own organization, and
+ * neither could a `moderator`.
+ *
+ * Ordering matters more than the list. Organization access is established
+ * first, so by the time this is consulted the caller is already known to belong
+ * to the meeting's organization and the role means what it appears to mean.
+ */
+const MODERATOR_ROLES = new Set(["owner", "admin", "moderator"]);
+
+/**
+ * Resolves the annotation at `:id` and the meeting it belongs to, and confirms
+ * the caller may see that meeting.
+ *
+ * Returns `null` after responding, so callers can `if (!ctx) return;`.
+ *
+ * `TranscriptAnnotation` carries no `organization` field of its own — the
+ * tenant boundary lives on the meeting — so every check has to route through
+ * the meeting. That indirection is presumably why the four write handlers ended
+ * up with no check at all.
+ */
+const loadAccessibleAnnotation = async (req, res) => {
+  const { id } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(400).json({ success: false, message: "Invalid annotation ID" });
+    return null;
+  }
+
+  const annotation = await TranscriptAnnotation.findById(id);
+  if (!annotation) {
+    res.status(404).json({ success: false, message: "Annotation not found" });
+    return null;
+  }
+
+  const meeting = await Meeting.findById(annotation.meeting);
+
+  // A 404 rather than a 403: telling a cross-tenant caller "this exists, but
+  // not for you" confirms the id is real.
+  if (!meeting || !canAccessMeetingDoc(meeting, req.user)) {
+    res.status(404).json({ success: false, message: "Annotation not found" });
+    return null;
+  }
+
+  return { annotation, meeting };
+};
+
+/**
+ * True when the caller may modify an annotation they can already see.
+ */
+const canModerate = (annotation, user) =>
+  annotation.author.toString() === user._id.toString() ||
+  MODERATOR_ROLES.has(user.role);
 
 export const createAnnotation = async (req, res) => {
   try {
@@ -27,6 +96,33 @@ export const createAnnotation = async (req, res) => {
         .json({ success: false, message: "Missing required fields" });
     }
 
+    if (
+      !mongoose.Types.ObjectId.isValid(transcript) ||
+      !mongoose.Types.ObjectId.isValid(meeting)
+    ) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid transcript or meeting ID" });
+    }
+
+    // Authorize the *caller* against the target meeting (Issue #1274).
+    //
+    // `transcript` and `meeting` arrive from the request body, and the service
+    // only ever checked that the two were consistent with each other:
+    //
+    //     if (transcript.meeting.toString() !== data.meeting.toString())
+    //
+    // Two ids belonging to the same foreign meeting satisfy that perfectly.
+    // Nothing asked whether the caller could see it, so any authenticated user
+    // could attach free-text annotations to any organization's transcript, and
+    // they then rendered in that organization's transcript viewer.
+    const targetMeeting = await Meeting.findById(meeting);
+    if (!targetMeeting || !canAccessMeetingDoc(targetMeeting, req.user)) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Forbidden: meeting not accessible" });
+    }
+
     const annotation = await transcriptAnnotationService.createAnnotation({
       transcript,
       meeting,
@@ -50,9 +146,21 @@ export const listAnnotations = async (req, res) => {
     const { meetingId } = req.params;
     const { type, author, resolved } = req.query;
 
+    // The route already runs `requireOrgAccess(Meeting)`, so the meeting itself
+    // is authorized by the time this executes.
     const query = { meeting: meetingId };
     if (type) query.type = type;
-    if (author) query.author = author;
+
+    if (author) {
+      // A non-ObjectId `author` produced an unhandled CastError and a 500.
+      if (!mongoose.Types.ObjectId.isValid(author)) {
+        return res
+          .status(400)
+          .json({ success: false, message: "Invalid author ID" });
+      }
+      query.author = author;
+    }
+
     if (resolved !== undefined) query.resolved = resolved === "true";
 
     const annotations =
@@ -65,32 +173,22 @@ export const listAnnotations = async (req, res) => {
 
 export const updateAnnotation = async (req, res) => {
   try {
-    const { id } = req.params;
+    const context = await loadAccessibleAnnotation(req, res);
+    if (!context) return;
+
     const { body, color, type } = req.body;
 
-    const existingAnnotation = await TranscriptAnnotation.findById(id);
-    if (!existingAnnotation) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Annotation not found" });
-    }
-
-    // Only author can update the annotation body, type, color
-    if (
-      existingAnnotation.author.toString() !== req.user._id.toString() &&
-      req.user.role !== "admin"
-    ) {
+    if (!canModerate(context.annotation, req.user)) {
       return res.status(403).json({
         success: false,
         message: "Not authorized to update this annotation",
       });
     }
 
-    const annotation = await transcriptAnnotationService.updateAnnotation(id, {
-      body,
-      color,
-      type,
-    });
+    const annotation = await transcriptAnnotationService.updateAnnotation(
+      req.params.id,
+      { body, color, type },
+    );
     res.status(200).json({ success: true, annotation });
   } catch (error) {
     res.status(400).json({ success: false, message: error.message });
@@ -99,25 +197,17 @@ export const updateAnnotation = async (req, res) => {
 
 export const deleteAnnotation = async (req, res) => {
   try {
-    const { id } = req.params;
-    const existingAnnotation = await TranscriptAnnotation.findById(id);
-    if (!existingAnnotation) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Annotation not found" });
-    }
+    const context = await loadAccessibleAnnotation(req, res);
+    if (!context) return;
 
-    if (
-      existingAnnotation.author.toString() !== req.user._id.toString() &&
-      req.user.role !== "admin"
-    ) {
+    if (!canModerate(context.annotation, req.user)) {
       return res.status(403).json({
         success: false,
         message: "Not authorized to delete this annotation",
       });
     }
 
-    await transcriptAnnotationService.deleteAnnotation(id);
+    await transcriptAnnotationService.deleteAnnotation(req.params.id);
     res.status(200).json({ success: true, message: "Annotation deleted" });
   } catch (error) {
     res.status(500).json({ success: false, message: error.message });
@@ -126,9 +216,19 @@ export const deleteAnnotation = async (req, res) => {
 
 export const resolveAnnotation = async (req, res) => {
   try {
-    const { id } = req.params;
+    // This handler previously had no check of any kind: it loaded by id and
+    // toggled `resolved`, stamping `resolvedBy` with the caller. Any user could
+    // mark any organization's annotations resolved, or un-resolve them, and be
+    // recorded as having done so.
+    //
+    // Resolving is a collaborative action rather than an edit, so anyone who
+    // can see the meeting may do it — the check is organization access, not
+    // authorship.
+    const context = await loadAccessibleAnnotation(req, res);
+    if (!context) return;
+
     const annotation = await transcriptAnnotationService.resolveAnnotation(
-      id,
+      req.params.id,
       req.user._id,
     );
     res.status(200).json({ success: true, annotation });

--- a/server/routes/transcriptAnnotationRoutes.js
+++ b/server/routes/transcriptAnnotationRoutes.js
@@ -7,25 +7,40 @@ import {
   resolveAnnotation,
 } from "../controllers/transcriptAnnotationController.js";
 import userAuth from "../middleware/userAuth.js";
-import { requireOrgAccess } from "../middleware/rbac.js";
+import { requireOrgAccess, requireOrgMembership } from "../middleware/rbac.js";
 import Meeting from "../models/meetingModel.js";
 
 const router = express.Router({ mergeParams: true });
 
-// Protect all routes
+/**
+ * Transcript annotation routes, mounted at `/api/transcript-annotations`
+ * (Issue #1274).
+ *
+ * Only the list route carried an authorization check; the four write routes
+ * had none, and the file's own comments recorded the gap as an open question
+ * ("We should perhaps validate access inside createAnnotation…"). It was never
+ * answered, so any authenticated user could create, edit, delete and resolve
+ * annotations on any organization's transcript given only an id.
+ *
+ * The checks land in two different places because the routes carry two
+ * different identifiers:
+ *
+ *   - `/meeting/:meetingId` names the meeting, so `requireOrgAccess(Meeting)`
+ *     can resolve and authorize it as middleware.
+ *   - `POST /` names the meeting in the *body*, and `/:id` names an annotation
+ *     whose meeting has to be looked up first. Neither shape fits a middleware
+ *     that reads a meeting id from the path, so those authorize inside the
+ *     controller, via the same `canAccessMeetingDoc` predicate the middleware
+ *     uses.
+ *
+ * `requireOrgMembership` runs first so a caller with no organization is refused
+ * once, here, rather than in four separate handlers.
+ */
 router.use(userAuth);
+router.use(requireOrgMembership);
 
-// Routes
-// Note: We mount these routes under /api/meetings/:meetingId/transcript-annotations
-// OR we mount them globally and pass meetingId. The prompt implies standard REST structure.
-// Let's assume global mount: /api/transcript-annotations/:meetingId
-// Actually, requireMeetingAccess expects req.params.meetingId to be present.
-
-// Apply requireMeetingAccess to routes that have meetingId in params
 router.post("/", createAnnotation);
-// We should perhaps validate access inside createAnnotation if meetingId is in body.
 
-// Let's create specific routes for listing under meeting
 router.get("/meeting/:meetingId", requireOrgAccess(Meeting), listAnnotations);
 
 router.put("/:id", updateAnnotation);

--- a/server/services/transcriptAnnotationService.js
+++ b/server/services/transcriptAnnotationService.js
@@ -13,8 +13,12 @@ class TranscriptAnnotationService {
       throw new Error("Transcript not found");
     }
 
-    // Validate meeting access logic should ideally be handled by controller,
-    // but here we just ensure the transcript belongs to the meeting
+    // Consistency, not authorization. This asserts the two ids the caller
+    // supplied refer to the same meeting — it says nothing about whether the
+    // *user* may reach that meeting, and two ids belonging to the same foreign
+    // meeting satisfy it perfectly. The access check now lives in
+    // `createAnnotation` in the controller, which is the layer that has the
+    // request's user (Issue #1274).
     if (transcript.meeting.toString() !== data.meeting.toString()) {
       throw new Error("Transcript does not belong to this meeting");
     }

--- a/server/tests/transcriptAnnotationAuthorization.test.js
+++ b/server/tests/transcriptAnnotationAuthorization.test.js
@@ -1,0 +1,460 @@
+/**
+ * Regression tests for Issue #1274 — four of the five transcript-annotation
+ * endpoints performed no meeting-scoped authorization.
+ *
+ * Only `GET /meeting/:meetingId` was protected, by `requireOrgAccess(Meeting)`
+ * in the route file. `POST /`, `PUT /:id`, `DELETE /:id` and
+ * `PATCH /:id/resolve` had nothing: any authenticated user could annotate,
+ * edit, delete and resolve on any organization's transcript given only an id.
+ *
+ * These mount the real router. The missing checks were spread across the route
+ * file and the controller, and the surviving author check was wrong in a way
+ * that only shows up with a *foreign* admin — a shape a handler-level test with
+ * one hand-built user would not naturally produce.
+ *
+ * Confirmed load-bearing: 8 of the 24 fail against `main` — every cross-tenant
+ * case (create, resolve, delete, and the foreign-admin edit), both moderation
+ * cases the old role check wrongly refused, the 500 on a malformed author
+ * filter, and the missing organization-membership guard. The other 16 assert
+ * behaviour that was already correct and must stay that way.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+// ── Session injection ──────────────────────────────────────────────────────
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: annotationRoutes } =
+  await import("../routes/transcriptAnnotationRoutes.js");
+const { default: TranscriptAnnotation } =
+  await import("../models/transcriptAnnotationModel.js");
+const { default: Transcript } = await import("../models/transcriptModel.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+/** Author of the seeded annotation, in org A. */
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+/** Colleague of alice — same organization, ordinary member. */
+const bob = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+/** Owner of org A. Strictly more privileged than an admin, yet the old check
+ *  accepted only the literal string "admin", so this user could not moderate. */
+const aliceOwner = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "owner",
+};
+
+/** Org B's own admin. Uploads the org-B meeting used below. */
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+/**
+ * An admin of org A, unrelated to org B's meetings — neither their uploader nor
+ * a member of their organization. The old check accepted this user for org B's
+ * annotations purely on the strength of the string "admin".
+ */
+const carolAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/transcript-annotations", annotationRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+});
+
+/** An org-A meeting with a transcript and one annotation authored by alice. */
+const seedOrgA = async () => {
+  const meeting = await Meeting.create({
+    uploadedBy: alice._id,
+    organization: ORG_A,
+    title: "Sprint review",
+    date: new Date(),
+  });
+
+  const transcript = await Transcript.create({
+    meeting: meeting._id,
+    segments: [{ speaker: "Alice", text: "Ship it", startTime: 0, endTime: 5 }],
+  });
+
+  const annotation = await TranscriptAnnotation.create({
+    transcript: transcript._id,
+    meeting: meeting._id,
+    author: alice._id,
+    type: "comment",
+    body: "Worth revisiting",
+    startTime: 0,
+    endTime: 5,
+  });
+
+  return { meeting, transcript, annotation };
+};
+
+/** The same shape, but owned entirely by org B. */
+const seedOrgB = async () => {
+  const meeting = await Meeting.create({
+    uploadedBy: mallory._id,
+    organization: ORG_B,
+    title: "Confidential planning",
+    date: new Date(),
+  });
+
+  const transcript = await Transcript.create({
+    meeting: meeting._id,
+    segments: [
+      { speaker: "Mallory", text: "Internal only", startTime: 0, endTime: 5 },
+    ],
+  });
+
+  const annotation = await TranscriptAnnotation.create({
+    transcript: transcript._id,
+    meeting: meeting._id,
+    author: mallory._id,
+    type: "comment",
+    body: "Org B private note",
+    startTime: 0,
+    endTime: 5,
+  });
+
+  return { meeting, transcript, annotation };
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("POST / — creating an annotation", () => {
+  it("refuses a meeting the caller cannot access, and persists nothing", async () => {
+    const { meeting, transcript } = await seedOrgB();
+    const before = await TranscriptAnnotation.countDocuments();
+
+    // Against `main`: 201. The annotation then rendered in org B's viewer.
+    await request(app)
+      .post("/api/transcript-annotations")
+      .send({
+        transcript: transcript._id.toString(),
+        meeting: meeting._id.toString(),
+        type: "comment",
+        body: "injected",
+        startTime: 0,
+        endTime: 1,
+      })
+      .expect(403);
+
+    expect(await TranscriptAnnotation.countDocuments()).toBe(before);
+  });
+
+  it("still allows an annotation on the caller's own meeting", async () => {
+    const { meeting, transcript } = await seedOrgA();
+
+    const res = await request(app)
+      .post("/api/transcript-annotations")
+      .send({
+        transcript: transcript._id.toString(),
+        meeting: meeting._id.toString(),
+        type: "highlight",
+        startTime: 1,
+        endTime: 3,
+      })
+      .expect(201);
+
+    expect(res.body.annotation.author).toBe(alice._id.toString());
+  });
+
+  it("still rejects a transcript that belongs to a different meeting", async () => {
+    const { meeting } = await seedOrgA();
+    const other = await seedOrgA();
+
+    await request(app)
+      .post("/api/transcript-annotations")
+      .send({
+        transcript: other.transcript._id.toString(),
+        meeting: meeting._id.toString(),
+        type: "comment",
+        body: "mismatched",
+        startTime: 0,
+        endTime: 1,
+      })
+      .expect(400);
+  });
+
+  it("rejects malformed ids with 400 rather than 500", async () => {
+    await request(app)
+      .post("/api/transcript-annotations")
+      .send({
+        transcript: "not-an-id",
+        meeting: "also-not-an-id",
+        type: "comment",
+        body: "x",
+        startTime: 0,
+        endTime: 1,
+      })
+      .expect(400);
+  });
+
+  it("still rejects startTime after endTime", async () => {
+    const { meeting, transcript } = await seedOrgA();
+
+    await request(app)
+      .post("/api/transcript-annotations")
+      .send({
+        transcript: transcript._id.toString(),
+        meeting: meeting._id.toString(),
+        type: "comment",
+        body: "backwards",
+        startTime: 10,
+        endTime: 5,
+      })
+      .expect(400);
+  });
+});
+
+describe("PATCH /:id/resolve", () => {
+  it("refuses an annotation in another organization", async () => {
+    const { annotation } = await seedOrgB();
+
+    // Against `main`: 200, with alice recorded as the resolver.
+    await request(app)
+      .patch(`/api/transcript-annotations/${annotation._id}/resolve`)
+      .expect(404);
+
+    const stored = await TranscriptAnnotation.findById(annotation._id);
+    expect(stored.resolved).toBe(false);
+    expect(stored.resolvedBy).toBeNull();
+  });
+
+  it("lets any member of the owning organization resolve", async () => {
+    const { annotation } = await seedOrgA();
+    currentUser = bob;
+
+    await request(app)
+      .patch(`/api/transcript-annotations/${annotation._id}/resolve`)
+      .expect(200);
+
+    const stored = await TranscriptAnnotation.findById(annotation._id);
+    expect(stored.resolved).toBe(true);
+    expect(stored.resolvedBy.toString()).toBe(bob._id.toString());
+  });
+
+  it("toggles back on a second call", async () => {
+    const { annotation } = await seedOrgA();
+
+    await request(app)
+      .patch(`/api/transcript-annotations/${annotation._id}/resolve`)
+      .expect(200);
+    await request(app)
+      .patch(`/api/transcript-annotations/${annotation._id}/resolve`)
+      .expect(200);
+
+    const stored = await TranscriptAnnotation.findById(annotation._id);
+    expect(stored.resolved).toBe(false);
+    expect(stored.resolvedBy).toBeNull();
+  });
+});
+
+describe("PUT /:id", () => {
+  it("refuses a foreign admin and leaves the annotation intact", async () => {
+    const { annotation } = await seedOrgB();
+    currentUser = carolAdmin;
+
+    // Against `main`: 200 — `req.user.role === "admin"` passed, even though the
+    // annotation belongs to an organization this admin has nothing to do with.
+    await request(app)
+      .put(`/api/transcript-annotations/${annotation._id}`)
+      .send({ body: "rewritten" })
+      .expect(404);
+
+    const stored = await TranscriptAnnotation.findById(annotation._id);
+    expect(stored.body).toBe("Org B private note");
+  });
+
+  it("lets the author edit their own annotation", async () => {
+    const { annotation } = await seedOrgA();
+
+    const res = await request(app)
+      .put(`/api/transcript-annotations/${annotation._id}`)
+      .send({ body: "revised" })
+      .expect(200);
+
+    expect(res.body.annotation.body).toBe("revised");
+  });
+
+  it("refuses an ordinary colleague who is not the author", async () => {
+    const { annotation } = await seedOrgA();
+    currentUser = bob;
+
+    await request(app)
+      .put(`/api/transcript-annotations/${annotation._id}`)
+      .send({ body: "not mine" })
+      .expect(403);
+
+    const stored = await TranscriptAnnotation.findById(annotation._id);
+    expect(stored.body).toBe("Worth revisiting");
+  });
+
+  it("lets an owner of the annotation's own organization moderate", async () => {
+    const { annotation } = await seedOrgA();
+    currentUser = aliceOwner;
+
+    // Against `main`: 403 — only the literal role "admin" was accepted, so an
+    // org owner could not moderate their own organization's annotations.
+    await request(app)
+      .put(`/api/transcript-annotations/${annotation._id}`)
+      .send({ body: "moderated" })
+      .expect(200);
+  });
+
+  it("returns 400 for a malformed id", async () => {
+    await request(app)
+      .put("/api/transcript-annotations/not-an-object-id")
+      .send({ body: "x" })
+      .expect(400);
+  });
+
+  it("returns 404 for an id that does not exist", async () => {
+    await request(app)
+      .put(`/api/transcript-annotations/${new mongoose.Types.ObjectId()}`)
+      .send({ body: "x" })
+      .expect(404);
+  });
+});
+
+describe("DELETE /:id", () => {
+  it("refuses a caller from another organization", async () => {
+    const { annotation } = await seedOrgB();
+
+    await request(app)
+      .delete(`/api/transcript-annotations/${annotation._id}`)
+      .expect(404);
+
+    expect(await TranscriptAnnotation.findById(annotation._id)).not.toBeNull();
+  });
+
+  it("lets the author delete their own annotation", async () => {
+    const { annotation } = await seedOrgA();
+
+    await request(app)
+      .delete(`/api/transcript-annotations/${annotation._id}`)
+      .expect(200);
+
+    expect(await TranscriptAnnotation.findById(annotation._id)).toBeNull();
+  });
+
+  it("refuses an ordinary colleague", async () => {
+    const { annotation } = await seedOrgA();
+    currentUser = bob;
+
+    await request(app)
+      .delete(`/api/transcript-annotations/${annotation._id}`)
+      .expect(403);
+
+    expect(await TranscriptAnnotation.findById(annotation._id)).not.toBeNull();
+  });
+
+  it("lets a moderator of the owning organization delete", async () => {
+    const { annotation } = await seedOrgA();
+    currentUser = { ...bob, role: "moderator" };
+
+    await request(app)
+      .delete(`/api/transcript-annotations/${annotation._id}`)
+      .expect(200);
+  });
+});
+
+describe("GET /meeting/:meetingId", () => {
+  it("still serves a member of the owning organization", async () => {
+    const { meeting } = await seedOrgA();
+
+    const res = await request(app)
+      .get(`/api/transcript-annotations/meeting/${meeting._id}`)
+      .expect(200);
+
+    expect(res.body.annotations).toHaveLength(1);
+  });
+
+  it("still refuses a cross-organization caller", async () => {
+    const { meeting } = await seedOrgB();
+
+    await request(app)
+      .get(`/api/transcript-annotations/meeting/${meeting._id}`)
+      .expect(403);
+  });
+
+  it("returns 400 for a non-ObjectId author filter rather than 500", async () => {
+    const { meeting } = await seedOrgA();
+
+    await request(app)
+      .get(`/api/transcript-annotations/meeting/${meeting._id}`)
+      .query({ author: "not-an-object-id" })
+      .expect(400);
+  });
+
+  it("filters by author when the value is valid", async () => {
+    const { meeting } = await seedOrgA();
+
+    const res = await request(app)
+      .get(`/api/transcript-annotations/meeting/${meeting._id}`)
+      .query({ author: bob._id.toString() })
+      .expect(200);
+
+    expect(res.body.annotations).toHaveLength(0);
+  });
+});
+
+describe("baseline guards", () => {
+  it("rejects an unauthenticated caller", async () => {
+    currentUser = null;
+
+    await request(app).post("/api/transcript-annotations").send({}).expect(401);
+  });
+
+  it("rejects a caller with no organization", async () => {
+    currentUser = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: null,
+      role: "member",
+    };
+
+    await request(app).post("/api/transcript-annotations").send({}).expect(403);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Only `GET /meeting/:meetingId` was protected, by `requireOrgAccess(Meeting)` in the route file. The four write routes had no check at all — and the route file's own comments recorded the gap as an open question:

```js
router.post("/", createAnnotation);
// We should perhaps validate access inside createAnnotation if meetingId is in body.
```

It was never answered.

### `createAnnotation` trusted client-supplied ids

The controller destructured `transcript` and `meeting` from the request body and handed them to a service that only verified the two were consistent **with each other**:

```js
if (transcript.meeting.toString() !== data.meeting.toString()) {
  throw new Error("Transcript does not belong to this meeting");
}
```

Two ids belonging to the same *foreign* meeting satisfy that perfectly. Nothing asked whether the caller could see it, so any authenticated user could attach free-text annotations to any organization's transcript, where they then rendered in that organization's transcript viewer.

### `resolveAnnotation` had no check whatsoever

It loaded by id and toggled `resolved`, stamping `resolvedBy` with the caller. Any user could mark any organization's annotations resolved — or un-resolve them — and be recorded as having done so.

### `updateAnnotation` / `deleteAnnotation` let a foreign admin through

```js
if (
  existingAnnotation.author.toString() !== req.user._id.toString() &&
  req.user.role !== "admin"
) {
```

`req.user.role` is the caller's role in **their** organization. Nothing established that it was the annotation's. An `admin` of org B therefore passed this check for org A's annotations.

The role list was wrong in the other direction too: an org `owner` — strictly more privileged than an admin — could **not** moderate annotations in their own organization, and neither could a `moderator`.

### The fix

`TranscriptAnnotation` carries no `organization` field of its own; the tenant boundary lives on the meeting. That indirection is presumably why the write handlers ended up with no check. Every check now resolves the annotation's meeting first and applies `canAccessMeetingDoc` — the predicate `requireOrgAccess` already uses, which #1158 exported for exactly this shape of problem.

**Ordering is the load-bearing part.** Organization access is established first; role is consulted only afterwards. By the time `MODERATOR_ROLES` is read, the caller is already known to belong to the meeting's organization, so the role means what it appears to mean.

The checks land in two places because the routes carry two different identifiers — `/meeting/:meetingId` names the meeting and can be authorized as middleware; `POST /` names it in the *body* and `/:id` names an annotation whose meeting has to be looked up first. Neither of those fits a middleware that reads a meeting id from the path, so they authorize inside the controller via the same predicate.

Cross-tenant responses are **404 rather than 403**: 403 confirms the id is real to someone who should not be able to tell.

### Also

- Ids are validated as ObjectIds. A malformed `:id`, or a non-ObjectId `author` query filter on the list route, was an unhandled `CastError` reported as a 500.
- `requireOrgMembership` moved onto the router, so a caller with no organization is refused once rather than in four handlers.
- Replaced the stale stream-of-consciousness comments in the route file with a description of where each check actually lives and why.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #1274

## Testing

Adds `server/tests/transcriptAnnotationAuthorization.test.js` (24 cases) against the mounted router.

**Confirmed load-bearing** — stashed the three source files and re-ran against `main`: **8 of 24 fail**, and they are the right 8:

```
● POST / › refuses a meeting the caller cannot access, and persists nothing
● PATCH /:id/resolve › refuses an annotation in another organization
● DELETE /:id › refuses a caller from another organization
● PUT /:id › refuses a foreign admin and leaves the annotation intact
● PUT /:id › lets an owner of the annotation's own organization moderate
● DELETE /:id › lets a moderator of the owning organization delete
● GET /meeting/:meetingId › returns 400 for a non-ObjectId author filter rather than 500
● baseline guards › rejects a caller with no organization
```

The other 16 pass on `main` and still pass here — they pin behaviour that was already correct (the author can edit their own; an ordinary colleague cannot; the transcript/meeting consistency check; `startTime > endTime`; the list route's existing 403). That split is deliberate: a suite where everything fails on `main` usually means the tests only describe the fix, not the feature.

One fixture detail worth flagging, because it caught me out while writing this: the "foreign admin" user must not also be the meeting's `uploadedBy`. `canAccessMeetingDoc` grants access to the uploader *or* a same-org member, so my first attempt at that test passed for a legitimate reason and proved nothing. `carolAdmin` is now an admin of org A with no relationship to org B's meetings at all.

```
$ npx jest tests/transcriptAnnotationAuthorization.test.js tests/transcriptAnnotation.test.js
Test Suites: 2 passed, 2 total
Tests:       26 passed, 26 total
```

The pre-existing `transcriptAnnotation.test.js` service suite passes unchanged.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — server-side only.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

### Notes for reviewers

- **Resolving is deliberately not restricted to the author or moderators.** Marking a comment resolved is a collaborative action, so anyone who can see the meeting may do it. If maintainers want it narrowed to author-or-moderator, that is a one-line change to use `canModerate` in `resolveAnnotation` — say the word.
- I did not add a `transcript_annotations` resource to `PERMISSIONS`. Access here is meeting-scoped rather than role-scoped, and adding a resource would need the client mirror updated too. Happy to do it as a follow-up if you'd rather annotations were also gated on `comments:create`/`comments:delete`.
