### PR TITLE
fix: improve ConfirmModal loading feedback

### DIFF
--- a/client/src/components/ConfirmModal.jsx
+++ b/client/src/components/ConfirmModal.jsx
@@ -21,6 +21,7 @@ import { AlertTriangle, X, Loader2 } from "lucide-react";
  * @param {string} confirmText - Confirm button text
  * @param {string} cancelText - Cancel button text
  * @param {boolean} isLoading - Loading state
+ * @param {string} loadingText - Text to display when loading
  * @param {string} variant - "danger" or "warning"
  */
 const ConfirmModal = ({
@@ -32,6 +33,7 @@ const ConfirmModal = ({
   confirmText = "Delete",
   cancelText = "Cancel",
   isLoading = false,
+  loadingText = "Processing...",
   variant = "danger",
 }) => {
   const modalRef = useRef(null);
@@ -235,7 +237,7 @@ const ConfirmModal = ({
             tabIndex={0}
           >
             {isLoading && <Loader2 size={16} className="animate-spin" />}
-            <span>{isLoading ? "Deleting..." : confirmText}</span>
+            <span>{isLoading ? loadingText : confirmText}</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Description

Replaces the hardcoded "Deleting..." loading message in `ConfirmModal` with
a configurable `loadingText` prop.

The default value is `"Processing..."`, preventing misleading feedback when
the modal is used for non-delete actions such as disconnecting integrations.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1357 

## Testing

- Reviewed existing `ConfirmModal` usages.
- Verified the implementation with `git diff`.
- Full lint/test execution was not possible because `client/node_modules`
  is not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable loading text for confirmation dialogs.
  * Confirmation buttons now display “Processing...” by default while an action is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->