### PR TITLE
Fix/validate notification action urls

### DIFF
--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -235,18 +235,25 @@ const Notifications = () => {
     }
   };
 
-  /**
-   * Handle notification click - mark as read and navigate to action URL
-   * @param {Object} notification - Notification object
-   */
-  const handleNotificationClick = (notification) => {
-    if (!notification.isRead) {
-      handleMarkAsRead(notification._id);
+  import { validateRedirect } from "../utils/validateRedirect.js";
+
+/**
+ * Handle notification click - mark as read and navigate to action URL
+ * @param {Object} notification - Notification object
+ */
+const handleNotificationClick = (notification) => {
+  if (!notification.isRead) {
+    handleMarkAsRead(notification._id);
+  }
+  if (notification.actionUrl) {
+    const safeUrl = validateRedirect(notification.actionUrl, null);
+    if (safeUrl) {
+      navigate(safeUrl);
+    } else {
+      toast.error("Invalid or unsafe link");
     }
-    if (notification.actionUrl) {
-      navigate(notification.actionUrl);
-    }
-  };
+  }
+};
 
   // Redirect to login if not authenticated
   if (!userData) {

--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -4,6 +4,7 @@ import AppContent from "../context/AppContent";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
 import { notificationApi } from "../services";
+import { validateRedirect } from "../utils/validateRedirect.js";
 import {
   Bell,
   Check,
@@ -235,25 +236,23 @@ const Notifications = () => {
     }
   };
 
-  import { validateRedirect } from "../utils/validateRedirect.js";
-
-/**
- * Handle notification click - mark as read and navigate to action URL
- * @param {Object} notification - Notification object
- */
-const handleNotificationClick = (notification) => {
-  if (!notification.isRead) {
-    handleMarkAsRead(notification._id);
-  }
-  if (notification.actionUrl) {
-    const safeUrl = validateRedirect(notification.actionUrl, null);
-    if (safeUrl) {
-      navigate(safeUrl);
-    } else {
-      toast.error("Invalid or unsafe link");
+  /**
+   * Handle notification click - mark as read and navigate to action URL
+   * @param {Object} notification - Notification object
+   */
+  const handleNotificationClick = (notification) => {
+    if (!notification.isRead) {
+      handleMarkAsRead(notification._id);
     }
-  }
-};
+    if (notification.actionUrl) {
+      const safeUrl = validateRedirect(notification.actionUrl, null);
+      if (safeUrl) {
+        navigate(safeUrl);
+      } else {
+        toast.error("Invalid or unsafe link");
+      }
+    }
+  };
 
   // Redirect to login if not authenticated
   if (!userData) {

--- a/client/src/pages/__tests__/NotificationsActionUrl.test.jsx
+++ b/client/src/pages/__tests__/NotificationsActionUrl.test.jsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+import { validateRedirect } from "../../utils/validateRedirect.js";
+
+describe("Notifications actionUrl validation (#1215)", () => {
+  it("validates internal action URLs correctly", () => {
+    expect(validateRedirect("/meetings/meeting-123", null)).toBe("/meetings/meeting-123");
+    expect(validateRedirect("/tasks/task-456", null)).toBe("/tasks/task-456");
+    expect(validateRedirect("/reports/summary", null)).toBe("/reports/summary");
+  });
+
+  it("blocks external and unsafe action URLs", () => {
+    expect(validateRedirect("https://phishing.com/steal-auth", null)).toBeNull();
+    expect(validateRedirect("//malicious-domain.com/login", null)).toBeNull();
+    expect(validateRedirect("javascript:alert(document.cookie)", null)).toBeNull();
+    expect(validateRedirect("http://evil.com", null)).toBeNull();
+  });
+});

--- a/client/src/pages/__tests__/NotificationsActionUrl.test.jsx
+++ b/client/src/pages/__tests__/NotificationsActionUrl.test.jsx
@@ -1,17 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { validateRedirect } from "../../utils/validateRedirect.js";
 
 describe("Notifications actionUrl validation (#1215)", () => {
   it("validates internal action URLs correctly", () => {
-    expect(validateRedirect("/meetings/meeting-123", null)).toBe("/meetings/meeting-123");
+    expect(validateRedirect("/meetings/meeting-123", null)).toBe(
+      "/meetings/meeting-123",
+    );
     expect(validateRedirect("/tasks/task-456", null)).toBe("/tasks/task-456");
     expect(validateRedirect("/reports/summary", null)).toBe("/reports/summary");
   });
 
   it("blocks external and unsafe action URLs", () => {
-    expect(validateRedirect("https://phishing.com/steal-auth", null)).toBeNull();
+    expect(
+      validateRedirect("https://phishing.com/steal-auth", null),
+    ).toBeNull();
     expect(validateRedirect("//malicious-domain.com/login", null)).toBeNull();
-    expect(validateRedirect("javascript:alert(document.cookie)", null)).toBeNull();
+    expect(
+      validateRedirect("javascript:alert(document.cookie)", null),
+    ).toBeNull();
     expect(validateRedirect("http://evil.com", null)).toBeNull();
   });
 });

--- a/server/tests/corsOptions.test.js
+++ b/server/tests/corsOptions.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { corsOptions, allowedOrigins } from "../config/corsOptions.js";
+
+describe("corsOptions", () => {
+  it("allows approved origins", () => {
+    const testOrigin = allowedOrigins[0];
+    corsOptions.origin(testOrigin, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+  });
+
+  it("rejects untrusted origins", () => {
+    corsOptions.origin("http://untrusted.com", (err, allow) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Not allowed by CORS");
+    });
+  });
+
+  it("explicitly rejects null origin", () => {
+    corsOptions.origin("null", (err, allow) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Not allowed by CORS");
+    });
+  });
+
+  it("allows requests with missing origin (server-to-server / CLI)", () => {
+    corsOptions.origin(undefined, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+  });
+
+  it("grants credentials only to approved origins", () => {
+    const approvedOrigin = allowedOrigins[0];
+    const reqApproved = { headers: { origin: approvedOrigin } };
+    corsOptions.credentials(reqApproved, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+
+    const reqNull = { headers: { origin: "null" } };
+    corsOptions.credentials(reqNull, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+
+    const reqMissing = { headers: {} };
+    corsOptions.credentials(reqMissing, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+
+    const reqUntrusted = { headers: { origin: "http://untrusted.com" } };
+    corsOptions.credentials(reqUntrusted, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+  });
+});

--- a/server/tests/meetingClipAuthorization.test.js
+++ b/server/tests/meetingClipAuthorization.test.js
@@ -33,24 +33,56 @@ describe("Meeting Clip Authorization", () => {
   const validMongoId = "507f1f77bcf86cd799439011";
 
   // Mock Tokens
-  const noOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c1", role: "member" }, JWT_SECRET);
-  const differentOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c2", role: "member" }, JWT_SECRET);
-  const correctOrgToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c3", role: "member" }, JWT_SECRET);
-  const adminToken = jwt.sign({ id: "6a74b2d9ce08c6d9eb0e32c4", role: "admin" }, JWT_SECRET);
+  const noOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c1", role: "member" },
+    JWT_SECRET,
+  );
+  const differentOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c2", role: "member" },
+    JWT_SECRET,
+  );
+  const correctOrgToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c3", role: "member" },
+    JWT_SECRET,
+  );
+  const adminToken = jwt.sign(
+    { id: "6a74b2d9ce08c6d9eb0e32c4", role: "admin" },
+    JWT_SECRET,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Mock user DB lookups for userAuth middleware
     mockUserFindById.mockImplementation((id) => {
       const mockChain = {
         select: jest.fn().mockImplementation(() => {
-          if (id === "6a74b2d9ce08c6d9eb0e32c1") return Promise.resolve({ _id: id, role: "member", organization: null });
-          if (id === "6a74b2d9ce08c6d9eb0e32c2") return Promise.resolve({ _id: id, role: "member", organization: otherOrgId });
-          if (id === "6a74b2d9ce08c6d9eb0e32c3") return Promise.resolve({ _id: id, role: "member", organization: orgId });
-          if (id === "6a74b2d9ce08c6d9eb0e32c4") return Promise.resolve({ _id: id, role: "admin", organization: orgId });
+          if (id === "6a74b2d9ce08c6d9eb0e32c1")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: null,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c2")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: otherOrgId,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c3")
+            return Promise.resolve({
+              _id: id,
+              role: "member",
+              organization: orgId,
+            });
+          if (id === "6a74b2d9ce08c6d9eb0e32c4")
+            return Promise.resolve({
+              _id: id,
+              role: "admin",
+              organization: orgId,
+            });
           return Promise.resolve(null);
-        })
+        }),
       };
       return mockChain;
     });
@@ -66,7 +98,9 @@ describe("Meeting Clip Authorization", () => {
 
   describe("GET /api/meetings/:id/clip/:clipId", () => {
     it("should reject access if no token is provided (401)", async () => {
-      const res = await request(app).get(`/api/meetings/${validMongoId}/clip/clip123`);
+      const res = await request(app).get(
+        `/api/meetings/${validMongoId}/clip/clip123`,
+      );
       expect(res.status).toBe(401);
     });
 
@@ -104,7 +138,9 @@ describe("Meeting Clip Authorization", () => {
 
   describe("POST /api/meetings/:id/clip", () => {
     it("should reject access if no token is provided (401)", async () => {
-      const res = await request(app).post(`/api/meetings/${validMongoId}/clip`).send({ data: "test" });
+      const res = await request(app)
+        .post(`/api/meetings/${validMongoId}/clip`)
+        .send({ data: "test" });
       expect(res.status).toBe(401);
     });
 

--- a/server/tests/transcriptTranslation.test.js
+++ b/server/tests/transcriptTranslation.test.js
@@ -15,7 +15,7 @@ import jwt from "jsonwebtoken";
 describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () => {
   let uploaderToken, viewerToken, externalToken, adminToken;
   let meetingId;
-  
+
   beforeAll(async () => {
     process.env.JWT_SECRET = "testsecret";
 
@@ -31,13 +31,29 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
     // Setup mocks
     jest.spyOn(User, "findById").mockImplementation((id) => {
       const users = {
-        [uploaderId.toString()]: { _id: uploaderId, organization: orgId, role: "member" },
-        [viewerId.toString()]: { _id: viewerId, organization: orgId, role: "member" },
-        [externalId.toString()]: { _id: externalId, organization: otherOrgId, role: "member" },
-        [adminId.toString()]: { _id: adminId, organization: orgId, role: "admin" }
+        [uploaderId.toString()]: {
+          _id: uploaderId,
+          organization: orgId,
+          role: "member",
+        },
+        [viewerId.toString()]: {
+          _id: viewerId,
+          organization: orgId,
+          role: "member",
+        },
+        [externalId.toString()]: {
+          _id: externalId,
+          organization: otherOrgId,
+          role: "member",
+        },
+        [adminId.toString()]: {
+          _id: adminId,
+          organization: orgId,
+          role: "admin",
+        },
       };
       return {
-        select: () => Promise.resolve(users[id.toString()])
+        select: () => Promise.resolve(users[id.toString()]),
       };
     });
 
@@ -55,26 +71,38 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
     jest.spyOn(Transcript, "findOne").mockImplementation(({ meeting }) => {
       if (meeting.toString() === meetingId.toString()) {
         return {
-          populate: () => Promise.resolve({
-            _id: new mongoose.Types.ObjectId(),
-            meeting: {
-              _id: meetingId,
-              organization: orgId,
-              uploadedBy: uploaderId,
-            },
-            fullText: "Hello world"
-          })
+          populate: () =>
+            Promise.resolve({
+              _id: new mongoose.Types.ObjectId(),
+              meeting: {
+                _id: meetingId,
+                organization: orgId,
+                uploadedBy: uploaderId,
+              },
+              fullText: "Hello world",
+            }),
         };
       }
       return { populate: () => Promise.resolve(null) };
     });
 
     // We will simulate JWT generation
-    uploaderToken = jwt.sign({ id: uploaderId, role: "member" }, process.env.JWT_SECRET);
-    viewerToken = jwt.sign({ id: viewerId, role: "member" }, process.env.JWT_SECRET);
-    externalToken = jwt.sign({ id: externalId, role: "member" }, process.env.JWT_SECRET);
-    adminToken = jwt.sign({ id: adminId, role: "admin" }, process.env.JWT_SECRET);
-    
+    uploaderToken = jwt.sign(
+      { id: uploaderId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    viewerToken = jwt.sign(
+      { id: viewerId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    externalToken = jwt.sign(
+      { id: externalId, role: "member" },
+      process.env.JWT_SECRET,
+    );
+    adminToken = jwt.sign(
+      { id: adminId, role: "admin" },
+      process.env.JWT_SECRET,
+    );
   });
 
   afterAll(() => {
@@ -82,7 +110,9 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
   });
 
   it("should reject translation request without a token (401)", async () => {
-    const res = await request(app).post(`/api/transcripts/meeting/${meetingId}/translate`);
+    const res = await request(app).post(
+      `/api/transcripts/meeting/${meetingId}/translate`,
+    );
     expect(res.status).toBe(401);
   });
 
@@ -98,7 +128,9 @@ describe("POST /api/transcripts/meeting/:meetingId/translate Authorization", () 
       .post(`/api/transcripts/meeting/${meetingId}/translate`)
       .set("Cookie", [`token=${viewerToken}`]);
     expect(res.status).toBe(403);
-    expect(res.body.message).toContain("Forbidden: You do not own this meeting");
+    expect(res.body.message).toContain(
+      "Forbidden: You do not own this meeting",
+    );
   });
 
   it("should allow translation request for the uploader (200)", async () => {


### PR DESCRIPTION
### Description
Protect client-side routing against Open Redirect vulnerabilities in notification action links by validating `actionUrl` prior to executing `navigate()`.

### Changes Included
- **`client/src/pages/Notifications.jsx`**:
  - Imported `validateRedirect` utility in `Notifications.jsx`.
  - Wrapped `notification.actionUrl` with `validateRedirect(notification.actionUrl, null)` inside `handleNotificationClick()`.
  - Blocks external URLs (e.g., `https://...`), protocol-relative URLs (`//...`), and malformed/executable schemes while permitting valid internal relative routes (e.g., `/meetings/...`, `/tasks/...`).
  - Displays a safe user notification toast when an invalid link is clicked.
- **`client/src/pages/__tests__/NotificationsActionUrl.test.jsx`**: Added unit tests confirming that internal action URLs navigate as expected while external/malformed URLs are blocked.

### Related Issue
Closes #1215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked unsafe or external notification action links from triggering navigation.
  * Added an error notification when a notification link is invalid.

* **Tests**
  * Added coverage for safe and unsafe notification URLs.
  * Added coverage for CORS behavior across trusted, untrusted, null, and missing origins.
  * Reformatted existing authorization tests without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->