### PR TITLE
fix: sync user role when membership role changes

### DIFF
--- a/server/controllers/membershipController.js
+++ b/server/controllers/membershipController.js
@@ -4,6 +4,7 @@ import Organization from "../models/organizationModel.js";
 import userModel from "../models/userModel.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 import * as activityService from "../services/activityService.js";
+import { syncMembershipAndUserRole } from "../services/MembershipService.js";
 
 /**
  * ✅ Get User Memberships
@@ -123,24 +124,32 @@ export const updateMembershipRole = async (req, res) => {
       }
     }
 
-    membership.role = role;
-    await membership.save();
+    // Issue #1361: update Membership.role and User.role atomically when the
+    // membership belongs to the user's primary organization.
+    const { membership: updatedMembership } = await syncMembershipAndUserRole(
+      membership,
+      role,
+    );
 
     const io = req.app.get("io");
     activityService.logActivity(
       io,
-      membership.organization._id || membership.organization,
+      updatedMembership.organization._id || updatedMembership.organization,
       req.user.id,
       "membership.role_updated",
       "User",
-      membership.user,
+      updatedMembership.user,
       "Role updated to " + role,
     );
 
-    sendSuccess(res, { membership }, "Membership role updated successfully.");
+    sendSuccess(
+      res,
+      { membership: updatedMembership },
+      "Membership role updated successfully.",
+    );
   } catch (error) {
     console.error("❌ Error updating membership role:", error);
-    sendError(res, 500, "Server error");
+    sendError(res, error.statusCode || 500, error.message || "Server error");
   }
 };
 

--- a/server/services/MembershipService.js
+++ b/server/services/MembershipService.js
@@ -1,0 +1,101 @@
+// server/services/MembershipService.js
+//
+// Membership mutations that must stay consistent with the denormalized
+// User.role / User.organization fields (backward-compatibility copies).
+
+import mongoose from "mongoose";
+import userModel from "../models/userModel.js";
+import { NotFoundError, ValidationError } from "../utils/errors.js";
+
+/**
+ * True when the connected MongoDB topology can run multi-document transactions.
+ * Standalone servers (including default MongoMemoryServer) cannot.
+ */
+const topologySupportsTransactions = () => {
+  const type = mongoose.connection?.client?.topology?.description?.type;
+  return (
+    type === "ReplicaSetWithPrimary" ||
+    type === "ReplicaSetNoPrimary" ||
+    type === "Sharded"
+  );
+};
+
+/**
+ * Run `work(session)` inside a transaction when the topology supports it.
+ * Falls back to `work(null)` on standalone MongoDB so local/test environments
+ * still execute the same business logic without multi-doc transactions.
+ *
+ * @param {(session: import("mongoose").ClientSession|null) => Promise<T>} work
+ * @returns {Promise<T>}
+ * @template T
+ */
+export const runMembershipTransaction = async (work) => {
+  if (!topologySupportsTransactions()) {
+    return work(null);
+  }
+
+  const session = await mongoose.startSession();
+  session.startTransaction();
+  try {
+    const result = await work(session);
+    await session.commitTransaction();
+    return result;
+  } catch (error) {
+    await session.abortTransaction();
+    throw error;
+  } finally {
+    session.endSession();
+  }
+};
+
+/**
+ * Persist a membership role change and, when the membership org is the user's
+ * primary organization, sync User.role in the same transaction (Issue #1361).
+ *
+ * @param {import("mongoose").Document} membership populated with organization
+ * @param {string} role
+ * @returns {Promise<{ membership: import("mongoose").Document, userSynced: boolean, unchanged: boolean }>}
+ */
+export const syncMembershipAndUserRole = async (membership, role) => {
+  if (!membership) {
+    throw new NotFoundError("Membership not found.");
+  }
+
+  if (!role || !["admin", "member"].includes(role)) {
+    throw new ValidationError("Invalid role. Must be 'admin' or 'member'.");
+  }
+
+  // Avoid duplicate writes when nothing would change.
+  if (membership.role === role) {
+    return { membership, userSynced: false, unchanged: true };
+  }
+
+  const orgId = membership.organization?._id || membership.organization;
+
+  return runMembershipTransaction(async (session) => {
+    membership.role = role;
+    await membership.save(session ? { session } : undefined);
+
+    const targetUser = await userModel
+      .findById(membership.user)
+      .session(session || null);
+
+    let userSynced = false;
+
+    if (
+      targetUser &&
+      targetUser.organization &&
+      orgId &&
+      targetUser.organization.toString() === orgId.toString()
+    ) {
+      // Skip the User write when the denormalized role already matches.
+      if (targetUser.role !== role) {
+        targetUser.role = role;
+        await targetUser.save(session ? { session } : undefined);
+        userSynced = true;
+      }
+    }
+
+    return { membership, userSynced, unchanged: false };
+  });
+};

--- a/server/tests/MembershipService.test.js
+++ b/server/tests/MembershipService.test.js
@@ -1,0 +1,231 @@
+/**
+ * Issue #1361 — Membership.role and User.role stay in sync.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+const mockSave = jest.fn();
+const mockFindById = jest.fn();
+const mockStartSession = jest.fn();
+
+jest.unstable_mockModule("../models/membershipModel.js", () => ({
+  default: {},
+}));
+
+jest.unstable_mockModule("../models/userModel.js", () => ({
+  default: {
+    findById: mockFindById,
+  },
+}));
+
+const originalStartSession = mongoose.startSession;
+
+beforeAll(() => {
+  mongoose.startSession = mockStartSession;
+});
+
+afterAll(() => {
+  mongoose.startSession = originalStartSession;
+});
+
+const { syncMembershipAndUserRole, runMembershipTransaction } =
+  await import("../services/MembershipService.js");
+
+describe("MembershipService — syncMembershipAndUserRole (#1361)", () => {
+  const orgId = new mongoose.Types.ObjectId();
+  const userId = new mongoose.Types.ObjectId();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: standalone topology (no multi-doc transactions)
+    Object.defineProperty(mongoose.connection, "client", {
+      configurable: true,
+      value: {
+        topology: { description: { type: "Single" } },
+      },
+    });
+  });
+
+  const makeMembership = (role = "member") => ({
+    user: userId,
+    organization: { _id: orgId },
+    role,
+    save: mockSave.mockResolvedValue(undefined),
+  });
+
+  it("returns unchanged without writing when role is already set", async () => {
+    const membership = makeMembership("admin");
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(result.unchanged).toBe(true);
+    expect(result.userSynced).toBe(false);
+    expect(mockSave).not.toHaveBeenCalled();
+    expect(mockFindById).not.toHaveBeenCalled();
+  });
+
+  it("updates Membership.role and User.role for the primary organization", async () => {
+    const membership = makeMembership("member");
+    const targetUser = {
+      organization: orgId,
+      role: "member",
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(targetUser),
+    });
+
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(result.unchanged).toBe(false);
+    expect(result.userSynced).toBe(true);
+    expect(membership.role).toBe("admin");
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(targetUser.role).toBe("admin");
+    expect(targetUser.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not rewrite User.role when it already matches the new role", async () => {
+    const membership = makeMembership("member");
+    const targetUser = {
+      organization: orgId,
+      role: "admin", // already synced (legacy inconsistency on Membership only)
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(targetUser),
+    });
+
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(membership.role).toBe("admin");
+    expect(result.userSynced).toBe(false);
+    expect(targetUser.save).not.toHaveBeenCalled();
+  });
+
+  it("updates Membership only when it is not the user's primary organization", async () => {
+    const membership = makeMembership("member");
+    const otherOrg = new mongoose.Types.ObjectId();
+    const targetUser = {
+      organization: otherOrg,
+      role: "member",
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(targetUser),
+    });
+
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(membership.role).toBe("admin");
+    expect(result.userSynced).toBe(false);
+    expect(targetUser.role).toBe("member");
+    expect(targetUser.save).not.toHaveBeenCalled();
+  });
+
+  it("updates Membership when the linked user is missing", async () => {
+    const membership = makeMembership("member");
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(null),
+    });
+
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(membership.role).toBe("admin");
+    expect(result.userSynced).toBe(false);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("rolls back membership changes when User.save fails inside a transaction", async () => {
+    Object.defineProperty(mongoose.connection, "client", {
+      configurable: true,
+      value: {
+        topology: { description: { type: "ReplicaSetWithPrimary" } },
+      },
+    });
+
+    const abortTransaction = jest.fn().mockResolvedValue(undefined);
+    const commitTransaction = jest.fn().mockResolvedValue(undefined);
+    const endSession = jest.fn();
+    mockStartSession.mockResolvedValue({
+      startTransaction: jest.fn(),
+      commitTransaction,
+      abortTransaction,
+      endSession,
+    });
+
+    const membership = makeMembership("member");
+    const targetUser = {
+      organization: orgId,
+      role: "member",
+      save: jest.fn().mockRejectedValue(new Error("user write failed")),
+    };
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(targetUser),
+    });
+
+    await expect(
+      syncMembershipAndUserRole(membership, "admin"),
+    ).rejects.toThrow("user write failed");
+
+    expect(abortTransaction).toHaveBeenCalledTimes(1);
+    expect(commitTransaction).not.toHaveBeenCalled();
+    expect(endSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits both updates when the transaction succeeds", async () => {
+    Object.defineProperty(mongoose.connection, "client", {
+      configurable: true,
+      value: {
+        topology: { description: { type: "ReplicaSetWithPrimary" } },
+      },
+    });
+
+    const abortTransaction = jest.fn().mockResolvedValue(undefined);
+    const commitTransaction = jest.fn().mockResolvedValue(undefined);
+    const endSession = jest.fn();
+    const session = {
+      startTransaction: jest.fn(),
+      commitTransaction,
+      abortTransaction,
+      endSession,
+    };
+    mockStartSession.mockResolvedValue(session);
+
+    const membership = makeMembership("member");
+    const targetUser = {
+      organization: orgId,
+      role: "member",
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockFindById.mockReturnValue({
+      session: jest.fn().mockResolvedValue(targetUser),
+    });
+
+    const result = await syncMembershipAndUserRole(membership, "admin");
+
+    expect(result.userSynced).toBe(true);
+    expect(commitTransaction).toHaveBeenCalledTimes(1);
+    expect(abortTransaction).not.toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalledWith({ session });
+    expect(targetUser.save).toHaveBeenCalledWith({ session });
+  });
+});
+
+describe("runMembershipTransaction", () => {
+  it("runs work without a session on standalone topology", async () => {
+    Object.defineProperty(mongoose.connection, "client", {
+      configurable: true,
+      value: {
+        topology: { description: { type: "Single" } },
+      },
+    });
+
+    const work = jest.fn().mockResolvedValue("ok");
+    const result = await runMembershipTransaction(work);
+
+    expect(result).toBe("ok");
+    expect(work).toHaveBeenCalledWith(null);
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/membershipController.test.js
+++ b/server/tests/membershipController.test.js
@@ -148,3 +148,189 @@ describe("MembershipController - removeMembership", () => {
     expect(res.statusCode).toEqual(403);
   });
 });
+
+describe("MembershipController - updateMembershipRole (#1361)", () => {
+  let adminUser;
+  let adminToken;
+  let memberUser;
+  let organization;
+  let memberMembership;
+  let adminMembership;
+
+  beforeEach(async () => {
+    organization = await Organization.create({
+      name: "Test Org",
+      slug: "test-org-" + Math.random().toString(36).substring(7),
+      owner: new mongoose.Types.ObjectId(),
+    });
+
+    adminUser = await User.create({
+      name: "Admin User",
+      email: `admin-${Math.random()}@example.com`,
+      password: "password123",
+      organization: organization._id,
+      role: "admin",
+      isAccountVerified: true,
+    });
+    adminUser.clerkUserId = `user_test_${adminUser._id}`;
+    await adminUser.save();
+    adminToken = createClerkTestToken({
+      clerkUserId: adminUser.clerkUserId,
+      email: adminUser.email,
+    });
+
+    organization.owner = adminUser._id;
+    await organization.save();
+
+    adminMembership = await Membership.create({
+      user: adminUser._id,
+      organization: organization._id,
+      role: "admin",
+      status: "active",
+    });
+
+    memberUser = await User.create({
+      name: "Member User",
+      email: `member-${Math.random()}@example.com`,
+      password: "password123",
+      organization: organization._id,
+      role: "member",
+      isAccountVerified: true,
+    });
+    memberUser.clerkUserId = `user_test_${memberUser._id}`;
+    await memberUser.save();
+
+    memberMembership = await Membership.create({
+      user: memberUser._id,
+      organization: organization._id,
+      role: "member",
+      status: "active",
+    });
+  });
+
+  it("syncs User.role when Membership.role is updated for the primary org", async () => {
+    const res = await request(app)
+      .patch(`/api/memberships/${memberMembership._id}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "admin" });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.success).toBe(true);
+
+    const updatedMembership = await Membership.findById(memberMembership._id);
+    expect(updatedMembership.role).toBe("admin");
+
+    const updatedUser = await User.findById(memberUser._id);
+    expect(updatedUser.role).toBe("admin");
+  });
+
+  it("syncs User.role when Membership.role is downgraded", async () => {
+    memberMembership.role = "admin";
+    await memberMembership.save();
+    memberUser.role = "admin";
+    await memberUser.save();
+
+    const res = await request(app)
+      .patch(`/api/memberships/${memberMembership._id}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "member" });
+
+    expect(res.statusCode).toEqual(200);
+
+    const updatedMembership = await Membership.findById(memberMembership._id);
+    expect(updatedMembership.role).toBe("member");
+
+    const updatedUser = await User.findById(memberUser._id);
+    expect(updatedUser.role).toBe("member");
+  });
+
+  it("is a no-op when the membership role is unchanged", async () => {
+    const res = await request(app)
+      .patch(`/api/memberships/${memberMembership._id}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "member" });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.success).toBe(true);
+
+    const updatedMembership = await Membership.findById(memberMembership._id);
+    expect(updatedMembership.role).toBe("member");
+
+    const updatedUser = await User.findById(memberUser._id);
+    expect(updatedUser.role).toBe("member");
+  });
+
+  it("does not change User.role when membership is not for the primary org", async () => {
+    const otherOrg = await Organization.create({
+      name: "Other Org",
+      slug: "other-org-" + Math.random().toString(36).substring(7),
+      owner: new mongoose.Types.ObjectId(),
+    });
+
+    memberUser.organization = otherOrg._id;
+    await memberUser.save();
+
+    const res = await request(app)
+      .patch(`/api/memberships/${memberMembership._id}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "admin" });
+
+    expect(res.statusCode).toEqual(200);
+
+    const updatedMembership = await Membership.findById(memberMembership._id);
+    expect(updatedMembership.role).toBe("admin");
+
+    const updatedUser = await User.findById(memberUser._id);
+    expect(updatedUser.role).toBe("member");
+  });
+
+  it("still prevents removing the last admin", async () => {
+    const res = await request(app)
+      .patch(`/api/memberships/${adminMembership._id}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "member" });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.message).toContain("Cannot remove the last admin");
+  });
+
+  it("still rejects unauthorized role updates", async () => {
+    const otherMember = await User.create({
+      name: "Other Member",
+      email: `other-${Math.random()}@example.com`,
+      password: "password123",
+      organization: organization._id,
+      role: "member",
+      isAccountVerified: true,
+    });
+    otherMember.clerkUserId = `user_test_${otherMember._id}`;
+    await otherMember.save();
+    const otherToken = createClerkTestToken({
+      clerkUserId: otherMember.clerkUserId,
+      email: otherMember.email,
+    });
+
+    await Membership.create({
+      user: otherMember._id,
+      organization: organization._id,
+      role: "member",
+      status: "active",
+    });
+
+    const res = await request(app)
+      .patch(`/api/memberships/${memberMembership._id}/role`)
+      .set(authHeader(otherToken))
+      .send({ role: "admin" });
+
+    expect(res.statusCode).toEqual(403);
+  });
+
+  it("returns 404 for an invalid membership id", async () => {
+    const res = await request(app)
+      .patch(`/api/memberships/${new mongoose.Types.ObjectId()}/role`)
+      .set(authHeader(adminToken))
+      .send({ role: "admin" });
+
+    expect(res.statusCode).toEqual(404);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

### Summary

This PR fixes a data consistency issue where updating a membership role did not update the corresponding `User.role` value.

The application maintains role information in both the `Membership` and `User` models for backward compatibility. Previously, role updates only modified the membership document, leaving the user document outdated. This change ensures both records remain synchronized.

### Changes Made

- Added a dedicated `MembershipService` to centralize membership role synchronization logic.
- Updated membership role update flow to synchronize `User.role` when applicable.
- Added transactional support for role updates when MongoDB transactions are available.
- Added rollback protection to prevent partial updates.
- Preserved existing authorization, validation, and last-admin protections.
- Avoided unnecessary writes when the role remains unchanged.
- Added integration and service-level test coverage.

### Backend Changes

#### New Service

- `MembershipService.js`
  - `syncMembershipAndUserRole(...)`
  - `runMembershipTransaction(...)`

#### Updated Controller

- `membershipController.js`
  - Delegates role synchronization to the new service.
  - Preserves existing API responses and validation behavior.

### Synchronization Rules

User roles are synchronized only when:

- The membership belongs to the user's primary organization.
- The membership role actually changes.
- The user's stored role differs from the membership role.

User updates are skipped when synchronization is unnecessary.

### Transaction Behavior

When MongoDB transactions are available:

- Start transaction.
- Update Membership role.
- Update User role.
- Commit only if both succeed.
- Roll back if either operation fails.

For standalone MongoDB environments and local tests:

- Existing behavior is preserved through a non-transactional fallback path.

### Error Handling

- Existing validation and permission checks remain unchanged.
- Last-admin protections remain unchanged.
- Transaction failures correctly abort updates.
- Service errors propagate using existing project error patterns.

### Tests Added

#### Integration Tests

`membershipController.test.js`

- Membership promotion updates User role.
- Membership demotion updates User role.
- Unchanged role performs no extra updates.
- Non-primary organization memberships do not modify User role.
- Existing 403 / 404 / last-admin protections still work.

#### Service Tests

`MembershipService.test.js`

- Role synchronization behavior.
- No-op updates.
- Missing user scenarios.
- Transaction commit path.
- Transaction rollback path.
- User update failure handling.

### Edge Cases Covered

- Membership role unchanged.
- User role already synchronized.
- Missing linked user.
- Non-primary organization memberships.
- Transaction rollback on failure.
- Legacy Membership/User mismatches.
- Last-admin protection scenarios.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1361

## Testing

### Validation Performed

- Added integration tests for role synchronization.
- Added service-level transaction tests.
- Verified role updates remain consistent.
- Verified existing membership update behavior remains unchanged.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable (backend data consistency fix).

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Membership role updates now synchronize with the user’s account role when applicable.
  - Role changes provide clearer success and error responses.

- **Bug Fixes**
  - Prevented unnecessary updates when roles are unchanged.
  - Preserved primary organization roles when updating secondary memberships.
  - Prevented removal of the last administrator.
  - Improved consistency when role updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->