### PR TITLE
fix(jobs): register and initialize AI MoM worker during backend startup

### DIFF
--- a/server/config/workers.js
+++ b/server/config/workers.js
@@ -1,5 +1,6 @@
 import { initRedis } from "../services/redisService.js";
 import {
+  initAIWorker,
   initDataExportWorker,
   initExportCleanupWorker,
   initConflictScanWorker,
@@ -50,6 +51,7 @@ export async function startWorkers(app) {
   };
 
   await safeInit("Redis", () => initRedis());
+  await safeInit("AI Worker", () => initAIWorker(app));
   await safeInit("Data Export Worker", () => initDataExportWorker(app));
   await safeInit("Export Cleanup Worker", () => initExportCleanupWorker());
   await safeInit("Conflict Scan Worker", () => initConflictScanWorker(app));

--- a/server/tests/aiMomWorkerRegistration.test.js
+++ b/server/tests/aiMomWorkerRegistration.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { startWorkers } from "../config/workers.js";
+import * as queueService from "../services/queueService.js";
+
+vi.mock("../services/redisService.js", () => ({
+  initRedis: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../services/queueService.js", () => ({
+  initAIWorker: vi.fn().mockReturnValue({ id: "worker-ai" }),
+  initDataExportWorker: vi.fn().mockReturnValue({ id: "worker-export" }),
+  initExportCleanupWorker: vi.fn().mockResolvedValue({ id: "worker-cleanup" }),
+  initConflictScanWorker: vi.fn().mockReturnValue({ id: "worker-conflict" }),
+  initSentimentWorker: vi.fn().mockReturnValue({ id: "worker-sentiment" }),
+  initRecalculateImportanceWorker: vi
+    .fn()
+    .mockReturnValue({ id: "worker-importance" }),
+  initMemoryLifecycleWorker: vi
+    .fn()
+    .mockResolvedValue({ id: "worker-lifecycle" }),
+  initRecapDeliveryWorker: vi.fn().mockReturnValue({ id: "worker-recap" }),
+}));
+
+vi.mock("../services/webhookDispatcherService.js", () => ({
+  initWebhookWorker: vi.fn().mockReturnValue({ id: "worker-webhook" }),
+}));
+
+describe("AI MoM Worker Registration (#1392)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers and initializes the AI MoM worker during startWorkers execution", async () => {
+    const mockApp = {};
+    const result = await startWorkers(mockApp);
+
+    expect(queueService.initAIWorker).toHaveBeenCalledWith(mockApp);
+    expect(result.started).toContain("AI Worker");
+    expect(result.failed).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #1392

## Description
This PR registers and initializes the AI Minutes of Meeting (MoM) background worker during backend application startup in server/config/workers.js, preventing queued MoM jobs from remaining indefinitely in a pending state.

## Proposed Changes
- **Worker Registration**: Imported initAIWorker from queueService.js and registered it safely inside startWorkers(app) in server/config/workers.js.
- **Fault-Tolerant Initialization**: Ensured worker initialization errors are logged gracefully without preventing HTTP server startup.
- **Unit Test Coverage**: Added Vitest test suite (iMomWorkerRegistration.test.js) verifying worker startup registration.

## Checklist
- [x] Related Issue is linked (Fixes #1392).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.