### PR TITLE
fix(speaker-mapping): enforce organization authorization

### DIFF
--- a/server/routes/speakerMappingRoutes.js
+++ b/server/routes/speakerMappingRoutes.js
@@ -1,5 +1,7 @@
 import express from "express";
+import Meeting from "../models/meetingModel.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgAccess, requirePermission } from "../middleware/rbac.js";
 import {
   getMappings,
   suggestMappings,
@@ -11,9 +13,31 @@ const router = express.Router();
 
 router.use(userAuth);
 
-router.get("/:meetingId", getMappings);
-router.get("/:meetingId/suggest", suggestMappings);
-router.post("/:meetingId", saveAndApplyMapping);
-router.delete("/:meetingId/:mappingId", revertMapping);
+// Issue #1378: resolve the meeting server-side and enforce org membership
+// before any speaker-mapping read/write. Never trust meetingId alone.
+router.get(
+  "/:meetingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  getMappings,
+);
+router.get(
+  "/:meetingId/suggest",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  suggestMappings,
+);
+router.post(
+  "/:meetingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  saveAndApplyMapping,
+);
+router.delete(
+  "/:meetingId/:mappingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "edit"),
+  revertMapping,
+);
 
 export default router;

--- a/server/tests/speakerMappingAuthorization.test.js
+++ b/server/tests/speakerMappingAuthorization.test.js
@@ -1,0 +1,342 @@
+/**
+ * Issue #1378 — speaker mapping endpoints must resolve the meeting and enforce
+ * organization access before any read/write. Cross-org callers must not be able
+ * to list, suggest, apply, or revert mappings for another tenant's meeting.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const mockSuggestMappings = jest.fn().mockResolvedValue([]);
+const mockApplyMapping = jest.fn().mockResolvedValue(undefined);
+
+jest.unstable_mockModule("../services/speakerIdentificationService.js", () => ({
+  default: {
+    suggestMappings: mockSuggestMappings,
+    applyMapping: mockApplyMapping,
+  },
+}));
+
+const { default: speakerMappingRoutes } =
+  await import("../routes/speakerMappingRoutes.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: SpeakerMapping } =
+  await import("../models/speakerMappingModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const aliceViewer = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "viewer",
+};
+
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noOrgUser = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "member",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/speaker-mappings", speakerMappingRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+  mockSuggestMappings.mockClear();
+  mockApplyMapping.mockClear();
+});
+
+const seedMeeting = async ({
+  organization,
+  uploadedBy,
+  title = "Planning",
+} = {}) => {
+  return Meeting.create({
+    uploadedBy,
+    organization,
+    title,
+    date: new Date(),
+  });
+};
+
+describe("Speaker mapping authorization (#1378)", () => {
+  describe("same-organization access", () => {
+    it("allows a same-org member to list mappings", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+      await SpeakerMapping.create({
+        meeting: meeting._id,
+        organization: ORG_A,
+        originalLabel: "Speaker A",
+        mappedName: "Alice",
+        createdBy: alice._id,
+        isConfirmed: true,
+      });
+
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].mappedName).toBe("Alice");
+    });
+
+    it("allows a same-org member to create/apply a mapping", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      const res = await request(app)
+        .post(`/api/speaker-mappings/${meeting._id}`)
+        .send({ originalLabel: "Speaker A", mappedName: "Alice" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.mappedName).toBe("Alice");
+      expect(mockApplyMapping).toHaveBeenCalledWith(
+        meeting._id.toString(),
+        "Speaker A",
+        "Alice",
+      );
+    });
+
+    it("allows a same-org member to update/apply and revert a mapping", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      const createRes = await request(app)
+        .post(`/api/speaker-mappings/${meeting._id}`)
+        .send({ originalLabel: "Speaker B", mappedName: "Bob" });
+      expect(createRes.status).toBe(200);
+
+      const mappingId = createRes.body.data._id;
+      const revertRes = await request(app).delete(
+        `/api/speaker-mappings/${meeting._id}/${mappingId}`,
+      );
+
+      expect(revertRes.status).toBe(200);
+      expect(revertRes.body.success).toBe(true);
+      expect(mockApplyMapping).toHaveBeenCalled();
+    });
+
+    it("allows a same-org member to request suggestions", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+      mockSuggestMappings.mockResolvedValueOnce([
+        { originalLabel: "Speaker A", mappedName: "Alice" },
+      ]);
+
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}/suggest`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockSuggestMappings).toHaveBeenCalledWith(meeting._id.toString());
+    });
+  });
+
+  describe("cross-organization access", () => {
+    it("returns 403 when listing mappings for another org's meeting", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: mallory._id,
+        title: "Confidential",
+      });
+      await SpeakerMapping.create({
+        meeting: meeting._id,
+        organization: ORG_B,
+        originalLabel: "Speaker X",
+        mappedName: "Secret",
+        createdBy: mallory._id,
+        isConfirmed: true,
+      });
+
+      currentUser = alice;
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/access/i);
+    });
+
+    it("returns 403 when creating/applying a mapping on another org's meeting", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: mallory._id,
+      });
+
+      currentUser = alice;
+      const res = await request(app)
+        .post(`/api/speaker-mappings/${meeting._id}`)
+        .send({ originalLabel: "Speaker A", mappedName: "Attacker" });
+
+      expect(res.status).toBe(403);
+      expect(mockApplyMapping).not.toHaveBeenCalled();
+      const count = await SpeakerMapping.countDocuments({
+        meeting: meeting._id,
+      });
+      expect(count).toBe(0);
+    });
+
+    it("returns 403 when suggesting mappings for another org's meeting", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: mallory._id,
+      });
+
+      currentUser = alice;
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}/suggest`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockSuggestMappings).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when reverting a mapping on another org's meeting", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: mallory._id,
+      });
+      const mapping = await SpeakerMapping.create({
+        meeting: meeting._id,
+        organization: ORG_B,
+        originalLabel: "Speaker X",
+        mappedName: "Secret",
+        createdBy: mallory._id,
+        isConfirmed: true,
+      });
+
+      currentUser = alice;
+      const res = await request(app).delete(
+        `/api/speaker-mappings/${meeting._id}/${mapping._id}`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockApplyMapping).not.toHaveBeenCalled();
+      expect(await SpeakerMapping.findById(mapping._id)).not.toBeNull();
+    });
+  });
+
+  describe("missing meeting and forbidden roles", () => {
+    it("returns 404 when the meeting does not exist", async () => {
+      const missingId = new mongoose.Types.ObjectId();
+      const res = await request(app).get(`/api/speaker-mappings/${missingId}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/not found/i);
+    });
+
+    it("returns 403 when the user has no organization", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = noOrgUser;
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/organization membership/i);
+    });
+
+    it("returns 403 when a viewer tries to create/apply a mapping", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = aliceViewer;
+      const res = await request(app)
+        .post(`/api/speaker-mappings/${meeting._id}`)
+        .send({ originalLabel: "Speaker A", mappedName: "Alice" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(mockApplyMapping).not.toHaveBeenCalled();
+    });
+
+    it("allows a viewer to read mappings (meetings.view)", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = aliceViewer;
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = null;
+      const res = await request(app).get(
+        `/api/speaker-mappings/${meeting._id}`,
+      );
+
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h1 data-section-id="1n4c7de" data-start="708" data-end="722" class="PDq2pG_selectionAnchorContainer">Pull Request<span aria-hidden="true" class="PDq2pG_selectionAnchor"></span></h1>
<h2 data-section-id="rmw5tv" data-start="724" data-end="738">Description</h2>
<h3 data-section-id="wv8cei" data-start="740" data-end="751">Summary</h3>
<p data-start="753" data-end="920">This PR secures speaker mapping endpoints by enforcing organization-level authorization and existing RBAC permissions before any speaker mapping operation is executed.</p>
<p data-start="922" data-end="1155">Previously, speaker mapping routes only required authentication. An authenticated user who knew another meeting's <code data-start="1036" data-end="1047">meetingId</code> could potentially access or modify speaker mappings without verifying ownership or organization membership.</p>
<p data-start="1157" data-end="1324">The updated implementation resolves the target meeting server-side and applies existing organization access and permission checks before reaching the controller layer.</p>
<h3 data-section-id="10l9dha" data-start="1326" data-end="1342">Changes Made</h3>
<ul data-start="1344" data-end="1910">
<li data-section-id="12z38gf" data-start="1344" data-end="1422">
Added organization-level authorization checks to all speaker mapping routes.
</li>
<li data-section-id="j1t876" data-start="1423" data-end="1507">
Reused existing <code data-start="1441" data-end="1468">requireOrgAccess(Meeting)</code> middleware to validate meeting access.
</li>
<li data-section-id="ns0h3j" data-start="1508" data-end="1596">
Reused existing RBAC permission checks instead of introducing a new permission system.
</li>
<li data-section-id="1euqo72" data-start="1597" data-end="1682">
Ensured meetings are resolved and validated server-side before processing requests.
</li>
<li data-section-id="16eoowo" data-start="1683" data-end="1741">
Protected all speaker mapping read and write operations.
</li>
<li data-section-id="8897s3" data-start="1742" data-end="1837">
Added authorization tests covering same-organization and cross-organization access scenarios.
</li>
<li data-section-id="s68e78" data-start="1838" data-end="1910">
Preserved existing controller logic and speaker mapping functionality.
</li>
</ul>
<h3 data-section-id="d7p0du" data-start="1912" data-end="1935">Authorization Model</h3>
<h4 data-start="1937" data-end="1957">Read Operations</h4>
<p data-start="1959" data-end="1967">Require:</p>
<ul data-start="1969" data-end="2057">
<li data-section-id="fk0gda" data-start="1969" data-end="1991">
Valid authentication
</li>
<li data-section-id="37sjcc" data-start="1992" data-end="2028">
Organization access to the meeting
</li>
<li data-section-id="12ssju2" data-start="2029" data-end="2057">
<code data-start="2031" data-end="2046">meetings.view</code> permission
</li>
</ul>
<p data-start="2059" data-end="2076">Protected routes:</p>
<ul data-start="2078" data-end="2125">
<li data-section-id="nw2rq7" data-start="2078" data-end="2097">
<code data-start="2080" data-end="2097">GET /:meetingId</code>
</li>
<li data-section-id="c2tlf8" data-start="2098" data-end="2125">
<code data-start="2100" data-end="2125">GET /:meetingId/suggest</code>
</li>
</ul>
<h4 data-start="2127" data-end="2148">Write Operations</h4>
<p data-start="2150" data-end="2158">Require:</p>
<ul data-start="2160" data-end="2248">
<li data-section-id="fk0gda" data-start="2160" data-end="2182">
Valid authentication
</li>
<li data-section-id="37sjcc" data-start="2183" data-end="2219">
Organization access to the meeting
</li>
<li data-section-id="144qyxn" data-start="2220" data-end="2248">
<code data-start="2222" data-end="2237">meetings.edit</code> permission
</li>
</ul>
<p data-start="2250" data-end="2267">Protected routes:</p>
<ul data-start="2269" data-end="2323">
<li data-section-id="1nbxms1" data-start="2269" data-end="2289">
<code data-start="2271" data-end="2289">POST /:meetingId</code>
</li>
<li data-section-id="1yu40lg" data-start="2290" data-end="2323">
<code data-start="2292" data-end="2323">DELETE /:meetingId/:mappingId</code>
</li>
</ul>
<h3 data-section-id="g54eqz" data-start="2325" data-end="2350">Security Improvements</h3>
<ul data-start="2352" data-end="2640">
<li data-section-id="11zo46g" data-start="2352" data-end="2409">
Prevents cross-organization access to speaker mappings.
</li>
<li data-section-id="1x31kql" data-start="2410" data-end="2464">
Prevents unauthorized speaker mapping modifications.
</li>
<li data-section-id="1p8zl6d" data-start="2465" data-end="2525">
Ensures meeting ownership/access is validated server-side.
</li>
<li data-section-id="1oupz1v" data-start="2526" data-end="2583">
Eliminates trust in client-provided <code data-start="2564" data-end="2575">meetingId</code> values.
</li>
<li data-section-id="rdltda" data-start="2584" data-end="2640">
Maintains existing RBAC behavior and permission model.
</li>
</ul>
<h3 data-section-id="vqxngp" data-start="2642" data-end="2663">Response Behavior</h3>
<div class="group TyagGW_tableContainer"><div tabindex="-1" class="TyagGW_tableWrapper flex flex-col-reverse w-fit">
Scenario | Response
-- | --
Unauthenticated user | 401 Unauthorized
Authenticated but forbidden | 403 Forbidden
Meeting does not exist | 404 Not Found
Authorized access | Existing behavior unchanged

</div></div>
<h3 data-section-id="zp2zu8" data-start="2909" data-end="2920">Testing</h3>
<p data-start="2922" data-end="2955">Added authorization coverage for:</p>
<ul data-start="2957" data-end="3140">
<li data-section-id="730b9c" data-start="2957" data-end="2983">
Same-organization access
</li>
<li data-section-id="1nfa66c" data-start="2984" data-end="3011">
Cross-organization access
</li>
<li data-section-id="m3u16u" data-start="3012" data-end="3030">
Missing meetings
</li>
<li data-section-id="1epyf45" data-start="3031" data-end="3064">
Missing organization membership
</li>
<li data-section-id="18vvgck" data-start="3065" data-end="3085">
Viewer read access
</li>
<li data-section-id="1rxkg6g" data-start="3086" data-end="3113">
Viewer write restrictions
</li>
<li data-section-id="ckz80o" data-start="3114" data-end="3140">
Unauthenticated requests
</li>
</ul>
<h3 data-section-id="gqkwyf" data-start="3142" data-end="3161">Backend Changes</h3>
<ul data-start="3163" data-end="3248">
<li data-section-id="ychsxy" data-start="3163" data-end="3209">
Updated speaker mapping route authorization.
</li>
<li data-section-id="1xwxfz7" data-start="3210" data-end="3248">
Added dedicated authorization tests.
</li>
</ul>
<p data-start="3250" data-end="3291">No database schema changes were required.</p>
<h2 data-section-id="7inma" data-start="3293" data-end="3310">Type of Change</h2>
<ul class="contains-task-list" data-start="3312" data-end="3454">
<li data-section-id="1284gxy" class="task-list-item" data-start="3312" data-end="3329">
<input disabled="" type="checkbox"> New Feature
</li>
<li data-section-id="1rw82fl" class="task-list-item" data-start="3330" data-end="3343">
<input disabled="" type="checkbox" checked=""> Bug Fix
</li>
<li data-section-id="p45d71" class="task-list-item" data-start="3344" data-end="3370">
<input disabled="" type="checkbox"> Documentation Update
</li>
<li data-section-id="m6c0us" data-start="3371" data-end="3385" class="task-list-item">
<input disabled="" type="checkbox"> Refactor
</li>
<li data-section-id="154l4n2" class="task-list-item" data-start="3386" data-end="3415">
<input disabled="" type="checkbox"> Performance Improvement
</li>
<li data-section-id="1j9to2w" class="task-list-item" data-start="3416" data-end="3442">
<input disabled="" type="checkbox" checked=""> Security Improvement
</li>
<li data-section-id="12081oq" class="task-list-item" data-start="3443" data-end="3454">
<input disabled="" type="checkbox"> Other
</li>
</ul>
<h2 data-section-id="guz49f" data-start="3456" data-end="3472">Related Issue</h2>
<p data-start="3474" data-end="3486">Closes #1378</p>
<h2 data-section-id="23idtf" data-start="3488" data-end="3498">Testing</h2>
<p data-start="3500" data-end="3554">Validated authorization behavior and route protection.</p>
<ul data-start="3556" data-end="3646" class="contains-task-list">
<li data-section-id="fh6sux" data-start="3556" data-end="3576" class="task-list-item">
<input disabled="" type="checkbox" checked=""> Tested locally
</li>
<li data-section-id="cytga0" class="task-list-item" data-start="3577" data-end="3614">
<input disabled="" type="checkbox" checked=""> Existing functionality verified
</li>
<li data-section-id="1fnyfok" class="task-list-item" data-start="3615" data-end="3646">
<input disabled="" type="checkbox" checked=""> No new warnings or errors
</li>
</ul>
<h3 data-section-id="ppxge5" data-start="3648" data-end="3672">Validation Performed</h3>
<ul data-start="3674" data-end="3926">
<li data-section-id="1dj9p8j" data-start="3674" data-end="3697">
✅ Prettier formatting
</li>
<li data-section-id="iujilr" data-start="3698" data-end="3719">
✅ ESLint validation
</li>
<li data-section-id="1tgautg" data-start="3720" data-end="3759">
✅ Speaker mapping authorization tests
</li>
<li data-section-id="w0jal8" data-start="3760" data-end="3801">
✅ Same-organization access verification
</li>
<li data-section-id="14y5cs8" data-start="3802" data-end="3844">
✅ Cross-organization access verification
</li>
<li data-section-id="q7lt6j" data-start="3845" data-end="3884">
✅ Permission enforcement verification
</li>
<li data-section-id="18zd78l" data-start="3885" data-end="3926">
✅ 401 / 403 / 404 response verification
</li>
</ul>
<h2 data-section-id="4fwza2" data-start="3928" data-end="3942">Screenshots</h2>
<p data-start="3944" data-end="4004">Not applicable (backend authorization/security enhancement).</p>
<h2 data-section-id="17gbhj5" data-start="4006" data-end="4018">Checklist</h2>
<ul class="contains-task-list" data-start="4020" data-end="4191">
<li data-section-id="1xceb18" class="task-list-item" data-start="4020" data-end="4058">
<input disabled="" type="checkbox" checked=""> Code follows project conventions
</li>
<li data-section-id="12o154d" class="task-list-item" data-start="4059" data-end="4101">
<input disabled="" type="checkbox"> Documentation updated where required
</li>
<li data-section-id="180mmx2" class="task-list-item" data-start="4102" data-end="4137">
<input disabled="" type="checkbox" checked=""> No unnecessary files included
</li>
<li data-section-id="8igg4i" class="task-list-item" data-start="4138" data-end="4168">
<input disabled="" type="checkbox" checked=""> Changes have been tested
</li>
<li data-section-id="qwd8sc" class="task-list-item" data-start="4169" data-end="4191">
<input disabled="" type="checkbox" checked=""> Ready for review</li></ul><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access controls for speaker-mapping operations.
  * Restricted viewing and editing to authorized members of the relevant organization.
  * Prevented unauthorized access across organizations and for unauthenticated requests.
  * Added clearer handling when the associated meeting cannot be found.

* **Tests**
  * Added comprehensive coverage for authorization, permissions, organization membership, and access-denial scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->