### PR TITLE
fix(template-library): scope clone to the caller's organization

### DIFF
--- a/server/controllers/templateLibraryController.js
+++ b/server/controllers/templateLibraryController.js
@@ -1,5 +1,12 @@
+import mongoose from "mongoose";
 import TemplateLibrary from "../models/templateLibraryModel.js";
 import MeetingTemplate from "../models/meetingTemplateModel.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+
+/** Library listings are cheap rows; 50 is generous without being unbounded. */
+const MAX_BROWSE_LIMIT = 50;
+
+const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
 
 // Publish a template to the library
 export const publishTemplate = async (req, res) => {
@@ -7,6 +14,10 @@ export const publishTemplate = async (req, res) => {
     const { templateId, category, description } = req.body;
     const organizationId = req.user.organization;
     const userId = req.user._id;
+
+    if (!isValidId(templateId)) {
+      return res.status(400).json({ error: "Invalid template ID" });
+    }
 
     const originalTemplate = await MeetingTemplate.findOne({
       _id: templateId,
@@ -44,7 +55,7 @@ export const publishTemplate = async (req, res) => {
 export const browseTemplates = async (req, res) => {
   try {
     const organizationId = req.user.organization;
-    const { category, sort = "newest", page = 1, limit = 20 } = req.query;
+    const { category, sort = "newest" } = req.query;
 
     const query = { organizationId };
     if (category) {
@@ -58,20 +69,32 @@ export const browseTemplates = async (req, res) => {
       sortOptions = { averageRating: -1 };
     }
 
-    const skip = (parseInt(page, 10) - 1) * parseInt(limit, 10);
+    // Pagination was open-coded here as
+    // `(parseInt(page, 10) - 1) * parseInt(limit, 10)`, so `?limit=1000000`
+    // was honoured and `?page=abc` produced `skip: NaN` (Issue #1275).
+    // `parsePagination` clamps both and is the rule the rest of the codebase
+    // already uses — it was added for #1071 and this endpoint predates it.
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+      maxLimit: MAX_BROWSE_LIMIT,
+    });
 
     const templates = await TemplateLibrary.find(query)
       .sort(sortOptions)
       .skip(skip)
-      .limit(parseInt(limit, 10))
+      .limit(limit)
       .populate("publishedBy", "firstName lastName email");
 
     const total = await TemplateLibrary.countDocuments(query);
+    const pagination = buildPaginationMeta({ total, page, limit });
 
+    // `templates` / `totalPages` / `currentPage` are the keys the client reads
+    // today; `pagination` is added alongside rather than replacing them.
     res.status(200).json({
       templates,
-      totalPages: Math.ceil(total / parseInt(limit, 10)),
-      currentPage: parseInt(page, 10),
+      totalPages: pagination.totalPages,
+      currentPage: pagination.page,
+      pagination,
     });
   } catch (error) {
     console.error("Error browsing templates:", error);
@@ -86,35 +109,53 @@ export const cloneTemplate = async (req, res) => {
     const userId = req.user._id;
     const organizationId = req.user.organization;
 
-    const libraryEntry = await TemplateLibrary.findById(id);
+    if (!isValidId(id)) {
+      return res.status(400).json({ error: "Invalid template ID" });
+    }
+
+    // Scope the lookup to the caller's organization (Issue #1275).
+    //
+    // This was `TemplateLibrary.findById(id)`, the only unscoped lookup in the
+    // file — `publishTemplate`, `browseTemplates` and `rateTemplate` all filter
+    // on `organizationId`. `organizationId` was read from the caller and used
+    // only as the *destination*, so the source was whatever `:id` pointed at:
+    // any authenticated user could copy another organization's published
+    // template — name, title, description, duration and full agenda — into
+    // their own workspace, and `cloneCount += 1` then wrote to the victim's
+    // document.
+    const libraryEntry = await TemplateLibrary.findOne({
+      _id: id,
+      organizationId,
+    });
 
     if (!libraryEntry) {
       return res.status(404).json({ error: "Template not found in library" });
     }
 
-    const originalTemplate = await MeetingTemplate.findById(
-      libraryEntry.originalTemplateId,
-    );
-
-    if (!originalTemplate) {
-      return res.status(404).json({ error: "Original template not found" });
-    }
-
-    // Create a new cloned template for the user's organization
+    // Build the clone from the library entry's own snapshot, not from a fresh
+    // read of `MeetingTemplate.findById(libraryEntry.originalTemplateId)`.
+    //
+    // The library entry stores name, title, description, category, duration,
+    // agenda blocks and default participants precisely so that publishing is a
+    // point-in-time act. Re-reading the source meant a clone silently picked up
+    // edits made after publication — so users got something other than the
+    // entry they browsed and rated — and cloning a perfectly valid entry failed
+    // with "Original template not found" once the source template was deleted.
+    //
+    // It also fixes a quieter loss: `defaultParticipants` is published with the
+    // entry and supported by `MeetingTemplate`, but the old clone never copied
+    // it.
     const clonedTemplate = new MeetingTemplate({
       organizationId,
-      name: `${originalTemplate.name} (Clone)`,
-      title: originalTemplate.title,
-      description: originalTemplate.description,
-      category: originalTemplate.category,
-      defaultDuration: originalTemplate.defaultDuration,
-      agendaBlocks: originalTemplate.agendaBlocks,
+      name: `${libraryEntry.name} (Clone)`,
+      title: libraryEntry.title,
+      description: libraryEntry.description,
+      category: libraryEntry.category,
+      defaultDuration: libraryEntry.defaultDuration,
+      agendaBlocks: libraryEntry.agendaBlocks,
+      defaultParticipants: libraryEntry.defaultParticipants,
       createdBy: userId,
-      metadata: {
-        ...originalTemplate.metadata,
-        clonedFromLibrary: true,
-        clonedFromId: libraryEntry._id,
-      },
+      clonedFromLibraryId: libraryEntry._id,
     });
 
     await clonedTemplate.save();
@@ -138,8 +179,21 @@ export const rateTemplate = async (req, res) => {
     const organizationId = req.user.organization;
     const userId = req.user._id;
 
-    if (rating < 1 || rating > 5) {
-      return res.status(400).json({ error: "Rating must be between 1 and 5" });
+    if (!isValidId(id)) {
+      return res.status(400).json({ error: "Invalid template ID" });
+    }
+
+    // `if (rating < 1 || rating > 5)` passed for `undefined` (both comparisons
+    // are false against NaN) and for the string "3", which then failed schema
+    // validation as a 500 instead of a 400.
+    if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+      return res
+        .status(400)
+        .json({ error: "Rating must be an integer between 1 and 5" });
+    }
+
+    if (review !== undefined && typeof review !== "string") {
+      return res.status(400).json({ error: "Review must be text" });
     }
 
     const libraryTemplate = await TemplateLibrary.findOne({

--- a/server/models/meetingTemplateModel.js
+++ b/server/models/meetingTemplateModel.js
@@ -48,6 +48,24 @@ const meetingTemplateSchema = new mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
     },
+    /**
+     * Set when this template was cloned out of the shared library
+     * (Issue #1275).
+     *
+     * `cloneTemplate` already tried to record provenance, as
+     * `metadata: { clonedFromLibrary: true, clonedFromId: … }` — but this
+     * schema has never declared a `metadata` path, so Mongoose's default strict
+     * mode dropped the whole object on save without complaint. Every clone
+     * created since the feature shipped has no record of where it came from.
+     *
+     * A declared, typed ref instead of a Mixed bag: the intent was always a
+     * pointer to one library entry.
+     */
+    clonedFromLibraryId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "TemplateLibrary",
+      default: null,
+    },
   },
   { timestamps: true },
 );

--- a/server/routes/templateLibraryRoutes.js
+++ b/server/routes/templateLibraryRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership } from "../middleware/rbac.js";
 import {
   publishTemplate,
   browseTemplates,
@@ -9,8 +10,15 @@ import {
 
 const router = express.Router();
 
-// Apply auth middleware to all routes
+// Apply auth middleware to all routes.
+//
+// Every handler scopes its queries with `req.user.organization`. A caller
+// without one previously reached the handlers with `organizationId: undefined`,
+// which Mongoose treats as "match documents where the field is unset" rather
+// than as an error — so the filter that looks like a tenant boundary silently
+// stopped being one (Issue #1275).
 router.use(userAuth);
+router.use(requireOrgMembership);
 
 router.post("/", publishTemplate);
 router.get("/", browseTemplates);

--- a/server/tests/templateLibraryAuthorization.test.js
+++ b/server/tests/templateLibraryAuthorization.test.js
@@ -1,0 +1,366 @@
+/**
+ * Regression tests for Issue #1275 — `cloneTemplate` was the only handler in
+ * the template library that resolved a document by id without scoping it to
+ * the caller's organization.
+ *
+ * `publishTemplate`, `browseTemplates` and `rateTemplate` all filter on
+ * `organizationId`; `cloneTemplate` used a bare `findById`, and read
+ * `organizationId` from the caller only to decide where the copy should land.
+ * The source was whatever `:id` pointed at.
+ *
+ * The suite also covers the snapshot-fidelity and pagination problems that sit
+ * alongside it, since all three live in the same two functions.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+// ── Session injection ──────────────────────────────────────────────────────
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: templateLibraryRoutes } =
+  await import("../routes/templateLibraryRoutes.js");
+const { default: TemplateLibrary } =
+  await import("../models/templateLibraryModel.js");
+const { default: MeetingTemplate } =
+  await import("../models/meetingTemplateModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const bob = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+/** Deliberately privileged, but in a different organization. */
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "owner",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/template-library", templateLibraryRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+});
+
+/** A source template plus the library entry published from it. */
+const seedPublished = async (organizationId, publisher, overrides = {}) => {
+  const source = await MeetingTemplate.create({
+    organizationId,
+    name: "Sprint Planning",
+    title: "Sprint Planning Session",
+    description: "Plan the next two weeks",
+    category: "Engineering",
+    defaultDuration: 45,
+    agendaBlocks: [
+      { title: "Capacity", description: "Who is available", duration: 10 },
+      { title: "Backlog", description: "Groom the top items", duration: 35 },
+    ],
+    defaultParticipants: ["eng@example.com", "pm@example.com"],
+    createdBy: publisher._id,
+    ...overrides,
+  });
+
+  const entry = await TemplateLibrary.create({
+    organizationId,
+    originalTemplateId: source._id,
+    name: source.name,
+    title: source.title,
+    description: source.description,
+    category: source.category,
+    defaultDuration: source.defaultDuration,
+    agendaBlocks: source.agendaBlocks,
+    defaultParticipants: source.defaultParticipants,
+    publishedBy: publisher._id,
+  });
+
+  return { source, entry };
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("POST /:id/clone — organization scoping", () => {
+  it("refuses another organization's library entry", async () => {
+    const { entry } = await seedPublished(ORG_B, mallory);
+
+    // Against `main`: 201, with org B's template content copied into org A.
+    await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(404);
+
+    expect(
+      await MeetingTemplate.countDocuments({ organizationId: ORG_A }),
+    ).toBe(0);
+  });
+
+  it("does not increment the victim's clone count", async () => {
+    const { entry } = await seedPublished(ORG_B, mallory);
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(404);
+
+    const stored = await TemplateLibrary.findById(entry._id);
+    expect(stored.cloneCount).toBe(0);
+  });
+
+  it("still clones an entry from the caller's own organization", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(201);
+
+    expect(res.body.name).toBe("Sprint Planning (Clone)");
+    expect(res.body.organizationId).toBe(ORG_A.toString());
+    expect(res.body.createdBy).toBe(alice._id.toString());
+
+    const stored = await TemplateLibrary.findById(entry._id);
+    expect(stored.cloneCount).toBe(1);
+  });
+
+  it("rejects a malformed id with 400 rather than 500", async () => {
+    await request(app)
+      .post("/api/template-library/not-an-object-id/clone")
+      .expect(400);
+  });
+});
+
+describe("POST /:id/clone — snapshot fidelity", () => {
+  it("copies every published field, including defaultParticipants", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(201);
+
+    expect(res.body.title).toBe("Sprint Planning Session");
+    expect(res.body.description).toBe("Plan the next two weeks");
+    expect(res.body.category).toBe("Engineering");
+    expect(res.body.defaultDuration).toBe(45);
+    expect(res.body.agendaBlocks).toHaveLength(2);
+    // Against `main`: [] — the clone never copied defaultParticipants.
+    expect(res.body.defaultParticipants).toEqual([
+      "eng@example.com",
+      "pm@example.com",
+    ]);
+  });
+
+  it("reproduces what was published, not later edits to the source", async () => {
+    const { source, entry } = await seedPublished(ORG_A, bob);
+
+    source.title = "Completely different meeting";
+    source.defaultDuration = 5;
+    await source.save();
+
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(201);
+
+    // Against `main`: the clone silently picked up the edited source, so the
+    // user received something other than the entry they browsed and rated.
+    expect(res.body.title).toBe("Sprint Planning Session");
+    expect(res.body.defaultDuration).toBe(45);
+  });
+
+  it("still clones after the source template has been deleted", async () => {
+    const { source, entry } = await seedPublished(ORG_A, bob);
+    await MeetingTemplate.findByIdAndDelete(source._id);
+
+    // Against `main`: 404 "Original template not found", even though the
+    // library entry holds everything the clone needs.
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(201);
+
+    expect(res.body.title).toBe("Sprint Planning Session");
+  });
+
+  it("records which library entry the clone came from", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(201);
+
+    // Against `main`: undefined. The old code wrote provenance into a
+    // `metadata` object that the schema never declared, so Mongoose's strict
+    // mode discarded it on save without complaint.
+    expect(res.body.clonedFromLibraryId).toBe(entry._id.toString());
+  });
+});
+
+describe("GET / — pagination", () => {
+  const seedMany = async (count) => {
+    for (let i = 0; i < count; i += 1) {
+      await TemplateLibrary.create({
+        organizationId: ORG_A,
+        originalTemplateId: new mongoose.Types.ObjectId(),
+        name: `Template ${i}`,
+        title: `Title ${i}`,
+        publishedBy: bob._id,
+      });
+    }
+  };
+
+  it("clamps an absurd limit", async () => {
+    await seedMany(5);
+
+    // Against `main`: honoured verbatim and passed straight to `.limit()`.
+    const res = await request(app)
+      .get("/api/template-library")
+      .query({ limit: 1000000 })
+      .expect(200);
+
+    expect(res.body.pagination.limit).toBeLessThanOrEqual(50);
+    expect(res.body.templates).toHaveLength(5);
+  });
+
+  it("falls back to defaults for non-numeric page and limit", async () => {
+    await seedMany(3);
+
+    // Against `main`: `skip: NaN`, which Mongoose rejects.
+    const res = await request(app)
+      .get("/api/template-library")
+      .query({ page: "abc", limit: "xyz" })
+      .expect(200);
+
+    expect(res.body.currentPage).toBe(1);
+    expect(res.body.templates).toHaveLength(3);
+  });
+
+  it("keeps the response keys the client reads", async () => {
+    await seedMany(3);
+
+    const res = await request(app).get("/api/template-library").expect(200);
+
+    expect(Array.isArray(res.body.templates)).toBe(true);
+    expect(res.body.totalPages).toBe(1);
+    expect(res.body.currentPage).toBe(1);
+  });
+
+  it("never lists another organization's entries", async () => {
+    await seedPublished(ORG_B, mallory);
+    await seedMany(2);
+
+    const res = await request(app).get("/api/template-library").expect(200);
+
+    expect(res.body.templates).toHaveLength(2);
+  });
+});
+
+describe("POST /:id/rate — validation", () => {
+  it("rejects a missing rating", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    // Against `main`: `undefined < 1` is false and `undefined > 5` is false, so
+    // this passed the guard and failed later as a 500.
+    await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ review: "Nice" })
+      .expect(400);
+  });
+
+  it("rejects a numeric string rating", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ rating: "3" })
+      .expect(400);
+  });
+
+  it("rejects an out-of-range rating", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ rating: 9 })
+      .expect(400);
+  });
+
+  it("still accepts a valid rating and recomputes the average", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ rating: 4, review: "Solid" })
+      .expect(200);
+
+    currentUser = bob;
+    const res = await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ rating: 2 })
+      .expect(200);
+
+    expect(res.body.ratings).toHaveLength(2);
+    expect(res.body.averageRating).toBe(3);
+  });
+
+  it("refuses to rate another organization's entry", async () => {
+    const { entry } = await seedPublished(ORG_B, mallory);
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/rate`)
+      .send({ rating: 1 })
+      .expect(404);
+
+    const stored = await TemplateLibrary.findById(entry._id);
+    expect(stored.ratings).toHaveLength(0);
+  });
+});
+
+describe("baseline guards", () => {
+  it("rejects an unauthenticated caller", async () => {
+    currentUser = null;
+
+    await request(app).get("/api/template-library").expect(401);
+  });
+
+  it("rejects a caller with no organization", async () => {
+    const { entry } = await seedPublished(ORG_A, bob);
+    currentUser = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: null,
+      role: "member",
+    };
+
+    await request(app)
+      .post(`/api/template-library/${entry._id}/clone`)
+      .expect(403);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

### The tenant boundary

`cloneTemplate` was the only handler in the file that resolved a document by id without scoping it. The other three are all correct:

```js
// publishTemplate
await MeetingTemplate.findOne({ _id: templateId, organizationId });
// browseTemplates
const query = { organizationId };
// rateTemplate
await TemplateLibrary.findOne({ _id: id, organizationId });
```

`cloneTemplate`:

```js
const libraryEntry = await TemplateLibrary.findById(id);            // unscoped
const originalTemplate = await MeetingTemplate.findById(            // unscoped
  libraryEntry.originalTemplateId,
);
```

`organizationId` was read from the caller and used only as the **destination**. The source was whatever `:id` pointed at. Any authenticated user could copy another organization's published template — name, title, description, duration and full agenda blocks — into their own workspace, and `libraryEntry.cloneCount += 1; await libraryEntry.save()` then wrote to the victim's document as a side effect.

Fixed by scoping the lookup the same way the other three handlers do.

### Snapshot fidelity

The clone read from the **live** `MeetingTemplate` rather than from the library entry's snapshot. The entry stores `name`, `title`, `description`, `category`, `defaultDuration`, `agendaBlocks` and `defaultParticipants` precisely so that publishing is a point-in-time act. Reading past it caused three problems for entirely legitimate use:

- A clone silently picked up edits made to the source *after* publication, so users received something other than the entry they browsed and rated.
- Cloning a perfectly valid entry failed with `404 Original template not found` once the source template was deleted.
- `defaultParticipants` is published with the entry and supported by `MeetingTemplate`, but the clone never copied it — silently dropped on every clone.

The entry already holds everything the clone needs, so it now builds from there. That fixes all three at once.

### Provenance never worked

```js
metadata: {
  ...originalTemplate.metadata,
  clonedFromLibrary: true,
  clonedFromId: libraryEntry._id,
},
```

`meetingTemplateModel` has never declared a `metadata` path, so Mongoose's default strict mode discarded the whole object on save without complaint. **Every clone created since the feature shipped has no record of where it came from.** Replaced with a declared, typed `clonedFromLibraryId` ref, which is what that line was reaching for.

### Two smaller fixes in the same functions

- `browseTemplates` open-coded `(parseInt(page, 10) - 1) * parseInt(limit, 10)`, so `?limit=1000000` was honoured and `?page=abc` produced `skip: NaN`. It now uses `parsePagination` / `buildPaginationMeta` with a 50 ceiling — the rule added for #1071 that this endpoint predates. The `templates` / `totalPages` / `currentPage` keys `TemplateLibrary.jsx` reads are unchanged; `pagination` is added alongside them.
- `rateTemplate` guarded with `if (rating < 1 || rating > 5)`. Both comparisons are false against `NaN`, so `undefined` passed the guard, and the string `"3"` passed too and then failed schema validation as a 500.

### Router

`requireOrgMembership` added. A caller with no organization previously reached the handlers with `organizationId: undefined`, which Mongoose reads as *"match documents where the field is unset"* rather than as an error — so the filter that looks like a tenant boundary quietly stopped being one.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #1275

## Testing

Adds `server/tests/templateLibraryAuthorization.test.js` (19 cases) against the mounted router.

**Confirmed load-bearing** — stashed the source files and re-ran against `main`: **12 of 19 fail**.

```
● POST /:id/clone — organization scoping › refuses another organization's library entry
● POST /:id/clone — organization scoping › does not increment the victim's clone count
● POST /:id/clone — organization scoping › rejects a malformed id with 400 rather than 500
● POST /:id/clone — snapshot fidelity › copies every published field, including defaultParticipants
● POST /:id/clone — snapshot fidelity › reproduces what was published, not later edits to the source
● POST /:id/clone — snapshot fidelity › still clones after the source template has been deleted
● POST /:id/clone — snapshot fidelity › records which library entry the clone came from
● GET / — pagination › clamps an absurd limit
● GET / — pagination › falls back to defaults for non-numeric page and limit
● POST /:id/rate — validation › rejects a missing rating
● POST /:id/rate — validation › rejects a numeric string rating
● baseline guards › rejects a caller with no organization
```

The other 7 pass on `main` and still pass here — same-org clone, the response keys the client depends on, a valid rating and its average, cross-org listing, unauthenticated access.

```
$ npx jest tests/templateLibraryAuthorization.test.js tests/templateLibrary.test.js
Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
```

The pre-existing `templateLibrary.test.js` lifecycle suite (publish → fetch → clone → rate, all within one organization) passes unchanged.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — server-side only. `TemplateLibrary.jsx` reads only `data.templates`, which is unchanged.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

### Notes for reviewers

- **The `clonedFromLibraryId` schema field is the one thing here I'd call a judgment call.** Strictly, provenance is not in the issue's acceptance criteria. But the line attempting it sits in the middle of the function I rewrote, and leaving a silently-dead assignment in place after touching everything around it seemed worse than either fixing it or deleting it. I chose to fix it; if you'd rather I just delete the `metadata` line and open provenance as its own issue, that's a one-line change.
- Existing clones are unaffected — `clonedFromLibraryId` defaults to `null`, no migration needed. Their provenance was never recorded, so there is nothing to backfill from.
- The 50-row browse ceiling is a guess at "generous but bounded". Happy to change the number.
- Cross-organization clone/rate return **404**, matching the surrounding handlers, rather than 403.
