### PR TITLE
feat(meetings): replace fake collaborative presence with real-time presence

### DIFF
--- a/client/src/components/meetings/CollaborativeEditor.jsx
+++ b/client/src/components/meetings/CollaborativeEditor.jsx
@@ -21,30 +21,38 @@ const PRESENCE_COLORS = [
 ];
 
 const CollaborativeEditor = ({ meetingId }) => {
-  const { backendUrl, userData } = useContext(AppContent);
+  const { backendUrl } = useContext(AppContent);
   const textareaRef = useRef(null);
 
-  const { content, setContent, connectedUsers, isSynced, isConnected } =
-    useCollaborativeDoc(meetingId, backendUrl);
+  const {
+    content,
+    setContent,
+    collaborators,
+    connectedUsers,
+    isSynced,
+    isConnected,
+  } = useCollaborativeDoc(meetingId, backendUrl);
 
   const handleChange = (e) => {
     setContent(e.target.value);
   };
 
-  // Render N fake presence dots (simplified — no real user map yet)
-  const presenceDots = Array.from({ length: Math.min(connectedUsers, 5) }).map(
-    (_, i) => (
+  // Real-time presence avatars from the collaboration service (Issue #1236)
+  const presenceDots = collaborators.map((collaborator, i) => {
+    const initial = (collaborator.name || collaborator.email || "U")
+      .trim()
+      .charAt(0)
+      .toUpperCase();
+    return (
       <div
-        key={i}
-        title={i === 0 ? userData?.name || "You" : `Collaborator ${i + 1}`}
+        key={collaborator.socketId || collaborator.userId || i}
+        title={collaborator.name || collaborator.email || "Collaborator"}
         className={`w-7 h-7 rounded-full ${PRESENCE_COLORS[i % PRESENCE_COLORS.length]} border-2 border-gray-900 flex items-center justify-center text-white text-xs font-bold -ml-1 first:ml-0 shadow-md`}
       >
-        {i === 0
-          ? (userData?.name?.[0] || "Y").toUpperCase()
-          : String.fromCharCode(65 + i)}
+        {initial}
       </div>
-    ),
-  );
+    );
+  });
 
   return (
     <div className="flex flex-col h-full bg-gray-950 rounded-2xl overflow-hidden border border-gray-800 shadow-2xl">

--- a/client/src/hooks/useCollaborativeDoc.js
+++ b/client/src/hooks/useCollaborativeDoc.js
@@ -12,6 +12,7 @@ import { createClerkSocketOptions } from "../services/apiClient.js";
  * @returns {{
  *   content: string,           — current plain-text content
  *   setContent: Function,      — write new text (broadcasts CRDT update)
+ *   collaborators: Array,      — real-time presence list [{ socketId, userId, name, email }]
  *   connectedUsers: number,    — number of active collaborators
  *   isSynced: boolean,         — true once initial state received from server
  *   isConnected: boolean,      — socket connection status
@@ -19,7 +20,7 @@ import { createClerkSocketOptions } from "../services/apiClient.js";
  */
 const useCollaborativeDoc = (meetingId, backendUrl) => {
   const [content, setContentState] = useState("");
-  const [connectedUsers, setConnectedUsers] = useState(1);
+  const [collaborators, setCollaborators] = useState([]);
   const [isSynced, setIsSynced] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
@@ -28,6 +29,7 @@ const useCollaborativeDoc = (meetingId, backendUrl) => {
   const ydocRef = useRef(null);
   const ytextRef = useRef(null);
   const isRemoteUpdateRef = useRef(false); // prevent echo loops
+  const presenceRef = useRef(new Map()); // socketId -> collaborator
 
   useEffect(() => {
     if (!meetingId || !backendUrl) return;
@@ -89,11 +91,32 @@ const useCollaborativeDoc = (meetingId, backendUrl) => {
         }
       });
 
-      // 6. Receive cursor/presence updates
+      // 6. Receive real-time presence updates (Issue #1236)
+      socket.on("presence-update", ({ collaborators = [] }) => {
+        presenceRef.current = new Map(
+          collaborators.map((c) => [c.socketId || c.userId, c]),
+        );
+        setCollaborators(Array.from(presenceRef.current.values()));
+      });
+
+      socket.on("presence-joined", ({ collaborator }) => {
+        if (!collaborator) return;
+        presenceRef.current.set(
+          collaborator.socketId || collaborator.userId,
+          collaborator,
+        );
+        setCollaborators(Array.from(presenceRef.current.values()));
+      });
+
+      socket.on("presence-left", ({ socketId }) => {
+        if (presenceRef.current.delete(socketId)) {
+          setCollaborators(Array.from(presenceRef.current.values()));
+        }
+      });
+
+      // cursor-update — optional real-time cursor presence relay
       socket.on("cursor-update", () => {
-        // Presence tracking — bump connected user count (simple heuristic)
-        // A full implementation would maintain a map of { socketId → user }
-        setConnectedUsers((prev) => Math.max(prev, 2));
+        // Cursor telemetry only; presence is tracked via presence-* events above
       });
 
       // 7. Observe local Yjs changes and broadcast them
@@ -124,6 +147,8 @@ const useCollaborativeDoc = (meetingId, backendUrl) => {
       if (onUpdate) ydoc.off("update", onUpdate);
       socket?.disconnect();
       ydoc.destroy();
+      presenceRef.current = new Map();
+      setCollaborators([]);
     };
   }, [meetingId, backendUrl]);
 
@@ -175,7 +200,8 @@ const useCollaborativeDoc = (meetingId, backendUrl) => {
   return {
     content,
     setContent,
-    connectedUsers,
+    collaborators,
+    connectedUsers: collaborators.length,
     isSynced,
     isConnected,
   };

--- a/server/socket/documentSync.js
+++ b/server/socket/documentSync.js
@@ -124,12 +124,10 @@ function registerPresence(socket, roomName, meetingId) {
     email,
   });
 
-  socket
-    .to(roomName)
-    .emit("presence-joined", {
-      meetingId,
-      collaborator: members.get(socket.id),
-    });
+  socket.to(roomName).emit("presence-joined", {
+    meetingId,
+    collaborator: members.get(socket.id),
+  });
   broadcastPresence(roomName, meetingId);
 }
 

--- a/server/socket/documentSync.js
+++ b/server/socket/documentSync.js
@@ -16,6 +16,9 @@ import authenticateSocket from "../middleware/socketAuth.js";
 //     }
 const docRegistry = new Map();
 
+// Per-room presence registry: roomName -> Map<socketId, { userId, name, email }>
+const presenceRegistry = new Map();
+
 // Debounce window in milliseconds before a DB write is triggered
 const SAVE_DEBOUNCE_MS = 5000;
 
@@ -79,6 +82,77 @@ if (redisUri) {
     redisSub = null;
   }
 }
+
+// ── Real-time presence (Issue #1236) ──────────────────────────────────────────
+
+/**
+ * Broadcast the current presence list for a document room to all members.
+ * @param {string} roomName - Socket.IO room for the document
+ * @param {string} meetingId - Meeting id (included in the payload)
+ */
+function broadcastPresence(roomName, meetingId) {
+  if (!syncNamespace) return;
+  const members = presenceRegistry.get(roomName) || new Map();
+  const collaborators = Array.from(members.values());
+  syncNamespace
+    .to(roomName)
+    .emit("presence-update", { meetingId, collaborators });
+}
+
+/**
+ * Register a newly joined socket in the room's presence list and notify the
+ * other members. Falls back to the socket's authenticated identity when the
+ * User document is unavailable.
+ */
+function registerPresence(socket, roomName, meetingId) {
+  const name =
+    socket.user?.name ||
+    socket.user?.firstName ||
+    socket.user?.username ||
+    (socket.userId ? `User ${socket.userId.slice(0, 6)}` : "Anonymous");
+  const email = socket.user?.email || "";
+
+  let members = presenceRegistry.get(roomName);
+  if (!members) {
+    members = new Map();
+    presenceRegistry.set(roomName, members);
+  }
+  members.set(socket.id, {
+    socketId: socket.id,
+    userId: socket.userId || socket.id,
+    name,
+    email,
+  });
+
+  socket
+    .to(roomName)
+    .emit("presence-joined", {
+      meetingId,
+      collaborator: members.get(socket.id),
+    });
+  broadcastPresence(roomName, meetingId);
+}
+
+/**
+ * Remove a socket from the room's presence list and notify remaining members.
+ */
+function unregisterPresence(socket, roomName, meetingId) {
+  const members = presenceRegistry.get(roomName);
+  if (!members) return;
+  const removed = members.delete(socket.id);
+  if (removed) {
+    socket
+      .to(roomName)
+      .emit("presence-left", { meetingId, socketId: socket.id });
+  }
+  if (members.size === 0) {
+    presenceRegistry.delete(roomName);
+  } else {
+    broadcastPresence(roomName, meetingId);
+  }
+}
+
+// ── Real-time presence (Issue #1236) ──────────────────────────────────────────
 
 // Debounced save — resets the timer on every new update
 const scheduleSave = (meetingId, ydoc) => {
@@ -339,6 +413,9 @@ export default (io) => {
         `[documentSync] Socket ${socket.id} joined doc room: ${roomName}`,
       );
 
+      // Broadcast real-time presence (Issue #1236)
+      registerPresence(socket, roomName, meetingId);
+
       try {
         const ydoc = await getOrCreateDoc(meetingId);
 
@@ -418,10 +495,12 @@ export default (io) => {
       });
     });
 
-    // Disconnect — clean up if no one is left in the room
+    // Disconnect — clean up presence and release the doc if no one is left
     socket.on("disconnect", async () => {
       console.log(`[documentSync] Client disconnected: ${socket.id}`);
       if (currentMeetingId) {
+        // Notify remaining members and clean up presence (Issue #1236)
+        unregisterPresence(socket, `doc:${currentMeetingId}`, currentMeetingId);
         // Small delay to allow the socket to fully leave the room
         setTimeout(() => cleanupDoc(currentMeetingId, syncNamespace), 500);
       }


### PR DESCRIPTION
# Pull Request

## Description

Replaces the placeholder collaborative presence indicators with real-time user presence synchronized through the existing `/sync` Socket.IO infrastructure. The collaborative editor previously rendered fake presence dots (letter avatars labeled "Collaborator 1", "Collaborator 2") from a bare connected-user count that was bumped client-side on any cursor event.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1236

## Testing

- ESLint: clean on all three changed files
- Prettier: clean on both client files (the server file has a pre-existing prettier failure on upstream main — reformatting it would produce a ~500-line unrelated diff, so the additions match the file's existing style)
- Client build: 1962 modules transformed (files compile); the vite-plugin-pwa failure is pre-existing on upstream main
- Server: `node --check` passes (valid syntax)

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — presence avatars now show real user initials/names; light-mode styling unchanged.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time collaborator presence tracking in shared documents.
  * Display collaborator avatars using current names, email addresses, and identifiers.
  * Updated collaborator counts as people join or leave a document.
  * Removed collaborators from presence indicators when they disconnect.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->