### PR TITLE
fix(validation): enforce strict date range ordering and input validation in AttendanceAnalytics

### DIFF
--- a/client/src/pages/AttendanceAnalytics.jsx
+++ b/client/src/pages/AttendanceAnalytics.jsx
@@ -50,6 +50,7 @@ const AttendanceAnalytics = () => {
     endDate: format(new Date(), "yyyy-MM-dd"),
   });
   const [granularity, setGranularity] = useState("daily");
+  const [dateError, setDateError] = useState("");
 
   const [stats, setStats] = useState([]);
   const [totalOrgMeetings, setTotalOrgMeetings] = useState(0);
@@ -59,6 +60,18 @@ const AttendanceAnalytics = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    // Validate date range ordering (#1367)
+    if (
+      dateRange.startDate &&
+      dateRange.endDate &&
+      dateRange.startDate > dateRange.endDate
+    ) {
+      setDateError("Start date cannot be after end date");
+      setLoading(false);
+      return;
+    }
+    setDateError("");
+
     const fetchData = async () => {
       setLoading(true);
       try {
@@ -187,6 +200,15 @@ const AttendanceAnalytics = () => {
             </select>
           </div>
         </div>
+
+        {dateError && (
+          <div
+            role="alert"
+            className="p-3 bg-red-100 dark:bg-red-950/60 text-red-700 dark:text-red-300 rounded-lg border border-red-200 dark:border-red-800 text-sm font-medium"
+          >
+            {dateError}
+          </div>
+        )}
 
         {loading ? (
           <div className="flex justify-center items-center h-64">

--- a/client/src/pages/__tests__/AttendanceAnalyticsValidation.test.jsx
+++ b/client/src/pages/__tests__/AttendanceAnalyticsValidation.test.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AttendanceAnalytics from "../AttendanceAnalytics.jsx";
+import * as attendanceApi from "../../services/attendanceApi.js";
+
+vi.mock("../../context/useTheme.jsx", () => ({
+  default: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("../../services/attendanceApi.js", () => ({
+  getAttendanceStats: vi.fn(),
+  getAttendanceHeatmap: vi.fn(),
+  getAttendanceTrends: vi.fn(),
+  getMeetingTypeBreakdown: vi.fn(),
+}));
+
+describe("AttendanceAnalytics Date Range Validation (#1367)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    attendanceApi.getAttendanceStats.mockResolvedValue({
+      stats: [],
+      totalMeetings: 0,
+    });
+    attendanceApi.getAttendanceHeatmap.mockResolvedValue([]);
+    attendanceApi.getAttendanceTrends.mockResolvedValue([]);
+    attendanceApi.getMeetingTypeBreakdown.mockResolvedValue([]);
+  });
+
+  it("renders role=alert inline error when start date is after end date", async () => {
+    render(<AttendanceAnalytics />);
+
+    const inputs = screen.getAllByDisplayValue(/\d{4}-\d{2}-\d{2}/);
+    const startDateInput = inputs[0];
+
+    fireEvent.change(startDateInput, {
+      target: { name: "startDate", value: "2026-12-31" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Start date cannot be after end date",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1367

## Description
This PR enforces date range validation in AttendanceAnalytics.jsx, preventing startDate from occurring after endDate and rendering ole="alert" inline validation errors when date bounds are inverted.

## Proposed Changes
- **Date Range Validation**: Added validation preventing start dates from exceeding end dates, blocking invalid API request execution.
- **Inline Alert Feedback**: Rendered clear ole="alert" inline error messages when date bounds are inverted.
- **Unit Test Coverage**: Added Vitest test suite (AttendanceAnalyticsValidation.test.jsx) verifying date ordering validation and alert rendering.

## Checklist
- [x] Related Issue is linked (Fixes #1367).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully (npm run build).
- [x] Code is formatted (npm run format).
- [x] Code passes lint checks (npm run lint).
- [x] Unit tests added and passing cleanly (npm run test).
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent attendance analytics searches when the start date is later than the end date.
  - Displays a clear inline alert explaining the invalid date range.
  - Prevents unnecessary data loading when the date range is invalid.

- **Tests**
  - Added coverage confirming date-range validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->