### PR TITLE
fix(profile): preserve avatar on temporary load failures

### DIFF
--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -186,27 +186,11 @@ const Profile = () => {
                       src={userData.profilePic}
                       alt={userData.name}
                       className="w-20 h-20 rounded-full object-cover border border-slate-200 shadow-xs"
-                      onError={async () => {
+                      onError={() => {
                         toast.warning(
                           "Failed to load custom profile image. Displaying initials fallback.",
                         );
-                        setProfilePic("");
                         setProfilePicFailed(true);
-                        const cleared = { ...userData, profilePic: "" };
-                        setUserData(cleared);
-                        localStorage.setItem(
-                          "userData",
-                          JSON.stringify(cleared),
-                        );
-                        try {
-                          await userApi.updateProfile({
-                            name: userData.name,
-                            profilePic: "",
-                            bio: userData.bio,
-                          });
-                        } catch {
-                          // silent
-                        }
                       }}
                     />
                   ) : (


### PR DESCRIPTION
# Pull Request

## Description

This PR prevents temporary profile image loading failures from removing or overwriting a user's stored profile picture. When an image fails to load due to a transient issue, the application now displays a fallback avatar while preserving the existing profile image. Profile image updates and intentional removals continue to work as expected.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

- Closes #1222

## Testing

Verified that temporary image load failures display a fallback avatar without modifying stored profile data. Confirmed that profile image uploads and intentional removals continue to function correctly.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A (Bug fix)

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile image error handling by showing a warning and switching to an initials fallback.
  * Invalid profile images no longer remove saved profile data or trigger an account update request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->