### PR TITLE
Add trusted Origin validation for browser-based API requests

### DIFF
--- a/server/config/corsOptions.js
+++ b/server/config/corsOptions.js
@@ -1,11 +1,31 @@
-export const allowedOrigins = [
+const DEFAULT_ALLOWED_ORIGINS = [
   "http://localhost:5173",
   "http://localhost:5174",
   "http://localhost:4173",
   "http://127.0.0.1:5173",
   "http://127.0.0.1:5174",
   "http://127.0.0.1:4173",
-  process.env.CLIENT_URL,
+];
+
+const parseTrustedClientOrigin = () => {
+  const clientUrl = process.env.CLIENT_URL;
+  if (!clientUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(clientUrl).origin;
+  } catch {
+    console.warn(
+      "Ignored invalid CLIENT_URL environment variable for origin validation",
+    );
+    return null;
+  }
+};
+
+export const allowedOrigins = [
+  ...DEFAULT_ALLOWED_ORIGINS,
+  parseTrustedClientOrigin(),
 ].filter(Boolean);
 
 export const corsOptions = {

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -8,6 +8,7 @@ import { csrfErrorHandler } from "../middleware/csrfProtection.js";
 import { globalLimiter } from "../middleware/rateLimiter.js";
 import errorHandler from "../middleware/errorHandler.js";
 import requestContext from "../middleware/requestContext.js";
+import { originValidationMiddleware } from "../middleware/originValidation.js";
 
 import webhookRoutes from "../routes/webhookRoutes.js";
 import slackRoutes from "../routes/slackRoutes.js";
@@ -22,6 +23,7 @@ export function configureExpress(app) {
   app.use(requestContext);
   configureSecurity(app);
   app.use(cors(corsOptions));
+  app.use(originValidationMiddleware);
   app.use(cookieParser());
 
   // Public Slack webhooks are parsed by Slack-specific body parsers BEFORE the

--- a/server/middleware/originValidation.js
+++ b/server/middleware/originValidation.js
@@ -1,0 +1,41 @@
+import { allowedOrigins } from "../config/corsOptions.js";
+
+export function originValidationMiddleware(req, res, next) {
+  const origin = req.headers?.origin;
+
+  // Requests without Origin header are generally server-to-server or same-origin traffic
+  // and are explicitly trusted by the existing authentication/CSRF stack.
+  if (!origin) {
+    return next();
+  }
+
+  if (origin === "null") {
+    console.warn("Blocked by origin validation: null origin", {
+      method: req.method,
+      url: req.originalUrl || req.url,
+      requestId: req.requestId,
+    });
+    return res.status(403).json({
+      success: false,
+      message: "Untrusted request origin.",
+      requestId: req.requestId,
+    });
+  }
+
+  if (allowedOrigins.includes(origin)) {
+    return next();
+  }
+
+  console.warn("Blocked by origin validation: untrusted origin", {
+    origin,
+    method: req.method,
+    url: req.originalUrl || req.url,
+    requestId: req.requestId,
+  });
+
+  return res.status(403).json({
+    success: false,
+    message: "Untrusted request origin.",
+    requestId: req.requestId,
+  });
+}

--- a/server/tests/originValidation.test.js
+++ b/server/tests/originValidation.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { originValidationMiddleware } from "../middleware/originValidation.js";
+import { allowedOrigins } from "../config/corsOptions.js";
+
+const buildReq = ({ origin } = {}) => ({
+  headers: origin === undefined ? {} : { origin },
+  method: "POST",
+  originalUrl: "/api/user/data",
+  requestId: "req-id",
+});
+
+const buildRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe("originValidationMiddleware", () => {
+  it("allows requests without an Origin header", () => {
+    const req = buildReq({ origin: undefined });
+    const res = buildRes();
+    const next = vi.fn();
+
+    originValidationMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("allows a trusted origin", () => {
+    const req = buildReq({ origin: allowedOrigins[0] });
+    const res = buildRes();
+    const next = vi.fn();
+
+    originValidationMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects a null origin", () => {
+    const req = buildReq({ origin: "null" });
+    const res = buildRes();
+    const next = vi.fn();
+
+    originValidationMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Untrusted request origin.",
+      requestId: "req-id",
+    });
+  });
+
+  it("rejects an untrusted origin", () => {
+    const req = buildReq({ origin: "http://example.com" });
+    const res = buildRes();
+    const next = vi.fn();
+
+    originValidationMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Untrusted request origin.",
+      requestId: "req-id",
+    });
+  });
+});


### PR DESCRIPTION


##  Description

### Summary
Add server-side Origin validation for browser-based protected endpoints.

### What changed
- Added originValidation.js
- Wired origin validation into express.js after CORS setup
- Normalized `process.env.CLIENT_URL` in corsOptions.js so only valid origins are accepted
- Preserved local development origins
- Added originValidation.test.js covering allowed origins, missing Origin, `null` origin, and untrusted origin rejection

### Why
- Protects sensitive browser requests from unexpected origins
- Keeps existing authentication and CORS behavior intact
- Allows trusted server-to-server traffic by permitting requests without an `Origin` header
- Logs rejected origin validation attempts for security visibility

### Testing
- New unit tests added for origin validation
- Verified no editor diagnostics in touched files

### Files changed
- corsOptions.js
- express.js
- originValidation.js
- originValidation.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Added validation for cross-origin requests.
  - Trusted origins are now configured safely, with invalid client URLs excluded.
  - Untrusted or `"null"` origins receive a 403 response with request context.

- **Tests**
  - Added coverage for trusted, untrusted, missing, and null origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #1238