### PR TITLE
fix(security): validate Calendar OAuth redirect destinations

### DIFF
--- a/client/src/components/CalendarIntegrations.jsx
+++ b/client/src/components/CalendarIntegrations.jsx
@@ -10,6 +10,11 @@ import {
 } from "lucide-react";
 import apiClient from "../services/apiClient.js";
 import ConfirmModal from "./ConfirmModal.jsx";
+import {
+  validateCalendarOAuthAuthUrl,
+  CALENDAR_OAUTH_FALLBACK_PATH,
+} from "../utils/validateCalendarOAuthRedirect.js";
+import { validateRedirect } from "../utils/validateRedirect.js";
 
 const CalendarIntegrations = () => {
   const [integrations, setIntegrations] = useState([]);
@@ -50,7 +55,15 @@ const CalendarIntegrations = () => {
       const res = await apiClient.get(`/api/calendar/${provider}/connect`);
       const redirectUrl = res.data?.url || res.data?.authUrl;
       if (res.data.success && redirectUrl) {
-        window.location.href = redirectUrl;
+        const safeAuthUrl = validateCalendarOAuthAuthUrl(redirectUrl);
+        if (safeAuthUrl) {
+          window.location.href = safeAuthUrl;
+          return;
+        }
+        toast.error(`Invalid authorization URL for ${provider}`);
+        window.location.assign(
+          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
+        );
       } else {
         toast.error(`Failed to get authorization URL for ${provider}`);
       }

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -31,6 +31,11 @@ import { ClerkManageAccountButton } from "../components/ClerkUserControls.jsx";
 import apiClient from "../services/apiClient.js";
 import { notificationApi } from "../services/notificationApi.js";
 import { userApi } from "../services/userApi.js";
+import {
+  validateCalendarOAuthAuthUrl,
+  CALENDAR_OAUTH_FALLBACK_PATH,
+} from "../utils/validateCalendarOAuthRedirect.js";
+import { validateRedirect } from "../utils/validateRedirect.js";
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -247,10 +252,20 @@ const Settings = () => {
     try {
       setCalendarLoading(true);
       const response = await apiClient.get("/api/calendar/google/auth-url");
+      const safeAuthUrl = validateCalendarOAuthAuthUrl(response.data.authUrl);
+
+      if (!safeAuthUrl) {
+        toast.error("Invalid Google Calendar authorization URL");
+        setCalendarLoading(false);
+        window.location.assign(
+          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
+        );
+        return;
+      }
 
       // Open OAuth popup
       const authWindow = window.open(
-        response.data.authUrl,
+        safeAuthUrl,
         "_blank",
         "width=500,height=600",
       );
@@ -275,10 +290,20 @@ const Settings = () => {
     try {
       setCalendarLoading(true);
       const response = await apiClient.get("/api/calendar/microsoft/auth-url");
+      const safeAuthUrl = validateCalendarOAuthAuthUrl(response.data.authUrl);
+
+      if (!safeAuthUrl) {
+        toast.error("Invalid Microsoft Calendar authorization URL");
+        setCalendarLoading(false);
+        window.location.assign(
+          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
+        );
+        return;
+      }
 
       // Open OAuth popup
       const authWindow = window.open(
-        response.data.authUrl,
+        safeAuthUrl,
         "_blank",
         "width=500,height=600",
       );

--- a/client/src/utils/validateCalendarOAuthRedirect.js
+++ b/client/src/utils/validateCalendarOAuthRedirect.js
@@ -1,0 +1,30 @@
+/**
+ * Validate Calendar OAuth *provider* auth URLs before client-side navigation.
+ * Only https destinations on approved Google / Microsoft OAuth hosts are allowed.
+ * Returns the safe href, or null when the URL must not be followed.
+ */
+const ALLOWED_OAUTH_HOSTS = new Set([
+  "accounts.google.com",
+  "login.microsoftonline.com",
+]);
+
+export const CALENDAR_OAUTH_FALLBACK_PATH = "/settings";
+
+export const validateCalendarOAuthAuthUrl = (url) => {
+  if (!url || typeof url !== "string") {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url.trim());
+    if (parsed.protocol !== "https:") {
+      return null;
+    }
+    if (!ALLOWED_OAUTH_HOSTS.has(parsed.hostname)) {
+      return null;
+    }
+    return parsed.href;
+  } catch {
+    return null;
+  }
+};

--- a/client/src/utils/validateCalendarOAuthRedirect.test.js
+++ b/client/src/utils/validateCalendarOAuthRedirect.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateCalendarOAuthAuthUrl,
+  CALENDAR_OAUTH_FALLBACK_PATH,
+} from "./validateCalendarOAuthRedirect.js";
+
+describe("validateCalendarOAuthAuthUrl", () => {
+  it("allows Google OAuth https URLs", () => {
+    const url =
+      "https://accounts.google.com/o/oauth2/v2/auth?client_id=abc&redirect_uri=x";
+    expect(validateCalendarOAuthAuthUrl(url)).toBe(url);
+  });
+
+  it("allows Microsoft OAuth https URLs", () => {
+    const url =
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=abc";
+    expect(validateCalendarOAuthAuthUrl(url)).toBe(url);
+  });
+
+  it("rejects external or untrusted hosts", () => {
+    expect(validateCalendarOAuthAuthUrl("https://evil.com/phish")).toBeNull();
+    expect(
+      validateCalendarOAuthAuthUrl("https://accounts.google.com.evil.com/o"),
+    ).toBeNull();
+  });
+
+  it("rejects non-https and malformed values", () => {
+    expect(
+      validateCalendarOAuthAuthUrl(
+        "http://accounts.google.com/o/oauth2/v2/auth",
+      ),
+    ).toBeNull();
+    expect(validateCalendarOAuthAuthUrl("javascript:alert(1)")).toBeNull();
+    expect(validateCalendarOAuthAuthUrl("//accounts.google.com/x")).toBeNull();
+    expect(validateCalendarOAuthAuthUrl("")).toBeNull();
+    expect(validateCalendarOAuthAuthUrl(null)).toBeNull();
+  });
+
+  it("exposes a safe internal fallback path", () => {
+    expect(CALENDAR_OAUTH_FALLBACK_PATH).toBe("/settings");
+  });
+});

--- a/server/controllers/calendarController.js
+++ b/server/controllers/calendarController.js
@@ -9,6 +9,7 @@ import {
   fetchExternalEvents,
 } from "../services/calendarService.js";
 import { triggerManualSync } from "../jobs/calendarSyncJob.js";
+import { buildCalendarOAuthClientRedirect } from "../utils/calendarOAuthRedirect.js";
 
 const getUserId = (req) => {
   const id = req.user?._id || req.user?.id;
@@ -72,7 +73,9 @@ export const handleGoogleCallback = async (req, res) => {
     if (!code || !userId) {
       if (isGetRequest) {
         return res.redirect(
-          `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?error=google_sync_failed`,
+          buildCalendarOAuthClientRedirect(
+            "/settings?error=google_sync_failed",
+          ),
         );
       }
       return res.status(400).json({
@@ -118,7 +121,7 @@ export const handleGoogleCallback = async (req, res) => {
 
     if (isGetRequest) {
       return res.redirect(
-        `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?sync=success`,
+        buildCalendarOAuthClientRedirect("/settings?sync=success"),
       );
     }
 
@@ -135,7 +138,7 @@ export const handleGoogleCallback = async (req, res) => {
     console.error("Error handling Google callback:", error.message);
     if (isGetRequest) {
       return res.redirect(
-        `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?error=google_sync_failed`,
+        buildCalendarOAuthClientRedirect("/settings?error=google_sync_failed"),
       );
     }
     res.status(500).json({ success: false, message: error.message });
@@ -167,7 +170,9 @@ export const handleMicrosoftCallback = async (req, res) => {
     if (!code || !userId) {
       if (isGetRequest) {
         return res.redirect(
-          `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?error=outlook_sync_failed`,
+          buildCalendarOAuthClientRedirect(
+            "/settings?error=outlook_sync_failed",
+          ),
         );
       }
       return res.status(400).json({
@@ -219,7 +224,7 @@ export const handleMicrosoftCallback = async (req, res) => {
 
     if (isGetRequest) {
       return res.redirect(
-        `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?sync=success`,
+        buildCalendarOAuthClientRedirect("/settings?sync=success"),
       );
     }
 
@@ -236,7 +241,7 @@ export const handleMicrosoftCallback = async (req, res) => {
     console.error("Error handling Microsoft callback:", error.message);
     if (isGetRequest) {
       return res.redirect(
-        `${process.env.CLIENT_URL || "http://localhost:5173"}/settings?error=outlook_sync_failed`,
+        buildCalendarOAuthClientRedirect("/settings?error=outlook_sync_failed"),
       );
     }
     res.status(500).json({ success: false, message: error.message });

--- a/server/tests/calendarOAuthRedirect.test.js
+++ b/server/tests/calendarOAuthRedirect.test.js
@@ -1,0 +1,58 @@
+import {
+  buildCalendarOAuthClientRedirect,
+  validateInternalAppPath,
+  getTrustedClientOrigin,
+  CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+} from "../utils/calendarOAuthRedirect.js";
+
+describe("calendarOAuthRedirect", () => {
+  const originalClientUrl = process.env.CLIENT_URL;
+
+  afterEach(() => {
+    process.env.CLIENT_URL = originalClientUrl;
+  });
+
+  describe("validateInternalAppPath", () => {
+    it("allows internal paths with query strings", () => {
+      expect(validateInternalAppPath("/settings?sync=success")).toBe(
+        "/settings?sync=success",
+      );
+    });
+
+    it("rejects external and malformed destinations", () => {
+      expect(validateInternalAppPath("https://evil.com")).toBe(
+        CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+      );
+      expect(validateInternalAppPath("//evil.com")).toBe(
+        CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+      );
+      expect(validateInternalAppPath("settings")).toBe(
+        CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+      );
+    });
+  });
+
+  describe("buildCalendarOAuthClientRedirect", () => {
+    it("joins trusted origin with a validated internal path", () => {
+      process.env.CLIENT_URL = "https://app.example.com/extra";
+      expect(buildCalendarOAuthClientRedirect("/settings?sync=success")).toBe(
+        "https://app.example.com/settings?sync=success",
+      );
+    });
+
+    it("falls back when path is unsafe", () => {
+      process.env.CLIENT_URL = "https://app.example.com";
+      expect(buildCalendarOAuthClientRedirect("https://evil.com")).toBe(
+        "https://app.example.com/settings",
+      );
+    });
+
+    it("falls back to localhost origin when CLIENT_URL is invalid", () => {
+      process.env.CLIENT_URL = "not-a-url";
+      expect(getTrustedClientOrigin()).toBe("http://localhost:5173");
+      expect(buildCalendarOAuthClientRedirect("/settings?error=x")).toBe(
+        "http://localhost:5173/settings?error=x",
+      );
+    });
+  });
+});

--- a/server/utils/calendarOAuthRedirect.js
+++ b/server/utils/calendarOAuthRedirect.js
@@ -1,0 +1,51 @@
+/**
+ * Build a post–Calendar-OAuth redirect back into the app.
+ * Only relative internal paths are allowed; CLIENT_URL is used as origin only.
+ */
+
+const DEFAULT_ORIGIN = "http://localhost:5173";
+export const CALENDAR_OAUTH_CLIENT_FALLBACK_PATH = "/settings";
+
+export const validateInternalAppPath = (
+  path,
+  fallback = CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+) => {
+  if (!path || typeof path !== "string") {
+    return fallback;
+  }
+
+  const trimmed = path.trim();
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return fallback;
+  }
+
+  try {
+    // Absolute URLs parse without a base — reject them.
+    new URL(trimmed);
+    return fallback;
+  } catch {
+    return trimmed;
+  }
+};
+
+export const getTrustedClientOrigin = () => {
+  try {
+    const base = new URL(process.env.CLIENT_URL || DEFAULT_ORIGIN);
+    if (base.protocol !== "http:" && base.protocol !== "https:") {
+      return DEFAULT_ORIGIN;
+    }
+    return base.origin;
+  } catch {
+    return DEFAULT_ORIGIN;
+  }
+};
+
+export const buildCalendarOAuthClientRedirect = (
+  pathWithQuery = CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+) => {
+  const safePath = validateInternalAppPath(
+    pathWithQuery,
+    CALENDAR_OAUTH_CLIENT_FALLBACK_PATH,
+  );
+  return `${getTrustedClientOrigin()}${safePath}`;
+};


### PR DESCRIPTION
## Summary
Closes #1223

Validates Calendar OAuth redirect destinations before navigation so users are not sent to untrusted URLs, while keeping the existing Google/Microsoft connect flow intact.

- Client: allow only `https` auth URLs on `accounts.google.com` and `login.microsoftonline.com` before `window.location` / `window.open` (`CalendarIntegrations`, `Settings`)
- On invalid/malformed/external auth URLs, fall back to `/settings`
- Server: post-OAuth redirects use a trusted `CLIENT_URL` origin plus a validated internal path (`/settings?...`)
- Add unit tests for client and server redirect helpers

## Test plan
- [ ] `npm run lint:changed --prefix client`
- [ ] `npm run format:check:changed --prefix client`
- [ ] `npm run lint:changed --prefix server`
- [ ] `npm run format:check:changed --prefix server`
- [ ] `cd client && npx vitest run src/utils/validateCalendarOAuthRedirect.test.js`
- [ ] `cd server && node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --runInBand tests/calendarOAuthRedirect.test.js`
- [ ] Connect Google Calendar from Settings / Calendar Integrations → navigates to Google OAuth
- [ ] Connect Microsoft Outlook → navigates to Microsoft OAuth
- [ ] After successful OAuth callback → lands on `/settings?sync=success`
- [ ] Simulated untrusted auth URL → stays on app (`/settings`) instead of external redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Calendar sign-in redirects are now validated before navigation or popup launch.
  * Untrusted, malformed, or unsupported redirect URLs are blocked and replaced with a safe Settings destination.
  * OAuth callback redirects now remain within trusted application paths and origins.
  * Added safer fallback handling when redirect configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->