### PR TITLE
fix(settings): persist notification preferences across sessions

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useContext, useEffect, useRef } from "react";
 import Navbar from "../components/Navbar.jsx";
 import AppContent from "../context/AppContent";
 import { useNavigate } from "react-router-dom";
@@ -29,11 +29,43 @@ import DigestPreferences from "../components/DigestPreferences.jsx";
 import RecapPreferences from "../components/RecapPreferences.jsx";
 import { ClerkManageAccountButton } from "../components/ClerkUserControls.jsx";
 import apiClient from "../services/apiClient.js";
+import { notificationApi } from "../services/notificationApi.js";
+import { userApi } from "../services/userApi.js";
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
+/** Map NotificationPreference document fields → Settings toggle keys. */
+const prefsFromApi = (preferences, emailDigestEnabled) => ({
+  meetingNotifications: preferences?.pushMeetingReminders !== false,
+  organizationUpdates: preferences?.pushOrganizationUpdates !== false,
+  aiProcessingUpdates: preferences?.pushAiProcessingComplete !== false,
+  emailNotifications:
+    preferences?.emailMeetingReminders !== false &&
+    preferences?.emailTaskAssignments !== false,
+  emailDigestEnabled: emailDigestEnabled !== false,
+});
+
+/** Map a Settings toggle change → NotificationPreference allowlisted fields. */
+const apiPayloadForToggle = (key, value) => {
+  switch (key) {
+    case "meetingNotifications":
+      return { pushMeetingReminders: value };
+    case "organizationUpdates":
+      return { pushOrganizationUpdates: value };
+    case "aiProcessingUpdates":
+      return { pushAiProcessingComplete: value };
+    case "emailNotifications":
+      return {
+        emailMeetingReminders: value,
+        emailTaskAssignments: value,
+      };
+    default:
+      return null;
+  }
+};
+
 const Settings = () => {
-  const { userData, logoutUser } = useContext(AppContent);
+  const { userData, setUserData, logoutUser } = useContext(AppContent);
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
 
@@ -44,14 +76,17 @@ const Settings = () => {
   });
   const [calendarLoading, setCalendarLoading] = useState(false);
 
-  // Notification preferences state (UI only - no backend support except emailDigestEnabled)
   const [notificationPrefs, setNotificationPrefs] = useState({
     meetingNotifications: true,
     organizationUpdates: true,
     aiProcessingUpdates: true,
     emailNotifications: true,
-    emailDigestEnabled: userData?.emailDigestEnabled !== false,
+    emailDigestEnabled: true,
   });
+  const [prefsLoading, setPrefsLoading] = useState(true);
+  // Serialize preference writes so rapid toggles cannot race on the server.
+  const prefsSaveChainRef = useRef(Promise.resolve());
+  const latestIntentRef = useRef({});
 
   const { theme, toggleTheme } = useTheme();
 
@@ -72,6 +107,37 @@ const Settings = () => {
       fetchCalendarStatus();
     }
   }, [userData]);
+
+  // Load persisted notification preferences (Issue #1137)
+  useEffect(() => {
+    if (!userData?.id) return;
+
+    let cancelled = false;
+
+    const loadPreferences = async () => {
+      setPrefsLoading(true);
+      try {
+        const response = await notificationApi.getPreferences();
+        if (cancelled) return;
+        setNotificationPrefs(
+          prefsFromApi(response.data.preferences, userData.emailDigestEnabled),
+        );
+      } catch (error) {
+        console.error("Error loading notification preferences:", error);
+        if (!cancelled) {
+          setNotificationPrefs(prefsFromApi(null, userData.emailDigestEnabled));
+          toast.error("Failed to load notification preferences");
+        }
+      } finally {
+        if (!cancelled) setPrefsLoading(false);
+      }
+    };
+
+    loadPreferences();
+    return () => {
+      cancelled = true;
+    };
+  }, [userData?.id]);
 
   // Appearance preferences state (UI only - no backend support)
   const [appearancePrefs, setAppearancePrefs] = useState({
@@ -120,29 +186,54 @@ const Settings = () => {
     }
   };
 
-  const handleNotificationChange = async (key) => {
-    const newValue = !notificationPrefs[key];
+  const handleNotificationChange = (key) => {
+    const previousValue = notificationPrefs[key];
+    const newValue = !previousValue;
+
+    latestIntentRef.current[key] = newValue;
     setNotificationPrefs((prev) => ({
       ...prev,
       [key]: newValue,
     }));
 
-    if (key === "emailDigestEnabled") {
-      try {
-        await apiClient.put("/api/user/update", {
-          emailDigestEnabled: newValue,
-        });
-        toast.success("Email digest preference updated");
-      } catch (error) {
-        console.error("Error updating preference:", error);
-        toast.error("Failed to update preference");
-        // Revert on error
-        setNotificationPrefs((prev) => ({
-          ...prev,
-          [key]: !newValue,
-        }));
-      }
-    }
+    prefsSaveChainRef.current = prefsSaveChainRef.current
+      .catch(() => {})
+      .then(async () => {
+        try {
+          if (key === "emailDigestEnabled") {
+            const response = await userApi.updateProfile({
+              name: userData.name,
+              profilePic: userData.profilePic || "",
+              bio: userData.bio || "",
+              emailDigestEnabled: newValue,
+            });
+            if (latestIntentRef.current[key] !== newValue) return;
+            if (response.data?.user && setUserData) {
+              setUserData(response.data.user);
+            }
+            toast.success("Email digest preference updated");
+            return;
+          }
+
+          const payload = apiPayloadForToggle(key, newValue);
+          if (!payload) return;
+
+          await notificationApi.updatePreferences(payload);
+          if (latestIntentRef.current[key] !== newValue) return;
+          toast.success("Notification preference updated");
+        } catch (error) {
+          console.error("Error updating preference:", error);
+          if (latestIntentRef.current[key] !== newValue) return;
+          toast.error(
+            error.response?.data?.message || "Failed to update preference",
+          );
+          setNotificationPrefs((prev) => ({
+            ...prev,
+            [key]: previousValue,
+          }));
+          latestIntentRef.current[key] = previousValue;
+        }
+      });
   };
 
   const handleThemeChange = (newTheme) => {
@@ -452,151 +543,169 @@ const Settings = () => {
             </div>
 
             <div className="space-y-4">
-              <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
-                    Meeting Notifications
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                    Get notified about meeting updates
-                  </p>
+              {prefsLoading ? (
+                <div className="flex items-center justify-center py-8 text-slate-500 dark:text-slate-400">
+                  <Loader2 className="animate-spin w-5 h-5 mr-2" />
+                  <span className="text-sm">Loading preferences...</span>
                 </div>
-                <button
-                  onClick={() =>
-                    handleNotificationChange("meetingNotifications")
-                  }
-                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                    notificationPrefs.meetingNotifications
-                      ? "bg-blue-600"
-                      : "bg-slate-200 dark:bg-slate-700"
-                  }`}
-                  aria-pressed={notificationPrefs.meetingNotifications}
-                >
-                  <span
-                    className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
-                      notificationPrefs.meetingNotifications
-                        ? "translate-x-5"
-                        : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
+              ) : (
+                <>
+                  <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                        Meeting Notifications
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        Get notified about meeting updates
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleNotificationChange("meetingNotifications")
+                      }
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        notificationPrefs.meetingNotifications
+                          ? "bg-blue-600"
+                          : "bg-slate-200 dark:bg-slate-700"
+                      }`}
+                      aria-pressed={notificationPrefs.meetingNotifications}
+                    >
+                      <span
+                        className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
+                          notificationPrefs.meetingNotifications
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
 
-              <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
-                    Organization Updates
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                    Updates about your organization
-                  </p>
-                </div>
-                <button
-                  onClick={() =>
-                    handleNotificationChange("organizationUpdates")
-                  }
-                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                    notificationPrefs.organizationUpdates
-                      ? "bg-blue-600"
-                      : "bg-slate-200 dark:bg-slate-700"
-                  }`}
-                  aria-pressed={notificationPrefs.organizationUpdates}
-                >
-                  <span
-                    className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
-                      notificationPrefs.organizationUpdates
-                        ? "translate-x-5"
-                        : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
+                  <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                        Organization Updates
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        Updates about your organization
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleNotificationChange("organizationUpdates")
+                      }
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        notificationPrefs.organizationUpdates
+                          ? "bg-blue-600"
+                          : "bg-slate-200 dark:bg-slate-700"
+                      }`}
+                      aria-pressed={notificationPrefs.organizationUpdates}
+                    >
+                      <span
+                        className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
+                          notificationPrefs.organizationUpdates
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
 
-              <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
-                    AI Processing Updates
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                    Notifications when AI processing completes
-                  </p>
-                </div>
-                <button
-                  onClick={() =>
-                    handleNotificationChange("aiProcessingUpdates")
-                  }
-                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                    notificationPrefs.aiProcessingUpdates
-                      ? "bg-blue-600"
-                      : "bg-slate-200 dark:bg-slate-700"
-                  }`}
-                  aria-pressed={notificationPrefs.aiProcessingUpdates}
-                >
-                  <span
-                    className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
-                      notificationPrefs.aiProcessingUpdates
-                        ? "translate-x-5"
-                        : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
+                  <div className="flex items-center justify-between py-3 border-b border-slate-100 dark:border-slate-800">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                        AI Processing Updates
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        Notifications when AI processing completes
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleNotificationChange("aiProcessingUpdates")
+                      }
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        notificationPrefs.aiProcessingUpdates
+                          ? "bg-blue-600"
+                          : "bg-slate-200 dark:bg-slate-700"
+                      }`}
+                      aria-pressed={notificationPrefs.aiProcessingUpdates}
+                    >
+                      <span
+                        className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
+                          notificationPrefs.aiProcessingUpdates
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
 
-              <div className="flex items-center justify-between py-3">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
-                    Email Notifications
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                    Receive notifications via email
-                  </p>
-                </div>
-                <button
-                  onClick={() => handleNotificationChange("emailNotifications")}
-                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                    notificationPrefs.emailNotifications
-                      ? "bg-blue-600"
-                      : "bg-slate-200 dark:bg-slate-700"
-                  }`}
-                  aria-pressed={notificationPrefs.emailNotifications}
-                >
-                  <span
-                    className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
-                      notificationPrefs.emailNotifications
-                        ? "translate-x-5"
-                        : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
+                  <div className="flex items-center justify-between py-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                        Email Notifications
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        Receive notifications via email
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleNotificationChange("emailNotifications")
+                      }
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        notificationPrefs.emailNotifications
+                          ? "bg-blue-600"
+                          : "bg-slate-200 dark:bg-slate-700"
+                      }`}
+                      aria-pressed={notificationPrefs.emailNotifications}
+                    >
+                      <span
+                        className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
+                          notificationPrefs.emailNotifications
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
 
-              <div className="flex items-center justify-between py-3">
-                <div>
-                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
-                    Receive email digest after meetings
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                    Get an automated summary of completed meetings
-                  </p>
-                </div>
-                <button
-                  onClick={() => handleNotificationChange("emailDigestEnabled")}
-                  className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
-                    notificationPrefs.emailDigestEnabled
-                      ? "bg-blue-600"
-                      : "bg-slate-200 dark:bg-slate-700"
-                  }`}
-                  aria-pressed={notificationPrefs.emailDigestEnabled}
-                >
-                  <span
-                    className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
-                      notificationPrefs.emailDigestEnabled
-                        ? "translate-x-5"
-                        : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
+                  <div className="flex items-center justify-between py-3">
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                        Receive email digest after meetings
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                        Get an automated summary of completed meetings
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        handleNotificationChange("emailDigestEnabled")
+                      }
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer ${
+                        notificationPrefs.emailDigestEnabled
+                          ? "bg-blue-600"
+                          : "bg-slate-200 dark:bg-slate-700"
+                      }`}
+                      aria-pressed={notificationPrefs.emailDigestEnabled}
+                    >
+                      <span
+                        className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${
+                          notificationPrefs.emailDigestEnabled
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
           </div>
 

--- a/client/src/services/notificationApi.js
+++ b/client/src/services/notificationApi.js
@@ -6,4 +6,7 @@ export const notificationApi = {
   markAsRead: (id) => apiClient.patch(`/api/notifications/${id}/read`),
   markAllAsRead: () => apiClient.patch("/api/notifications/mark-all-read"),
   deleteNotification: (id) => apiClient.delete(`/api/notifications/${id}`),
+  getPreferences: () => apiClient.get("/api/notifications/preferences"),
+  updatePreferences: (data) =>
+    apiClient.put("/api/notifications/preferences", data),
 };

--- a/server/routes/notificationRoutes.js
+++ b/server/routes/notificationRoutes.js
@@ -47,7 +47,7 @@ notificationRouter.get(
 notificationRouter.put(
   "/preferences",
   writeLimiter,
-  requirePermission("notifications", "manage"),
+  requirePermission("notifications", "self_manage"),
   updatePreferences,
 );
 


### PR DESCRIPTION
# Pull Request

## Description

### Summary

This PR persists notification preferences across user sessions by connecting the Settings page to the existing backend notification preference APIs instead of relying solely on local React state.

Notification preferences are now loaded automatically when the Settings page opens and saved immediately after changes, ensuring user preferences remain consistent across page refreshes, sign-ins, and devices.

### Changes Made

- Added notification preference API helpers for retrieving and updating user preferences.
- Updated the Settings page to load persisted notification preferences from the backend.
- Persisted preference changes immediately when toggles are updated.
- Implemented optimistic UI updates with automatic rollback if a save request fails.
- Added user feedback using the existing toast notification system.
- Serialized rapid toggle updates to prevent race conditions and stale writes.
- Fixed email digest persistence by including the required `name` field during profile updates.
- Updated the notification preferences route to use the existing `notifications:self_manage` permission so users can manage their own notification settings.

### Backend Changes

- Reused the existing notification preference endpoints.
- No new API endpoints were introduced.
- Updated RBAC for `PUT /api/notifications/preferences` to use `notifications:self_manage` instead of the broader management permission.

### Data Model

No database schema changes were required.

The implementation reuses the existing:

- `NotificationPreference`
- `user.emailDigestEnabled`

fields.

### Error Handling

- Optimistically updates the UI.
- Reverts the affected toggle if saving fails.
- Displays the existing toast notification on failure.
- Prevents stale updates during rapid preference changes.

### Edge Cases Covered

- First-time users with no saved preferences.
- Refresh after saving.
- Sign out and sign back in.
- Multiple devices using the same account.
- Rapid toggle changes.
- Network failures during save.
- Partially populated preference documents.

---

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

---

## Related Issue

Closes #1137

---

## Testing

Validated the modified client and server files.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Validation Performed

- ✅ Prettier formatting
- ✅ Formatting validation
- ✅ ESLint validation
- ✅ Related client tests
- ✅ Related server tests
- ✅ Client PR validation
- ✅ Server PR validation

---

## Screenshots

Not applicable (notification settings persistence).

---

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification preferences now load from your account settings and can be updated directly.
  * Email digest changes are reflected across the app for a consistent experience.
* **Bug Fixes**
  * Added loading and error feedback while notification preferences are retrieved.
  * Preference updates are handled reliably to prevent conflicting changes and restore the intended setting if an update fails.
  * Notification controls are available only after preferences finish loading, reducing inconsistent interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->