### PR TITLE
fix(ui): add dark mode support to Tasks error banners

### DIFF
--- a/client/src/components/tasks.jsx
+++ b/client/src/components/tasks.jsx
@@ -460,12 +460,12 @@ const Tasks = () => {
             </p>
           </div>
         ) : error ? (
-          <div className="bg-red-50 border border-red-200 rounded-xl p-8 text-center fade-in-up">
-            <AlertCircle className="w-12 h-12 text-red-600 mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-red-900 mb-2">
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800/60 rounded-xl p-8 text-center fade-in-up">
+            <AlertCircle className="w-12 h-12 text-red-600 dark:text-red-400 mx-auto mb-4" />
+            <h3 className="text-lg font-semibold text-red-900 dark:text-red-200 mb-2">
               Error Loading Tasks
             </h3>
-            <p className="text-red-700">{error}</p>
+            <p className="text-red-700 dark:text-red-300">{error}</p>
             <button
               onClick={() => window.location.reload()}
               className="mt-4 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"

--- a/client/src/pages/Tasks.jsx
+++ b/client/src/pages/Tasks.jsx
@@ -63,12 +63,12 @@ const Tasks = () => {
             </p>
           </div>
         ) : taskState.error ? (
-          <div className="bg-red-50 border border-red-200 rounded-xl p-8 text-center fade-in-up">
-            <AlertCircle className="w-12 h-12 text-red-600 mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-red-900 mb-2">
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800/60 rounded-xl p-8 text-center fade-in-up">
+            <AlertCircle className="w-12 h-12 text-red-600 dark:text-red-400 mx-auto mb-4" />
+            <h3 className="text-lg font-semibold text-red-900 dark:text-red-200 mb-2">
               Error Loading Tasks
             </h3>
-            <p className="text-red-700">{taskState.error}</p>
+            <p className="text-red-700 dark:text-red-300">{taskState.error}</p>
             <button
               onClick={() => taskState.refetch()}
               className="mt-4 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"


### PR DESCRIPTION
# Pull Request

## Description

Adds dark mode support to the Tasks module error banners. Both the page-level (`src/pages/Tasks.jsx`) and component-level (`src/components/tasks.jsx`) error banners previously used light-only red styling that was difficult to read and visually inconsistent in dark mode. Added dark-mode variants for the background, border, icon, heading, and message text, following the application's existing dark-mode conventions.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1228

## Testing

- ESLint: clean on both changed files
- Prettier: clean (ran `prettier --write`; the CI `format:check:changed` gate passes on the committed files)
- Client build: 1959 modules transformed (files compile); the vite-plugin-pwa failure is pre-existing on upstream main

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — styling-only change; light mode styling is unchanged.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
