### PR TITLE
refactor(shared-links): remove obsolete controller logic

### DIFF
--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -22,17 +22,7 @@ const getSharedLinkJwtSecret = () =>
   "default_shared_link_secret";
 
 /**
- * The shareable resource types and the model each one resolves against.
- *
- * A single map, rather than an `includes()` check in one place and an
- * `if/else` on the same string in another. The version this replaces had those
- * two drift apart: inside the type guard, the `resourceType === "Meeting"` arm
- * was unreachable — the enclosing condition had already excluded `"Meeting"` —
- * so an unknown type was looked up as a Policy and reported as
- * `"<type> not found"` instead of "invalid resource type", which also told the
- * caller whether an arbitrary ObjectId existed as a Policy. Keeping the
- * type→model relationship in one place removes that class of mismatch.
- *
+ * Maps shareable resource types to their Mongoose models.
  * Keys must stay in sync with the `resourceModel` enum on sharedLinkModel.
  */
 export const SHARE_MODELS_BY_TYPE = Object.freeze({
@@ -189,13 +179,7 @@ export const createLink = async (req, res) => {
         .json({ success: false, message: "Missing required fields" });
     }
 
-    // Issue #1070: the ownership check used to live inside
-    // `if (!["Meeting", "Policy"].includes(resourceType))` — the branch that is
-    // only entered when the type is *invalid*, and which then returned 400 a
-    // few lines later regardless. Every real request (`"Meeting"` / `"Policy"`)
-    // skipped it entirely, so any authenticated user could mint a public link
-    // for any resource in any organization given only its ObjectId. The guards
-    // below run on the path requests actually take.
+    // Ownership + org checks run on the live create path (Issue #1070).
     if (!SHARE_MODELS_BY_TYPE[resourceType]) {
       return res
         .status(400)
@@ -216,8 +200,6 @@ export const createLink = async (req, res) => {
     }
 
     if (!mongoose.isValidObjectId(resourceId)) {
-      // Previously a malformed id reached `findById` and surfaced as a CastError
-      // 500 rather than a validation error.
       return res
         .status(400)
         .json({ success: false, message: "Invalid resource ID" });
@@ -225,8 +207,6 @@ export const createLink = async (req, res) => {
 
     const callerOrg = req.user?.organization;
     if (!callerOrg) {
-      // A session with no organization used to blow up on `.toString()` of
-      // undefined; it cannot own a shareable resource either way.
       return res.status(403).json({
         success: false,
         message: "Forbidden: Resource does not belong to your organization",
@@ -475,17 +455,10 @@ export const getPublicResource = async (req, res) => {
       }
 
       let decoded = null;
-      const secret = getSharedLinkJwtSecret();
       try {
-        decoded = jwt.verify(token, secret);
+        decoded = jwt.verify(token, getSharedLinkJwtSecret());
       } catch (_err) {
-        if (process.env.JWT_SECRET && process.env.JWT_SECRET !== secret) {
-          try {
-            decoded = jwt.verify(token, process.env.JWT_SECRET);
-          } catch (_fallbackErr) {
-            // ignore
-          }
-        }
+        decoded = null;
       }
 
       if (!decoded || decoded.hash !== hash) {
@@ -544,6 +517,12 @@ export const getPublicResource = async (req, res) => {
         summary: policy.summary,
         key_changes: policy.key_changes,
       };
+    } else {
+      // Enum should prevent this; treat unexpected models as not found.
+      return res.status(404).json({
+        success: false,
+        message: "Link not found or inactive",
+      });
     }
 
     // Record view only after successful access; never include analytics in public payload


### PR DESCRIPTION
# Pull Request

## Description

### Summary

This PR removes obsolete and unreachable logic from the Shared Link controller to reduce technical debt, improve maintainability, and simplify the controller implementation without changing any active shared-link functionality.

The cleanup focuses on legacy code paths that are no longer required by the current implementation while preserving all existing shared-link workflows.

### Changes Made

- Removed obsolete JWT verification fallback logic that attempted verification using `JWT_SECRET`.
- Standardized verification flow to rely on the dedicated shared-link JWT secret resolution mechanism.
- Removed outdated historical and migration-related comments that no longer provide implementation value.
- Eliminated an unnecessary fallback path that could return a successful response containing `data: null` for unexpected resource types.
- Added explicit handling for invalid or unsupported `resourceModel` values.
- Improved controller readability by simplifying conditional logic and reducing dead branches.
- Preserved all existing shared-link routes, permissions, payloads, and functionality.

### Refactoring Improvements

- Reduced controller complexity.
- Removed unreachable code paths.
- Improved code clarity and maintainability.
- Kept behavior consistent for valid Meeting and Policy shared links.

### Active Functionality Preserved

The following functionality remains unchanged:

- Shared link creation
- Shared link verification
- Passcode-protected shared links
- Shared link access
- Shared link revocation
- Shared link analytics and permissions
- Meeting shared links
- Policy shared links

### Risk Assessment

- Legacy cookies signed exclusively with `JWT_SECRET` may no longer verify when a dedicated shared-link secret is configured. Existing shared-link tokens expire within one hour, minimizing impact.
- Invalid database records containing unsupported `resourceModel` values now return an explicit `404` response instead of a successful response with empty data.

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1142

## Testing

Validated the modified Shared Link controller and related functionality.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

### Validation Performed

- ✅ Prettier formatting
- ✅ Formatting validation
- ✅ ESLint validation
- ✅ Related shared-link tests
- ✅ Shared link creation verified
- ✅ Shared link access verified
- ✅ Shared link revocation verified
- ✅ Passcode verification verified

## Screenshots

Not applicable (controller refactoring and dead code cleanup).

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for public shared-link access by requiring the current shared-link secret.
  - Public-resource requests now return a clear 404 response when the requested resource type is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->