### PR TITLE
fix: enforce invitation expiry validation for token access

### DIFF
--- a/server/controllers/invitationController.js
+++ b/server/controllers/invitationController.js
@@ -7,6 +7,7 @@ import crypto from "crypto";
 import mongoose from "mongoose";
 import EmailService from "../services/EmailService.js";
 import AuditService from "../services/AuditService.js";
+import * as InvitationService from "../services/InvitationService.js";
 
 /**
  * Validate MongoDB ObjectId
@@ -496,6 +497,14 @@ export const rejectInvitation = async (req, res) => {
       });
     }
 
+    if (InvitationService.isInvitationExpired(invitation.expiresAt)) {
+      invitation.status = "expired";
+      await invitation.save();
+      return res
+        .status(400)
+        .json({ success: false, message: "Invitation has expired." });
+    }
+
     // Verify email matches
     const user = await userModel.findById(req.user.id);
 
@@ -604,35 +613,15 @@ export const revokeInvitation = async (req, res) => {
 export const getInvitationByToken = async (req, res) => {
   try {
     const { token } = req.params;
-
-    const invitation = await Invitation.findOne({ token })
-      .populate("organization", "name slug description logo")
-      .populate("invitedBy", "name email");
-
-    if (!invitation) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Invitation not found." });
-    }
-
-    if (invitation.status !== "pending") {
-      return res.status(400).json({
-        success: false,
-        message: "Invitation is not in pending status.",
-      });
-    }
-
-    if (invitation.expiresAt < new Date()) {
-      invitation.status = "expired";
-      await invitation.save();
-      return res
-        .status(400)
-        .json({ success: false, message: "Invitation has expired." });
-    }
-
-    res.status(200).json({ success: true, invitation });
+    const result = await InvitationService.getInvitationByToken(token);
+    res.status(200).json(result);
   } catch (error) {
     console.error("❌ Error fetching invitation:", error);
+    if (error.statusCode) {
+      return res
+        .status(error.statusCode)
+        .json({ success: false, message: error.message });
+    }
     res.status(500).json({ success: false, message: "Server error" });
   }
 };

--- a/server/services/InvitationService.js
+++ b/server/services/InvitationService.js
@@ -74,6 +74,47 @@ const generateInvitationToken = () => {
 };
 
 /**
+ * Returns true when an invitation is past its expiry timestamp.
+ * Treats missing or invalid expiry values as expired.
+ * @param {Date|string|number|null|undefined} expiresAt
+ * @returns {boolean}
+ */
+export const isInvitationExpired = (expiresAt) => {
+  if (expiresAt == null) return true;
+  const expiryMs = new Date(expiresAt).getTime();
+  return Number.isNaN(expiryMs) || expiryMs <= Date.now();
+};
+
+/**
+ * Ensures an invitation is pending and not expired.
+ * Marks expired invitations when persistExpired is true.
+ *
+ * @param {import("mongoose").Document} invitation
+ * @param {{ persistExpired?: boolean, session?: import("mongoose").ClientSession }} [options]
+ * @throws {NotFoundError|ValidationError}
+ */
+export const assertInvitationPendingAndActive = async (
+  invitation,
+  { persistExpired = true, session = null } = {},
+) => {
+  if (!invitation) {
+    throw new NotFoundError("Invitation not found.");
+  }
+
+  if (invitation.status !== "pending") {
+    throw new ValidationError("Invitation is not in pending status.");
+  }
+
+  if (isInvitationExpired(invitation.expiresAt)) {
+    if (persistExpired) {
+      invitation.status = "expired";
+      await invitation.save(session ? { session } : undefined);
+    }
+    throw new ValidationError("Invitation has expired.");
+  }
+};
+
+/**
  * Check if a user is admin or owner of the given organization.
  * Returns true if authorized, false otherwise.
  */
@@ -313,19 +354,8 @@ export const acceptInvitation = async (userId, token) => {
       throw new NotFoundError("Invitation not found.");
     }
 
-    // Step 2: Validate invitation status
-    if (invitation.status !== "pending") {
-      throw new ValidationError(
-        `Invitation is not in pending status. Current status: ${invitation.status}`,
-      );
-    }
-
-    // Step 3: Check expiration
-    if (invitation.expiresAt < new Date()) {
-      invitation.status = "expired";
-      await invitation.save({ session });
-      throw new ValidationError("Invitation has expired.");
-    }
+    // Step 2–3: Validate pending status and expiry (Issue #1358)
+    await assertInvitationPendingAndActive(invitation, { session });
 
     // Step 4: Verify email matches authenticated user
     const user = await userModel.findById(userId).session(session);
@@ -408,9 +438,7 @@ export const rejectInvitation = async (userId, token) => {
     throw new NotFoundError("Invitation not found.");
   }
 
-  if (invitation.status !== "pending") {
-    throw new ValidationError("Invitation is not in pending status.");
-  }
+  await assertInvitationPendingAndActive(invitation);
 
   // Verify email matches
   const user = await userModel.findById(userId);
@@ -477,15 +505,7 @@ export const getInvitationByToken = async (token) => {
     throw new NotFoundError("Invitation not found.");
   }
 
-  if (invitation.status !== "pending") {
-    throw new ValidationError("Invitation is not in pending status.");
-  }
-
-  if (invitation.expiresAt < new Date()) {
-    invitation.status = "expired";
-    await invitation.save();
-    throw new ValidationError("Invitation has expired.");
-  }
+  await assertInvitationPendingAndActive(invitation);
 
   return { success: true, invitation };
 };

--- a/server/tests/InvitationService.test.js
+++ b/server/tests/InvitationService.test.js
@@ -464,6 +464,7 @@ describe("InvitationService", () => {
         status: "pending",
         expiresAt: new Date(Date.now() + 86400000),
         organization: { name: "Org" },
+        save: vi.fn(),
       };
       Invitation.findOne.mockReturnValue({
         populate: vi.fn().mockReturnValue({
@@ -475,6 +476,43 @@ describe("InvitationService", () => {
 
       expect(result.success).toBe(true);
       expect(result.invitation).toEqual(mockInvitation);
+    });
+
+    it("should throw ValidationError for an expired invitation token", async () => {
+      const mockInvitation = {
+        token: "expired-tok",
+        status: "pending",
+        expiresAt: new Date(Date.now() - 1000),
+        save: vi.fn().mockResolvedValue(undefined),
+      };
+      Invitation.findOne.mockReturnValue({
+        populate: vi.fn().mockReturnValue({
+          populate: vi.fn().mockResolvedValue(mockInvitation),
+        }),
+      });
+
+      await expect(
+        InvitationService.getInvitationByToken("expired-tok"),
+      ).rejects.toThrow("Invitation has expired.");
+
+      expect(mockInvitation.status).toBe("expired");
+      expect(mockInvitation.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isInvitationExpired", () => {
+    it("returns false for a future expiry", async () => {
+      const { isInvitationExpired } =
+        await import("../services/InvitationService.js");
+      expect(isInvitationExpired(new Date(Date.now() + 60_000))).toBe(false);
+    });
+
+    it("returns true for a past expiry and at the exact boundary", async () => {
+      const { isInvitationExpired } =
+        await import("../services/InvitationService.js");
+      expect(isInvitationExpired(new Date(Date.now() - 1000))).toBe(true);
+      expect(isInvitationExpired(new Date())).toBe(true);
+      expect(isInvitationExpired(null)).toBe(true);
     });
   });
 });

--- a/server/tests/invitation.test.js
+++ b/server/tests/invitation.test.js
@@ -181,6 +181,73 @@ describe("Organization Invitations & Member Onboarding", () => {
     });
   });
 
+  describe("GET /api/invitation/:token (Get invitation by token)", () => {
+    it("should return invitation details for a valid, non-expired token", async () => {
+      const invitation = await Invitation.create({
+        organization: organization._id,
+        email: inviteUser.email,
+        invitedBy: adminUser._id,
+        token: "valid_lookup_token",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      });
+
+      const res = await request(app).get(`/api/invitation/${invitation.token}`);
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.invitation.token).toBe("valid_lookup_token");
+      expect(res.body.invitation.organization.name).toBe("Acme Corp");
+    });
+
+    it("should reject an expired invitation token with HTTP 400", async () => {
+      const invitation = await Invitation.create({
+        organization: organization._id,
+        email: inviteUser.email,
+        invitedBy: adminUser._id,
+        token: "expired_lookup_token",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      const res = await request(app).get(`/api/invitation/${invitation.token}`);
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe("Invitation has expired.");
+
+      const updated = await Invitation.findById(invitation._id);
+      expect(updated.status).toBe("expired");
+    });
+
+    it("should treat an invitation expiring exactly now as expired", async () => {
+      const invitation = await Invitation.create({
+        organization: organization._id,
+        email: inviteUser.email,
+        invitedBy: adminUser._id,
+        token: "boundary_lookup_token",
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(),
+      });
+
+      const res = await request(app).get(`/api/invitation/${invitation.token}`);
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body.message).toBe("Invitation has expired.");
+    });
+
+    it("should return 404 for an unknown token", async () => {
+      const res = await request(app).get("/api/invitation/unknown_token_xyz");
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe("Invitation not found.");
+    });
+  });
+
   describe("POST /api/invitation/:token/accept (Accept invitation)", () => {
     let invitation;
 


### PR DESCRIPTION
# Pull Request

## Description

### Summary

This PR fixes an issue where expired invitations could still be accessed through token-based invitation endpoints.

Invitation expiry validation has been centralized in the service layer to ensure consistent enforcement across invitation lookup, acceptance, and rejection flows. Expired invitations are now rejected correctly and automatically marked as expired when accessed after their expiration time.

### Changes Made

- Added shared invitation expiry validation helpers in `InvitationService`.
- Added `isInvitationExpired()` utility for consistent expiration checks.
- Added `assertInvitationPendingAndActive()` to validate invitation status and expiration.
- Updated `getInvitationByToken()` to use centralized service-layer validation.
- Updated invitation acceptance and rejection flows to reuse the same validation logic.
- Ensured expired invitations are marked with `status: "expired"` before returning an error.
- Improved expiration boundary handling using `<= Date.now()` semantics.
- Added test coverage for expired invitation access and expiration edge cases.

### Backend Changes

- Centralized invitation validation logic in `InvitationService`.
- Removed controller-specific expiry handling in favor of shared validation.
- Preserved existing invitation creation and management functionality.
- No API contract changes for valid invitations.

### Validation Improvements

The following conditions are now enforced consistently:

- Invitation exists.
- Invitation status is pending.
- Invitation has not expired.
- Expired invitations are updated to `expired`.
- Exact expiration boundary timestamps are treated as expired.

### Error Response Behavior

| Scenario | Status | Response |
|-----------|--------|-----------|
| Valid invitation | 200 | Invitation details returned |
| Expired invitation | 400 | `"Invitation has expired."` |
| Non-pending invitation | 400 | `"Invitation is not in pending status."` |
| Unknown token | 404 | `"Invitation not found."` |

### Edge Cases Covered

- Expired invitations.
- Exact expiration timestamp boundary.
- Missing or invalid expiration dates.
- Unknown invitation tokens.
- Automatic status update to `expired`.
- Consistent validation across lookup, accept, and reject flows.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #1358

## Testing

### Validation Performed

- Added service-level expiry validation tests.
- Added API-level token lookup tests.
- Verified expired invitations return HTTP 400.
- Verified valid invitations continue working.
- Verified unknown tokens return HTTP 404.
- Verified expired invitations are marked as expired.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (backend validation fix).

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired invitations are now consistently detected during acceptance, rejection, and token lookup.
  * Expired invitations are automatically marked as expired and saved.
  * Invitation token requests now return clearer errors for expired, invalid, or unknown invitations.
  * Boundary expiration cases are handled correctly.

* **Tests**
  * Added coverage for invitation expiration, status updates, token validation, and related API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->