### PR TITLE
fix: close MeetingCard menu on outside click

### DIFF
--- a/client/src/components/meetings/MeetingCard.jsx
+++ b/client/src/components/meetings/MeetingCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   Calendar,
   Clock,
@@ -21,6 +21,24 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
   const [isRenaming, setIsRenaming] = useState(false);
   const [newTitle, setNewTitle] = useState(meeting.title);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setShowMenu(false);
+        setShowExportSubMenu(false);
+      }
+    };
+
+    if (showMenu) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [showMenu]);
 
   const handleRenameSubmit = (e) => {
     e.preventDefault();
@@ -80,7 +98,7 @@ const MeetingCard = ({ meeting, onDelete, onRename, onView }) => {
               {meeting.title || "Untitled Meeting"}
             </h3>
           )}
-          <div className="relative">
+          <div className="relative" ref={menuRef}>
             <button
               onClick={() => {
                 setShowMenu(!showMenu);


### PR DESCRIPTION
## Description

Fixes the MeetingCard action dropdown so it closes when the user clicks
outside the menu.

The click-outside listener also closes the export submenu and is properly
cleaned up when the component unmounts.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1363

## Testing

- Reviewed the existing MeetingCard dropdown behavior.
- Verified the implementation with git diff.
- Full lint execution was not possible because `client/node_modules`
  is not installed locally.