### PR TITLE
fix(a11y): replace Live Meeting CTA with semantic button

### DIFF
--- a/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeeting.jsx
@@ -1,4 +1,4 @@
-import { Video, ExternalLink } from "lucide-react";
+import { Video } from "lucide-react";
 import LiveParticipants from "./LiveParticipants";
 import LiveMeetingInfo from "./LiveMeetingInfo";
 import RecordingDialog from "./RecordingDialog";
@@ -41,21 +41,14 @@ const LiveMeeting = ({ hookProps }) => {
       <LiveMeetingInfo />
 
       {/* Start Meeting Button */}
-      <a
-        href="#"
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={(e) => {
-          e.preventDefault();
-          handleStartLiveMeeting();
-        }}
-        className={`w-full px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition flex items-center justify-center gap-2 shadow-md hover:shadow-xl ${
-          liveParticipants.length === 0 ? "opacity-50 cursor-not-allowed" : ""
-        }`}
+      <button
+        type="button"
+        onClick={handleStartLiveMeeting}
+        disabled={liveParticipants.length === 0}
+        className={`w-full px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold transition flex items-center justify-center gap-2 shadow-md hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed enabled:hover:bg-indigo-700`}
       >
         <Video size={18} /> 🚀 Start Live Meeting
-        <ExternalLink size={16} />
-      </a>
+      </button>
 
       {showRecordingDialog && (
         <RecordingDialog handleRecordingChoice={handleRecordingChoice} />


### PR DESCRIPTION
# Pull Request

## Description

Replaces the Live Meeting start call-to-action with a native semantic `<button>` element. The previous implementation was an `<a href="#" target="_blank">` with `preventDefault` — semantically a link rather than a button, poorly announced by screen readers, and with a disabled state that was visual-only (the click still fired with zero participants).

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1230

## Testing

- ESLint: clean
- Prettier: clean (CI format gate passes)
- Client build: 1955 modules transformed (file compiles); the vite-plugin-pwa failure is pre-existing on upstream main

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — styling/behavior preserved; `handleStartLiveMeeting` unchanged.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
