### PR TITLE
fix(topics): scope meeting topics and cluster renames to the caller's organization

### DIFF
--- a/server/controllers/topicController.js
+++ b/server/controllers/topicController.js
@@ -1,14 +1,48 @@
+import mongoose from "mongoose";
 import * as topicExtractionService from "../services/topicExtractionService.js";
 import MeetingTopic from "../models/meetingTopicModel.js";
 import TopicCluster from "../models/topicClusterModel.js";
+import Meeting from "../models/meetingModel.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+import { AppError } from "../utils/errors.js";
+
+/** Cluster labels appear in chart axes and legends; long ones break the view. */
+const MAX_CLUSTER_LABEL_LENGTH = 120;
+
+const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+/**
+ * Maps an `AppError` from the service onto its own status.
+ *
+ * Every handler here caught everything and answered 500, so a cross-organization
+ * extraction attempt was indistinguishable from a server fault — both to the
+ * caller and in the logs (Issue #1276).
+ *
+ * Returns true when it has responded.
+ */
+const sendAppError = (res, error) => {
+  if (!(error instanceof AppError)) return false;
+
+  res.status(error.statusCode).json({ success: false, error: error.message });
+  return true;
+};
 
 export const extractForMeeting = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const orgId = req.user.organization;
+
+    if (!isValidId(meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, error: "Invalid meeting ID" });
+    }
+
     const result = await topicExtractionService.extractTopics(meetingId, orgId);
     res.status(200).json({ success: true, data: result });
   } catch (error) {
+    if (sendAppError(res, error)) return;
+
     console.error("Error extracting topics:", error);
     res
       .status(500)
@@ -19,6 +53,38 @@ export const extractForMeeting = async (req, res) => {
 export const getTopicsForMeeting = async (req, res) => {
   try {
     const { meetingId } = req.params;
+
+    if (!isValidId(meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, error: "Invalid meeting ID" });
+    }
+
+    // Authorize against the meeting before reading its topics (Issue #1276).
+    //
+    // This handler never consulted `req.user` at all. `MeetingTopic.findOne({
+    // meeting: meetingId })` returned the AI-extracted topic names, keywords
+    // and discussion time ranges for *any* meeting in the database, and
+    // `.populate("topics.clusterId")` pulled the owning organization's cluster
+    // labels and descriptions along with them — a summary of what was said in
+    // a private meeting, readable by id.
+    //
+    // `canAccessMeetingDoc` is the predicate `requireOrgAccess` uses, so this
+    // is the same rule the rest of the meeting surface applies, not a second
+    // definition of it.
+    const meeting = await Meeting.findById(meetingId);
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ success: false, error: "Meeting not found" });
+    }
+    if (!canAccessMeetingDoc(meeting, req.user)) {
+      return res.status(403).json({
+        success: false,
+        error: "Forbidden: You don't have access to this meeting",
+      });
+    }
+
     const meetingTopic = await MeetingTopic.findOne({
       meeting: meetingId,
     }).populate("topics.clusterId");
@@ -33,10 +99,42 @@ export const getTopicsForMeeting = async (req, res) => {
   }
 };
 
+/**
+ * Rejects a `:orgId` path parameter that names an organization other than the
+ * caller's.
+ *
+ * The two cluster routes declare `:orgId`, and both handlers ignored it and
+ * used `req.user.organization` instead. Passing another organization's id
+ * therefore returned 200 with *your own* clusters — quietly misleading rather
+ * than an explicit refusal, and an invitation to assume the parameter is what
+ * scopes the query.
+ *
+ * The parameter is validated rather than removed because
+ * `client/src/pages/TopicExplorer.jsx` calls the parameterised URL; dropping it
+ * would break that page. Validating is strictly stronger than ignoring.
+ *
+ * Returns true when it has responded.
+ */
+const rejectMismatchedOrgParam = (req, res) => {
+  const { orgId } = req.params;
+  if (!orgId) return false;
+
+  if (orgId !== req.user.organization.toString()) {
+    res.status(403).json({
+      success: false,
+      error: "Forbidden: organization does not match your membership",
+    });
+    return true;
+  }
+
+  return false;
+};
+
 export const getTopicClusters = async (req, res) => {
   try {
+    if (rejectMismatchedOrgParam(req, res)) return;
+
     const orgId = req.user.organization;
-    // Re-run clustering if needed or simply fetch? Let's just fetch for now, optionally trigger cluster
     const clusters = await TopicCluster.find({ organization: orgId }).sort({
       meetingCount: -1,
     });
@@ -54,20 +152,46 @@ export const renameCluster = async (req, res) => {
     const { clusterId } = req.params;
     const { label } = req.body;
 
-    if (!label) {
+    if (!isValidId(clusterId)) {
+      return res
+        .status(400)
+        .json({ success: false, error: "Invalid cluster ID" });
+    }
+
+    // `if (!label)` accepted any truthy value, so a number or an object reached
+    // `cluster.label = label` and was coerced on save.
+    if (typeof label !== "string" || label.trim().length === 0) {
       return res
         .status(400)
         .json({ success: false, error: "Label is required" });
     }
+    if (label.trim().length > MAX_CLUSTER_LABEL_LENGTH) {
+      return res.status(400).json({
+        success: false,
+        error: `Label cannot exceed ${MAX_CLUSTER_LABEL_LENGTH} characters`,
+      });
+    }
 
-    const cluster = await TopicCluster.findById(clusterId);
+    // Scope the lookup (Issue #1276).
+    //
+    // This was `TopicCluster.findById(clusterId)`. `TopicCluster` has a
+    // required, indexed `organization` field that the handler never used, so
+    // any authenticated user could rewrite the label on another organization's
+    // cluster — and `isUserRenamed = true` then stopped the clustering job from
+    // ever correcting it. The label is what that organization's topic dashboard
+    // displays.
+    const cluster = await TopicCluster.findOne({
+      _id: clusterId,
+      organization: req.user.organization,
+    });
+
     if (!cluster) {
       return res
         .status(404)
         .json({ success: false, error: "Cluster not found" });
     }
 
-    cluster.label = label;
+    cluster.label = label.trim();
     cluster.isUserRenamed = true;
     await cluster.save();
 
@@ -82,6 +206,8 @@ export const renameCluster = async (req, res) => {
 
 export const triggerClustering = async (req, res) => {
   try {
+    if (rejectMismatchedOrgParam(req, res)) return;
+
     const orgId = req.user.organization;
     const clusters = await topicExtractionService.clusterTopics(orgId);
     res.status(200).json({ success: true, data: clusters });

--- a/server/routes/topicRoutes.js
+++ b/server/routes/topicRoutes.js
@@ -7,17 +7,32 @@ import {
   triggerClustering,
 } from "../controllers/topicController.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership } from "../middleware/rbac.js";
 
 const router = express.Router();
 
-// Apply auth middleware to all routes
+/**
+ * Topic routes (Issue #1276).
+ *
+ * `requireOrgMembership` is what makes the handlers' scoping meaningful. Every
+ * one of them filters on `req.user.organization`; a caller without one reached
+ * them with `undefined`, and Mongoose reads `{ organization: undefined }` as
+ * "match documents where the field is unset" rather than as an error — so the
+ * filter that looks like a tenant boundary silently stopped being one.
+ */
 router.use(userAuth);
+router.use(requireOrgMembership);
 
 // Meeting specific topic routes
 router.post("/extract/:meetingId", extractForMeeting);
 router.get("/meeting/:meetingId", getTopicsForMeeting);
 
-// Organization cluster routes
+// Organization cluster routes.
+//
+// `:orgId` is kept rather than removed — `client/src/pages/TopicExplorer.jsx`
+// calls the parameterised URL — but the handlers now reject a value that does
+// not match the caller's own organization instead of ignoring it and returning
+// the caller's data under someone else's id.
 router.get("/clusters/org/:orgId", getTopicClusters);
 router.post("/clusters/org/:orgId/cluster", triggerClustering);
 router.put("/clusters/:clusterId", renameCluster);

--- a/server/services/topicExtractionService.js
+++ b/server/services/topicExtractionService.js
@@ -5,23 +5,29 @@ import TopicCluster from "../models/topicClusterModel.js";
 import { generateText, parseJsonOutput } from "./GenerativeAIService.js";
 import { embedText } from "../utils/embeddingUtils.js";
 import cosineSimilarity from "../utils/similarity.js";
+import { ForbiddenError, NotFoundError } from "../utils/errors.js";
 
 const CLUSTER_SIMILARITY_THRESHOLD = 0.85;
 
 /**
  * Extracts 3-8 topics from a meeting's transcript using Generative AI.
+ *
+ * The checks below were already correct; they now throw the typed errors from
+ * `utils/errors.js` rather than bare `Error`s, so the controller can answer 403
+ * and 404 instead of flattening every failure into a 500 (Issue #1276). The
+ * messages are unchanged, so callers matching on them still behave the same.
  */
 export const extractTopics = async (meetingId, userOrgId) => {
   const meeting = await Meeting.findById(meetingId);
-  if (!meeting) throw new Error("Meeting not found");
+  if (!meeting) throw new NotFoundError("Meeting not found");
 
   if (meeting.organization.toString() !== userOrgId.toString()) {
-    throw new Error("Unauthorized access to meeting");
+    throw new ForbiddenError("Unauthorized access to meeting");
   }
 
   const transcript = await Transcript.findOne({ meeting: meetingId });
   if (!transcript || !transcript.segments || transcript.segments.length === 0) {
-    throw new Error("No transcript found for meeting");
+    throw new NotFoundError("No transcript found for meeting");
   }
 
   // To help the AI map back to timestamps, include them in the prompt context

--- a/server/tests/topicOrgScoping.test.js
+++ b/server/tests/topicOrgScoping.test.js
@@ -1,0 +1,379 @@
+/**
+ * Regression tests for Issue #1276 — `getTopicsForMeeting` and `renameCluster`
+ * resolved documents by id with no organization filter.
+ *
+ * One leaked another organization's extracted meeting topics (names, keywords,
+ * discussion time ranges, plus the populated cluster labels); the other let any
+ * authenticated user rewrite another organization's cluster labels and set
+ * `isUserRenamed`, which stops the clustering job from ever correcting them.
+ *
+ * These mount the real router so the `:orgId` path-parameter behaviour is
+ * covered as well.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+// ── Session injection ──────────────────────────────────────────────────────
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+// ── AI / embedding stubs ───────────────────────────────────────────────────
+// The authorization checks under test all run before these are reached. The
+// stubs let the extraction test assert that the transcript never got as far as
+// the model, rather than passing on a network failure.
+const generateText = jest.fn();
+const embedText = jest.fn();
+
+jest.unstable_mockModule("../services/GenerativeAIService.js", () => ({
+  generateText,
+  parseJsonOutput: (text) => JSON.parse(text),
+}));
+jest.unstable_mockModule("../utils/embeddingUtils.js", () => ({
+  embedText,
+}));
+
+const { default: topicRoutes } = await import("../routes/topicRoutes.js");
+const { default: MeetingTopic } =
+  await import("../models/meetingTopicModel.js");
+const { default: TopicCluster } =
+  await import("../models/topicClusterModel.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: Transcript } = await import("../models/transcriptModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+/** Deliberately privileged, but in a different organization. */
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "owner",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/topics", topicRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+  generateText.mockReset();
+  embedText.mockReset();
+});
+
+/** A meeting with one extracted topic, assigned to one cluster. */
+const seedTopics = async (organization, owner) => {
+  const meeting = await Meeting.create({
+    uploadedBy: owner._id,
+    organization,
+    title: "Roadmap sync",
+    date: new Date(),
+    transcript: "We discussed the migration timeline at length.",
+  });
+
+  const cluster = await TopicCluster.create({
+    organization,
+    label: "Migration Planning",
+    description: "Work relating to the platform migration",
+    canonicalTopicNames: ["Migration Planning"],
+    meetingCount: 1,
+    centroidEmbedding: [0.1, 0.2, 0.3],
+  });
+
+  const meetingTopic = await MeetingTopic.create({
+    organization,
+    meeting: meeting._id,
+    topics: [
+      {
+        name: "Migration timeline",
+        confidence: 92,
+        keywords: ["migration", "timeline", "cutover"],
+        timeRanges: [{ start: 0, end: 45 }],
+        embedding: [0.1, 0.2, 0.3],
+        clusterId: cluster._id,
+      },
+    ],
+  });
+
+  return { meeting, cluster, meetingTopic };
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+describe("GET /meeting/:meetingId", () => {
+  it("refuses a meeting in another organization", async () => {
+    const { meeting } = await seedTopics(ORG_B, mallory);
+
+    // Against `main`: 200, with org B's topic names, keywords and time ranges,
+    // plus the populated cluster label.
+    const res = await request(app)
+      .get(`/api/topics/meeting/${meeting._id}`)
+      .expect(403);
+
+    expect(res.body.data).toBeUndefined();
+  });
+
+  it("still serves a meeting in the caller's organization", async () => {
+    const { meeting } = await seedTopics(ORG_A, alice);
+
+    const res = await request(app)
+      .get(`/api/topics/meeting/${meeting._id}`)
+      .expect(200);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe("Migration timeline");
+    expect(res.body.data[0].clusterId.label).toBe("Migration Planning");
+  });
+
+  it("returns an empty list for an accessible meeting with no topics", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: alice._id,
+      organization: ORG_A,
+      title: "Untouched",
+      date: new Date(),
+    });
+
+    const res = await request(app)
+      .get(`/api/topics/meeting/${meeting._id}`)
+      .expect(200);
+
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns 404 for a meeting that does not exist", async () => {
+    await request(app)
+      .get(`/api/topics/meeting/${new mongoose.Types.ObjectId()}`)
+      .expect(404);
+  });
+
+  it("returns 400 for a malformed id rather than 500", async () => {
+    await request(app).get("/api/topics/meeting/not-an-object-id").expect(400);
+  });
+});
+
+describe("PUT /clusters/:clusterId", () => {
+  it("refuses a cluster in another organization and leaves it unmodified", async () => {
+    const { cluster } = await seedTopics(ORG_B, mallory);
+
+    // Against `main`: 200, and org B's dashboard shows the new label from then
+    // on — `isUserRenamed` stops the clustering job correcting it.
+    await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({ label: "Renamed by an outsider" })
+      .expect(404);
+
+    const stored = await TopicCluster.findById(cluster._id);
+    expect(stored.label).toBe("Migration Planning");
+    expect(stored.isUserRenamed).toBe(false);
+  });
+
+  it("still renames a cluster in the caller's organization", async () => {
+    const { cluster } = await seedTopics(ORG_A, alice);
+
+    const res = await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({ label: "  Platform Migration  " })
+      .expect(200);
+
+    expect(res.body.data.label).toBe("Platform Migration");
+    expect(res.body.data.isUserRenamed).toBe(true);
+  });
+
+  it("rejects a missing label", async () => {
+    const { cluster } = await seedTopics(ORG_A, alice);
+
+    await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({})
+      .expect(400);
+  });
+
+  it("rejects a whitespace-only label", async () => {
+    const { cluster } = await seedTopics(ORG_A, alice);
+
+    await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({ label: "   " })
+      .expect(400);
+  });
+
+  it("rejects a non-string label", async () => {
+    const { cluster } = await seedTopics(ORG_A, alice);
+
+    // Against `main`: `if (!label)` passes for 42, which was then coerced to
+    // the string "42" on save.
+    await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({ label: 42 })
+      .expect(400);
+
+    const stored = await TopicCluster.findById(cluster._id);
+    expect(stored.label).toBe("Migration Planning");
+  });
+
+  it("rejects an over-long label", async () => {
+    const { cluster } = await seedTopics(ORG_A, alice);
+
+    await request(app)
+      .put(`/api/topics/clusters/${cluster._id}`)
+      .send({ label: "x".repeat(500) })
+      .expect(400);
+  });
+
+  it("returns 400 for a malformed cluster id", async () => {
+    await request(app)
+      .put("/api/topics/clusters/not-an-object-id")
+      .send({ label: "x" })
+      .expect(400);
+  });
+});
+
+describe("GET /clusters/org/:orgId", () => {
+  it("serves the caller's own clusters", async () => {
+    await seedTopics(ORG_A, alice);
+
+    const res = await request(app)
+      .get(`/api/topics/clusters/org/${ORG_A}`)
+      .expect(200);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].label).toBe("Migration Planning");
+  });
+
+  it("refuses another organization's id instead of quietly serving your own", async () => {
+    await seedTopics(ORG_A, alice);
+    await seedTopics(ORG_B, mallory);
+
+    // Against `main`: 200 with ORG_A's clusters, under ORG_B's id. Misleading
+    // rather than dangerous, but it is what invites the assumption that the
+    // path parameter is what scopes the query.
+    await request(app).get(`/api/topics/clusters/org/${ORG_B}`).expect(403);
+  });
+
+  it("refuses another organization's id on the clustering trigger too", async () => {
+    await request(app)
+      .post(`/api/topics/clusters/org/${ORG_B}/cluster`)
+      .expect(403);
+  });
+});
+
+describe("POST /extract/:meetingId", () => {
+  it("returns 403, not 500, for a meeting in another organization", async () => {
+    const { meeting } = await seedTopics(ORG_B, mallory);
+
+    const res = await request(app)
+      .post(`/api/topics/extract/${meeting._id}`)
+      .expect(403);
+
+    expect(res.body.error).toMatch(/unauthorized access to meeting/i);
+    // The transcript never reached the model.
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a meeting that does not exist", async () => {
+    await request(app)
+      .post(`/api/topics/extract/${new mongoose.Types.ObjectId()}`)
+      .expect(404);
+  });
+
+  it("returns 404 when an accessible meeting has no transcript segments", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: alice._id,
+      organization: ORG_A,
+      title: "No transcript",
+      date: new Date(),
+    });
+
+    await request(app).post(`/api/topics/extract/${meeting._id}`).expect(404);
+  });
+
+  it("extracts from the caller's own meeting", async () => {
+    const meeting = await Meeting.create({
+      uploadedBy: alice._id,
+      organization: ORG_A,
+      title: "Roadmap sync",
+      date: new Date(),
+    });
+    await Transcript.create({
+      meeting: meeting._id,
+      segments: [
+        {
+          speaker: "Alice",
+          text: "The migration timeline slips a week",
+          startTime: 0,
+          endTime: 12,
+        },
+      ],
+    });
+
+    generateText.mockResolvedValue(
+      JSON.stringify([
+        {
+          name: "Migration timeline",
+          confidence: 90,
+          keywords: ["migration"],
+          timeRanges: [{ start: 0, end: 12 }],
+        },
+      ]),
+    );
+    embedText.mockResolvedValue([0.1, 0.2, 0.3]);
+
+    const res = await request(app)
+      .post(`/api/topics/extract/${meeting._id}`)
+      .expect(200);
+
+    expect(generateText).toHaveBeenCalled();
+    expect(res.body.data.topics).toHaveLength(1);
+    expect(res.body.data.organization).toBe(ORG_A.toString());
+  });
+
+  it("returns 400 for a malformed meeting id", async () => {
+    await request(app).post("/api/topics/extract/not-an-object-id").expect(400);
+  });
+});
+
+describe("baseline guards", () => {
+  it("rejects an unauthenticated caller", async () => {
+    currentUser = null;
+
+    await request(app).get(`/api/topics/clusters/org/${ORG_A}`).expect(401);
+  });
+
+  it("rejects a caller with no organization", async () => {
+    const { meeting } = await seedTopics(ORG_A, alice);
+    currentUser = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: null,
+      role: "member",
+    };
+
+    await request(app).get(`/api/topics/meeting/${meeting._id}`).expect(403);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Two handlers in `topicController` resolved documents by id with no organization filter.

### `getTopicsForMeeting` never consulted `req.user` at all

```js
export const getTopicsForMeeting = async (req, res) => {
  const { meetingId } = req.params;
  const meetingTopic = await MeetingTopic.findOne({ meeting: meetingId })
    .populate("topics.clusterId");
  res.status(200).json({ success: true, data: meetingTopic ? meetingTopic.topics : [] });
};
```

`GET /api/topics/meeting/<any meeting id>` returned the AI-extracted topic names, keywords and discussion time ranges for **any** meeting in the database, and `.populate("topics.clusterId")` pulled the owning organization's cluster labels and descriptions along with them.

That is a summary of what was said in a private meeting, readable by id — the same category of data #1244 and #1245 are hardening on the vector-search side. The extraction path *in this very module* already gets it right:

```js
// services/topicExtractionService.js
if (meeting.organization.toString() !== userOrgId.toString()) {
  throw new Error("Unauthorized access to meeting");
}
```

The read path simply omitted it.

### `renameCluster` was a bare `findById`

```js
const cluster = await TopicCluster.findById(clusterId);
...
cluster.label = label;
cluster.isUserRenamed = true;
```

`TopicCluster` has a required, indexed `organization` field that the handler never used. `PUT /api/topics/clusters/<any cluster id>` rewrote the label on another organization's cluster — and `isUserRenamed = true` then stopped the clustering job from ever correcting it. That label is what the owning organization's topic dashboard displays.

Both now resolve through the meeting or organization the document actually belongs to. `getTopicsForMeeting` reuses `canAccessMeetingDoc` from `middleware/rbac.js`, so this is the same rule the rest of the meeting surface applies rather than a second definition of it.

### The ignored `:orgId` parameter

```js
router.get("/clusters/org/:orgId", getTopicClusters);
router.post("/clusters/org/:orgId/cluster", triggerClustering);
```

Both handlers read `req.user.organization` and never touched `req.params.orgId`. Passing another organization's id returned **200 with your own clusters** — quietly misleading rather than an explicit refusal, and an invitation to assume the path parameter is what scopes the query.

**I validated it rather than removing it**, which is a deliberate deviation from what I proposed in the issue. `client/src/pages/TopicExplorer.jsx` calls the parameterised URL:

```js
const res = await axios.get(`/api/topics/clusters/org/${orgId}`, ...);
```

so dropping the parameter would break that page, and rejecting a mismatch is strictly stronger than ignoring one. Happy to do the removal plus the client change instead if you'd prefer the URL to match the semantics.

### Alongside

- `extractTopics` throws `ForbiddenError` / `NotFoundError` from `utils/errors.js` instead of bare `Error`s, so the controller can answer 403 and 404. Every failure was previously flattened to a 500, which made a cross-tenant attempt indistinguishable from a server fault, both to the caller and in the logs. The **messages are unchanged**, so the existing `topicExtraction.test.js` assertions that match on them still pass.
- `label` is validated for type and length. `if (!label)` accepted `42`, which was then coerced to the string `"42"` on save.
- Ids are validated as ObjectIds rather than becoming `CastError` 500s.
- `requireOrgMembership` on the router. A caller without an organization reached the handlers with `undefined`, and Mongoose reads `{ organization: undefined }` as *"match documents where the field is unset"* rather than as an error — so the filter that looks like a tenant boundary silently stopped being one.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #1276

## Testing

Adds `server/tests/topicOrgScoping.test.js` (22 cases) against the mounted router, so the `:orgId` path-parameter behaviour is covered too.

**Confirmed load-bearing** — stashed the source files and re-ran against `main`: **15 of 22 fail**, including every cross-tenant case:

```
● GET /meeting/:meetingId › refuses a meeting in another organization
● PUT /clusters/:clusterId › refuses a cluster in another organization and leaves it unmodified
● GET /clusters/org/:orgId › refuses another organization's id instead of quietly serving your own
● GET /clusters/org/:orgId › refuses another organization's id on the clustering trigger too
● POST /extract/:meetingId › returns 403, not 500, for a meeting in another organization
● baseline guards › rejects a caller with no organization
  … plus the label-validation and malformed-id cases
```

The other 7 pass on `main` and still pass — same-org read with the populated cluster label, same-org rename, empty-topics list, a successful extraction, unauthenticated access.

The AI and embedding services are stubbed rather than skipped, so the cross-tenant extraction test can assert `expect(generateText).not.toHaveBeenCalled()` — the transcript never reached the model. Without the stub that test would pass on a network error and prove nothing.

```
$ npx jest tests/topicOrgScoping.test.js tests/topicExtraction.test.js
Test Suites: 2 passed, 2 total
Tests:       27 passed, 27 total
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — server-side only. `TopicExplorer.jsx` is unchanged and its two calls behave the same for legitimate use.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

### Notes for reviewers

- The `:orgId` decision above is the one place I did something other than what the issue proposed, and the reasoning is in the code comment as well as here.
- `getTopicsForMeeting` returns **403** for a cross-organization meeting rather than 404. That is inconsistent with the 404s I used in the sibling PRs, but it matches what `requireOrgAccess` already returns for meeting-scoped resources, and consistency with the existing middleware seemed more valuable here than consistency across my own patches. Easy to flip if you disagree.
