### PR TITLE
fix: enforce HTTPS for all webhook destinations

### DIFF
--- a/client/src/components/WebhookModal.jsx
+++ b/client/src/components/WebhookModal.jsx
@@ -194,8 +194,8 @@ const WebhookModal = ({
       return;
     }
 
-    if (!targetUrl.startsWith("http://") && !targetUrl.startsWith("https://")) {
-      toast.error("Target URL must start with http:// or https://");
+    if (!targetUrl.startsWith("https://")) {
+      toast.error("Target URL must start with https://");
       return;
     }
 

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -251,18 +251,26 @@ const MeetingRoom = () => {
         const { segment } = data;
         setCaptions((prev) => {
           // Check for exact duplicate in captions
-          const exists = prev.some(c => c.text === segment.text && c.timestamp === data.timestamp);
+          const exists = prev.some(
+            (c) => c.text === segment.text && c.timestamp === data.timestamp,
+          );
           if (exists) return prev;
           return [
             ...prev.slice(-4),
-            { text: segment.text, speaker: segment.speaker, isFinal: true, timestamp: data.timestamp },
+            {
+              text: segment.text,
+              speaker: segment.speaker,
+              isFinal: true,
+              timestamp: data.timestamp,
+            },
           ];
         });
         setTranscriptSegments((prev) => {
-          const exists = prev.some(s => 
-            s.startTime === segment.startTime && 
-            s.text === segment.text && 
-            s.speaker === segment.speaker
+          const exists = prev.some(
+            (s) =>
+              s.startTime === segment.startTime &&
+              s.text === segment.text &&
+              s.speaker === segment.speaker,
           );
           if (exists) return prev;
           return [...prev, segment];

--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -59,12 +59,15 @@ const TranscriptViewer = () => {
 
       const data = response.data;
       if (data && data.segments) {
-        data.segments = data.segments.filter((segment, index, self) =>
-          index === self.findIndex(s => 
-            s.startTime === segment.startTime && 
-            s.text === segment.text && 
-            s.speaker === segment.speaker
-          )
+        data.segments = data.segments.filter(
+          (segment, index, self) =>
+            index ===
+            self.findIndex(
+              (s) =>
+                s.startTime === segment.startTime &&
+                s.text === segment.text &&
+                s.speaker === segment.speaker,
+            ),
         );
       }
       setTranscript(data);

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -44,4 +44,4 @@ if (typeof globalThis.IntersectionObserver === "undefined") {
   };
 }
 
-vi.stubEnv('VITE_CLERK_PUBLISHABLE_KEY', 'pk_test_bW9jay1jbGVyay1rZXk');
+vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "pk_test_bW9jay1jbGVyay1rZXk");

--- a/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
+++ b/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
@@ -230,12 +230,12 @@ Frontend: `/email-verify`, `/reset-password`.
 
 ## 14. Frontend auth surface
 
-| Piece   | Path                                                 |
-| ------- | ---------------------------------------------------- |
-| Context | `AppContext.jsx` / `AppContent.js` (not AuthContext) |
-| Guard   | `ProtectedRoute.jsx`                                 |
+| Piece   | Path                                                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Context | `AppContext.jsx` / `AppContent.js` (not AuthContext)                                                                                                                      |
+| Guard   | `ProtectedRoute.jsx`                                                                                                                                                      |
 | API     | **Current:** `apiClient.js` (Clerk Bearer). **Legacy:** `authApi.js` (`/api/auth/*` identity helpers; do not use for new work). CSRF client helper removed (Issue #1139). |
-| Pages   | `Login.jsx`, `EmailVerify.jsx`, `ResetPassword.jsx`  |
+| Pages   | `Login.jsx`, `EmailVerify.jsx`, `ResetPassword.jsx`                                                                                                                       |
 
 **Legacy inconsistency:** some pages read `localStorage.token` or parse `document.cookie` for Bearer headers; AppContext **does not** set `localStorage.token`.
 

--- a/server/controllers/webhookController.js
+++ b/server/controllers/webhookController.js
@@ -51,8 +51,8 @@ const createWebhookSchema = z.object({
     .string({ required_error: "Target URL is required." })
     .trim()
     .min(1, "Target URL cannot be empty.")
-    .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
-      message: "Target URL must start with http:// or https://.",
+    .refine((url) => url.startsWith("https://"), {
+      message: "Target URL must start with https://.",
     })
     .refine((url) => isSafeWebhookUrl(url), {
       message:
@@ -76,8 +76,8 @@ const updateWebhookSchema = z.object({
     .string()
     .trim()
     .min(1, "Target URL cannot be empty.")
-    .refine((url) => url.startsWith("http://") || url.startsWith("https://"), {
-      message: "Target URL must start with http:// or https://.",
+    .refine((url) => url.startsWith("https://"), {
+      message: "Target URL must start with https://.",
     })
     .refine(async (url) => await isSafeWebhookUrl(url), {
       message:

--- a/server/models/Webhook.js
+++ b/server/models/Webhook.js
@@ -13,6 +13,12 @@ const webhookSchema = new mongoose.Schema(
       type: String,
       required: true,
       trim: true,
+      validate: {
+        validator: function (v) {
+          return typeof v === "string" && v.startsWith("https://");
+        },
+        message: "Target URL must start with https://",
+      },
     },
     events: {
       type: [String],

--- a/server/tests/webhook.test.js
+++ b/server/tests/webhook.test.js
@@ -151,8 +151,8 @@ describe("Webhook Endpoints & Dispatcher", () => {
       expect(res.body.success).toBe(false);
     });
 
-    it("should validate targetUrl schema", async () => {
-      const res = await request(app)
+    it("should validate targetUrl schema and reject HTTP URLs", async () => {
+      const ftpRes = await request(app)
         .post("/api/webhooks")
         .set("Authorization", `Bearer ${adminToken}`)
         .send({
@@ -160,8 +160,20 @@ describe("Webhook Endpoints & Dispatcher", () => {
           events: ["meeting.created"],
           organizationId: organization._id.toString(),
         });
-      if (res.statusCode !== 400) console.log("VALIDATE URL FAILED:", res.body);
-      expect(res.statusCode).toEqual(400);
+      expect(ftpRes.statusCode).toEqual(400);
+
+      const httpRes = await request(app)
+        .post("/api/webhooks")
+        .set("Authorization", `Bearer ${adminToken}`)
+        .send({
+          targetUrl: "http://example.com/webhook",
+          events: ["meeting.created"],
+          organizationId: organization._id.toString(),
+        });
+      expect(httpRes.statusCode).toEqual(400);
+      expect(httpRes.body.message || JSON.stringify(httpRes.body)).toMatch(
+        /Target URL must start with https:\/\//i,
+      );
     });
   });
 

--- a/server/tests/webhookUrlSafety.test.js
+++ b/server/tests/webhookUrlSafety.test.js
@@ -38,7 +38,7 @@ describe("webhookUrlSafety", () => {
 
   it("rejects localhost hostnames without DNS", async () => {
     const result = await validateWebhookDestination(
-      "http://localhost:3000/hook",
+      "https://localhost:3000/hook",
     );
 
     expect(result.ok).toBe(false);
@@ -84,15 +84,23 @@ describe("webhookUrlSafety", () => {
     lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
 
     const result = await validateWebhookDestination(
-      "http://metadata.example/latest",
+      "https://metadata.example/latest",
     );
 
     expect(result.ok).toBe(false);
   });
 
-  it("rejects non-http protocols", async () => {
-    const result = await validateWebhookDestination("ftp://example.com/hook");
-    expect(result.ok).toBe(false);
-    expect(result.reason).toMatch(/http:\/\/ or https:\/\//i);
+  it("rejects non-https protocols including http", async () => {
+    const httpResult = await validateWebhookDestination(
+      "http://example.com/hook",
+    );
+    expect(httpResult.ok).toBe(false);
+    expect(httpResult.reason).toMatch(/must use https:\/\//i);
+
+    const ftpResult = await validateWebhookDestination(
+      "ftp://example.com/hook",
+    );
+    expect(ftpResult.ok).toBe(false);
+    expect(ftpResult.reason).toMatch(/must use https:\/\//i);
   });
 });

--- a/server/utils/webhookUrlSafety.js
+++ b/server/utils/webhookUrlSafety.js
@@ -88,10 +88,10 @@ export const validateWebhookDestination = async (urlStr) => {
     return { ok: false, reason: "Destination URL is not a valid URL." };
   }
 
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+  if (parsed.protocol !== "https:") {
     return {
       ok: false,
-      reason: "Destination URL must use http:// or https://.",
+      reason: "Destination URL must use https://.",
     };
   }
 


### PR DESCRIPTION
### Description
Strengthen webhook security across the application by requiring all webhook destinations to use HTTPS. Insecure HTTP endpoints expose sensitive webhook payloads and authentication headers to eavesdropping and interception in transit.

### Changes Included
- **`server/utils/webhookUrlSafety.js`**: Enforce `parsed.protocol === "https:"` in `validateWebhookDestination()`. Non-HTTPS endpoints are rejected with a clear safety error.
- **`server/controllers/webhookController.js`**: Updated Zod request validation schemas (`createWebhookSchema`, `updateWebhookSchema`) to require webhook URLs to start with `https://`.
- **`server/models/Webhook.js`**: Added schema-level validation on `targetUrl` requiring `https://`.
- **`client/src/components/WebhookModal.jsx`**: Added client-side validation toast preventing submission of non-HTTPS webhook URLs.
- **`server/tests/`**: Added test cases verifying HTTPS enforcement and HTTP endpoint rejection.

### Related Issue
Closes #1112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Webhook destinations must now use secure `https://` URLs.
  * Insecure HTTP, FTP, and other unsupported protocols are rejected during webhook creation and updates.
  * Existing safe-address validation remains in place.

* **Bug Fixes**
  * Duplicate transcript captions and segments continue to be prevented reliably.

* **Documentation**
  * Improved table formatting in the authentication architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->