### PR TITLE
fix(accessibility): improve WAI-ARIA compliance and keyboard navigation in NoteVersionHistory modal

### DIFF
--- a/client/src/components/NoteVersionHistory.jsx
+++ b/client/src/components/NoteVersionHistory.jsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef, useId } from "react";
 import { toast } from "react-toastify";
 import { format } from "date-fns";
 import apiClient from "../services/apiClient";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
   const [history, setHistory] = useState([]);
@@ -10,6 +13,11 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
   const [diffData, setDiffData] = useState(null);
   const [loadingDiff, setLoadingDiff] = useState(false);
   const [showRestoreConfirm, setShowRestoreConfirm] = useState(false);
+
+  const titleId = useId();
+  const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const previouslyFocusedRef = useRef(null);
 
   const fetchHistory = useCallback(async () => {
     try {
@@ -57,6 +65,46 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
     }
   }, [selectedVersionId, fetchDiff]);
 
+  // Accessibility: Focus management & Escape key handling (#1338)
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement;
+    const frame = window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab" || !dialogRef.current) return;
+      const focusables = [
+        ...dialogRef.current.querySelectorAll(FOCUSABLE_SELECTOR),
+      ];
+      if (!focusables.length) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocusedRef.current?.focus?.();
+    };
+  }, [onClose]);
+
   const handleRestore = async () => {
     try {
       const res = await apiClient.post(
@@ -80,19 +128,19 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
     switch (source) {
       case "ai_processing":
         return (
-          <span className="px-2 py-0.5 bg-purple-100 text-purple-700 rounded-full text-xs">
+          <span className="px-2 py-0.5 bg-purple-100 text-purple-700 dark:bg-purple-950/50 dark:text-purple-300 rounded-full text-xs font-medium">
             AI
           </span>
         );
       case "user_edit":
         return (
-          <span className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded-full text-xs">
+          <span className="px-2 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300 rounded-full text-xs font-medium">
             User
           </span>
         );
       default:
         return (
-          <span className="px-2 py-0.5 bg-gray-100 text-gray-700 rounded-full text-xs">
+          <span className="px-2 py-0.5 bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 rounded-full text-xs font-medium">
             System
           </span>
         );
@@ -100,17 +148,34 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-xl w-full max-w-4xl h-[80vh] flex flex-col overflow-hidden">
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex justify-center items-center p-4"
+      role="presentation"
+      onClick={() => onClose()}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="bg-white dark:bg-gray-800 rounded-xl w-full max-w-4xl h-[80vh] flex flex-col overflow-hidden shadow-2xl border border-gray-200 dark:border-gray-700"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          <h2
+            id={titleId}
+            className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+          >
             Version History -{" "}
             {field === "summary" ? "AI Summary" : "Collaborative Notes"}
           </h2>
           <button
+            ref={closeButtonRef}
+            type="button"
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700"
+            aria-label="Close version history"
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 cursor-pointer rounded-md p-1"
           >
             <svg
               className="w-5 h-5"
@@ -145,12 +210,20 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
                 {history.map((ver, idx) => (
                   <li
                     key={ver._id}
-                    className={`p-4 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => setSelectedVersionId(ver._id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedVersionId(ver._id);
+                      }
+                    }}
+                    className={`p-4 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
                       selectedVersionId === ver._id
                         ? "bg-blue-50 dark:bg-blue-900/30"
                         : ""
                     }`}
-                    onClick={() => setSelectedVersionId(ver._id)}
                   >
                     <div className="flex justify-between items-center mb-1">
                       <span className="font-medium text-sm text-gray-900 dark:text-gray-100">
@@ -158,10 +231,10 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
                       </span>
                       {getSourceBadge(ver.changeSource)}
                     </div>
-                    <div className="text-xs text-gray-500 mb-1">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">
                       {format(new Date(ver.createdAt), "MMM d, yyyy h:mm a")}
                     </div>
-                    <div className="text-xs text-gray-400">
+                    <div className="text-xs text-gray-400 dark:text-gray-500">
                       {ver.changedBy ? ver.changedBy.name : "System"}
                       {" • "}
                       <span
@@ -186,24 +259,25 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
           {/* Main Area: Diff Viewer */}
           <div className="flex-1 bg-white dark:bg-gray-800 overflow-y-auto flex flex-col relative">
             {!selectedVersionId ? (
-              <div className="flex-1 flex items-center justify-center text-gray-500">
+              <div className="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400 text-sm">
                 Select a version to view changes
               </div>
             ) : loadingDiff ? (
-              <div className="flex-1 flex items-center justify-center text-gray-500">
+              <div className="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400 text-sm">
                 Loading diff...
               </div>
             ) : diffData ? (
               <div className="p-4 flex-1">
                 <div className="flex justify-end mb-4">
                   <button
+                    type="button"
                     onClick={() => setShowRestoreConfirm(true)}
-                    className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700"
+                    className="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 cursor-pointer font-medium"
                   >
                     Restore this version
                   </button>
                 </div>
-                <div className="font-mono text-sm border border-gray-200 dark:border-gray-700 rounded p-4 bg-gray-50 dark:bg-gray-900 whitespace-pre-wrap">
+                <div className="font-mono text-sm border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-gray-50 dark:bg-gray-900 whitespace-pre-wrap">
                   {diffData.map((part, index) => {
                     const colorClass = part.added
                       ? "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300"
@@ -226,25 +300,32 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
 
       {/* Restore Confirmation Modal */}
       {showRestoreConfirm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 z-[60] flex justify-center items-center">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full">
+        <div
+          className="fixed inset-0 bg-black/50 z-[60] flex justify-center items-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Confirm restore version"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-xl p-6 max-w-sm w-full shadow-2xl border border-gray-200 dark:border-gray-700">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
               Confirm Restore
             </h3>
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
+            <p className="text-gray-600 dark:text-gray-400 mb-4 text-sm">
               Are you sure you want to restore this version? This will overwrite
               the current content and create a new version snapshot.
             </p>
             <div className="flex justify-end gap-2">
               <button
+                type="button"
                 onClick={() => setShowRestoreConfirm(false)}
-                className="px-4 py-2 border border-gray-300 rounded text-gray-700 hover:bg-gray-50"
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 text-sm cursor-pointer"
               >
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={handleRestore}
-                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium cursor-pointer"
               >
                 Confirm Restore
               </button>

--- a/client/src/components/__tests__/NoteVersionHistoryAccessibility.test.jsx
+++ b/client/src/components/__tests__/NoteVersionHistoryAccessibility.test.jsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import NoteVersionHistory from "../NoteVersionHistory.jsx";
+import apiClient from "../../services/apiClient";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/apiClient", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("NoteVersionHistory Accessibility (#1338)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes WAI-ARIA dialog attributes when rendered", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        versions: [
+          {
+            _id: "v-1",
+            version: 1,
+            changeSource: "user_edit",
+            createdAt: "2026-08-01T10:00:00.000Z",
+            bytesDiff: 15,
+          },
+        ],
+      },
+    });
+
+    render(
+      <NoteVersionHistory
+        meetingId="meeting-1"
+        field="summary"
+        onClose={() => {}}
+        onRestored={() => {}}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+  });
+
+  it("closes modal on Escape key press", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { success: true, versions: [] },
+    });
+
+    const onClose = vi.fn();
+    render(
+      <NoteVersionHistory
+        meetingId="meeting-1"
+        field="summary"
+        onClose={onClose}
+        onRestored={() => {}}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("supports keyboard selection on version list items", async () => {
+    apiClient.get.mockImplementation((url) => {
+      if (url.includes("/history")) {
+        return Promise.resolve({
+          data: {
+            success: true,
+            versions: [
+              {
+                _id: "v-1",
+                version: 1,
+                changeSource: "user_edit",
+                createdAt: "2026-08-01T10:00:00.000Z",
+                bytesDiff: 15,
+              },
+            ],
+          },
+        });
+      }
+      if (url.includes("/diff")) {
+        return Promise.resolve({
+          data: {
+            success: true,
+            diff: [{ value: "Sample diff text", added: true }],
+          },
+        });
+      }
+      return Promise.resolve({ data: { success: false } });
+    });
+
+    render(
+      <NoteVersionHistory
+        meetingId="meeting-1"
+        field="summary"
+        onClose={() => {}}
+        onRestored={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Version 1 (Latest)")).toBeInTheDocument();
+    });
+
+    const versionItem = screen.getByRole("button", { name: /version 1/i });
+    fireEvent.keyDown(versionItem, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        "/api/note-versions/version/v-1/diff",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1338

## Description
This PR enhances the accessibility of the NoteVersionHistory.jsx component, adhering to WAI-ARIA modal dialog patterns, focus trapping, Escape key handling, and keyboard selection.

## Proposed Changes
- **WAI-ARIA Attributes**: Added ole="dialog", ria-modal="true", and ria-labelledby to history and restore confirmation dialog wrappers.
- **Keyboard Navigation**: Implemented Escape key dismissal, focus trapping, and keyboard controls (ole="button", 	abIndex={0}, onKeyDown) for version history list items.
- **Unit Test Coverage**: Added Vitest test suite (NoteVersionHistoryAccessibility.test.jsx) verifying ARIA dialog attributes, Escape key handling, and keyboard list selection.

## Checklist
- [x] Related Issue is linked (Fixes #1338).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation and activation for note version history.
  * Added focus trapping, focus restoration, and Escape-key dismissal for the dialog.
  * Added semantic dialog labeling and clearer focus indicators.

* **Style**
  * Refined dark-mode styling, borders, spacing, and modal presentation.

* **Tests**
  * Added accessibility coverage for dialog behavior, keyboard selection, and dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->