### PR TITLE
fix: prevent race conditions during initial Clerk user provisioning

### DIFF
--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -251,18 +251,26 @@ const MeetingRoom = () => {
         const { segment } = data;
         setCaptions((prev) => {
           // Check for exact duplicate in captions
-          const exists = prev.some(c => c.text === segment.text && c.timestamp === data.timestamp);
+          const exists = prev.some(
+            (c) => c.text === segment.text && c.timestamp === data.timestamp,
+          );
           if (exists) return prev;
           return [
             ...prev.slice(-4),
-            { text: segment.text, speaker: segment.speaker, isFinal: true, timestamp: data.timestamp },
+            {
+              text: segment.text,
+              speaker: segment.speaker,
+              isFinal: true,
+              timestamp: data.timestamp,
+            },
           ];
         });
         setTranscriptSegments((prev) => {
-          const exists = prev.some(s => 
-            s.startTime === segment.startTime && 
-            s.text === segment.text && 
-            s.speaker === segment.speaker
+          const exists = prev.some(
+            (s) =>
+              s.startTime === segment.startTime &&
+              s.text === segment.text &&
+              s.speaker === segment.speaker,
           );
           if (exists) return prev;
           return [...prev, segment];

--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -59,12 +59,15 @@ const TranscriptViewer = () => {
 
       const data = response.data;
       if (data && data.segments) {
-        data.segments = data.segments.filter((segment, index, self) =>
-          index === self.findIndex(s => 
-            s.startTime === segment.startTime && 
-            s.text === segment.text && 
-            s.speaker === segment.speaker
-          )
+        data.segments = data.segments.filter(
+          (segment, index, self) =>
+            index ===
+            self.findIndex(
+              (s) =>
+                s.startTime === segment.startTime &&
+                s.text === segment.text &&
+                s.speaker === segment.speaker,
+            ),
         );
       }
       setTranscript(data);

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -44,4 +44,4 @@ if (typeof globalThis.IntersectionObserver === "undefined") {
   };
 }
 
-vi.stubEnv('VITE_CLERK_PUBLISHABLE_KEY', 'pk_test_bW9jay1jbGVyay1rZXk');
+vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "pk_test_bW9jay1jbGVyay1rZXk");

--- a/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
+++ b/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
@@ -230,12 +230,12 @@ Frontend: `/email-verify`, `/reset-password`.
 
 ## 14. Frontend auth surface
 
-| Piece   | Path                                                 |
-| ------- | ---------------------------------------------------- |
-| Context | `AppContext.jsx` / `AppContent.js` (not AuthContext) |
-| Guard   | `ProtectedRoute.jsx`                                 |
+| Piece   | Path                                                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Context | `AppContext.jsx` / `AppContent.js` (not AuthContext)                                                                                                                      |
+| Guard   | `ProtectedRoute.jsx`                                                                                                                                                      |
 | API     | **Current:** `apiClient.js` (Clerk Bearer). **Legacy:** `authApi.js` (`/api/auth/*` identity helpers; do not use for new work). CSRF client helper removed (Issue #1139). |
-| Pages   | `Login.jsx`, `EmailVerify.jsx`, `ResetPassword.jsx`  |
+| Pages   | `Login.jsx`, `EmailVerify.jsx`, `ResetPassword.jsx`                                                                                                                       |
 
 **Legacy inconsistency:** some pages read `localStorage.token` or parse `document.cookie` for Bearer headers; AppContext **does not** set `localStorage.token`.
 

--- a/docs/clerk-migration/06_FILES_TO_REMOVE.md
+++ b/docs/clerk-migration/06_FILES_TO_REMOVE.md
@@ -23,13 +23,13 @@ If a file also contains calendar logic, **relocate calendar handlers first** (Ph
 
 ## Frontend
 
-| File                                 | Why obsolete after cutover        |
-| ------------------------------------ | --------------------------------- |
+| File                                     | Why obsolete after cutover                               |
+| ---------------------------------------- | -------------------------------------------------------- |
 | ~~`client/src/services/csrfService.js`~~ | **Removed** (Issue #1139) — unused after Clerk migration |
-| `client/src/services/authApi.js`     | Legacy `/api/auth/*` identity API |
-| `client/src/pages/Login.jsx`         | Replaced by Clerk UI              |
-| `client/src/pages/EmailVerify.jsx`   | Clerk email verification          |
-| `client/src/pages/ResetPassword.jsx` | Clerk password reset              |
+| `client/src/services/authApi.js`         | Legacy `/api/auth/*` identity API                        |
+| `client/src/pages/Login.jsx`             | Replaced by Clerk UI                                     |
+| `client/src/pages/EmailVerify.jsx`       | Clerk email verification                                 |
+| `client/src/pages/ResetPassword.jsx`     | Clerk password reset                                     |
 
 ---
 
@@ -43,7 +43,7 @@ If a file also contains calendar logic, **relocate calendar handlers first** (Ph
 | `server/tests/authVerifyEmailRegression.test.js`    | OTP verify                                               |
 | `server/tests/csrfErrors.test.js`                   | CSRF errors                                              |
 | `server/tests/helpers/csrfHelper.js`                | CSRF test helper (replace with Clerk test helpers first) |
-| `client/src/services/__tests__/csrfService.test.js` | **Removed with** `csrfService.js` (Issue #1139) |
+| `client/src/services/__tests__/csrfService.test.js` | **Removed with** `csrfService.js` (Issue #1139)          |
 | `client/src/services/__tests__/authApi.test.js`     | Legacy auth API                                          |
 
 Rewrite (do not silently delete without replacements): integration tests that only exist to exercise cookie+CSRF login (`integration.test.js` patterns).

--- a/docs/clerk-migration/11_ARCHITECTURE_VERIFICATION.md
+++ b/docs/clerk-migration/11_ARCHITECTURE_VERIFICATION.md
@@ -20,8 +20,8 @@ Evidence-based checklist for the current auth system.
 | Membership roles narrower                     | ✅ Verified    | `membershipModel.js` enum `admin\|member`                                                                   |
 | Socket cookie JWT auth                        | ✅ Verified    | `meetingSocket.js`, `transcriptSocket.js`, `documentSync.js`                                                |
 | AppContext CSRF + is-auth bootstrap           | ✅ Verified    | `AppContext.jsx`                                                                                            |
-| apiClient CSRF header                         | ❌ Retired     | Client CSRF helper removed (`csrfService.js`, Issue #1139); requests use Clerk Bearer |
-| Clerk identity                                | ✅ Current     | Clerk session + Bearer via `apiClient.js` (replaces the former “No Clerk today” planning-time claim)       |
+| apiClient CSRF header                         | ❌ Retired     | Client CSRF helper removed (`csrfService.js`, Issue #1139); requests use Clerk Bearer                       |
+| Clerk identity                                | ✅ Current     | Clerk session + Bearer via `apiClient.js` (replaces the former “No Clerk today” planning-time claim)        |
 | `password` required on User                   | ✅ Verified    | `userModel.js`                                                                                              |
 | ChatSession is not login session              | ✅ Verified    | `ChatSession.js` AI history                                                                                 |
 | Secondary JWTs exist                          | ✅ Verified    | shared links, export, Slack state                                                                           |

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -714,22 +714,31 @@ export const resolveMeetingInvite = async (req, res, next) => {
 
 export const handleMeetingClipOperation = async (req, res) => {
   try {
-    res.json({ success: true, message: "Clip operation authorized and processed successfully" });
+    res.json({
+      success: true,
+      message: "Clip operation authorized and processed successfully",
+    });
   } catch (error) {
-    res.status(500).json({ success: false, message: "Server error handling clip" });
+    res
+      .status(500)
+      .json({ success: false, message: "Server error handling clip" });
   }
 };
 
 export const getMeetingClip = async (req, res) => {
   try {
     const { clipId } = req.params;
-    
+
     if (clipId === "deleted-clip-id") {
-      return res.status(404).json({ success: false, message: "Clip has been deleted or archived" });
+      return res
+        .status(404)
+        .json({ success: false, message: "Clip has been deleted or archived" });
     }
 
     res.json({ success: true, message: "Clip retrieved successfully" });
   } catch (error) {
-    res.status(500).json({ success: false, message: "Server error fetching clip" });
+    res
+      .status(500)
+      .json({ success: false, message: "Server error fetching clip" });
   }
 };

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -293,8 +293,6 @@ export const createLink = async (req, res) => {
   }
 };
 
-
-
 export const getActiveLinks = async (req, res) => {
   try {
     const { resourceType, resourceId } = req.params;

--- a/server/routes/transcriptRoutes.js
+++ b/server/routes/transcriptRoutes.js
@@ -73,7 +73,7 @@ router.post(
   userAuth,
   requireOrgAccess(Meeting),
   requirePermission("meetings", "view"),
-  translateTranscript
+  translateTranscript,
 );
 // Update speaker names in transcript
 router.put("/:id/speakers", userAuth, updateSpeakers);

--- a/server/services/authLinkingService.js
+++ b/server/services/authLinkingService.js
@@ -246,6 +246,34 @@ export const provisionOrLinkClerkUser = async ({
       mongoUserId: newUser?._id?.toString?.(),
     });
   } catch (err) {
+    const isDuplicateKey =
+      err?.code === 11000 ||
+      err?.name === "MongoServerError" ||
+      (err?.message && err.message.includes("E11000"));
+
+    if (isDuplicateKey) {
+      console.warn(
+        `${DIAG} 10. Concurrent user creation race detected (E11000). Retrying lookup by clerkUserId/email...`,
+      );
+      // Retry finding existing user created by parallel request
+      const existingUser = await userModel
+        .findOne({
+          $or: [{ clerkUserId }, ...(email ? [{ email }] : [])],
+        })
+        .select("-password");
+
+      if (existingUser) {
+        console.warn(
+          `${DIAG} 10. Concurrent provisioning race resolved cleanly. Reusing existing user ${existingUser._id}`,
+        );
+        const existingObj = existingUser.toObject
+          ? existingUser.toObject()
+          : existingUser;
+        delete existingObj.password;
+        return existingObj;
+      }
+    }
+
     console.error(`${DIAG} 10. userModel.create() FAILED`);
     console.error(err);
     console.error(err?.stack);

--- a/server/tests/clerkUserProvisioningRace.test.js
+++ b/server/tests/clerkUserProvisioningRace.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { provisionOrLinkClerkUser } from "../services/authLinkingService.js";
+import userModel from "../models/userModel.js";
+
+vi.mock("../models/userModel.js", () => ({
+  default: {
+    findOne: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+describe("Clerk User Provisioning Concurrency & Race Condition (#1115)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("handles duplicate key error (E11000) during concurrent user creation gracefully", async () => {
+    // 1. Initial lookup by clerkUserId returns null
+    // 2. Lookup by email returns null
+    // 3. userModel.create throws Mongo E11000 duplicate key error
+    // 4. Retry lookup finds existing user created by parallel request
+
+    const existingUser = {
+      _id: "mongo_parallel_123",
+      clerkUserId: "user_race_1115",
+      email: "concurrent@example.com",
+      name: "Concurrent User",
+      toObject: vi.fn().mockReturnValue({
+        _id: "mongo_parallel_123",
+        clerkUserId: "user_race_1115",
+        email: "concurrent@example.com",
+        name: "Concurrent User",
+        password: "CLERK_AUTH_dummy",
+      }),
+    };
+
+    userModel.findOne
+      .mockReturnValueOnce({ select: vi.fn().mockResolvedValue(null) })
+      .mockReturnValueOnce({ select: vi.fn().mockResolvedValue(null) })
+      .mockReturnValueOnce({ select: vi.fn().mockResolvedValue(existingUser) });
+
+    const dupKeyError = new Error(
+      "E11000 duplicate key error collection: users index: clerkUserId_1 dup key",
+    );
+    dupKeyError.code = 11000;
+    dupKeyError.name = "MongoServerError";
+
+    userModel.create.mockRejectedValueOnce(dupKeyError);
+
+    const result = await provisionOrLinkClerkUser({
+      clerkUserId: "user_race_1115",
+      email: "concurrent@example.com",
+      name: "Concurrent User",
+    });
+
+    expect(result._id).toBe("mongo_parallel_123");
+    expect(result.clerkUserId).toBe("user_race_1115");
+    expect(result.password).toBeUndefined();
+    expect(userModel.create).toHaveBeenCalledTimes(1);
+    expect(userModel.findOne).toHaveBeenCalledTimes(3);
+  });
+});

--- a/server/tests/commentController.test.js
+++ b/server/tests/commentController.test.js
@@ -117,7 +117,9 @@ describe("Comment Controller - Length Validation", () => {
     let consoleErrorSpy;
 
     beforeEach(() => {
-      consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
     });
 
     afterEach(() => {
@@ -137,7 +139,10 @@ describe("Comment Controller - Length Validation", () => {
       await createComment(req, res);
 
       // Verify internal error is logged
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error creating comment:", internalError);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error creating comment:",
+        internalError,
+      );
 
       // Verify response is standardized 500 error
       expect(res.status).toHaveBeenCalledWith(500);
@@ -150,7 +155,9 @@ describe("Comment Controller - Length Validation", () => {
 
       // Verify no stack trace or internal message is exposed
       const jsonArgs = res.json.mock.calls[0][0];
-      expect(JSON.stringify(jsonArgs)).not.toContain("Database connection failed");
+      expect(JSON.stringify(jsonArgs)).not.toContain(
+        "Database connection failed",
+      );
     });
   });
 });

--- a/server/tests/meetingClipAuthorization.test.js
+++ b/server/tests/meetingClipAuthorization.test.js
@@ -33,24 +33,56 @@ describe("Meeting Clip Authorization", () => {
   const validMongoId = "507f1f77bcf86cd799439011";
 
   // Mock Tokens
-  const noOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c1", role: "member" }, JWT_SECRET);
-  const differentOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c2", role: "member" }, JWT_SECRET);
-  const correctOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c3", role: "member" }, JWT_SECRET);
-  const adminToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c4", role: "admin" }, JWT_SECRET);
+  const noOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c1", role: "member" },
+    JWT_SECRET,
+  );
+  const differentOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c2", role: "member" },
+    JWT_SECRET,
+  );
+  const correctOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c3", role: "member" },
+    JWT_SECRET,
+  );
+  const adminToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c4", role: "admin" },
+    JWT_SECRET,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Mock user DB lookups for userAuth middleware
     mockUserFindById.mockImplementation((id) => {
       const mockChain = {
         select: jest.fn().mockImplementation(() => {
-          if (id === "6a74b2d9ce08c6d9eb0e32c1") return Promise.resolve({ _id: id, role: "member", organization: null });
-          if (id === "6a74b2d9ce08c6d9eb0e32c2") return Promise.resolve({ _id: id, role: "member", organization: otherOrgId });
-          if (id === "6a74b2d9ce08c6d9eb0e32c3") return Promise.resolve({ _id: id, role: "member", organization: orgId });
-          if (id === "6a74b2d9ce08c6d9eb0e32c4") return Promise.resolve({ _id: id, role: "admin", organization: orgId });
+          if (id === "6a74b2d9ce08c6d9eb0e32c1")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: null,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c2")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: otherOrgId,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c3")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: orgId,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c4")
+            return Promise.resolve({
+              _id: id,
+              role: "admin",
+              organization: orgId,
+            });
           return Promise.resolve(null);
-        })
+        }),
       };
       return mockChain;
     });
@@ -66,7 +98,9 @@ describe("Meeting Clip Authorization", () => {
 
   describe("GET /api/meetings/:id/clip/:clipId", () => {
     it("should reject access if no token is provided (401)", async () => {
-      const res = await request(app).get(`/api/meetings/${validMongoId}/clip/clip123`);
+      const res = await request(app).get(
+        `/api/meetings/${validMongoId}/clip/clip123`,
+      );
       expect(res.status).toBe(401);
     });
 
@@ -104,7 +138,9 @@ describe("Meeting Clip Authorization", () => {
 
   describe("POST /api/meetings/:id/clip", () => {
     it("should reject access if no token is provided (401)", async () => {
-      const res = await request(app).post(`/api/meetings/${validMongoId}/clip`).send({ data: "test" });
+      const res = await request(app)
+        .post(`/api/meetings/${validMongoId}/clip`)
+        .send({ data: "test" });
       expect(res.status).toBe(401);
     });
 

--- a/server/tests/transcriptTranslation.test.js
+++ b/server/tests/transcriptTranslation.test.js
@@ -15,7 +15,7 @@ import jwt from "jsonwebtoken";
 describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () => {
   let uploaderToken, viewerToken, externalToken, adminToken;
   let meetingId;
-  
+
   beforeAll(async () => {
     process.env.JWT_SECRET = "testsecret";
 
@@ -31,13 +31,29 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
     // Setup mocks
     jest.spyOn(User, "findById").mockImplementation((id) => {
       const users = {
-        [uploaderId.toString()]: { _id: uploaderId, organization: orgId, role: "member" },
-        [viewerId.toString()]: { _id: viewerId, organization: orgId, role: "member" },
-        [externalId.toString()]: { _id: externalId, organization: otherOrgId, role: "member" },
-        [adminId.toString()]: { _id: adminId, organization: orgId, role: "admin" }
+        [uploaderId.toString()]: {
+          _id: uploaderId,
+          organization: orgId,
+          role: "member",
+        },
+        [viewerId.toString()]: {
+          _id: viewerId,
+          organization: orgId,
+          role: "member",
+        },
+        [externalId.toString()]: {
+          _id: externalId,
+          organization: otherOrgId,
+          role: "member",
+        },
+        [adminId.toString()]: {
+          _id: adminId,
+          organization: orgId,
+          role: "admin",
+        },
       };
       return {
-        select: () => Promise.resolve(users[id.toString()])
+        select: () => Promise.resolve(users[id.toString()]),
       };
     });
 
@@ -55,26 +71,38 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
     jest.spyOn(Transcript, "findOne").mockImplementation(({ meeting }) => {
       if (meeting.toString() === meetingId.toString()) {
         return {
-          populate: () => Promise.resolve({
-            _id: new mongoose.Types.ObjectId(),
-            meeting: {
-              _id: meetingId,
-              organization: orgId,
-              uploadedBy: uploaderId,
-            },
-            fullText: "Hello world"
-          })
+          populate: () =>
+            Promise.resolve({
+              _id: new mongoose.Types.ObjectId(),
+              meeting: {
+                _id: meetingId,
+                organization: orgId,
+                uploadedBy: uploaderId,
+              },
+              fullText: "Hello world",
+            }),
         };
       }
       return { populate: () => Promise.resolve(null) };
     });
 
     // We will simulate JWT generation
-    uploaderToken = jwt.sign({ id: uploaderId, role: "member" }, process.env.JWT_SECRET);
-    viewerToken = jwt.sign({ id: viewerId, role: "member" }, process.env.JWT_SECRET);
-    externalToken = jwt.sign({ id: externalId, role: "member" }, process.env.JWT_SECRET);
-    adminToken = jwt.sign({ id: adminId, role: "admin" }, process.env.JWT_SECRET);
-    
+    uploaderToken = jwt.sign(
+      { id: uploaderId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    viewerToken = jwt.sign(
+      { id: viewerId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    externalToken = jwt.sign(
+      { id: externalId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    adminToken = jwt.sign(
+      { id: adminId, role: "admin" },
+      process.env.JWT_SECRET,
+    );
   });
 
   afterAll(() => {
@@ -82,7 +110,9 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
   });
 
   it("should reject translation request without a token (401)", async () => {
-    const res = await request(app).post(`/api/transcripts/meeting/${meetingId}/translate`);
+    const res = await request(app).post(
+      `/api/transcripts/meeting/${meetingId}/translate`,
+    );
     expect(res.status).toBe(401);
   });
 
@@ -98,7 +128,9 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
       .post(`/api/transcripts/meeting/${meetingId}/translate`)
       .set("Cookie", [`token=${viewerToken}`]);
     expect(res.status).toBe(403);
-    expect(res.body.message).toContain("Forbidden: You do not own this meeting");
+    expect(res.body.message).toContain(
+      "Forbidden: You do not own this meeting",
+    );
   });
 
   it("should allow translation request for the uploader (200)", async () => {


### PR DESCRIPTION
### Description
Prevent database race conditions and 500/401 authentication errors during initial Clerk user provisioning under concurrent request execution.

### Changes Included
- **`server/services/authLinkingService.js`**: Updated `provisionOrLinkClerkUser()` to handle MongoDB duplicate key errors (code `11000` / `E11000` on `clerkUserId` or `email`) during `userModel.create()` or `user.save()`.
- When a race condition occurs (e.g. concurrent sign-in or initial session sync requests), the service catches the duplicate key exception, re-fetches the user document by `clerkUserId` or `email`, and returns the existing user object without throwing an authentication failure.
- **`server/tests/clerkUserProvisioningRace.test.js`**: Added unit tests verifying that concurrent creation collisions resolve cleanly by returning the existing provisioned user.

### Related Issue
Closes #1115
