### PR TITLE
fix(security): harden Gemini insights auth, org scope, and validation

### DIFF
--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -891,11 +891,13 @@ function formatTimestamp(seconds) {
 export const translateTranscript = async (req, res) => {
   try {
     const { meetingId } = req.params;
-    
+
     // Authorization: User must be authenticated (handled by userAuth)
     // Authorization: User must be part of organization and have view permission (handled by requireOrgAccess and requirePermission)
-    
-    const transcript = await Transcript.findOne({ meeting: meetingId }).populate("meeting");
+
+    const transcript = await Transcript.findOne({
+      meeting: meetingId,
+    }).populate("meeting");
     if (!transcript) {
       return res.status(404).json({ message: "Transcript not found" });
     }
@@ -906,19 +908,27 @@ export const translateTranscript = async (req, res) => {
     // Ensure only the user who uploaded the meeting or an admin can perform translation operations
     const isOwner = meeting.uploadedBy?.toString() === req.user._id.toString();
     const isAdmin = req.user.role === "admin";
-    
+
     if (!isOwner && !isAdmin) {
-      return res.status(403).json({ 
-        message: "Forbidden: You do not own this meeting and cannot perform translation operations" 
+      return res.status(403).json({
+        message:
+          "Forbidden: You do not own this meeting and cannot perform translation operations",
       });
     }
 
-    // Since this is a placeholder for actual translation logic (per constraints), 
+    // Since this is a placeholder for actual translation logic (per constraints),
     // we return a success response immediately.
-    res.json({ message: "Translation authorized and processed successfully", transcript: transcript.fullText });
+    res.json({
+      message: "Translation authorized and processed successfully",
+      transcript: transcript.fullText,
+    });
   } catch (error) {
     console.error("Error translating transcript:", error);
     res.status(500).json({ message: "Failed to translate transcript" });
+  }
+};
+
+/**
  * Update speaker tags in a transcript
  */
 export const updateSpeakers = async (req, res) => {

--- a/server/routes/geminiRoutes.js
+++ b/server/routes/geminiRoutes.js
@@ -3,19 +3,40 @@ import axios from "axios";
 import dotenv from "dotenv";
 import userAuth from "../middleware/userAuth.js";
 import { writeLimiter } from "../middleware/rateLimiter.js";
-import { requirePermission } from "../middleware/rbac.js";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
+import { validateGeminiInsightsRequest } from "../utils/validateGeminiInsightsRequest.js";
 
 dotenv.config();
 
 const router = express.Router();
 
+/**
+ * Gemini insights (Issue #1243).
+ *
+ * Guard order matches report routes so refusals are clear and consistent:
+ *   userAuth             → 401
+ *   requireOrgMembership → 403 (no org to scope against)
+ *   requirePermission    → 403 (insufficient role)
+ *   writeLimiter         → 429
+ *   body validation      → 400
+ */
 router.post(
   "/insights",
   userAuth,
-  writeLimiter,
+  requireOrgMembership,
   requirePermission("reports", "view"),
+  writeLimiter,
   async (req, res) => {
     try {
+      const validation = validateGeminiInsightsRequest(req.body);
+      if (!validation.isValid) {
+        return res.status(400).json({
+          success: false,
+          message: "Validation failed",
+          details: validation.errors,
+        });
+      }
+
       const { summary } = req.body;
 
       const prompt = `

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -399,7 +399,7 @@ router.post(
   requireOrgMembership,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "edit"),
-  handleMeetingClipOperation
+  handleMeetingClipOperation,
 );
 
 // ✅ View Meeting Clip
@@ -409,7 +409,9 @@ router.get(
   requireOrgMembership,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "view"),
-  getMeetingClip
+  getMeetingClip,
+);
+
 // ✅ Resend Meeting Digest
 router.post(
   "/:id/digest/resend",

--- a/server/tests/gemini.test.js
+++ b/server/tests/gemini.test.js
@@ -18,9 +18,11 @@ jest.mock("../config/nodeMailer.js", () => ({
 describe("Gemini AI Endpoint Authentication and Authorization", () => {
   let user;
   let guestUser;
+  let noOrgUser;
   let organization;
   let userToken;
   let guestToken;
+  let noOrgToken;
   let axiosSpy;
 
   beforeAll(() => {
@@ -48,6 +50,8 @@ describe("Gemini AI Endpoint Authentication and Authorization", () => {
   });
 
   beforeEach(async () => {
+    axiosSpy.mockClear();
+
     // Set up test organization
     organization = await Organization.create({
       name: "Acme Analytics",
@@ -91,33 +95,94 @@ describe("Gemini AI Endpoint Authentication and Authorization", () => {
       clerkUserId: guestUser.clerkUserId,
       email: guestUser.email,
     });
+
+    // Authenticated user with no organization (org isolation)
+    noOrgUser = await User.create({
+      name: "No Org User",
+      email: `no-org-${Math.random()}@example.com`,
+      password: "password123",
+      role: "admin",
+    });
+    noOrgUser.clerkUserId = `user_test_${noOrgUser._id}`;
+    await noOrgUser.save();
+    noOrgToken = createClerkTestToken({
+      clerkUserId: noOrgUser.clerkUserId,
+      email: noOrgUser.email,
+    });
   });
 
   describe("POST /api/gemini/insights", () => {
+    const validBody = { summary: { totalMeetings: 5, activePolicies: 2 } };
+
     it("should reject unauthenticated requests with 401", async () => {
       const res = await request(app)
         .post("/api/gemini/insights")
-        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+        .send(validBody);
 
       expect(res.statusCode).toEqual(401);
       expect(res.body.success).toBe(false);
+    });
+
+    it("should reject users without organization membership with 403", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set(authHeader(noOrgToken))
+        .send(validBody);
+
+      expect(res.statusCode).toEqual(403);
+      expect(res.body.success).toBe(false);
+      expect(axiosSpy).not.toHaveBeenCalled();
     });
 
     it("should reject unauthorized requests from guest with 403", async () => {
       const res = await request(app)
         .post("/api/gemini/insights")
         .set(authHeader(guestToken))
-        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+        .send(validBody);
 
       expect(res.statusCode).toEqual(403);
       expect(res.body.success).toBe(false);
+    });
+
+    it("should reject missing summary with 400", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set(authHeader(userToken))
+        .send({});
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe("Validation failed");
+      expect(axiosSpy).not.toHaveBeenCalled();
+    });
+
+    it("should reject non-object summary with 400", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set(authHeader(userToken))
+        .send({ summary: "not-an-object" });
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.success).toBe(false);
+      expect(axiosSpy).not.toHaveBeenCalled();
+    });
+
+    it("should reject oversized summary with 400", async () => {
+      const res = await request(app)
+        .post("/api/gemini/insights")
+        .set(authHeader(userToken))
+        .send({ summary: { blob: "x".repeat(10_001) } });
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.success).toBe(false);
+      expect(axiosSpy).not.toHaveBeenCalled();
     });
 
     it("should allow authenticated member with view reports permission to generate insights", async () => {
       const res = await request(app)
         .post("/api/gemini/insights")
         .set(authHeader(userToken))
-        .send({ summary: { totalMeetings: 5, activePolicies: 2 } });
+        .send(validBody);
 
       expect(res.statusCode).toEqual(200);
       expect(res.body.success).toBe(true);

--- a/server/tests/validateGeminiInsightsRequest.test.js
+++ b/server/tests/validateGeminiInsightsRequest.test.js
@@ -1,0 +1,37 @@
+import { validateGeminiInsightsRequest } from "../utils/validateGeminiInsightsRequest.js";
+
+describe("validateGeminiInsightsRequest", () => {
+  it("accepts a non-empty plain object summary", () => {
+    const result = validateGeminiInsightsRequest({
+      summary: { totalMeetings: 3 },
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects missing summary", () => {
+    const result = validateGeminiInsightsRequest({});
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Summary is required.");
+  });
+
+  it("rejects array summary", () => {
+    const result = validateGeminiInsightsRequest({ summary: [1, 2] });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Summary must be a plain object.");
+  });
+
+  it("rejects empty object summary", () => {
+    const result = validateGeminiInsightsRequest({ summary: {} });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain("Summary must not be empty.");
+  });
+
+  it("rejects oversized summary", () => {
+    const result = validateGeminiInsightsRequest({
+      summary: { blob: "x".repeat(10_001) },
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.includes("must not exceed"))).toBe(true);
+  });
+});

--- a/server/utils/validateGeminiInsightsRequest.js
+++ b/server/utils/validateGeminiInsightsRequest.js
@@ -1,0 +1,39 @@
+const MAX_SUMMARY_JSON_LENGTH = 10_000;
+
+/**
+ * Validate POST /api/gemini/insights body.
+ * Rejects missing, malformed, or oversized `summary` payloads before calling Gemini.
+ */
+export const validateGeminiInsightsRequest = (body) => {
+  const errors = [];
+  const { summary } = body ?? {};
+
+  if (summary === undefined || summary === null) {
+    errors.push("Summary is required.");
+  } else if (typeof summary !== "object" || Array.isArray(summary)) {
+    errors.push("Summary must be a plain object.");
+  } else {
+    let serialized;
+    try {
+      serialized = JSON.stringify(summary);
+    } catch {
+      errors.push("Summary must be JSON-serializable.");
+      return { isValid: false, errors };
+    }
+
+    if (serialized === "{}") {
+      errors.push("Summary must not be empty.");
+    }
+
+    if (serialized.length > MAX_SUMMARY_JSON_LENGTH) {
+      errors.push(
+        `Summary must not exceed ${MAX_SUMMARY_JSON_LENGTH} characters when serialized.`,
+      );
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+};


### PR DESCRIPTION
## Summary
Closes #1243

Hardens `POST /api/gemini/insights` so Gemini analytics requests go through the same auth/authz pattern as report routes, and invalid payloads are rejected before calling Gemini.

- Require Clerk auth (`userAuth`), organization membership (`requireOrgMembership`), and `reports:view`
- Keep existing write rate limiting
- Validate `summary` as a non-empty plain object with a serialized size cap (10k)
- Extend route + unit tests for 401 / no-org 403 / guest 403 / validation 400 / success 200
- Repair two upstream syntax breaks in `meetingRoutes.js` and `transcriptController.js` that prevented the app (and Gemini integration tests) from loading

## Test plan
- [ ] `npm run lint:changed --prefix server`
- [ ] `npm run format:check:changed --prefix server`
- [ ] `cd server && node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand tests/gemini.test.js tests/validateGeminiInsightsRequest.test.js`
- [ ] Unauthenticated `POST /api/gemini/insights` → 401
- [ ] Authenticated user with no org → 403
- [ ] Guest with org → 403
- [ ] Valid admin/member + valid `summary` → 200 insight
- [ ] Missing / non-object / oversized `summary` → 400
- [ ] Reports AI insights flow still works for permitted org members

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for insight requests, including required, non-empty, serializable summaries within the supported size limit.
  * Insight generation now verifies organization access and the required reporting permission.
  * Invalid insight requests return clear validation errors with a 400 response.

* **Bug Fixes**
  * Improved protection against unauthorized access to organization-specific insights.

* **Tests**
  * Expanded coverage for authorization, organization isolation, invalid requests, and summary validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->