### PR TITLE
fix: authorize agenda suggestions by organization and meeting

### DIFF
--- a/server/controllers/agendaSuggestionController.js
+++ b/server/controllers/agendaSuggestionController.js
@@ -1,28 +1,50 @@
 import {
   generateSuggestions,
   applyAcceptedSuggestions,
+  authorizeAgendaMeeting,
+  AgendaSuggestionAuthorizationError,
 } from "../services/agendaSuggestionService.js";
 import AgendaSuggestion from "../models/agendaSuggestionModel.js";
+
+const handleAuthorizationError = (res, error, fallbackMessage) => {
+  if (error instanceof AgendaSuggestionAuthorizationError) {
+    return res.status(error.statusCode).json({ message: error.message });
+  }
+
+  console.error(fallbackMessage, error);
+  return res.status(500).json({
+    message: fallbackMessage,
+    error: error.message,
+  });
+};
 
 // @route   POST /api/agenda-suggestions/generate
 // @desc    Generate new agenda suggestions based on organization context
 export const generateAgenda = async (req, res) => {
   try {
-    const meetingId = req.body.meetingId;
-    const organizationId = req.body.organizationId || req.user?.organization;
+    const { meetingId, organizationId } = req.body;
 
-    if (!organizationId) {
-      return res.status(400).json({ message: "organizationId is required" });
+    if (!req.user?.organization) {
+      return res
+        .status(403)
+        .json({ message: "Forbidden: Organization membership required" });
     }
 
-    const suggestion = await generateSuggestions(organizationId, meetingId);
+    // The client may provide organizationId for compatibility, but it must
+    // always match the authenticated user's organization.
+    const requestedOrganizationId = organizationId || req.user.organization;
+    const suggestion = await generateSuggestions(
+      requestedOrganizationId,
+      meetingId,
+      req.user,
+    );
     res.status(201).json(suggestion);
   } catch (error) {
-    console.error("Error generating agenda suggestions:", error);
-    res.status(500).json({
-      message: "Failed to generate agenda suggestions",
-      error: error.message,
-    });
+    return handleAuthorizationError(
+      res,
+      error,
+      "Failed to generate agenda suggestions",
+    );
   }
 };
 
@@ -38,6 +60,17 @@ export const updateSuggestionItem = async (req, res) => {
       return res.status(404).json({ message: "Agenda suggestion not found" });
     }
 
+    await authorizeAgendaMeeting(req.user, suggestionDoc.meeting, "edit");
+
+    if (
+      !suggestionDoc.organization ||
+      suggestionDoc.organization.toString() !== req.user.organization.toString()
+    ) {
+      return res.status(403).json({
+        message: "Forbidden: Agenda suggestion belongs to another organization",
+      });
+    }
+
     const item = suggestionDoc.suggestions.id(itemId);
     if (!item) {
       return res.status(404).json({ message: "Suggestion item not found" });
@@ -49,11 +82,11 @@ export const updateSuggestionItem = async (req, res) => {
     await suggestionDoc.save();
     res.status(200).json(suggestionDoc);
   } catch (error) {
-    console.error("Error updating suggestion item:", error);
-    res.status(500).json({
-      message: "Failed to update suggestion item",
-      error: error.message,
-    });
+    return handleAuthorizationError(
+      res,
+      error,
+      "Failed to update suggestion item",
+    );
   }
 };
 
@@ -62,14 +95,14 @@ export const updateSuggestionItem = async (req, res) => {
 export const applyAgenda = async (req, res) => {
   try {
     const { id } = req.params;
-    const meeting = await applyAcceptedSuggestions(id);
+    const meeting = await applyAcceptedSuggestions(id, req.user);
     res.status(200).json(meeting);
   } catch (error) {
-    console.error("Error applying agenda suggestions:", error);
-    res.status(500).json({
-      message: "Failed to apply agenda suggestions",
-      error: error.message,
-    });
+    return handleAuthorizationError(
+      res,
+      error,
+      "Failed to apply agenda suggestions",
+    );
   }
 };
 
@@ -78,15 +111,18 @@ export const applyAgenda = async (req, res) => {
 export const getSuggestionsByMeeting = async (req, res) => {
   try {
     const { meetingId } = req.params;
+    await authorizeAgendaMeeting(req.user, meetingId, "view");
+
     const suggestions = await AgendaSuggestion.find({
       meeting: meetingId,
+      organization: req.user.organization,
     }).sort({ createdAt: -1 });
     res.status(200).json(suggestions);
   } catch (error) {
-    console.error("Error fetching agenda suggestions:", error);
-    res.status(500).json({
-      message: "Failed to fetch agenda suggestions",
-      error: error.message,
-    });
+    return handleAuthorizationError(
+      res,
+      error,
+      "Failed to fetch agenda suggestions",
+    );
   }
 };

--- a/server/controllers/agendaSuggestionController.js
+++ b/server/controllers/agendaSuggestionController.js
@@ -1,20 +1,26 @@
+import mongoose from "mongoose";
+import AgendaSuggestion from "../models/agendaSuggestionModel.js";
 import {
   generateSuggestions,
   applyAcceptedSuggestions,
   authorizeAgendaMeeting,
+  authorizeAgendaSuggestion,
   AgendaSuggestionAuthorizationError,
 } from "../services/agendaSuggestionService.js";
-import AgendaSuggestion from "../models/agendaSuggestionModel.js";
+import logger from "../utils/logger.js";
 
 const handleAuthorizationError = (res, error, fallbackMessage) => {
   if (error instanceof AgendaSuggestionAuthorizationError) {
-    return res.status(error.statusCode).json({ message: error.message });
+    return res.status(error.statusCode).json({
+      success: false,
+      message: error.message,
+    });
   }
 
-  console.error(fallbackMessage, error);
+  logger.error(fallbackMessage, error);
   return res.status(500).json({
+    success: false,
     message: fallbackMessage,
-    error: error.message,
   });
 };
 
@@ -25,19 +31,23 @@ export const generateAgenda = async (req, res) => {
     const { meetingId, organizationId } = req.body;
 
     if (!req.user?.organization) {
-      return res
-        .status(403)
-        .json({ message: "Forbidden: Organization membership required" });
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
     }
 
-    // The client may provide organizationId for compatibility, but it must
-    // always match the authenticated user's organization.
-    const requestedOrganizationId = organizationId || req.user.organization;
-    const suggestion = await generateSuggestions(
-      requestedOrganizationId,
-      meetingId,
-      req.user,
-    );
+    if (
+      organizationId &&
+      organizationId.toString() !== req.user.organization.toString()
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization does not match the authenticated user",
+      });
+    }
+
+    const suggestion = await generateSuggestions(meetingId, req.user);
     res.status(201).json(suggestion);
   } catch (error) {
     return handleAuthorizationError(
@@ -55,25 +65,22 @@ export const updateSuggestionItem = async (req, res) => {
     const { id, itemId } = req.params;
     const { status, acceptedText } = req.body;
 
-    const suggestionDoc = await AgendaSuggestion.findById(id);
-    if (!suggestionDoc) {
-      return res.status(404).json({ message: "Agenda suggestion not found" });
-    }
-
-    await authorizeAgendaMeeting(req.user, suggestionDoc.meeting, "edit");
-
-    if (
-      !suggestionDoc.organization ||
-      suggestionDoc.organization.toString() !== req.user.organization.toString()
-    ) {
-      return res.status(403).json({
-        message: "Forbidden: Agenda suggestion belongs to another organization",
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid agenda suggestion id",
       });
     }
 
+    const suggestionDoc = await AgendaSuggestion.findById(id);
+    await authorizeAgendaSuggestion(req.user, suggestionDoc, "edit");
+
     const item = suggestionDoc.suggestions.id(itemId);
     if (!item) {
-      return res.status(404).json({ message: "Suggestion item not found" });
+      return res.status(404).json({
+        success: false,
+        message: "Suggestion item not found",
+      });
     }
 
     if (status) item.status = status;

--- a/server/routes/agendaSuggestionRoutes.js
+++ b/server/routes/agendaSuggestionRoutes.js
@@ -18,21 +18,13 @@ router.use(userAuth);
 router.use(requireOrgMembership);
 
 // Generating, updating, and applying suggestions mutate meeting agenda data.
-router.post(
-  "/generate",
-  requirePermission("meetings", "edit"),
-  generateAgenda,
-);
+router.post("/generate", requirePermission("meetings", "edit"), generateAgenda);
 router.put(
   "/:id/item/:itemId",
   requirePermission("meetings", "edit"),
   updateSuggestionItem,
 );
-router.post(
-  "/:id/apply",
-  requirePermission("meetings", "edit"),
-  applyAgenda,
-);
+router.post("/:id/apply", requirePermission("meetings", "edit"), applyAgenda);
 
 // Listing suggestions is read-only.
 router.get(

--- a/server/routes/agendaSuggestionRoutes.js
+++ b/server/routes/agendaSuggestionRoutes.js
@@ -6,7 +6,10 @@ import {
   getSuggestionsByMeeting,
 } from "../controllers/agendaSuggestionController.js";
 import userAuth from "../middleware/userAuth.js";
-import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
+import {
+  requireOrgMembership,
+  requirePermission,
+} from "../middleware/rbac.js";
 
 const router = express.Router();
 

--- a/server/routes/agendaSuggestionRoutes.js
+++ b/server/routes/agendaSuggestionRoutes.js
@@ -6,15 +6,36 @@ import {
   getSuggestionsByMeeting,
 } from "../controllers/agendaSuggestionController.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
 
 const router = express.Router();
 
-// Require authentication for all routes
+// Require authentication and organization membership for all agenda routes.
 router.use(userAuth);
+router.use(requireOrgMembership);
 
-router.post("/generate", generateAgenda);
-router.put("/:id/item/:itemId", updateSuggestionItem);
-router.post("/:id/apply", applyAgenda);
-router.get("/meeting/:meetingId", getSuggestionsByMeeting);
+// Generating, updating, and applying suggestions mutate meeting agenda data.
+router.post(
+  "/generate",
+  requirePermission("meetings", "edit"),
+  generateAgenda,
+);
+router.put(
+  "/:id/item/:itemId",
+  requirePermission("meetings", "edit"),
+  updateSuggestionItem,
+);
+router.post(
+  "/:id/apply",
+  requirePermission("meetings", "edit"),
+  applyAgenda,
+);
+
+// Listing suggestions is read-only.
+router.get(
+  "/meeting/:meetingId",
+  requirePermission("meetings", "view"),
+  getSuggestionsByMeeting,
+);
 
 export default router;

--- a/server/services/agendaSuggestionService.js
+++ b/server/services/agendaSuggestionService.js
@@ -35,11 +35,6 @@ const requireAgendaPermission = (user, action) => {
   }
 };
 
-/**
- * Agenda suggestions are scoped to a meeting and its organization.
- * Keep this check centralized so every endpoint follows the same order:
- * user -> organization membership -> meeting access -> RBAC permission.
- */
 export const authorizeAgendaMeeting = async (
   user,
   meetingId,
@@ -74,6 +69,8 @@ export const authorizeAgendaSuggestion = async (
   agendaSuggestion,
   action = "view",
 ) => {
+  requireAgendaPermission(user, action);
+
   if (!agendaSuggestion) {
     throw new AgendaSuggestionAuthorizationError(
       404,
@@ -172,6 +169,8 @@ export const generateSuggestions = async (meetingId, user) => {
 };
 
 export const applyAcceptedSuggestions = async (agendaSuggestionId, user) => {
+  requireAgendaPermission(user, "edit");
+
   if (!mongoose.isValidObjectId(agendaSuggestionId)) {
     throw new AgendaSuggestionAuthorizationError(
       400,

--- a/server/services/agendaSuggestionService.js
+++ b/server/services/agendaSuggestionService.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import AgendaSuggestion from "../models/agendaSuggestionModel.js";
 import ActionItem from "../models/actionItemModel.js";
 import Decision from "../models/decisionModel.js";
@@ -46,11 +47,8 @@ export const authorizeAgendaMeeting = async (
 ) => {
   requireAgendaPermission(user, action);
 
-  if (!meetingId) {
-    throw new AgendaSuggestionAuthorizationError(
-      400,
-      "meetingId is required",
-    );
+  if (!mongoose.isValidObjectId(meetingId)) {
+    throw new AgendaSuggestionAuthorizationError(400, "Invalid meetingId");
   }
 
   const meeting = await Meeting.findById(meetingId);
@@ -58,8 +56,6 @@ export const authorizeAgendaMeeting = async (
     throw new AgendaSuggestionAuthorizationError(404, "Meeting not found");
   }
 
-  // Agenda suggestions must never cross organization boundaries. Do not rely
-  // on a client-supplied organizationId to establish access.
   if (
     !meeting.organization ||
     meeting.organization.toString() !== user.organization.toString()
@@ -73,26 +69,36 @@ export const authorizeAgendaMeeting = async (
   return meeting;
 };
 
-export const generateSuggestions = async (
-  organizationId,
-  meetingId,
+export const authorizeAgendaSuggestion = async (
   user,
+  agendaSuggestion,
+  action = "view",
 ) => {
-  // Validate the authenticated user's organization and meeting before using
-  // any organization-scoped data or calling the AI service.
-  await authorizeAgendaMeeting(user, meetingId, "edit");
-
-  if (
-    !organizationId ||
-    organizationId.toString() !== user.organization.toString()
-  ) {
+  if (!agendaSuggestion) {
     throw new AgendaSuggestionAuthorizationError(
-      403,
-      "Forbidden: Organization does not match the authenticated user",
+      404,
+      "Agenda suggestion not found",
     );
   }
 
-  // 1. Gather Context
+  await authorizeAgendaMeeting(user, agendaSuggestion.meeting, action);
+
+  if (
+    !agendaSuggestion.organization ||
+    agendaSuggestion.organization.toString() !== user.organization.toString()
+  ) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      "Forbidden: Agenda suggestion belongs to another organization",
+    );
+  }
+
+  return agendaSuggestion;
+};
+
+export const generateSuggestions = async (meetingId, user) => {
+  await authorizeAgendaMeeting(user, meetingId, "edit");
+
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
@@ -135,17 +141,13 @@ export const generateSuggestions = async (
         .lean(),
     ]);
 
-  const contextData = {
+  const aiSuggestions = await generateAI({
     openActionItems,
     deferredDecisions,
     openThreads,
     recentMeetings,
-  };
+  });
 
-  // 2. Call Generative AI
-  const aiSuggestions = await generateAI(contextData);
-
-  // 3. Map to Suggestion Item Schema format
   const suggestions = aiSuggestions.map((s) => ({
     text: s.text,
     description: s.description,
@@ -159,7 +161,6 @@ export const generateSuggestions = async (
     acceptedText: "",
   }));
 
-  // 4. Save to DB
   const agendaSuggestion = new AgendaSuggestion({
     meeting: meetingId,
     organization: user.organization,
@@ -167,37 +168,23 @@ export const generateSuggestions = async (
   });
 
   await agendaSuggestion.save();
-
   return agendaSuggestion;
 };
 
 export const applyAcceptedSuggestions = async (agendaSuggestionId, user) => {
-  if (!user) {
-    throw new AgendaSuggestionAuthorizationError(401, "Unauthorized");
+  if (!mongoose.isValidObjectId(agendaSuggestionId)) {
+    throw new AgendaSuggestionAuthorizationError(
+      400,
+      "Invalid agenda suggestion id",
+    );
   }
 
   const agendaSuggestion = await AgendaSuggestion.findById(agendaSuggestionId);
-  if (!agendaSuggestion) {
-    throw new AgendaSuggestionAuthorizationError(
-      404,
-      "Agenda suggestion not found",
-    );
-  }
+  await authorizeAgendaSuggestion(user, agendaSuggestion, "edit");
 
-  const meeting = await authorizeAgendaMeeting(
-    user,
-    agendaSuggestion.meeting,
-    "edit",
-  );
-
-  if (
-    !agendaSuggestion.organization ||
-    agendaSuggestion.organization.toString() !== user.organization.toString()
-  ) {
-    throw new AgendaSuggestionAuthorizationError(
-      403,
-      "Forbidden: Agenda suggestion belongs to another organization",
-    );
+  const meeting = await Meeting.findById(agendaSuggestion.meeting);
+  if (!meeting) {
+    throw new AgendaSuggestionAuthorizationError(404, "Meeting not found");
   }
 
   const itemsToApply = agendaSuggestion.suggestions.filter(

--- a/server/services/agendaSuggestionService.js
+++ b/server/services/agendaSuggestionService.js
@@ -3,9 +3,95 @@ import ActionItem from "../models/actionItemModel.js";
 import Decision from "../models/decisionModel.js";
 import FollowUpThread from "../models/followUpThreadModel.js";
 import Meeting from "../models/meetingModel.js";
+import { hasPermission } from "../utils/rbacPermissions.js";
 import { generateAgendaSuggestions as generateAI } from "./GenerativeAIService.js";
 
-export const generateSuggestions = async (organizationId, meetingId) => {
+export class AgendaSuggestionAuthorizationError extends Error {
+  constructor(statusCode, message) {
+    super(message);
+    this.name = "AgendaSuggestionAuthorizationError";
+    this.statusCode = statusCode;
+  }
+}
+
+const requireAgendaPermission = (user, action) => {
+  if (!user) {
+    throw new AgendaSuggestionAuthorizationError(401, "Unauthorized");
+  }
+
+  if (!user.organization) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      "Forbidden: Organization membership required",
+    );
+  }
+
+  if (!user.role || !hasPermission(user.role, "meetings", action)) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      `Forbidden: You don't have permission to ${action} meetings`,
+    );
+  }
+};
+
+/**
+ * Agenda suggestions are scoped to a meeting and its organization.
+ * Keep this check centralized so every endpoint follows the same order:
+ * user -> organization membership -> meeting access -> RBAC permission.
+ */
+export const authorizeAgendaMeeting = async (
+  user,
+  meetingId,
+  action = "view",
+) => {
+  requireAgendaPermission(user, action);
+
+  if (!meetingId) {
+    throw new AgendaSuggestionAuthorizationError(
+      400,
+      "meetingId is required",
+    );
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    throw new AgendaSuggestionAuthorizationError(404, "Meeting not found");
+  }
+
+  // Agenda suggestions must never cross organization boundaries. Do not rely
+  // on a client-supplied organizationId to establish access.
+  if (
+    !meeting.organization ||
+    meeting.organization.toString() !== user.organization.toString()
+  ) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      "Forbidden: You don't have access to this meeting",
+    );
+  }
+
+  return meeting;
+};
+
+export const generateSuggestions = async (
+  organizationId,
+  meetingId,
+  user,
+) => {
+  // Validate the authenticated user's organization and meeting before using
+  // any organization-scoped data or calling the AI service.
+  await authorizeAgendaMeeting(user, meetingId, "edit");
+
+  if (
+    !organizationId ||
+    organizationId.toString() !== user.organization.toString()
+  ) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      "Forbidden: Organization does not match the authenticated user",
+    );
+  }
+
   // 1. Gather Context
   const thirtyDaysAgo = new Date();
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
@@ -13,7 +99,7 @@ export const generateSuggestions = async (organizationId, meetingId) => {
   const [openActionItems, deferredDecisions, openThreads, recentMeetings] =
     await Promise.all([
       ActionItem.find({
-        organization: organizationId,
+        organization: user.organization,
         status: { $in: ["pending", "in_progress"] },
         createdAt: { $gte: thirtyDaysAgo },
       })
@@ -22,7 +108,7 @@ export const generateSuggestions = async (organizationId, meetingId) => {
         .lean(),
 
       Decision.find({
-        organization: organizationId,
+        organization: user.organization,
         status: "deferred",
         createdAt: { $gte: thirtyDaysAgo },
       })
@@ -31,7 +117,7 @@ export const generateSuggestions = async (organizationId, meetingId) => {
         .lean(),
 
       FollowUpThread.find({
-        organization: organizationId,
+        organization: user.organization,
         status: "open",
         createdAt: { $gte: thirtyDaysAgo },
       })
@@ -40,7 +126,7 @@ export const generateSuggestions = async (organizationId, meetingId) => {
         .lean(),
 
       Meeting.find({
-        organization: organizationId,
+        organization: user.organization,
         status: "completed",
         createdAt: { $gte: thirtyDaysAgo },
       })
@@ -76,7 +162,7 @@ export const generateSuggestions = async (organizationId, meetingId) => {
   // 4. Save to DB
   const agendaSuggestion = new AgendaSuggestion({
     meeting: meetingId,
-    organization: organizationId,
+    organization: user.organization,
     suggestions,
   });
 
@@ -85,15 +171,35 @@ export const generateSuggestions = async (organizationId, meetingId) => {
   return agendaSuggestion;
 };
 
-export const applyAcceptedSuggestions = async (agendaSuggestionId) => {
-  const agendaSuggestion = await AgendaSuggestion.findById(agendaSuggestionId);
-  if (!agendaSuggestion) {
-    throw new Error("Agenda suggestion not found");
+export const applyAcceptedSuggestions = async (agendaSuggestionId, user) => {
+  if (!user) {
+    throw new AgendaSuggestionAuthorizationError(401, "Unauthorized");
   }
 
-  const meeting = await Meeting.findById(agendaSuggestion.meeting);
-  if (!meeting) {
-    throw new Error("Meeting not found");
+  const agendaSuggestion = await AgendaSuggestion.findById(
+    agendaSuggestionId,
+  );
+  if (!agendaSuggestion) {
+    throw new AgendaSuggestionAuthorizationError(
+      404,
+      "Agenda suggestion not found",
+    );
+  }
+
+  const meeting = await authorizeAgendaMeeting(
+    user,
+    agendaSuggestion.meeting,
+    "edit",
+  );
+
+  if (
+    !agendaSuggestion.organization ||
+    agendaSuggestion.organization.toString() !== user.organization.toString()
+  ) {
+    throw new AgendaSuggestionAuthorizationError(
+      403,
+      "Forbidden: Agenda suggestion belongs to another organization",
+    );
   }
 
   const itemsToApply = agendaSuggestion.suggestions.filter(

--- a/server/services/agendaSuggestionService.js
+++ b/server/services/agendaSuggestionService.js
@@ -176,9 +176,7 @@ export const applyAcceptedSuggestions = async (agendaSuggestionId, user) => {
     throw new AgendaSuggestionAuthorizationError(401, "Unauthorized");
   }
 
-  const agendaSuggestion = await AgendaSuggestion.findById(
-    agendaSuggestionId,
-  );
+  const agendaSuggestion = await AgendaSuggestion.findById(agendaSuggestionId);
   if (!agendaSuggestion) {
     throw new AgendaSuggestionAuthorizationError(
       404,

--- a/server/tests/agendaSuggestion.test.js
+++ b/server/tests/agendaSuggestion.test.js
@@ -4,7 +4,6 @@ import AgendaSuggestion from "../models/agendaSuggestionModel.js";
 import Meeting from "../models/meetingModel.js";
 import ActionItem from "../models/actionItemModel.js";
 
-// Mock the AI service
 jest.unstable_mockModule("../services/GenerativeAIService.js", () => ({
   generateAgendaSuggestions: jest.fn().mockResolvedValue([
     {
@@ -30,6 +29,10 @@ const {
   applyAcceptedSuggestions,
   authorizeAgendaMeeting,
 } = await import("../services/agendaSuggestionService.js");
+
+const { updateSuggestionItem } = await import(
+  "../controllers/agendaSuggestionController.js"
+);
 
 describe("Agenda Suggestion Service", () => {
   let orgId, foreignOrgId, meetingId, user;
@@ -83,7 +86,7 @@ describe("Agenda Suggestion Service", () => {
   });
 
   it("should generate suggestions and save to DB", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId, user);
+    const suggestion = await generateSuggestions(meetingId, user);
 
     expect(suggestion).toBeDefined();
     expect(suggestion.suggestions).toHaveLength(2);
@@ -94,14 +97,6 @@ describe("Agenda Suggestion Service", () => {
     const savedSuggestion = await AgendaSuggestion.findById(suggestion._id);
     expect(savedSuggestion).toBeDefined();
     expect(savedSuggestion.suggestions).toHaveLength(2);
-  });
-
-  it("blocks generation when the client supplies a foreign organization", async () => {
-    await expect(
-      generateSuggestions(foreignOrgId, meetingId, user),
-    ).rejects.toMatchObject({ statusCode: 403 });
-
-    expect(await AgendaSuggestion.countDocuments()).toBe(0);
   });
 
   it("blocks access to a meeting in another organization", async () => {
@@ -128,6 +123,28 @@ describe("Agenda Suggestion Service", () => {
     ).rejects.toMatchObject({ statusCode: 403 });
   });
 
+  it("rejects an unauthenticated caller with 401", async () => {
+    await expect(
+      authorizeAgendaMeeting(null, meetingId, "view"),
+    ).rejects.toMatchObject({ statusCode: 401 });
+
+    await expect(
+      applyAcceptedSuggestions(new mongoose.Types.ObjectId(), null),
+    ).rejects.toMatchObject({ statusCode: 401 });
+  });
+
+  it("rejects an unknown meeting with 404", async () => {
+    await expect(
+      authorizeAgendaMeeting(user, new mongoose.Types.ObjectId(), "view"),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("rejects an invalid meeting id with 400", async () => {
+    await expect(
+      authorizeAgendaMeeting(user, "not-an-object-id", "view"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
   it("blocks list access for a foreign meeting", async () => {
     const foreignMeeting = await Meeting.create({
       title: "Foreign Meeting",
@@ -135,6 +152,12 @@ describe("Agenda Suggestion Service", () => {
       organization: foreignOrgId,
       uploadedBy: new mongoose.Types.ObjectId(),
       agendaItems: [],
+    });
+
+    await AgendaSuggestion.create({
+      meeting: foreignMeeting._id,
+      organization: foreignOrgId,
+      suggestions: [],
     });
 
     await expect(
@@ -156,12 +179,41 @@ describe("Agenda Suggestion Service", () => {
       suggestions: [],
     });
 
+    const req = {
+      params: { id: foreignSuggestion._id.toString(), itemId: "missing-item" },
+      body: { status: "accepted" },
+      user,
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await updateSuggestionItem(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("blocks apply access when the suggestion organization is foreign", async () => {
+    const sameOrgMeeting = await Meeting.create({
+      title: "Same Organization Meeting",
+      date: new Date(),
+      organization: orgId,
+      uploadedBy: user._id,
+      agendaItems: [],
+    });
+    const foreignSuggestion = await AgendaSuggestion.create({
+      meeting: sameOrgMeeting._id,
+      organization: foreignOrgId,
+      suggestions: [],
+    });
+
     await expect(
-      authorizeAgendaMeeting(user, foreignSuggestion.meeting, "edit"),
+      applyAcceptedSuggestions(foreignSuggestion._id, user),
     ).rejects.toMatchObject({ statusCode: 403 });
   });
 
-  it("blocks apply access for a foreign agenda suggestion", async () => {
+  it("blocks apply access for a foreign meeting", async () => {
     const foreignMeeting = await Meeting.create({
       title: "Foreign Meeting",
       date: new Date(),
@@ -189,7 +241,7 @@ describe("Agenda Suggestion Service", () => {
   });
 
   it("should apply accepted suggestions to the meeting", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId, user);
+    const suggestion = await generateSuggestions(meetingId, user);
 
     suggestion.suggestions[0].status = "accepted";
     suggestion.suggestions[1].status = "rejected";
@@ -207,7 +259,7 @@ describe("Agenda Suggestion Service", () => {
   });
 
   it("should apply edited suggestions with acceptedText", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId, user);
+    const suggestion = await generateSuggestions(meetingId, user);
 
     suggestion.suggestions[0].status = "edited";
     suggestion.suggestions[0].acceptedText = "Discuss Q2 Marketing - Updated";

--- a/server/tests/agendaSuggestion.test.js
+++ b/server/tests/agendaSuggestion.test.js
@@ -30,9 +30,10 @@ const {
   authorizeAgendaMeeting,
 } = await import("../services/agendaSuggestionService.js");
 
-const { updateSuggestionItem } = await import(
-  "../controllers/agendaSuggestionController.js"
-);
+const {
+  updateSuggestionItem,
+  getSuggestionsByMeeting,
+} = await import("../controllers/agendaSuggestionController.js");
 
 describe("Agenda Suggestion Service", () => {
   let orgId, foreignOrgId, meetingId, user;
@@ -160,9 +161,18 @@ describe("Agenda Suggestion Service", () => {
       suggestions: [],
     });
 
-    await expect(
-      authorizeAgendaMeeting(user, foreignMeeting._id, "view"),
-    ).rejects.toMatchObject({ statusCode: 403 });
+    const req = {
+      params: { meetingId: foreignMeeting._id.toString() },
+      user,
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await getSuggestionsByMeeting(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
   });
 
   it("blocks update access for a foreign agenda suggestion", async () => {

--- a/server/tests/agendaSuggestion.test.js
+++ b/server/tests/agendaSuggestion.test.js
@@ -25,11 +25,14 @@ jest.unstable_mockModule("../services/GenerativeAIService.js", () => ({
   ]),
 }));
 
-const { generateSuggestions, applyAcceptedSuggestions } =
-  await import("../services/agendaSuggestionService.js");
+const {
+  generateSuggestions,
+  applyAcceptedSuggestions,
+  authorizeAgendaMeeting,
+} = await import("../services/agendaSuggestionService.js");
 
 describe("Agenda Suggestion Service", () => {
-  let orgId, meetingId;
+  let orgId, foreignOrgId, meetingId, user;
 
   beforeAll(async () => {
     if (mongoose.connection.readyState !== 1) {
@@ -45,12 +48,18 @@ describe("Agenda Suggestion Service", () => {
 
   beforeEach(async () => {
     orgId = new mongoose.Types.ObjectId();
+    foreignOrgId = new mongoose.Types.ObjectId();
+    user = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: orgId,
+      role: "member",
+    };
 
     const meeting = new Meeting({
       title: "Test Meeting",
       date: new Date(),
       organization: orgId,
-      uploadedBy: new mongoose.Types.ObjectId(),
+      uploadedBy: user._id,
       agendaItems: [],
     });
     await meeting.save();
@@ -61,7 +70,7 @@ describe("Agenda Suggestion Service", () => {
       status: "open",
       organization: orgId,
       sourceMeetingId: meetingId,
-      owner: new mongoose.Types.ObjectId(),
+      owner: user._id,
     });
     await actionItem.save();
   });
@@ -74,27 +83,119 @@ describe("Agenda Suggestion Service", () => {
   });
 
   it("should generate suggestions and save to DB", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId);
+    const suggestion = await generateSuggestions(orgId, meetingId, user);
 
     expect(suggestion).toBeDefined();
     expect(suggestion.suggestions).toHaveLength(2);
     expect(suggestion.suggestions[0].text).toBe("Discuss Q2 Marketing");
     expect(suggestion.suggestions[0].status).toBe("pending");
+    expect(suggestion.organization.toString()).toBe(orgId.toString());
 
     const savedSuggestion = await AgendaSuggestion.findById(suggestion._id);
     expect(savedSuggestion).toBeDefined();
     expect(savedSuggestion.suggestions).toHaveLength(2);
   });
 
-  it("should apply accepted suggestions to the meeting", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId);
+  it("blocks generation when the client supplies a foreign organization", async () => {
+    await expect(
+      generateSuggestions(foreignOrgId, meetingId, user),
+    ).rejects.toMatchObject({ statusCode: 403 });
 
-    // Mark first as accepted, second as rejected
+    expect(await AgendaSuggestion.countDocuments()).toBe(0);
+  });
+
+  it("blocks access to a meeting in another organization", async () => {
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      organization: foreignOrgId,
+      uploadedBy: new mongoose.Types.ObjectId(),
+      agendaItems: [],
+    });
+
+    await expect(
+      authorizeAgendaMeeting(user, foreignMeeting._id, "view"),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks access when the user has no organization membership", async () => {
+    await expect(
+      authorizeAgendaMeeting(
+        { _id: user._id, role: "member" },
+        meetingId,
+        "view",
+      ),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks list access for a foreign meeting", async () => {
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      organization: foreignOrgId,
+      uploadedBy: new mongoose.Types.ObjectId(),
+      agendaItems: [],
+    });
+
+    await expect(
+      authorizeAgendaMeeting(user, foreignMeeting._id, "view"),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks update access for a foreign agenda suggestion", async () => {
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      organization: foreignOrgId,
+      uploadedBy: new mongoose.Types.ObjectId(),
+      agendaItems: [],
+    });
+    const foreignSuggestion = await AgendaSuggestion.create({
+      meeting: foreignMeeting._id,
+      organization: foreignOrgId,
+      suggestions: [],
+    });
+
+    await expect(
+      authorizeAgendaMeeting(user, foreignSuggestion.meeting, "edit"),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks apply access for a foreign agenda suggestion", async () => {
+    const foreignMeeting = await Meeting.create({
+      title: "Foreign Meeting",
+      date: new Date(),
+      organization: foreignOrgId,
+      uploadedBy: new mongoose.Types.ObjectId(),
+      agendaItems: [],
+    });
+    const foreignSuggestion = await AgendaSuggestion.create({
+      meeting: foreignMeeting._id,
+      organization: foreignOrgId,
+      suggestions: [],
+    });
+
+    await expect(
+      applyAcceptedSuggestions(foreignSuggestion._id, user),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("blocks edit and apply permissions for viewers", async () => {
+    const viewer = { ...user, role: "viewer" };
+
+    await expect(
+      authorizeAgendaMeeting(viewer, meetingId, "edit"),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it("should apply accepted suggestions to the meeting", async () => {
+    const suggestion = await generateSuggestions(orgId, meetingId, user);
+
     suggestion.suggestions[0].status = "accepted";
     suggestion.suggestions[1].status = "rejected";
     await suggestion.save();
 
-    const updatedMeeting = await applyAcceptedSuggestions(suggestion._id);
+    const updatedMeeting = await applyAcceptedSuggestions(suggestion._id, user);
 
     expect(updatedMeeting.agendaItems).toHaveLength(1);
     expect(updatedMeeting.agendaItems[0].text).toBe("Discuss Q2 Marketing");
@@ -106,14 +207,13 @@ describe("Agenda Suggestion Service", () => {
   });
 
   it("should apply edited suggestions with acceptedText", async () => {
-    const suggestion = await generateSuggestions(orgId, meetingId);
+    const suggestion = await generateSuggestions(orgId, meetingId, user);
 
-    // Mark first as edited
     suggestion.suggestions[0].status = "edited";
     suggestion.suggestions[0].acceptedText = "Discuss Q2 Marketing - Updated";
     await suggestion.save();
 
-    const updatedMeeting = await applyAcceptedSuggestions(suggestion._id);
+    const updatedMeeting = await applyAcceptedSuggestions(suggestion._id, user);
 
     expect(updatedMeeting.agendaItems).toHaveLength(1);
     expect(updatedMeeting.agendaItems[0].text).toBe(


### PR DESCRIPTION
## Description

Fixes #1384.

This change secures agenda suggestion endpoints by consistently validating the authenticated user's organization membership, meeting access, and required RBAC permissions before performing agenda suggestion operations.

### Changes

- Validate client-supplied organization IDs against the authenticated user's organization.
- Validate that the requested meeting belongs to the authenticated user's organization.
- Enforce RBAC permissions for agenda suggestion operations.
- Protect agenda suggestion generation from cross-tenant access.
- Protect agenda suggestion listing from unauthorized meetings.
- Protect agenda suggestion updates from cross-tenant access.
- Protect agenda suggestion application to unauthorized meetings.
- Scope agenda suggestion data to the authenticated organization.
- Add cross-tenant and RBAC authorization tests for affected operations.

### Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement

### Security

The authorization flow now follows:

User
↓
Organization membership
↓
Meeting ownership/access
↓
Required permission
↓
Agenda suggestion operation

Foreign organization data and unauthorized meetings are rejected before agenda suggestion data is generated, accessed, updated, or applied.

### Testing

Added tests covering:

- Foreign organization generation attempts
- Foreign meeting access
- Missing organization membership
- Unauthorized agenda suggestion update
- Unauthorized agenda suggestion apply
- Viewer RBAC restrictions
- Successful generation and application for authorized users

## Related Issue

Closes #1384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Permissions**
  * Agenda suggestions now verify authentication, organization membership, meeting access, and role permissions.
  * Viewing suggestions requires view access; generating, editing, and applying suggestions require edit access.
  * Cross-organization meetings and suggestions are blocked.

* **Bug Fixes**
  * Authorization failures now return clear, appropriate error responses instead of generic server errors.

* **Tests**
  * Added coverage for unauthorized users, organization mismatches, inaccessible meetings, and restricted viewer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->