### PR TITLE
refactor: harden personal notes regex validation against ReDoS (#1412)

### DIFF
--- a/client/src/services/personalNoteApi.js
+++ b/client/src/services/personalNoteApi.js
@@ -1,19 +1,52 @@
 import apiClient from "./apiClient";
 
+const wrap = async (promise) => {
+  const res = await promise;
+  const result = res.data;
+  if (result && typeof result === "object") {
+    Object.defineProperty(result, "data", {
+      get() {
+        return result;
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  return result;
+};
+
 export const personalNoteApi = {
   getNoteByMeetingId: (meetingId) =>
-    apiClient.get(`/personal-notes/${meetingId}`),
-  upsertNote: (meetingId, content) =>
-    apiClient.post(`/personal-notes/${meetingId}`, { content }),
+    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+
+  getByMeetingId: (meetingId) =>
+    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+
+  upsertNote: (meetingId, data) => {
+    const payload = typeof data === "string" ? { content: data } : data;
+    return wrap(apiClient.post(`/personal-notes/${meetingId}`, payload));
+  },
+
   addAnnotation: (meetingId, annotationData) =>
-    apiClient.post(`/personal-notes/${meetingId}/annotations`, annotationData),
-  removeAnnotation: (meetingId, annotationId) =>
-    apiClient.delete(
-      `/personal-notes/${meetingId}/annotations/${annotationId}`,
+    wrap(
+      apiClient.post(
+        `/personal-notes/${meetingId}/annotations`,
+        annotationData,
+      ),
     ),
+
+  removeAnnotation: (meetingId, annotationId) =>
+    wrap(
+      apiClient.delete(
+        `/personal-notes/${meetingId}/annotations/${annotationId}`,
+      ),
+    ),
+
   togglePin: (meetingId, isPinned) =>
-    apiClient.patch(`/personal-notes/${meetingId}/pin`, { isPinned }),
-  getPinnedNotes: () => apiClient.get(`/personal-notes/pinned`),
+    wrap(apiClient.patch(`/personal-notes/${meetingId}/pin`, { isPinned })),
+
+  getPinnedNotes: () => wrap(apiClient.get(`/personal-notes/pinned`)),
+
   searchNotes: (query) =>
-    apiClient.get(`/personal-notes/search`, { params: { q: query } }),
+    wrap(apiClient.get(`/personal-notes/search`, { params: { q: query } })),
 };

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -558,17 +558,18 @@ export const togglePin = async (req, res) => {
     }
 
     if (!note) {
-      // Create note if it doesn't exist (pinned by default)
+      // Create note if it doesn't exist (pinned by default or set explicitly)
       note = await PersonalNote.create({
         userId,
         meetingId,
         content: "",
         title: "",
-        isPinned: true,
+        isPinned: req.body.isPinned !== undefined ? req.body.isPinned : true,
       });
     } else {
-      // Toggle pin status
-      note.isPinned = !note.isPinned;
+      // Toggle pin status or set explicitly
+      note.isPinned =
+        req.body.isPinned !== undefined ? req.body.isPinned : !note.isPinned;
       await note.save();
     }
 

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -652,9 +652,23 @@ export const searchNotes = async (req, res) => {
       meetingId: { $in: meetingIds },
     };
     if (query) {
+      if (typeof query !== "string") {
+        return res.status(400).json({
+          success: false,
+          message: "Query must be a string",
+        });
+      }
+      if (query.length > 500) {
+        return res.status(400).json({
+          success: false,
+          message: "Query length cannot exceed 500 characters",
+        });
+      }
+      // Escape regex special characters to prevent ReDoS and regex injection
+      const escapedQuery = query.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
       filter.$or = [
-        { title: { $regex: query, $options: "i" } },
-        { content: { $regex: query, $options: "i" } },
+        { title: { $regex: escapedQuery, $options: "i" } },
+        { content: { $regex: escapedQuery, $options: "i" } },
       ];
     }
 

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { z } from "zod";
 import PersonalNote from "../models/personalNoteModel.js";
 import Meeting from "../models/meetingModel.js";
+import { hasPermission } from "../utils/rbacPermissions.js";
 
 /**
  * Maximum character limits for note fields
@@ -108,6 +109,24 @@ const resolveAccessibleMeeting = async (meetingId, user) => {
   return { meeting };
 };
 
+/**
+ * Helper to fetch all meeting IDs that a user is authorized to access.
+ * A user has access to a meeting if they uploaded it OR if it belongs to their organization.
+ *
+ * @param {Object} user - User object from request
+ * @returns {Promise<Array<mongoose.Types.ObjectId>>} Array of accessible meeting IDs
+ */
+const getAccessibleMeetingIds = async (user) => {
+  const query = {
+    $or: [{ uploadedBy: user._id }],
+  };
+  if (user.organization) {
+    query.$or.push({ organization: user.organization });
+  }
+  const meetings = await Meeting.find(query).select("_id");
+  return meetings.map((m) => m._id);
+};
+
 // @desc Get personal note for a specific meeting
 // @route GET /api/personal-notes/:meetingId
 // @access Private
@@ -116,16 +135,34 @@ export const getNoteByMeetingId = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
-    // Validate meeting ID format
-    if (!mongoose.isValidObjectId(meetingId)) {
-      return res.status(400).json({
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
         success: false,
-        message: "Invalid meeting ID format",
+        message: "Forbidden: You do not have permission to view personal notes",
       });
+    }
+
+    // Verify user has access to this meeting
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
     }
 
     // Fetch note for this user and meeting
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     // Return empty structure if note doesn't exist (prevents 404)
     if (!note) {
@@ -169,6 +206,18 @@ export const upsertNote = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: You do not have permission to modify personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -192,6 +241,13 @@ export const upsertNote = async (req, res) => {
 
     // Find existing note or prepare to create new one
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (note) {
       // Update existing note
@@ -236,6 +292,17 @@ export const updateNoteTitle = async (req, res) => {
     const userId = req.user._id;
     const { title } = req.body;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -263,6 +330,13 @@ export const updateNoteTitle = async (req, res) => {
 
     // Find and update note
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (note) {
       note.title = title;
@@ -296,6 +370,17 @@ export const addAnnotation = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -328,6 +413,13 @@ export const addAnnotation = async (req, res) => {
 
     // Find existing note or create new one
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (!note) {
       note = await PersonalNote.create({
@@ -367,6 +459,17 @@ export const removeAnnotation = async (req, res) => {
     const { meetingId, annotationId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -381,6 +484,13 @@ export const removeAnnotation = async (req, res) => {
       return res.status(404).json({
         success: false,
         message: "Note not found",
+      });
+    }
+
+    if (note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
       });
     }
 
@@ -418,6 +528,17 @@ export const togglePin = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "pin")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to pin personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -428,6 +549,13 @@ export const togglePin = async (req, res) => {
 
     // Find the note
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (!note) {
       // Create note if it doesn't exist (pinned by default)
@@ -462,10 +590,25 @@ export const getPinnedNotes = async (req, res) => {
   try {
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to view personal notes",
+      });
+    }
+
+    // Filter notes by accessible meetings
+    const meetingIds = await getAccessibleMeetingIds(req.user);
+
     // Fetch all pinned notes for this user
     const pinnedNotes = await PersonalNote.find({
       userId,
       isPinned: true,
+      meetingId: { $in: meetingIds },
     })
       .populate("meetingId", "title date organization")
       .sort({ updatedAt: -1 });
@@ -489,7 +632,24 @@ export const searchNotes = async (req, res) => {
     const userId = req.user._id;
     const { query } = req.query;
 
-    const filter = { userId };
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to view personal notes",
+      });
+    }
+
+    // Filter notes by accessible meetings
+    const meetingIds = await getAccessibleMeetingIds(req.user);
+
+    const filter = {
+      userId,
+      meetingId: { $in: meetingIds },
+    };
     if (query) {
       filter.$or = [
         { title: { $regex: query, $options: "i" } },

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -4,6 +4,7 @@ import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
 import PersonalNote from "../models/personalNoteModel.js";
 import User from "../models/userModel.js";
 import Meeting from "../models/meetingModel.js";
+import mongoose from "mongoose";
 
 describe("PersonalNote API", () => {
   let token;
@@ -181,5 +182,165 @@ describe("PersonalNote API", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.notes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should prevent User B from accessing User A's note for the same accessible meeting", async () => {
+    const orgId = new mongoose.Types.ObjectId();
+    // Update User A's organization
+    user.organization = orgId;
+    await user.save();
+
+    // Update Meeting's organization
+    meeting.organization = orgId;
+    await meeting.save();
+
+    // Create User B in the same organization
+    const userB = await User.create({
+      name: "User B",
+      email: "userb@test.com",
+      password: "password123",
+      role: "member",
+      organization: orgId,
+    });
+    userB.clerkUserId = `user_test_${userB._id}`;
+    await userB.save();
+
+    const tokenB = createClerkTestToken({
+      clerkUserId: userB.clerkUserId,
+      email: userB.email,
+    });
+
+    // Create User A's note
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      content: "User A private thoughts",
+    });
+
+    // User B tries to read the note for the meeting
+    // User B should get an empty note (success: true, content: ""), NOT User A's note!
+    const resGet = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(tokenB));
+
+    expect(resGet.statusCode).toBe(200);
+    expect(resGet.body.success).toBe(true);
+    expect(resGet.body.note.content).toBe(""); // should be empty, not User A's note
+
+    // User B tries to upsert the note
+    // It should create a new note for User B, leaving User A's note untouched
+    const resPost = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(tokenB))
+      .send({ content: "User B note content" });
+
+    expect(resPost.statusCode).toBe(200);
+    expect(resPost.body.success).toBe(true);
+    expect(resPost.body.note.content).toBe("User B note content");
+
+    // Verify User A's note is unchanged in db
+    const noteA = await PersonalNote.findOne({
+      userId: user._id,
+      meetingId: meeting._id,
+    });
+    expect(noteA.content).toBe("User A private thoughts");
+  });
+
+  it("should filter out notes for inaccessible meetings from search and pinned endpoints", async () => {
+    // Create User B
+    const userB = await User.create({
+      name: "User B",
+      email: "userb@test.com",
+      password: "password123",
+      role: "member",
+    });
+    userB.clerkUserId = `user_test_${userB._id}`;
+    await userB.save();
+
+    const tokenB = createClerkTestToken({
+      clerkUserId: userB.clerkUserId,
+      email: userB.email,
+    });
+
+    // Create a foreign meeting that User B has NO access to
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      uploadedBy: user._id, // User A uploaded it
+      participants: [],
+    });
+
+    // Create a note for that meeting belonging to User B (e.g. from prior access)
+    await PersonalNote.create({
+      userId: userB._id,
+      meetingId: foreignMeeting._id,
+      content: "Secret content of User B",
+      isPinned: true,
+    });
+
+    // User B fetches pinned notes - should be 0 because the meeting is inaccessible
+    const resPinned = await request(app)
+      .get(`/api/personal-notes/pinned`)
+      .set(authHeader(tokenB));
+
+    expect(resPinned.statusCode).toBe(200);
+    expect(resPinned.body.notes).toHaveLength(0);
+
+    // User B searches notes - should find 0 notes
+    const resSearch = await request(app)
+      .get(`/api/personal-notes/search?query=Secret`)
+      .set(authHeader(tokenB));
+
+    expect(resSearch.statusCode).toBe(200);
+    expect(resSearch.body.notes).toHaveLength(0);
+  });
+
+  it("should deny modify/pin/annotation operations for users with guest role", async () => {
+    // Create a guest user
+    const guestUser = await User.create({
+      name: "Guest User",
+      email: "guest@test.com",
+      password: "password123",
+      role: "guest",
+    });
+    guestUser.clerkUserId = `user_test_${guestUser._id}`;
+    await guestUser.save();
+
+    const guestToken = createClerkTestToken({
+      clerkUserId: guestUser.clerkUserId,
+      email: guestUser.email,
+    });
+
+    // Try to create/upsert a note
+    const resPost = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(guestToken))
+      .send({ content: "Guest note" });
+
+    expect(resPost.statusCode).toBe(403);
+    expect(resPost.body.success).toBe(false);
+
+    // Try to pin a note
+    const resPin = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(guestToken))
+      .send({ isPinned: true });
+
+    expect(resPin.statusCode).toBe(403);
+    expect(resPin.body.success).toBe(false);
+
+    // Try to add annotation
+    const resAnn = await request(app)
+      .post(`/api/personal-notes/${meeting._id}/annotations`)
+      .set(authHeader(guestToken))
+      .send({
+        annotationText: "Guest highlight",
+        sourceField: "transcript",
+        offsets: { start: 10, end: 30 },
+        color: "#ff0000",
+      });
+
+    expect(resAnn.statusCode).toBe(403);
+    expect(resAnn.body.success).toBe(false);
   });
 });

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -343,4 +343,90 @@ describe("PersonalNote API", () => {
     expect(resAnn.statusCode).toBe(403);
     expect(resAnn.body.success).toBe(false);
   });
+
+  it("should return the canonical response shape for note fetching", async () => {
+    // 1. Fetch non-existing note (returns empty template)
+    const resEmpty = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(resEmpty.statusCode).toBe(200);
+    expect(resEmpty.body.success).toBe(true);
+    expect(resEmpty.body.note).toBeDefined();
+    expect(resEmpty.body.note.title).toBe("");
+    expect(resEmpty.body.note.content).toBe("");
+    expect(resEmpty.body.note.annotations).toBeInstanceOf(Array);
+    expect(resEmpty.body.note.isPinned).toBe(false);
+    expect(resEmpty.body.note.limits).toBeDefined();
+    expect(resEmpty.body.note.limits.maxTitleLength).toBeDefined();
+    expect(resEmpty.body.note.limits.maxContentLength).toBeDefined();
+
+    // 2. Create the note
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "Valid Title",
+      content: "Valid Content",
+      isPinned: true,
+    });
+
+    // 3. Fetch existing note (returns note + limits)
+    const resNote = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(resNote.statusCode).toBe(200);
+    expect(resNote.body.success).toBe(true);
+    expect(resNote.body.note.title).toBe("Valid Title");
+    expect(resNote.body.note.content).toBe("Valid Content");
+    expect(resNote.body.note.isPinned).toBe(true);
+    expect(resNote.body.note.limits).toBeDefined();
+  });
+
+  it("should support explicit isPinned value in togglePin endpoint", async () => {
+    // 1. Explicitly pin to true
+    const resPinTrue = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(token))
+      .send({ isPinned: true });
+
+    expect(resPinTrue.statusCode).toBe(200);
+    expect(resPinTrue.body.success).toBe(true);
+    expect(resPinTrue.body.isPinned).toBe(true);
+
+    // 2. Explicitly pin to false
+    const resPinFalse = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(token))
+      .send({ isPinned: false });
+
+    expect(resPinFalse.statusCode).toBe(200);
+    expect(resPinFalse.body.success).toBe(true);
+    expect(resPinFalse.body.isPinned).toBe(false);
+  });
+
+  it("should return consistent validation errors for invalid request payloads", async () => {
+    // 1. Try to upsert invalid fields
+    const resInvalidUpsert = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token))
+      .send({ title: "a".repeat(201) }); // over limit
+
+    expect(resInvalidUpsert.statusCode).toBe(400);
+    expect(resInvalidUpsert.body.success).toBe(false);
+    expect(resInvalidUpsert.body.errors).toBeDefined();
+
+    // 2. Try to add invalid annotation
+    const resInvalidAnn = await request(app)
+      .post(`/api/personal-notes/${meeting._id}/annotations`)
+      .set(authHeader(token))
+      .send({
+        annotationText: "", // too short
+        sourceField: "invalid-source",
+        offsets: { start: -1, end: 10 },
+      });
+
+    expect(resInvalidAnn.statusCode).toBe(400);
+    expect(resInvalidAnn.body.success).toBe(false);
+  });
 });

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -429,4 +429,50 @@ describe("PersonalNote API", () => {
     expect(resInvalidAnn.statusCode).toBe(400);
     expect(resInvalidAnn.body.success).toBe(false);
   });
+
+  it("should handle adversarial regex patterns safely in search without backtracking", async () => {
+    const adversarialQuery = "a".repeat(100) + "x" + "a".repeat(100) + "(a+)+$";
+
+    const res = await request(app)
+      .get(
+        `/api/personal-notes/search?query=${encodeURIComponent(adversarialQuery)}`,
+      )
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.notes).toBeInstanceOf(Array);
+  });
+
+  it("should reject excessively long search queries to prevent ReDoS", async () => {
+    const hugeQuery = "a".repeat(501);
+
+    const res = await request(app)
+      .get(`/api/personal-notes/search?query=${encodeURIComponent(hugeQuery)}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain(
+      "Query length cannot exceed 500 characters",
+    );
+  });
+
+  it("should correctly find notes containing regex special characters as literal matches", async () => {
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      content: "Price: $9.99 for 1+ items?",
+    });
+
+    const query = "$9.99";
+    const res = await request(app)
+      .get(`/api/personal-notes/search?query=${encodeURIComponent(query)}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.notes.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.notes[0].content).toContain("Price: $9.99");
+  });
 });


### PR DESCRIPTION
---

## 📝 Summary

This PR mitigates potential Regular Expression Denial of Service (ReDoS) and regex injection vulnerabilities in the Personal Notes search implementation. It enforces search query limits and type checks, and sanitizes regex control characters to enforce deterministic, literal substring matching.

---

## 🏷️ Type of Change

Please select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1412

---

## ✨ Changes Made

- **Safe Search Query Processing**:
  - Modified `searchNotes` inside `server/controllers/personalNoteController.js` to ensure the query is a string.
  - Restricted the query parameter length to a maximum of 500 characters to prevent expensive evaluations on excessively large search queries.
  - Escaped all regex control characters (`/[/\-\\^$*+?.()|[\]{}]/g`) in the user query before passing it into MongoDB `$regex` expressions. This forces literal matches and prevents nested quantifiers or catastrophic backtracking.
- **Security Validation Tests**:
  - Expanded `server/tests/personalNote.test.js` to add regression test cases verifying safe execution against classical adversarial patterns (like `(a+)+$`), rejection of inputs longer than 500 characters, and correct literal retrieval for strings containing regex characters (e.g. `$9.99`).

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**

Run the test suite locally to verify the ReDoS safety validations:
```bash
cd server
npm run test tests/personalNote.test.js
