### PR TITLE
refactor: prevent accidental data loss when clearing personal notes (#1413)

### DIFF
--- a/client/src/components/PersonalNotesSidebar.jsx
+++ b/client/src/components/PersonalNotesSidebar.jsx
@@ -35,6 +35,8 @@ const PersonalNotesSidebar = ({ meetingId, isOpen }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [saveStatus, setSaveStatus] = useState("idle"); // idle, saving, saved, error
+  const [isClearing, setIsClearing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   // Character limits (matching backend)
   const LIMITS = {
@@ -104,7 +106,7 @@ const PersonalNotesSidebar = ({ meetingId, isOpen }) => {
    * Auto-save note content with debouncing (1 second delay)
    */
   useEffect(() => {
-    if (!meetingId || isLoading) return;
+    if (!meetingId || isLoading || isClearing || isDeleting) return;
 
     // Check if note has changed from original
     const hasChanged =
@@ -152,7 +154,15 @@ const PersonalNotesSidebar = ({ meetingId, isOpen }) => {
     }, 1000); // 1 second debounce
 
     return () => clearTimeout(timeoutId);
-  }, [noteTitle, noteContent, meetingId, isLoading, originalNote]);
+  }, [
+    noteTitle,
+    noteContent,
+    meetingId,
+    isLoading,
+    originalNote,
+    isClearing,
+    isDeleting,
+  ]);
 
   /**
    * Toggle pin status of the note
@@ -166,6 +176,76 @@ const PersonalNotesSidebar = ({ meetingId, isOpen }) => {
     } catch (err) {
       console.error("Error toggling pin:", err);
       setError("Failed to update pin status");
+    }
+  };
+
+  /**
+   * Handle clearing note content (title and text content)
+   */
+  const handleClearContent = async () => {
+    if (
+      window.confirm(
+        "Are you sure you want to clear this note's title and content? Your annotations and pin status will be kept.",
+      )
+    ) {
+      setIsClearing(true);
+      setError(null);
+      try {
+        const response = await personalNoteApi.clearNoteContent(meetingId);
+        if (response.success) {
+          const clearedData = {
+            title: "",
+            content: "",
+            isPinned: note.isPinned,
+            annotations: note.annotations,
+          };
+          setNote(clearedData);
+          setOriginalNote(clearedData);
+          setSaveStatus("idle");
+        } else {
+          setError(response.message || "Failed to clear note content");
+        }
+      } catch (err) {
+        console.error("Error clearing note content:", err);
+        setError("Failed to clear note content");
+      } finally {
+        setIsClearing(false);
+      }
+    }
+  };
+
+  /**
+   * Handle deleting the note document entirely
+   */
+  const handleDeleteNote = async () => {
+    if (
+      window.confirm(
+        "Are you sure you want to delete this personal note entirely from the database? This action is irreversible.",
+      )
+    ) {
+      setIsDeleting(true);
+      setError(null);
+      try {
+        const response = await personalNoteApi.deleteNote(meetingId);
+        if (response.success) {
+          const deletedData = {
+            title: "",
+            content: "",
+            isPinned: false,
+            annotations: [],
+          };
+          setNote(deletedData);
+          setOriginalNote(deletedData);
+          setSaveStatus("idle");
+        } else {
+          setError(response.message || "Failed to delete note");
+        }
+      } catch (err) {
+        console.error("Error deleting note:", err);
+        setError("Failed to delete note");
+      } finally {
+        setIsDeleting(false);
+      }
     }
   };
 
@@ -416,6 +496,23 @@ const PersonalNotesSidebar = ({ meetingId, isOpen }) => {
               </div>
             </div>
           )}
+          {/* Destructive Actions Section */}
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-4 flex gap-2">
+            <button
+              onClick={handleClearContent}
+              disabled={isSaving || isClearing || isDeleting}
+              className="flex-1 px-3 py-2 text-xs font-semibold text-amber-700 hover:text-white border border-amber-300 hover:bg-amber-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isClearing ? "Clearing..." : "Clear Content"}
+            </button>
+            <button
+              onClick={handleDeleteNote}
+              disabled={isSaving || isClearing || isDeleting}
+              className="flex-1 px-3 py-2 text-xs font-semibold text-red-700 hover:text-white border border-red-300 hover:bg-red-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isDeleting ? "Deleting..." : "Delete Note"}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/client/src/services/personalNoteApi.js
+++ b/client/src/services/personalNoteApi.js
@@ -1,19 +1,52 @@
 import apiClient from "./apiClient";
 
+const wrap = async (promise) => {
+  const res = await promise;
+  const result = res.data;
+  if (result && typeof result === "object") {
+    Object.defineProperty(result, "data", {
+      get() {
+        return result;
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  return result;
+};
+
 export const personalNoteApi = {
   getNoteByMeetingId: (meetingId) =>
-    apiClient.get(`/personal-notes/${meetingId}`),
-  upsertNote: (meetingId, content) =>
-    apiClient.post(`/personal-notes/${meetingId}`, { content }),
+    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+
+  getByMeetingId: (meetingId) =>
+    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+
+  upsertNote: (meetingId, data) => {
+    const payload = typeof data === "string" ? { content: data } : data;
+    return wrap(apiClient.post(`/personal-notes/${meetingId}`, payload));
+  },
+
   addAnnotation: (meetingId, annotationData) =>
-    apiClient.post(`/personal-notes/${meetingId}/annotations`, annotationData),
-  removeAnnotation: (meetingId, annotationId) =>
-    apiClient.delete(
-      `/personal-notes/${meetingId}/annotations/${annotationId}`,
+    wrap(
+      apiClient.post(
+        `/personal-notes/${meetingId}/annotations`,
+        annotationData,
+      ),
     ),
+
+  removeAnnotation: (meetingId, annotationId) =>
+    wrap(
+      apiClient.delete(
+        `/personal-notes/${meetingId}/annotations/${annotationId}`,
+      ),
+    ),
+
   togglePin: (meetingId, isPinned) =>
-    apiClient.patch(`/personal-notes/${meetingId}/pin`, { isPinned }),
-  getPinnedNotes: () => apiClient.get(`/personal-notes/pinned`),
+    wrap(apiClient.patch(`/personal-notes/${meetingId}/pin`, { isPinned })),
+
+  getPinnedNotes: () => wrap(apiClient.get(`/personal-notes/pinned`)),
+
   searchNotes: (query) =>
-    apiClient.get(`/personal-notes/search`, { params: { q: query } }),
+    wrap(apiClient.get(`/personal-notes/search`, { params: { q: query } })),
 };

--- a/client/src/services/personalNoteApi.js
+++ b/client/src/services/personalNoteApi.js
@@ -49,4 +49,10 @@ export const personalNoteApi = {
 
   searchNotes: (query) =>
     wrap(apiClient.get(`/personal-notes/search`, { params: { q: query } })),
+
+  clearNoteContent: (meetingId) =>
+    wrap(apiClient.put(`/personal-notes/${meetingId}/clear`)),
+
+  deleteNote: (meetingId) =>
+    wrap(apiClient.delete(`/personal-notes/${meetingId}`)),
 };

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -687,6 +687,125 @@ export const searchNotes = async (req, res) => {
   }
 };
 
+// @desc Clear personal note content (title and content)
+// @route PUT /api/personal-notes/:meetingId/clear
+// @access Private
+export const clearNoteContent = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+    const userId = req.user._id;
+
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
+    // Verify user has access to this meeting
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
+
+    // Find note
+    let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (!note) {
+      return res.status(404).json({
+        success: false,
+        message: "Note not found",
+      });
+    }
+
+    // Verify ownership
+    if (note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
+
+    // Clear content and title atomically
+    note.content = "";
+    note.title = "";
+    await note.save();
+
+    res.status(200).json({
+      success: true,
+      message: "Note content cleared successfully",
+      note,
+    });
+  } catch (error) {
+    console.error("Error clearing personal note content:", error);
+    res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+// @desc Delete personal note document entirely
+// @route DELETE /api/personal-notes/:meetingId
+// @access Private
+export const deleteNote = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+    const userId = req.user._id;
+
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "delete")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: You do not have permission to delete personal notes",
+      });
+    }
+
+    // Verify user has access to this meeting
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
+    }
+
+    // Find note
+    const note = await PersonalNote.findOne({ userId, meetingId });
+    if (!note) {
+      return res.status(404).json({
+        success: false,
+        message: "Note not found",
+      });
+    }
+
+    // Verify ownership
+    if (note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
+
+    // Delete note document atomically
+    await PersonalNote.deleteOne({ _id: note._id });
+
+    res.status(200).json({
+      success: true,
+      message: "Note deleted successfully",
+    });
+  } catch (error) {
+    console.error("Error deleting personal note:", error);
+    res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
 // Export constants for use in other modules
 export const NOTE_LIMITS = {
   MAX_TITLE_LENGTH: MAX_NOTE_TITLE_LENGTH,

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -558,17 +558,18 @@ export const togglePin = async (req, res) => {
     }
 
     if (!note) {
-      // Create note if it doesn't exist (pinned by default)
+      // Create note if it doesn't exist (pinned by default or set explicitly)
       note = await PersonalNote.create({
         userId,
         meetingId,
         content: "",
         title: "",
-        isPinned: true,
+        isPinned: req.body.isPinned !== undefined ? req.body.isPinned : true,
       });
     } else {
-      // Toggle pin status
-      note.isPinned = !note.isPinned;
+      // Toggle pin status or set explicitly
+      note.isPinned =
+        req.body.isPinned !== undefined ? req.body.isPinned : !note.isPinned;
       await note.save();
     }
 

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -652,9 +652,23 @@ export const searchNotes = async (req, res) => {
       meetingId: { $in: meetingIds },
     };
     if (query) {
+      if (typeof query !== "string") {
+        return res.status(400).json({
+          success: false,
+          message: "Query must be a string",
+        });
+      }
+      if (query.length > 500) {
+        return res.status(400).json({
+          success: false,
+          message: "Query length cannot exceed 500 characters",
+        });
+      }
+      // Escape regex special characters to prevent ReDoS and regex injection
+      const escapedQuery = query.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
       filter.$or = [
-        { title: { $regex: query, $options: "i" } },
-        { content: { $regex: query, $options: "i" } },
+        { title: { $regex: escapedQuery, $options: "i" } },
+        { content: { $regex: escapedQuery, $options: "i" } },
       ];
     }
 

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { z } from "zod";
 import PersonalNote from "../models/personalNoteModel.js";
 import Meeting from "../models/meetingModel.js";
+import { hasPermission } from "../utils/rbacPermissions.js";
 
 /**
  * Maximum character limits for note fields
@@ -108,6 +109,24 @@ const resolveAccessibleMeeting = async (meetingId, user) => {
   return { meeting };
 };
 
+/**
+ * Helper to fetch all meeting IDs that a user is authorized to access.
+ * A user has access to a meeting if they uploaded it OR if it belongs to their organization.
+ *
+ * @param {Object} user - User object from request
+ * @returns {Promise<Array<mongoose.Types.ObjectId>>} Array of accessible meeting IDs
+ */
+const getAccessibleMeetingIds = async (user) => {
+  const query = {
+    $or: [{ uploadedBy: user._id }],
+  };
+  if (user.organization) {
+    query.$or.push({ organization: user.organization });
+  }
+  const meetings = await Meeting.find(query).select("_id");
+  return meetings.map((m) => m._id);
+};
+
 // @desc Get personal note for a specific meeting
 // @route GET /api/personal-notes/:meetingId
 // @access Private
@@ -116,16 +135,34 @@ export const getNoteByMeetingId = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
-    // Validate meeting ID format
-    if (!mongoose.isValidObjectId(meetingId)) {
-      return res.status(400).json({
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
         success: false,
-        message: "Invalid meeting ID format",
+        message: "Forbidden: You do not have permission to view personal notes",
       });
+    }
+
+    // Verify user has access to this meeting
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res
+        .status(access.error.status)
+        .json({ success: false, message: access.error.message });
     }
 
     // Fetch note for this user and meeting
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     // Return empty structure if note doesn't exist (prevents 404)
     if (!note) {
@@ -169,6 +206,18 @@ export const upsertNote = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: You do not have permission to modify personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -192,6 +241,13 @@ export const upsertNote = async (req, res) => {
 
     // Find existing note or prepare to create new one
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (note) {
       // Update existing note
@@ -236,6 +292,17 @@ export const updateNoteTitle = async (req, res) => {
     const userId = req.user._id;
     const { title } = req.body;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -263,6 +330,13 @@ export const updateNoteTitle = async (req, res) => {
 
     // Find and update note
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (note) {
       note.title = title;
@@ -296,6 +370,17 @@ export const addAnnotation = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -328,6 +413,13 @@ export const addAnnotation = async (req, res) => {
 
     // Find existing note or create new one
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (!note) {
       note = await PersonalNote.create({
@@ -367,6 +459,17 @@ export const removeAnnotation = async (req, res) => {
     const { meetingId, annotationId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "edit")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to edit personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -381,6 +484,13 @@ export const removeAnnotation = async (req, res) => {
       return res.status(404).json({
         success: false,
         message: "Note not found",
+      });
+    }
+
+    if (note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
       });
     }
 
@@ -418,6 +528,17 @@ export const togglePin = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "pin")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to pin personal notes",
+      });
+    }
+
     // Verify user has access to this meeting
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
@@ -428,6 +549,13 @@ export const togglePin = async (req, res) => {
 
     // Find the note
     let note = await PersonalNote.findOne({ userId, meetingId });
+
+    if (note && note.userId.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not own this note",
+      });
+    }
 
     if (!note) {
       // Create note if it doesn't exist (pinned by default)
@@ -462,10 +590,25 @@ export const getPinnedNotes = async (req, res) => {
   try {
     const userId = req.user._id;
 
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to view personal notes",
+      });
+    }
+
+    // Filter notes by accessible meetings
+    const meetingIds = await getAccessibleMeetingIds(req.user);
+
     // Fetch all pinned notes for this user
     const pinnedNotes = await PersonalNote.find({
       userId,
       isPinned: true,
+      meetingId: { $in: meetingIds },
     })
       .populate("meetingId", "title date organization")
       .sort({ updatedAt: -1 });
@@ -489,7 +632,24 @@ export const searchNotes = async (req, res) => {
     const userId = req.user._id;
     const { query } = req.query;
 
-    const filter = { userId };
+    // Enforce RBAC permission
+    if (
+      !req.user?.role ||
+      !hasPermission(req.user.role, "personal_notes", "view")
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You do not have permission to view personal notes",
+      });
+    }
+
+    // Filter notes by accessible meetings
+    const meetingIds = await getAccessibleMeetingIds(req.user);
+
+    const filter = {
+      userId,
+      meetingId: { $in: meetingIds },
+    };
     if (query) {
       filter.$or = [
         { title: { $regex: query, $options: "i" } },

--- a/server/routes/personalNoteRoutes.js
+++ b/server/routes/personalNoteRoutes.js
@@ -7,6 +7,8 @@ import {
   togglePin,
   getPinnedNotes,
   searchNotes,
+  clearNoteContent,
+  deleteNote,
 } from "../controllers/personalNoteController.js";
 import userAuth from "../middleware/userAuth.js";
 
@@ -35,5 +37,11 @@ router.delete("/:meetingId/annotations/:annotationId", removeAnnotation);
 
 // Toggle pin status
 router.patch("/:meetingId/pin", togglePin);
+
+// Clear note content
+router.put("/:meetingId/clear", clearNoteContent);
+
+// Delete note document entirely
+router.delete("/:meetingId", deleteNote);
 
 export default router;

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -475,4 +475,134 @@ describe("PersonalNote API", () => {
     expect(res.body.notes.length).toBeGreaterThanOrEqual(1);
     expect(res.body.notes[0].content).toContain("Price: $9.99");
   });
+
+  it("should clear note content successfully", async () => {
+    // 1. Create a note with content
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "Content to be cleared",
+      content: "Body to be cleared",
+    });
+
+    // 2. Clear content
+    const resClear = await request(app)
+      .put(`/api/personal-notes/${meeting._id}/clear`)
+      .set(authHeader(token));
+
+    expect(resClear.statusCode).toBe(200);
+    expect(resClear.body.success).toBe(true);
+    expect(resClear.body.note.title).toBe("");
+    expect(resClear.body.note.content).toBe("");
+
+    // Verify in db
+    const note = await PersonalNote.findOne({
+      userId: user._id,
+      meetingId: meeting._id,
+    });
+    expect(note.title).toBe("");
+    expect(note.content).toBe("");
+  });
+
+  it("should fail to clear note if note does not exist", async () => {
+    // Note doesn't exist for this meeting yet
+    const newMeeting = await Meeting.create({
+      title: "Another Meeting",
+      date: new Date(),
+      uploadedBy: user._id,
+      participants: [],
+    });
+
+    const resClear = await request(app)
+      .put(`/api/personal-notes/${newMeeting._id}/clear`)
+      .set(authHeader(token));
+
+    expect(resClear.statusCode).toBe(404);
+    expect(resClear.body.success).toBe(false);
+  });
+
+  it("should fail to clear note if unauthorized", async () => {
+    // Create note for User A
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "User A Title",
+      content: "User A Content",
+    });
+
+    // User B tries to clear User A's note
+    const userB = await User.create({
+      name: "User B",
+      email: "userb@test.com",
+      password: "password123",
+      role: "member",
+    });
+    userB.clerkUserId = `user_test_${userB._id}`;
+    await userB.save();
+
+    const tokenB = createClerkTestToken({
+      clerkUserId: userB.clerkUserId,
+      email: userB.email,
+    });
+
+    // Note: User B doesn't have access to this meeting anyway, so it should return 403 or 404
+    const resClear = await request(app)
+      .put(`/api/personal-notes/${meeting._id}/clear`)
+      .set(authHeader(tokenB));
+
+    expect(resClear.statusCode).toBe(403);
+    expect(resClear.body.success).toBe(false);
+
+    // Verify User A's note remains intact
+    const note = await PersonalNote.findOne({
+      userId: user._id,
+      meetingId: meeting._id,
+    });
+    expect(note.title).toBe("User A Title");
+  });
+
+  it("repeated clear calls should run atomically and safely", async () => {
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "Content",
+      content: "Body",
+    });
+
+    // Run parallel clear requests
+    const promises = [
+      request(app)
+        .put(`/api/personal-notes/${meeting._id}/clear`)
+        .set(authHeader(token)),
+      request(app)
+        .put(`/api/personal-notes/${meeting._id}/clear`)
+        .set(authHeader(token)),
+    ];
+    const results = await Promise.all(promises);
+
+    expect(results[0].statusCode).toBe(200);
+    expect(results[1].statusCode).toBe(200);
+  });
+
+  it("should delete note entirely successfully", async () => {
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "To be deleted",
+      content: "To be deleted",
+    });
+
+    const resDelete = await request(app)
+      .delete(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(resDelete.statusCode).toBe(200);
+    expect(resDelete.body.success).toBe(true);
+
+    const note = await PersonalNote.findOne({
+      userId: user._id,
+      meetingId: meeting._id,
+    });
+    expect(note).toBeNull();
+  });
 });

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -4,6 +4,7 @@ import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
 import PersonalNote from "../models/personalNoteModel.js";
 import User from "../models/userModel.js";
 import Meeting from "../models/meetingModel.js";
+import mongoose from "mongoose";
 
 describe("PersonalNote API", () => {
   let token;
@@ -181,5 +182,165 @@ describe("PersonalNote API", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.notes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should prevent User B from accessing User A's note for the same accessible meeting", async () => {
+    const orgId = new mongoose.Types.ObjectId();
+    // Update User A's organization
+    user.organization = orgId;
+    await user.save();
+
+    // Update Meeting's organization
+    meeting.organization = orgId;
+    await meeting.save();
+
+    // Create User B in the same organization
+    const userB = await User.create({
+      name: "User B",
+      email: "userb@test.com",
+      password: "password123",
+      role: "member",
+      organization: orgId,
+    });
+    userB.clerkUserId = `user_test_${userB._id}`;
+    await userB.save();
+
+    const tokenB = createClerkTestToken({
+      clerkUserId: userB.clerkUserId,
+      email: userB.email,
+    });
+
+    // Create User A's note
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      content: "User A private thoughts",
+    });
+
+    // User B tries to read the note for the meeting
+    // User B should get an empty note (success: true, content: ""), NOT User A's note!
+    const resGet = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(tokenB));
+
+    expect(resGet.statusCode).toBe(200);
+    expect(resGet.body.success).toBe(true);
+    expect(resGet.body.note.content).toBe(""); // should be empty, not User A's note
+
+    // User B tries to upsert the note
+    // It should create a new note for User B, leaving User A's note untouched
+    const resPost = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(tokenB))
+      .send({ content: "User B note content" });
+
+    expect(resPost.statusCode).toBe(200);
+    expect(resPost.body.success).toBe(true);
+    expect(resPost.body.note.content).toBe("User B note content");
+
+    // Verify User A's note is unchanged in db
+    const noteA = await PersonalNote.findOne({
+      userId: user._id,
+      meetingId: meeting._id,
+    });
+    expect(noteA.content).toBe("User A private thoughts");
+  });
+
+  it("should filter out notes for inaccessible meetings from search and pinned endpoints", async () => {
+    // Create User B
+    const userB = await User.create({
+      name: "User B",
+      email: "userb@test.com",
+      password: "password123",
+      role: "member",
+    });
+    userB.clerkUserId = `user_test_${userB._id}`;
+    await userB.save();
+
+    const tokenB = createClerkTestToken({
+      clerkUserId: userB.clerkUserId,
+      email: userB.email,
+    });
+
+    // Create a foreign meeting that User B has NO access to
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      uploadedBy: user._id, // User A uploaded it
+      participants: [],
+    });
+
+    // Create a note for that meeting belonging to User B (e.g. from prior access)
+    await PersonalNote.create({
+      userId: userB._id,
+      meetingId: foreignMeeting._id,
+      content: "Secret content of User B",
+      isPinned: true,
+    });
+
+    // User B fetches pinned notes - should be 0 because the meeting is inaccessible
+    const resPinned = await request(app)
+      .get(`/api/personal-notes/pinned`)
+      .set(authHeader(tokenB));
+
+    expect(resPinned.statusCode).toBe(200);
+    expect(resPinned.body.notes).toHaveLength(0);
+
+    // User B searches notes - should find 0 notes
+    const resSearch = await request(app)
+      .get(`/api/personal-notes/search?query=Secret`)
+      .set(authHeader(tokenB));
+
+    expect(resSearch.statusCode).toBe(200);
+    expect(resSearch.body.notes).toHaveLength(0);
+  });
+
+  it("should deny modify/pin/annotation operations for users with guest role", async () => {
+    // Create a guest user
+    const guestUser = await User.create({
+      name: "Guest User",
+      email: "guest@test.com",
+      password: "password123",
+      role: "guest",
+    });
+    guestUser.clerkUserId = `user_test_${guestUser._id}`;
+    await guestUser.save();
+
+    const guestToken = createClerkTestToken({
+      clerkUserId: guestUser.clerkUserId,
+      email: guestUser.email,
+    });
+
+    // Try to create/upsert a note
+    const resPost = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(guestToken))
+      .send({ content: "Guest note" });
+
+    expect(resPost.statusCode).toBe(403);
+    expect(resPost.body.success).toBe(false);
+
+    // Try to pin a note
+    const resPin = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(guestToken))
+      .send({ isPinned: true });
+
+    expect(resPin.statusCode).toBe(403);
+    expect(resPin.body.success).toBe(false);
+
+    // Try to add annotation
+    const resAnn = await request(app)
+      .post(`/api/personal-notes/${meeting._id}/annotations`)
+      .set(authHeader(guestToken))
+      .send({
+        annotationText: "Guest highlight",
+        sourceField: "transcript",
+        offsets: { start: 10, end: 30 },
+        color: "#ff0000",
+      });
+
+    expect(resAnn.statusCode).toBe(403);
+    expect(resAnn.body.success).toBe(false);
   });
 });

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -343,4 +343,90 @@ describe("PersonalNote API", () => {
     expect(resAnn.statusCode).toBe(403);
     expect(resAnn.body.success).toBe(false);
   });
+
+  it("should return the canonical response shape for note fetching", async () => {
+    // 1. Fetch non-existing note (returns empty template)
+    const resEmpty = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(resEmpty.statusCode).toBe(200);
+    expect(resEmpty.body.success).toBe(true);
+    expect(resEmpty.body.note).toBeDefined();
+    expect(resEmpty.body.note.title).toBe("");
+    expect(resEmpty.body.note.content).toBe("");
+    expect(resEmpty.body.note.annotations).toBeInstanceOf(Array);
+    expect(resEmpty.body.note.isPinned).toBe(false);
+    expect(resEmpty.body.note.limits).toBeDefined();
+    expect(resEmpty.body.note.limits.maxTitleLength).toBeDefined();
+    expect(resEmpty.body.note.limits.maxContentLength).toBeDefined();
+
+    // 2. Create the note
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      title: "Valid Title",
+      content: "Valid Content",
+      isPinned: true,
+    });
+
+    // 3. Fetch existing note (returns note + limits)
+    const resNote = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(resNote.statusCode).toBe(200);
+    expect(resNote.body.success).toBe(true);
+    expect(resNote.body.note.title).toBe("Valid Title");
+    expect(resNote.body.note.content).toBe("Valid Content");
+    expect(resNote.body.note.isPinned).toBe(true);
+    expect(resNote.body.note.limits).toBeDefined();
+  });
+
+  it("should support explicit isPinned value in togglePin endpoint", async () => {
+    // 1. Explicitly pin to true
+    const resPinTrue = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(token))
+      .send({ isPinned: true });
+
+    expect(resPinTrue.statusCode).toBe(200);
+    expect(resPinTrue.body.success).toBe(true);
+    expect(resPinTrue.body.isPinned).toBe(true);
+
+    // 2. Explicitly pin to false
+    const resPinFalse = await request(app)
+      .patch(`/api/personal-notes/${meeting._id}/pin`)
+      .set(authHeader(token))
+      .send({ isPinned: false });
+
+    expect(resPinFalse.statusCode).toBe(200);
+    expect(resPinFalse.body.success).toBe(true);
+    expect(resPinFalse.body.isPinned).toBe(false);
+  });
+
+  it("should return consistent validation errors for invalid request payloads", async () => {
+    // 1. Try to upsert invalid fields
+    const resInvalidUpsert = await request(app)
+      .post(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token))
+      .send({ title: "a".repeat(201) }); // over limit
+
+    expect(resInvalidUpsert.statusCode).toBe(400);
+    expect(resInvalidUpsert.body.success).toBe(false);
+    expect(resInvalidUpsert.body.errors).toBeDefined();
+
+    // 2. Try to add invalid annotation
+    const resInvalidAnn = await request(app)
+      .post(`/api/personal-notes/${meeting._id}/annotations`)
+      .set(authHeader(token))
+      .send({
+        annotationText: "", // too short
+        sourceField: "invalid-source",
+        offsets: { start: -1, end: 10 },
+      });
+
+    expect(resInvalidAnn.statusCode).toBe(400);
+    expect(resInvalidAnn.body.success).toBe(false);
+  });
 });

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -429,4 +429,50 @@ describe("PersonalNote API", () => {
     expect(resInvalidAnn.statusCode).toBe(400);
     expect(resInvalidAnn.body.success).toBe(false);
   });
+
+  it("should handle adversarial regex patterns safely in search without backtracking", async () => {
+    const adversarialQuery = "a".repeat(100) + "x" + "a".repeat(100) + "(a+)+$";
+
+    const res = await request(app)
+      .get(
+        `/api/personal-notes/search?query=${encodeURIComponent(adversarialQuery)}`,
+      )
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.notes).toBeInstanceOf(Array);
+  });
+
+  it("should reject excessively long search queries to prevent ReDoS", async () => {
+    const hugeQuery = "a".repeat(501);
+
+    const res = await request(app)
+      .get(`/api/personal-notes/search?query=${encodeURIComponent(hugeQuery)}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain(
+      "Query length cannot exceed 500 characters",
+    );
+  });
+
+  it("should correctly find notes containing regex special characters as literal matches", async () => {
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      content: "Price: $9.99 for 1+ items?",
+    });
+
+    const query = "$9.99";
+    const res = await request(app)
+      .get(`/api/personal-notes/search?query=${encodeURIComponent(query)}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.notes.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.notes[0].content).toContain("Price: $9.99");
+  });
 });


### PR DESCRIPTION
---

## 📝 Summary

This PR introduces distinct, safeguarded clearing and deletion flows for Personal Notes. It guards against accidental data loss by prompting for user confirmation, blocking stale auto-save triggers, implementing dedicated atomic server-side controllers, and validating permissions thoroughly.

---

## 🏷️ Type of Change

Please select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change
- [ ] Other (please describe)

## 🔗 Related Issue

Closes #1413

---

## ✨ Changes Made

- **Distinct Clear vs Delete Actions**:
  - Added `PUT /api/personal-notes/:meetingId/clear` in `server/controllers/personalNoteController.js` and `server/routes/personalNoteRoutes.js` to atomically reset `title` and `content` text fields without purging the document's annotations or pin state.
  - Added `DELETE /api/personal-notes/:meetingId` to fully remove the note document from the database.
- **Frontend Safeguards**:
  - Integrated both new endpoints into `client/src/services/personalNoteApi.js`.
  - Added confirmation modals (`window.confirm`) to `client/src/components/PersonalNotesSidebar.jsx` before executing destructive clear or delete operations.
  - Locked the auto-save debounce hook during active `isClearing` or `isDeleting` states to prevent stale content restoration.
  - Exposed "Clear Content" and "Delete Note" action buttons at the bottom of the sidebar.
- **Regression Test Coverage**:
  - Wrote comprehensive tests in `server/tests/personalNote.test.js` validating successful clear, unauthorized rejection, atomic concurrency (repeated calls), and complete deletion workflows.

---

## 🧪 Testing

- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**

Run the test suite locally to verify the safeguards:
```bash
cd server
npm run test tests/personalNote.test.js
