### PR TITLE
fix(security): sanitize HTML preview rendering in DigestPreferences to prevent XSS

### DIFF
--- a/client/src/components/DigestPreferences.jsx
+++ b/client/src/components/DigestPreferences.jsx
@@ -10,6 +10,18 @@ import {
   RefreshCw,
 } from "lucide-react";
 
+/**
+ * Client-side HTML sanitization helper for live email previews (#1339)
+ */
+const sanitizeHtml = (html) => {
+  if (typeof html !== "string") return "";
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
+    .replace(/on\w+="[^"]*"/gi, "")
+    .replace(/on\w+='[^']*'/gi, "")
+    .replace(/javascript:/gi, "");
+};
+
 const DigestPreferences = () => {
   const [preferences, setPreferences] = useState({
     frequency: "weekly",
@@ -82,7 +94,7 @@ const DigestPreferences = () => {
         "/api/digest-preferences/preview",
         preferences,
       );
-      setPreviewHtml(data.html);
+      setPreviewHtml(sanitizeHtml(data.html || ""));
     } catch (error) {
       console.error("Failed to fetch preview:", error);
       // fallback preview if error
@@ -254,9 +266,10 @@ const DigestPreferences = () => {
 
         <div className="flex gap-4">
           <button
+            type="button"
             onClick={handleSave}
             disabled={saving}
-            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg flex justify-center items-center gap-2 transition-colors disabled:opacity-50"
+            className="flex-1 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg flex justify-center items-center gap-2 transition-colors disabled:opacity-50 cursor-pointer"
           >
             {saving ? (
               <Loader2 className="w-4 h-4 animate-spin" />
@@ -265,8 +278,9 @@ const DigestPreferences = () => {
             )}
           </button>
           <button
+            type="button"
             onClick={handleSendTest}
-            className="flex-1 bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-200 font-medium py-2 px-4 rounded-lg flex justify-center items-center gap-2 transition-colors"
+            className="flex-1 bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-200 font-medium py-2 px-4 rounded-lg flex justify-center items-center gap-2 transition-colors cursor-pointer"
           >
             <Mail className="w-4 h-4" /> Send Test
           </button>

--- a/client/src/components/__tests__/DigestPreferencesSanitization.test.jsx
+++ b/client/src/components/__tests__/DigestPreferencesSanitization.test.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import DigestPreferences from "../DigestPreferences.jsx";
+import apiClient from "../../services/apiClient.js";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    update: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe("DigestPreferences HTML Sanitization (#1339)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sanitizes preview HTML returned from preview API before rendering", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        frequency: "weekly",
+        deliveryDay: "Monday",
+        deliveryHour: 9,
+        includeSections: ["summaries"],
+      },
+    });
+
+    apiClient.post.mockResolvedValue({
+      data: {
+        html: `<div><h3>Meeting Summary</h3><script>alert("xss")</script><img src="x" onerror="alert(1)"></div>`,
+      },
+    });
+
+    render(<DigestPreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Meeting Summary")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/alert\("xss"\)/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1339

## Description
This PR implements HTML sanitization on previewHtml before rendering via dangerouslySetInnerHTML in DigestPreferences.jsx, stripping executable <script> tags, inline event attributes (onerror=, onload=), and javascript: URIs.

## Proposed Changes
- **Client-Side HTML Sanitization**: Sanitized preview HTML payloads before setting state or injecting into DOM.
- **Security Protections**: Removed script tags and malicious attributes to prevent XSS execution during live email preview generation.
- **Unit Test Coverage**: Added Vitest test suite (DigestPreferencesSanitization.test.jsx) verifying script tag removal and safe preview rendering.

## Checklist
- [x] Related Issue is linked (Fixes #1339).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.