### PR TITLE
feat(ui): add complete dark mode support to LiveTranscriptPanel

### DIFF
--- a/client/src/components/LiveTranscriptPanel.jsx
+++ b/client/src/components/LiveTranscriptPanel.jsx
@@ -97,9 +97,9 @@ const LiveTranscriptPanel = ({ meetingId }) => {
 
   if (status === "disconnected") {
     return (
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <div className="flex items-center gap-3 text-gray-500">
-          <Loader2 className="w-5 h-5 animate-spin" />
+      <div className="bg-white dark:bg-slate-900 rounded-lg shadow-sm border border-gray-200 dark:border-slate-800 p-6">
+        <div className="flex items-center gap-3 text-gray-500 dark:text-slate-400">
+          <Loader2 className="w-5 h-5 animate-spin text-blue-500" />
           <span>Connecting to transcript service...</span>
         </div>
       </div>
@@ -108,8 +108,8 @@ const LiveTranscriptPanel = ({ meetingId }) => {
 
   if (status === "error") {
     return (
-      <div className="bg-white rounded-lg shadow-sm border border-red-200 p-6">
-        <div className="flex items-center gap-3 text-red-600">
+      <div className="bg-white dark:bg-slate-900 rounded-lg shadow-sm border border-red-200 dark:border-red-900/50 p-6">
+        <div className="flex items-center gap-3 text-red-600 dark:text-red-400">
           <AlertCircle className="w-5 h-5" />
           <span>{error || "Transcript service error"}</span>
         </div>
@@ -118,22 +118,22 @@ const LiveTranscriptPanel = ({ meetingId }) => {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+    <div className="bg-white dark:bg-slate-900 rounded-lg shadow-sm border border-gray-200 dark:border-slate-800 p-6">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
-          <Mic className="w-5 h-5" />
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+          <Mic className="w-5 h-5 text-blue-600 dark:text-blue-400" />
           Live Transcript
         </h3>
         <div className="flex items-center gap-2">
           <span
             className={`px-3 py-1 rounded-full text-xs font-medium ${
               status === "recording"
-                ? "bg-red-100 text-red-700"
+                ? "bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-400"
                 : status === "processing"
-                  ? "bg-yellow-100 text-yellow-700"
+                  ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-950/60 dark:text-yellow-400"
                   : status === "completed"
-                    ? "bg-green-100 text-green-700"
-                    : "bg-gray-100 text-gray-700"
+                    ? "bg-green-100 text-green-700 dark:bg-emerald-950/60 dark:text-emerald-400"
+                    : "bg-gray-100 text-gray-700 dark:bg-slate-800 dark:text-slate-300"
             }`}
           >
             {status.charAt(0).toUpperCase() + status.slice(1)}
@@ -142,17 +142,17 @@ const LiveTranscriptPanel = ({ meetingId }) => {
       </div>
 
       {status === "recording" && segments.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
+        <div className="text-center py-12 text-gray-500 dark:text-slate-400">
           <Mic className="w-12 h-12 mx-auto mb-3 opacity-50" />
           <p>Waiting for audio...</p>
         </div>
       ) : status === "processing" ? (
-        <div className="text-center py-12 text-gray-500">
-          <Loader2 className="w-12 h-12 mx-auto mb-3 animate-spin" />
+        <div className="text-center py-12 text-gray-500 dark:text-slate-400">
+          <Loader2 className="w-12 h-12 mx-auto mb-3 animate-spin text-blue-500" />
           <p>Processing transcription...</p>
         </div>
       ) : segments.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
+        <div className="text-center py-12 text-gray-500 dark:text-slate-400">
           <p>No transcript available yet</p>
         </div>
       ) : (
@@ -160,17 +160,19 @@ const LiveTranscriptPanel = ({ meetingId }) => {
           {segments.map((segment, index) => (
             <div
               key={index}
-              className="p-3 bg-gray-50 rounded-lg border border-gray-200"
+              className="p-3 bg-gray-50 dark:bg-slate-800/60 rounded-lg border border-gray-200 dark:border-slate-700/80"
             >
               <div className="flex items-center justify-between mb-1">
-                <span className="text-xs font-medium text-blue-600">
+                <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
                   {segment.speaker || "Unknown"}
                 </span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-500 dark:text-slate-400">
                   {formatTime(segment.startTime)}
                 </span>
               </div>
-              <p className="text-sm text-gray-700">{segment.text}</p>
+              <p className="text-sm text-gray-700 dark:text-slate-200">
+                {segment.text}
+              </p>
             </div>
           ))}
           <div ref={transcriptEndRef} />

--- a/client/src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx
+++ b/client/src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import LiveTranscriptPanel from "../LiveTranscriptPanel.jsx";
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn().mockResolvedValue({}),
+}));
+
+describe("LiveTranscriptPanel Dark Mode (#1340)", () => {
+  it("renders panel with dark mode CSS classes for complete theme support", () => {
+    const { container } = render(
+      <LiveTranscriptPanel meetingId="meeting-123" />,
+    );
+
+    const rootElement = container.firstChild;
+    expect(rootElement).toHaveClass("dark:bg-slate-900");
+    expect(rootElement).toHaveClass("dark:border-slate-800");
+    expect(
+      screen.getByText(/connecting to transcript service/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1340

## Description
This PR adds complete dark mode theme support to LiveTranscriptPanel.jsx, ensuring readable text contrast, dark container styling, and styled status badges matching application themes.

## Proposed Changes
- **Dark Mode Utility Classes**: Applied Tailwind dark: classes across panel backgrounds (dark:bg-slate-900), borders (dark:border-slate-800), headings (dark:text-white), status badges, and transcript segment items (dark:bg-slate-800/60).
- **Text Contrast**: Preserved WCAG compliant text contrast in both light and dark modes.
- **Unit Test Coverage**: Added Vitest test suite (LiveTranscriptPanelDarkMode.test.jsx) verifying dark mode CSS class rendering.

## Checklist
- [x] Related Issue is linked (Fixes #1340).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.