### PR TITLE
fix: sanitize recap HTML preview

### DIFF
--- a/client/src/components/RecapPreferences.jsx
+++ b/client/src/components/RecapPreferences.jsx
@@ -6,6 +6,8 @@ import {
 } from "../services/recapApi";
 import { Dialog } from "@headlessui/react";
 import { toast } from "react-toastify";
+import SandboxedHtmlPreview from "./SandboxedHtmlPreview";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 
 const RecapPreferences = () => {
   const [preferences, setPreferences] = useState({
@@ -115,7 +117,7 @@ const RecapPreferences = () => {
             : null,
       };
       const html = await previewRecapEmail(payload);
-      setPreviewHtml(html);
+      setPreviewHtml(sanitizeHtml(html));
       setIsPreviewOpen(true);
     } catch {
       toast.error("Failed to generate preview");
@@ -131,7 +133,6 @@ const RecapPreferences = () => {
         Configure how and when you want to receive meeting summaries via email.
       </p>
 
-      {/* Delivery Timing */}
       <div className="mb-6">
         <h3 className="text-lg font-medium mb-2">Delivery Timing</h3>
         <div className="space-y-2">
@@ -151,44 +152,24 @@ const RecapPreferences = () => {
         </div>
       </div>
 
-      {/* Content Preferences */}
       <div className="mb-6">
         <h3 className="text-lg font-medium mb-2">Content to Include</h3>
         <div className="space-y-2">
           <label className="flex items-center space-x-3">
-            <input
-              type="checkbox"
-              name="includeSummary"
-              checked={preferences.includeSummary}
-              onChange={handleChange}
-              className="h-4 w-4 text-blue-600 rounded border-gray-300"
-            />
+            <input type="checkbox" name="includeSummary" checked={preferences.includeSummary} onChange={handleChange} className="h-4 w-4 text-blue-600 rounded border-gray-300" />
             <span>Meeting Summary</span>
           </label>
           <label className="flex items-center space-x-3">
-            <input
-              type="checkbox"
-              name="includeActionItems"
-              checked={preferences.includeActionItems}
-              onChange={handleChange}
-              className="h-4 w-4 text-blue-600 rounded border-gray-300"
-            />
+            <input type="checkbox" name="includeActionItems" checked={preferences.includeActionItems} onChange={handleChange} className="h-4 w-4 text-blue-600 rounded border-gray-300" />
             <span>Action Items</span>
           </label>
           <label className="flex items-center space-x-3">
-            <input
-              type="checkbox"
-              name="includeTranscript"
-              checked={preferences.includeTranscript}
-              onChange={handleChange}
-              className="h-4 w-4 text-blue-600 rounded border-gray-300"
-            />
+            <input type="checkbox" name="includeTranscript" checked={preferences.includeTranscript} onChange={handleChange} className="h-4 w-4 text-blue-600 rounded border-gray-300" />
             <span>Transcript Snippet</span>
           </label>
         </div>
       </div>
 
-      {/* Quiet Hours */}
       <div className="mb-6">
         <h3 className="text-lg font-medium mb-2">Quiet Hours (Optional)</h3>
         <p className="text-sm text-gray-500 mb-2">
@@ -197,111 +178,48 @@ const RecapPreferences = () => {
         </p>
         <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4 items-start sm:items-center">
           <div className="w-full sm:w-auto">
-            <label
-              htmlFor="quietHoursStart"
-              className="block text-sm text-gray-700 mb-1"
-            >
-              Start Time
-            </label>
-            <select
-              id="quietHoursStart"
-              name="quietHoursStart"
-              value={preferences.quietHoursStart}
-              onChange={handleChange}
-              className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}
-            >
+            <label htmlFor="quietHoursStart" className="block text-sm text-gray-700 mb-1">Start Time</label>
+            <select id="quietHoursStart" name="quietHoursStart" value={preferences.quietHoursStart} onChange={handleChange} className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}>
               <option value="">None</option>
-              {hoursOptions.map((hour) => (
-                <option key={hour} value={hour}>
-                  {formatHour(hour)}
-                </option>
-              ))}
+              {hoursOptions.map((hour) => <option key={hour} value={hour}>{formatHour(hour)}</option>)}
             </select>
           </div>
           <div className="w-full sm:w-auto">
-            <label
-              htmlFor="quietHoursEnd"
-              className="block text-sm text-gray-700 mb-1"
-            >
-              End Time
-            </label>
-            <select
-              id="quietHoursEnd"
-              name="quietHoursEnd"
-              value={preferences.quietHoursEnd}
-              onChange={handleChange}
-              className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}
-            >
+            <label htmlFor="quietHoursEnd" className="block text-sm text-gray-700 mb-1">End Time</label>
+            <select id="quietHoursEnd" name="quietHoursEnd" value={preferences.quietHoursEnd} onChange={handleChange} className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}>
               <option value="">None</option>
-              {hoursOptions.map((hour) => (
-                <option key={hour} value={hour}>
-                  {formatHour(hour)}
-                </option>
-              ))}
+              {hoursOptions.map((hour) => <option key={hour} value={hour}>{formatHour(hour)}</option>)}
             </select>
           </div>
         </div>
-        {quietHoursError && (
-          <p className="text-sm text-red-500 mt-2 font-medium">
-            {quietHoursError}
-          </p>
-        )}
-        <p className="text-xs text-gray-500 mt-2">
-          Timezone: {preferences.timezone}
-        </p>
+        {quietHoursError && <p className="text-sm text-red-500 mt-2 font-medium">{quietHoursError}</p>}
+        <p className="text-xs text-gray-500 mt-2">Timezone: {preferences.timezone}</p>
       </div>
 
       <div className="flex space-x-4">
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded"
-        >
+        <button onClick={handleSave} disabled={saving} className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
           {saving ? "Saving..." : "Save Preferences"}
         </button>
-        <button
-          onClick={handlePreview}
-          className="bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium py-2 px-4 rounded border border-gray-300"
-        >
+        <button onClick={handlePreview} className="bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium py-2 px-4 rounded border border-gray-300">
           Preview Email
         </button>
       </div>
 
-      {/* Preview Modal */}
-      <Dialog
-        open={isPreviewOpen}
-        onClose={() => setIsPreviewOpen(false)}
-        className="fixed z-50 inset-0 overflow-y-auto"
-      >
+      <Dialog open={isPreviewOpen} onClose={() => setIsPreviewOpen(false)} className="fixed z-50 inset-0 overflow-y-auto">
         <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
           <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
-          <span
-            className="hidden sm:inline-block sm:align-middle sm:h-screen"
-            aria-hidden="true"
-          >
-            &#8203;
-          </span>
+          <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
           <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full sm:p-6">
             <div className="sm:flex sm:items-start">
               <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
-                <Dialog.Title
-                  as="h3"
-                  className="text-lg leading-6 font-medium text-gray-900 mb-4"
-                >
-                  Email Preview
-                </Dialog.Title>
-                <div className="mt-2 w-full border rounded p-4 max-h-[60vh] overflow-y-auto bg-gray-50">
-                  {/* Dangerously set HTML since we generate it in backend */}
-                  <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
+                <Dialog.Title as="h3" className="text-lg leading-6 font-medium text-gray-900 mb-4">Email Preview</Dialog.Title>
+                <div className="mt-2 w-full max-h-[60vh] overflow-y-auto bg-gray-50">
+                  <SandboxedHtmlPreview htmlContent={previewHtml} title="Recap Email Preview" className="w-full" />
                 </div>
               </div>
             </div>
             <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-              <button
-                type="button"
-                className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm"
-                onClick={() => setIsPreviewOpen(false)}
-              >
+              <button type="button" className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none sm:mt-0 sm:w-auto sm:text-sm" onClick={() => setIsPreviewOpen(false)}>
                 Close
               </button>
             </div>

--- a/client/src/utils/sanitizeHtml.js
+++ b/client/src/utils/sanitizeHtml.js
@@ -1,21 +1,22 @@
 import DOMPurify from "dompurify";
 
+const ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto):)/i;
+
 /**
- * Sanitizes an HTML string to prevent XSS attacks.
- * It removes unsafe tags (like <script>), inline event handlers, and javascript URIs.
- * It preserves safe formatting tags like headings, paragraphs, lists, links, and bold text.
+ * Sanitizes untrusted HTML for use in the restricted recap/email preview.
+ *
+ * The allow-list intentionally contains only the markup needed to display
+ * formatted email content. DOMPurify removes scripts, event handlers, and
+ * unsafe URL protocols before the HTML is passed to the preview iframe.
  *
  * @param {string} html - The raw, potentially unsafe HTML string.
- * @returns {string} - The sanitized, safe HTML string.
+ * @returns {string} - Sanitized HTML safe for the restricted preview.
  */
 export const sanitizeHtml = (html) => {
   if (typeof html !== "string" || !html) {
     return "";
   }
 
-  // DOMPurify blocks scripts, javascript: URLs, and inline event handlers by default.
-  // We explicitly configure allowed tags and attributes for added safety while
-  // preserving expected document formatting.
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: [
       "b",
@@ -57,6 +58,9 @@ export const sanitizeHtml = (html) => {
       "style",
       "id",
     ],
+    ALLOW_DATA_ATTR: false,
+    ALLOWED_URI_REGEXP,
+    FORBID_TAGS: ["script", "iframe", "object", "embed", "form"],
     RETURN_DOM: false,
     RETURN_DOM_FRAGMENT: false,
     RETURN_DOM_IMPORT: false,

--- a/client/src/utils/sanitizeHtml.test.js
+++ b/client/src/utils/sanitizeHtml.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeHtml } from "./sanitizeHtml";
+
+describe("sanitizeHtml", () => {
+  it("removes script elements", () => {
+    const sanitized = sanitizeHtml('<p>Hello</p><script>alert("xss")</script>');
+
+    expect(sanitized).toContain("<p>Hello</p>");
+    expect(sanitized).not.toContain("<script");
+    expect(sanitized).not.toContain("alert");
+  });
+
+  it("removes inline event handlers", () => {
+    const sanitized = sanitizeHtml('<button onclick="alert(1)">Click</button>');
+
+    expect(sanitized).not.toContain("onclick");
+    expect(sanitized).not.toContain("alert(1)");
+  });
+
+  it("blocks dangerous URL protocols", () => {
+    const sanitized = sanitizeHtml(
+      '<a href="javascript:alert(1)">Bad link</a><img src="javascript:alert(2)" />',
+    );
+
+    expect(sanitized).not.toContain("javascript:");
+    expect(sanitized).toContain("Bad link");
+  });
+
+  it("preserves legitimate recap formatting and styling", () => {
+    const sanitized = sanitizeHtml(
+      '<div class="recap"><h2>Meeting recap</h2><p style="font-weight:bold">Summary</p><a href="https://example.com" target="_blank">Details</a></div>',
+    );
+
+    expect(sanitized).toContain('<h2>Meeting recap</h2>');
+    expect(sanitized).toContain('class="recap"');
+    expect(sanitized).toContain('style="font-weight:bold"');
+    expect(sanitized).toContain('href="https://example.com"');
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes the XSS vulnerability in the Recap Preferences HTML preview.

### Changes

- Sanitized recap HTML using DOMPurify before rendering.
- Added a restricted HTML allow-list for email preview content.
- Blocked `<script>` and other dangerous embedded elements.
- Removed inline event-handler attributes such as `onclick`.
- Blocked dangerous URL protocols such as `javascript:`.
- Disabled data attributes that are not required by the preview.
- Rendered the sanitized HTML using the existing fully sandboxed iframe.
- Preserved legitimate recap formatting, links, images, classes, and inline styling.
- Added regression tests covering common XSS payloads and legitimate preview content.

### Security

The preview now follows:

API HTML → DOMPurify → Sandboxed iframe → Render

The iframe uses a restrictive `sandbox=""` policy, preventing scripts, same-origin access, forms, popups, and top-level navigation.

### Tests

Added regression tests for:

- `<script>` injection
- Inline event handlers such as `onclick`
- `javascript:` URLs
- Legitimate recap HTML formatting
- Preview styling and safe links

### Issue

Closes #1391