### PR TITLE
fix(reports): stop leaking cross-organization template existence

### DIFF
--- a/server/controllers/reportController.js
+++ b/server/controllers/reportController.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 import ReportTemplate from "../models/reportTemplateModel.js";
 import { generateReport } from "../services/reportGeneratorService.js";
 import { isSameOrganization } from "../utils/organizationScope.js";
+import { AppError } from "../utils/errors.js";
 
 // Validation Schemas
 const sectionSchema = z.object({
@@ -261,18 +262,21 @@ export const generateReportData = async (req, res) => {
 
     res.status(200).json({ success: true, data: reportData });
   } catch (error) {
-    // The service signals authorization and lookup failures with plain Errors.
-    // `error.message` was previously dereferenced unconditionally, so any
-    // rejection without a message (an aborted DB operation, for instance) threw
-    // a second time inside the catch block and escaped as an unhandled
-    // rejection instead of a response.
-    const message = typeof error?.message === "string" ? error.message : "";
-
-    if (message.includes("permission") || message.includes("authorized")) {
-      return res.status(403).json({ success: false, message });
-    }
-    if (message.includes("not found")) {
-      return res.status(404).json({ success: false, message });
+    // Map on the error's own status, not on the wording of its message.
+    //
+    // This was a chain of `error.message.includes("permission" | "authorized" |
+    // "not found")`. Two things were wrong with that. Rewording a message in
+    // the service silently turned a deliberate 403 into a 500, with nothing to
+    // connect the two edits. And the reverse held as well: any unrelated
+    // failure whose message happened to contain "not found" — a driver error,
+    // a populate on a missing ref — was reported to the client as a 404.
+    //
+    // The service now throws the typed errors from `utils/errors.js`, so the
+    // status travels with the error instead of being re-derived from prose.
+    if (error instanceof AppError) {
+      return res
+        .status(error.statusCode)
+        .json({ success: false, message: error.message });
     }
 
     console.error("Error generating report:", error);

--- a/server/services/reportGeneratorService.js
+++ b/server/services/reportGeneratorService.js
@@ -3,9 +3,24 @@ import ActionItem from "../models/actionItemModel.js";
 import Decision from "../models/decisionModel.js";
 import ReportTemplate from "../models/reportTemplateModel.js";
 import { isSameOrganization } from "../utils/organizationScope.js";
+import { ForbiddenError, NotFoundError } from "../utils/errors.js";
 
 /** Fallback window when neither the override nor the template supplies one. */
 const DEFAULT_DATE_RANGE_DAYS = 30;
+
+/**
+ * The single message used for "there is no such template *for you*".
+ *
+ * #1272 moved the organization check ahead of the sharing check so a
+ * cross-tenant caller could not tell "exists elsewhere" from "does not exist" —
+ * but it left the two branches with *different* messages, which gives the
+ * distinction straight back. `Report Template not found in your organization.`
+ * confirms the id names a real template; the generic message does not.
+ *
+ * One constant rather than two literals, so the two paths cannot drift apart
+ * again.
+ */
+const TEMPLATE_NOT_FOUND = "Report Template not found";
 
 export const generateReport = async (
   templateId,
@@ -15,15 +30,13 @@ export const generateReport = async (
 ) => {
   const template = await ReportTemplate.findById(templateId);
   if (!template) {
-    throw new Error("Report Template not found");
+    throw new NotFoundError(TEMPLATE_NOT_FOUND);
   }
 
   // Check RBAC.
   //
-  // The organization check runs *first* now (Issue #1272). Ordering it after
-  // the sharing check meant a shared template in another organization produced
-  // the tenant-mismatch message, which distinguishes "exists elsewhere" from
-  // "does not exist" for a caller who should not be able to tell the two apart.
+  // The organization check runs before the sharing check (Issue #1272), and
+  // both "no such template" and "not your organization" answer identically.
   //
   // The comparison itself was `template.organization.toString() !== orgId`.
   // `orgId` arrives from the controller as an `ObjectId`, so that compared a
@@ -31,14 +44,18 @@ export const generateReport = async (
   // the caller's own. The only reason the existing suite did not catch it is
   // that it passes `mockOrgId.toString()` by hand.
   if (!isSameOrganization(template.organization, orgId)) {
-    throw new Error("Report Template not found in your organization.");
+    throw new NotFoundError(TEMPLATE_NOT_FOUND);
   }
 
+  // Reached only by a caller who is already a member of the owning
+  // organization, so a 403 here reveals nothing they could not already infer.
   if (
     !template.isShared &&
     template.createdBy.toString() !== user._id.toString()
   ) {
-    throw new Error("You do not have permission to view this report template.");
+    throw new ForbiddenError(
+      "You do not have permission to view this report template.",
+    );
   }
 
   // Increment generation count
@@ -56,10 +73,16 @@ export const generateReport = async (
     filterOverrides?.dateRangeDays ||
     defaultFilters.dateRangeDays ||
     DEFAULT_DATE_RANGE_DAYS;
-  const tags = filterOverrides?.tags?.length
+  // `Array.isArray`, not `?.length`. With the truthiness test an override of
+  // `tags: []` fell through to the template's saved tags, so a caller could add
+  // filters for one run but never *clear* them — "show me everything in the
+  // last 30 days" was unreachable from a template that saves a tag filter.
+  // Supplying an array at all is the override; whether it is empty is the
+  // caller's business.
+  const tags = Array.isArray(filterOverrides?.tags)
     ? filterOverrides.tags
     : defaultFilters.tags;
-  const meetingTypes = filterOverrides?.meetingTypes?.length
+  const meetingTypes = Array.isArray(filterOverrides?.meetingTypes)
     ? filterOverrides.meetingTypes
     : defaultFilters.meetingTypes;
 

--- a/server/tests/reportGenerator.test.js
+++ b/server/tests/reportGenerator.test.js
@@ -42,7 +42,7 @@ describe("reportGeneratorService", () => {
     );
   });
 
-  it("should throw error if organization mismatch", async () => {
+  it("should throw the generic not-found error if organization mismatch", async () => {
     const template = {
       _id: "template-2",
       createdBy: mockUserId,
@@ -51,9 +51,44 @@ describe("reportGeneratorService", () => {
     };
     jest.spyOn(ReportTemplate, "findById").mockResolvedValue(template);
 
+    // Deliberately the *same* message as the missing-template case: a distinct
+    // "not found in your organization" wording confirms the id names a real
+    // template to a caller who should not be able to tell.
     await expect(
       generateReport("template-2", {}, mockUser, mockOrgId),
-    ).rejects.toThrow("Report Template not found in your organization.");
+    ).rejects.toThrow("Report Template not found");
+  });
+
+  it("should treat an empty tags override as a request to clear the filter", async () => {
+    const template = {
+      _id: "template-4",
+      name: "Filtered",
+      createdBy: mockUserId,
+      organization: mockOrgId,
+      isShared: true,
+      defaultFilters: {
+        dateRangeDays: 30,
+        tags: ["finance"],
+        meetingTypes: [],
+      },
+      sections: [],
+      generationCount: 0,
+      save: jest.fn(),
+    };
+    jest.spyOn(ReportTemplate, "findById").mockResolvedValue(template);
+
+    const findSpy = jest.spyOn(Meeting, "find").mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue([]),
+      }),
+    });
+
+    await generateReport("template-4", { tags: [] }, mockUser, mockOrgId);
+
+    // `filterOverrides.tags?.length` was falsy for `[]`, so the saved
+    // ["finance"] filter was reapplied and the caller could never widen the
+    // report back out.
+    expect(findSpy.mock.calls[0][0].tags).toBeUndefined();
   });
 
   it("should generate report data successfully", async () => {

--- a/server/tests/reportTemplateAuthorization.test.js
+++ b/server/tests/reportTemplateAuthorization.test.js
@@ -422,10 +422,29 @@ describe("POST /generate/:id", () => {
       .send({})
       .expect(404);
 
-    expect(res.body.message).toMatch(/not found in your organization/i);
+    // The message must not say "in your organization" — that wording confirms
+    // the id names a real template, which is the distinction the 404 exists to
+    // hide.
+    expect(res.body.message).toBe("Report Template not found");
 
     const stored = await ReportTemplate.findById(template._id);
     expect(stored.generationCount).toBe(0);
+  });
+
+  it("is indistinguishable from generating with an id that does not exist", async () => {
+    const foreign = await seedForeignSharedTemplate();
+
+    const existsElsewhere = await request(app)
+      .post(`/api/reports/generate/${foreign._id}`)
+      .send({})
+      .expect(404);
+
+    const doesNotExist = await request(app)
+      .post(`/api/reports/generate/${new mongoose.Types.ObjectId()}`)
+      .send({})
+      .expect(404);
+
+    expect(existsElsewhere.body).toEqual(doesNotExist.body);
   });
 
   it("refuses to generate from a colleague's private template", async () => {


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #1272, addressing the three findings CodeRabbit raised on #1277 after it was approved and merged. All three were valid.

### 1. The cross-tenant 404 was distinguishable from a genuine 404

#1272 moved the organization check ahead of the sharing check in `generateReport` so a caller could not tell "exists in another organization" from "does not exist" — but left the two branches with **different messages**, which gives the distinction straight back:

```
POST /api/reports/generate/<real id in another org>  → 404 "Report Template not found in your organization."
POST /api/reports/generate/<id that does not exist>  → 404 "Report Template not found"
```

The second wording confirms the id names a real template. That is the exact oracle the matching status code was chosen to deny — I got the status right and then undid it in the string. Worse, the test I added *asserted* the leaky wording, so it pinned the bug in place.

Both branches now throw one shared `TEMPLATE_NOT_FOUND` constant. The replacement test asserts the two responses are **equal** rather than asserting a particular message, so the paths cannot drift apart again:

```js
expect(existsElsewhere.body).toEqual(doesNotExist.body);
```

### 2. Status was inferred from the text of the message

```js
if (message.includes("permission") || message.includes("authorized")) return 403;
if (message.includes("not found")) return 404;
```

This fails in both directions:

- Reword a message in the service and a deliberate 403 silently becomes a 500, with nothing linking the two edits.
- Any *unrelated* failure whose message happens to contain `"not found"` — a driver error, a `populate` against a missing ref — is reported to the client as a 404.

The service now throws the typed errors from `utils/errors.js`, as `glossaryService` and `topicExtractionService` already do, and the controller maps on `error.statusCode`. The status travels with the error instead of being re-derived from prose.

I chose the existing `AppError` hierarchy over CodeRabbit's suggested string `code` field: it is already the codebase's convention for exactly this, it carries the status directly, and it needs no new vocabulary.

### 3. An empty filter override could not clear a saved filter

```js
const tags = filterOverrides?.tags?.length ? filterOverrides.tags : defaultFilters.tags;
```

`[].length` is `0`, so `tags: []` fell through to the template's saved tags. A caller could *add* filters for a single run but never *remove* them — "everything in the last 30 days" was unreachable from a template that saves a tag filter. Now `Array.isArray(...)`: supplying an array at all is the override, and whether it is empty is the caller's business.

This one was pre-existing rather than introduced by #1272, but I touched those exact lines there, so it belongs here.

## Type of Change

- [x] Bug Fix
- [x] Security Improvement

## Related Issue

Closes #1282

Follow-up to #1272 / #1277.

## Testing

```
$ npx jest tests/reportTemplateAuthorization.test.js tests/reportGenerator.test.js
Test Suites: 2 passed, 2 total
Tests:       36 passed, 36 total
```

Changes to the suites:

- `reportTemplateAuthorization.test.js` — the assertion that pinned the leaky wording now requires the generic message, plus a new case proving a cross-tenant generate and a non-existent-id generate return byte-identical bodies.
- `reportGenerator.test.js` — the organization-mismatch case now expects the generic message, and a new case asserts that `{ tags: [] }` reaches Mongoose as *no* tag filter rather than as the template's saved one (it inspects the actual `Meeting.find` argument, so it fails if the fallback comes back).

I also re-ran the four suites from the sibling PRs merged this week against this branch to confirm nothing regressed:

```
$ npx jest tests/reportTemplateAuthorization.test.js tests/glossaryAuthorization.test.js \
    tests/transcriptAnnotationAuthorization.test.js tests/templateLibraryAuthorization.test.js \
    tests/topicOrgScoping.test.js tests/reportGenerator.test.js tests/glossary.test.js \
    tests/templateLibrary.test.js tests/transcriptAnnotation.test.js tests/topicExtraction.test.js \
    tests/regexEscaping.test.js
Test Suites: 11 passed, 11 total
Tests:       1 skipped, 187 passed, 188 total
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — server-side only.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

### Notes for reviewers

- Finding 1 is my own mistake from #1277 and the most worth double-checking: getting the status code right and then leaking the same information through the message is an easy thing to repeat, which is why the new test compares whole response bodies instead of matching a string.
- The 403 for a colleague's private template is unchanged and intentional. That path is only reachable by someone already established as a member of the owning organization, so it reveals nothing they could not already infer.
