### PR TITLE
fix: harden CORS origin validation for null and missing origins

### DIFF
--- a/server/config/corsOptions.js
+++ b/server/config/corsOptions.js
@@ -10,14 +10,33 @@ export const allowedOrigins = [
 
 export const corsOptions = {
   origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true);
-    } else {
-      console.warn(`Blocked by CORS: ${origin}`);
-      callback(new Error("Not allowed by CORS"));
+    // Explicitly reject null origin string (sandboxed iframes, opaque origins)
+    if (origin === "null") {
+      console.warn("Blocked by CORS: null origin");
+      return callback(new Error("Not allowed by CORS"));
     }
+
+    // Allow requests without Origin header (e.g. server-to-server, cURL, same-origin)
+    if (!origin) {
+      return callback(null, true);
+    }
+
+    // Validate origin against allowed origins list
+    if (allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+
+    console.warn(`Blocked by CORS: ${origin}`);
+    return callback(new Error("Not allowed by CORS"));
   },
-  credentials: true,
+  credentials: function (req, callback) {
+    const origin = req.headers ? req.headers.origin : null;
+    // Credentials header is only granted if the request origin is explicitly approved
+    if (origin && origin !== "null" && allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(null, false);
+  },
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
   allowedHeaders: ["Content-Type", "Authorization"],
 };

--- a/server/tests/corsOptions.test.js
+++ b/server/tests/corsOptions.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { corsOptions, allowedOrigins } from "../config/corsOptions.js";
+
+describe("corsOptions", () => {
+  it("allows approved origins", () => {
+    const testOrigin = allowedOrigins[0];
+    corsOptions.origin(testOrigin, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+  });
+
+  it("rejects untrusted origins", () => {
+    corsOptions.origin("http://untrusted.com", (err, allow) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Not allowed by CORS");
+    });
+  });
+
+  it("explicitly rejects null origin", () => {
+    corsOptions.origin("null", (err, allow) => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe("Not allowed by CORS");
+    });
+  });
+
+  it("allows requests with missing origin (server-to-server / CLI)", () => {
+    corsOptions.origin(undefined, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+  });
+
+  it("grants credentials only to approved origins", () => {
+    const approvedOrigin = allowedOrigins[0];
+    const reqApproved = { headers: { origin: approvedOrigin } };
+    corsOptions.credentials(reqApproved, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(true);
+    });
+
+    const reqNull = { headers: { origin: "null" } };
+    corsOptions.credentials(reqNull, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+
+    const reqMissing = { headers: {} };
+    corsOptions.credentials(reqMissing, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+
+    const reqUntrusted = { headers: { origin: "http://untrusted.com" } };
+    corsOptions.credentials(reqUntrusted, (err, allow) => {
+      expect(err).toBeNull();
+      expect(allow).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Description
Harden Cross-Origin Resource Sharing (CORS) handling to properly handle `null` origins and requests missing an `Origin` header.

### Changes Included
- **`server/config/corsOptions.js`**:
  - Explicitly reject literal `"null"` string origins (sent by sandboxed iframes, `file://` URIs, or privacy mode redirects) so they are blocked by CORS and never granted credentialed access.
  - Allow non-browser server-to-server or CLI requests (missing `Origin` header) without returning `Access-Control-Allow-Credentials: true`.
  - Restrict credentialed access dynamically so `Access-Control-Allow-Credentials: true` is only returned for explicitly approved origins.
- **`server/tests/corsOptions.test.js`**: Added unit tests verifying rejection of `"null"` origin, handling of missing origins, and restricted credential header emission.

### Related Issue
Closes #1113
