### PR TITLE
fix(calendar): allow text selection where appropriate

### DIFF
--- a/client/src/components/calendar/CalendarGrid.jsx
+++ b/client/src/components/calendar/CalendarGrid.jsx
@@ -71,7 +71,7 @@ const CalendarGrid = ({
                         <button
                           key={event._id}
                           onClick={() => setSelectedMeeting(event)}
-                          className={`w-full text-left p-1.5 rounded-lg border text-[10px] font-semibold truncate flex items-center gap-1.5 transition-all cursor-pointer select-none ${style.bg}`}
+                          className={`w-full text-left p-1.5 rounded-lg border text-[10px] font-semibold truncate flex items-center gap-1.5 transition-all cursor-pointer ${style.bg}`}
                         >
                           <span
                             className={`w-1.5 h-1.5 rounded-full shrink-0 ${style.dot}`}
@@ -186,7 +186,7 @@ const CalendarGrid = ({
                         <button
                           key={event._id}
                           onClick={() => setSelectedMeeting(event)}
-                          className={`absolute left-1 right-1 p-2 rounded-xl border text-[10px] font-bold text-left overflow-hidden flex flex-col justify-between transition-all shadow-xs hover:z-10 cursor-pointer select-none ${style.bg}`}
+                          className={`absolute left-1 right-1 p-2 rounded-xl border text-[10px] font-bold text-left overflow-hidden flex flex-col justify-between transition-all shadow-xs hover:z-10 cursor-pointer ${style.bg}`}
                           style={{
                             top: `${top}px`,
                             height: `${height}px`,
@@ -269,7 +269,7 @@ const CalendarGrid = ({
                       <button
                         key={event._id}
                         onClick={() => setSelectedMeeting(event)}
-                        className={`absolute left-2 right-4 p-3 rounded-xl border text-left flex flex-col justify-between transition-all shadow-xs hover:z-10 cursor-pointer select-none ${style.bg}`}
+                        className={`absolute left-2 right-4 p-3 rounded-xl border text-left flex flex-col justify-between transition-all shadow-xs hover:z-10 cursor-pointer ${style.bg}`}
                         style={{
                           top: `${top}px`,
                           height: `${height}px`,

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -92,7 +92,7 @@ const Calendar = () => {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 flex flex-col font-sans select-none">
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 flex flex-col font-sans">
       <Navbar />
 
       <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16 flex flex-col">
@@ -188,7 +188,7 @@ const Calendar = () => {
             </div>
 
             {/* Date filter (Jump to Date) */}
-            <div className="flex items-center gap-1 bg-slate-50 dark:bg-slate-800 border border-slate-200/80 dark:border-slate-700 rounded-lg px-2.5 py-1 text-slate-700 dark:text-slate-300 select-none">
+            <div className="flex items-center gap-1 bg-slate-50 dark:bg-slate-800 border border-slate-200/80 dark:border-slate-700 rounded-lg px-2.5 py-1 text-slate-700 dark:text-slate-300">
               <span className="text-[10px] text-slate-400 uppercase font-bold mr-1">
                 Date:
               </span>


### PR DESCRIPTION
# Pull Request

## Description

This PR improves the Calendar interface by removing unnecessary `select-none` usage from informational content while preserving drag-and-drop behavior. Users can now select and copy relevant calendar text without affecting existing interactions.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

- Closes #1233

## Testing

Verified that text selection works where appropriate and drag-and-drop interactions continue functioning correctly.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (Minor UI/UX improvement)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review