### PR TITLE
feat(ui): add confirmation modal prior to disconnecting calendar integrations

### DIFF
--- a/client/src/components/CalendarIntegrations.jsx
+++ b/client/src/components/CalendarIntegrations.jsx
@@ -9,11 +9,13 @@ import {
   XCircle,
 } from "lucide-react";
 import apiClient from "../services/apiClient.js";
+import ConfirmModal from "./ConfirmModal.jsx";
 
 const CalendarIntegrations = () => {
   const [integrations, setIntegrations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [resyncing, setResyncing] = useState({});
+  const [providerToDisconnect, setProviderToDisconnect] = useState(null);
 
   const fetchIntegrations = useCallback(async () => {
     try {
@@ -197,6 +199,7 @@ const CalendarIntegrations = () => {
               <div className="flex items-center gap-2">
                 {connected && (
                   <button
+                    type="button"
                     onClick={() => resyncProvider(p.key)}
                     disabled={isSyncing}
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg transition-colors cursor-pointer"
@@ -210,13 +213,15 @@ const CalendarIntegrations = () => {
 
                 {connected ? (
                   <button
-                    onClick={() => disconnectProvider(p.key)}
+                    type="button"
+                    onClick={() => setProviderToDisconnect(p.key)}
                     className="px-3 py-1.5 text-xs font-semibold text-red-600 bg-red-50 hover:bg-red-100 dark:bg-red-950/40 dark:hover:bg-red-900/60 dark:text-red-400 rounded-lg transition-colors cursor-pointer"
                   >
                     Disconnect
                   </button>
                 ) : (
                   <button
+                    type="button"
                     onClick={() => connectProvider(p.connectKey)}
                     className="px-3 py-1.5 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-colors cursor-pointer shadow-xs"
                   >
@@ -228,6 +233,20 @@ const CalendarIntegrations = () => {
           );
         })}
       </div>
+
+      <ConfirmModal
+        isOpen={Boolean(providerToDisconnect)}
+        onClose={() => setProviderToDisconnect(null)}
+        onConfirm={() => {
+          if (providerToDisconnect) {
+            disconnectProvider(providerToDisconnect);
+            setProviderToDisconnect(null);
+          }
+        }}
+        title="Disconnect Calendar Integration"
+        message="Are you sure you want to disconnect this calendar provider? OAuth access will be revoked and meeting synchronization will be paused."
+        confirmText="Disconnect"
+      />
     </div>
   );
 };

--- a/client/src/components/__tests__/CalendarIntegrationsConfirm.test.jsx
+++ b/client/src/components/__tests__/CalendarIntegrationsConfirm.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CalendarIntegrations from "../CalendarIntegrations.jsx";
+import apiClient from "../../services/apiClient.js";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("CalendarIntegrations Disconnect Confirmation (#1304)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prompts confirmation modal before executing disconnect request", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        integrations: [
+          {
+            provider: "google",
+            syncEnabled: true,
+            syncStatus: "connected",
+            lastSyncedAt: "2026-08-01T12:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    apiClient.post.mockResolvedValue({
+      data: { success: true },
+    });
+
+    render(<CalendarIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Google Calendar")).toBeInTheDocument();
+    });
+
+    const disconnectBtn = screen.getByRole("button", { name: /disconnect/i });
+    fireEvent.click(disconnectBtn);
+
+    // ConfirmModal should appear
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(
+      screen.getByText("Disconnect Calendar Integration"),
+    ).toBeInTheDocument();
+
+    // Confirming disconnect inside dialog should trigger POST request
+    const modalConfirmBtn = within(dialog).getByRole("button", {
+      name: /disconnect/i,
+    });
+    fireEvent.click(modalConfirmBtn);
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/calendar/disconnect/google",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1304

## Description
This PR integrates a confirmation dialog (ConfirmModal.jsx) into CalendarIntegrations.jsx prior to disconnecting any calendar provider, preventing accidental sync loss and OAuth token revocation.

## Proposed Changes
- **Confirmation Dialog**: Prompt users with ConfirmModal before triggering disconnectProvider(provider).
- **State Management**: Added providerToDisconnect state to safely handle modal state transitions and provider disconnections.
- **Unit Test Coverage**: Added Vitest test suite (CalendarIntegrationsConfirm.test.jsx) verifying confirmation modal appearance and disconnect request invocation.

## Checklist
- [x] Related Issue is linked (Fixes #1304).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before disconnecting a connected calendar integration.
  * Users can cancel the action or confirm to complete the disconnection.

* **Bug Fixes**
  * Prevented calendar controls from unintentionally submitting surrounding forms.

* **Tests**
  * Added coverage for the disconnection confirmation flow and request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->