### PR TITLE
fix(client): stop polls from outliving their component

### DIFF
--- a/client/src/components/meeting-details/MeetingActions.jsx
+++ b/client/src/components/meeting-details/MeetingActions.jsx
@@ -6,6 +6,15 @@ import { Mic, MicOff, Loader2 } from "lucide-react";
 import { toast } from "react-toastify";
 import apiClient from "../../services/apiClient";
 import ConfirmModal from "../ConfirmModal.jsx";
+import { usePolling } from "../../hooks/usePolling.js";
+
+/**
+ * Deadline for the post-recording transcription poll (Issue #1455).
+ *
+ * The previous poll had none — it ran until the transcript reached a terminal
+ * status, which for a job that dies in the queue is never.
+ */
+const TRANSCRIPTION_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
 const MeetingActions = ({ meeting, onDelete, onRename }) => {
   const navigate = useNavigate();
@@ -21,6 +30,9 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
   const mediaRecorderRef = useRef(null);
   const chunksRef = useRef([]);
   const recordingIntervalRef = useRef(null);
+
+  // Owns the transcription poll below, including its teardown on unmount.
+  const { startPolling } = usePolling();
 
   const handleDownloadTranscript = () => {
     if (!meeting.transcript) {
@@ -184,33 +196,48 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
       setIsProcessing(true);
       toast.success("Recording stopped, transcription started");
 
-      const pollInterval = setInterval(async () => {
-        try {
+      // The transcription poll used to keep its interval id in a `const` local
+      // to this handler, so it survived unmount and had no deadline at all —
+      // it only stopped if the transcript reached a terminal status. The
+      // sibling `recordingIntervalRef` was already torn down properly; this one
+      // was not (Issue #1455).
+      startPolling(
+        async ({ signal }) => {
           const { data: transcriptData } = await apiClient.get(
             `/api/meetings/${meeting._id}/transcript`,
-            { withCredentials: true },
+            { withCredentials: true, signal },
           );
 
-          if (
-            transcriptData.success &&
-            transcriptData.transcript.status === "completed"
-          ) {
-            clearInterval(pollInterval);
+          if (!transcriptData.success) return false;
+
+          if (transcriptData.transcript.status === "completed") {
             setIsProcessing(false);
             toast.success("Transcription completed!");
             window.location.reload();
-          } else if (
-            transcriptData.success &&
-            transcriptData.transcript.status === "failed"
-          ) {
-            clearInterval(pollInterval);
+            return true;
+          }
+
+          if (transcriptData.transcript.status === "failed") {
             setIsProcessing(false);
             toast.error("Transcription failed. Please try again.");
+            return true;
           }
-        } catch (error) {
-          console.error("Error polling transcript status:", error);
-        }
-      }, 5000);
+
+          return false;
+        },
+        {
+          intervalMs: 5000,
+          timeoutMs: TRANSCRIPTION_POLL_TIMEOUT_MS,
+          onTimeout: () => {
+            setIsProcessing(false);
+            toast.info(
+              "Transcription is taking longer than expected. Refresh the page to check on it.",
+            );
+          },
+          onError: (error) =>
+            console.error("Error polling transcript status:", error),
+        },
+      );
     } catch (error) {
       console.error("Error stopping recording:", error);
       toast.error(error.message || "Failed to stop recording");

--- a/client/src/hooks/__tests__/usePolling.test.jsx
+++ b/client/src/hooks/__tests__/usePolling.test.jsx
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { usePolling } from "../usePolling.js";
+
+/**
+ * Issue #1455 — five call sites started a poll from an event handler and kept
+ * the timer id in a `const` scoped to that handler, so nothing on the unmount
+ * path could clear it.
+ *
+ * The tests below are organised around the two failures that were actually
+ * observed in the app:
+ *
+ *   - a poll that outlives its component (MeetingQuality, MeetingAnalytics,
+ *     MeetingActions), and
+ *   - a poll whose callback throws every tick with no deadline to stop it,
+ *     which is what a popup-blocked `authWindow.closed` did in Settings.
+ */
+
+describe("usePolling (#1455)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /** Advances timers inside `act` so React state updates are flushed. */
+  const advance = async (ms) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  describe("the leak: polls must not outlive the component", () => {
+    it("stops polling on unmount", async () => {
+      const poll = vi.fn(() => false);
+      const { result, unmount } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, {
+          intervalMs: 1000,
+          timeoutMs: 60000,
+        });
+      });
+
+      await advance(3000);
+      expect(poll).toHaveBeenCalledTimes(3);
+
+      unmount();
+
+      // Previously this kept firing for the full deadline, fetching and
+      // calling setState on an unmounted component every tick.
+      await advance(30000);
+      expect(poll).toHaveBeenCalledTimes(3);
+    });
+
+    it("clears the deadline timer on unmount too", async () => {
+      const onTimeout = vi.fn();
+      const { result, unmount } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(() => false, {
+          intervalMs: 1000,
+          timeoutMs: 5000,
+          onTimeout,
+        });
+      });
+
+      unmount();
+      await advance(10000);
+
+      // The old code's `setTimeout(..., 30000)` was untracked and fired after
+      // unmount, calling setState from a component that no longer existed.
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+
+    it("aborts the in-flight request on unmount", async () => {
+      let capturedSignal;
+      const { result, unmount } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(
+          ({ signal }) => {
+            capturedSignal = signal;
+            return new Promise(() => {}); // never settles
+          },
+          { intervalMs: 1000 },
+        );
+      });
+
+      await advance(1000);
+      expect(capturedSignal.aborted).toBe(false);
+
+      unmount();
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it("does not act on a result that arrives after unmount", async () => {
+      const onDone = vi.fn();
+      let resolvePoll;
+      const { result, unmount } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(
+          () =>
+            new Promise((resolve) => {
+              resolvePoll = resolve;
+            }),
+          { intervalMs: 1000 },
+        );
+      });
+
+      await advance(1000);
+      unmount();
+
+      await act(async () => {
+        resolvePoll(true);
+        await Promise.resolve();
+      });
+
+      expect(onDone).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the infinite error loop: a throwing poll must still terminate", () => {
+    it("keeps polling after an error but stops at the deadline", async () => {
+      // This is the popup-blocked Settings case: `authWindow.closed` threw a
+      // TypeError every tick, and the only clearInterval was inside the branch
+      // that had just thrown, so it never stopped.
+      const onError = vi.fn();
+      const onTimeout = vi.fn();
+      const poll = vi.fn(() => {
+        throw new TypeError(
+          "Cannot read properties of null (reading 'closed')",
+        );
+      });
+
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, {
+          intervalMs: 500,
+          timeoutMs: 3000,
+          onError,
+          onTimeout,
+        });
+      });
+
+      await advance(3000);
+
+      expect(onError).toHaveBeenCalled();
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+
+      const callsAtDeadline = poll.mock.calls.length;
+      await advance(10000);
+      expect(poll).toHaveBeenCalledTimes(callsAtDeadline);
+    });
+
+    it("does not report an abort as a polling error", async () => {
+      const onError = vi.fn();
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(
+          async ({ signal }) => {
+            await new Promise((resolve, reject) => {
+              signal.addEventListener("abort", () =>
+                reject(
+                  Object.assign(new Error("aborted"), { name: "AbortError" }),
+                ),
+              );
+            });
+          },
+          { intervalMs: 500 },
+        );
+      });
+
+      await advance(500);
+      act(() => result.current.stopPolling());
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Stopping is the cause of the abort — surfacing it as an error would
+      // put a spurious message in front of the user on every cancel.
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("survives a throwing onError handler", async () => {
+      const { result } = renderHook(() => usePolling());
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      act(() => {
+        result.current.startPolling(
+          () => {
+            throw new Error("poll failed");
+          },
+          {
+            intervalMs: 500,
+            timeoutMs: 2000,
+            onError: () => {
+              throw new Error("handler failed too");
+            },
+          },
+        );
+      });
+
+      await expect(advance(2000)).resolves.toBeUndefined();
+      expect(result.current.isPolling).toBe(false);
+    });
+  });
+
+  describe("stopping", () => {
+    it("stops when the poll function returns truthy", async () => {
+      const poll = vi.fn();
+      poll.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, { intervalMs: 1000 });
+      });
+
+      await advance(5000);
+      expect(poll).toHaveBeenCalledTimes(2);
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    it("stops when the caller calls stopPolling", async () => {
+      const poll = vi.fn(() => false);
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, { intervalMs: 1000 });
+      });
+
+      await advance(2000);
+      act(() => result.current.stopPolling());
+      await advance(10000);
+
+      expect(poll).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops via the function returned by startPolling", async () => {
+      const poll = vi.fn(() => false);
+      const { result } = renderHook(() => usePolling());
+      let stop;
+
+      act(() => {
+        stop = result.current.startPolling(poll, { intervalMs: 1000 });
+      });
+
+      await advance(2000);
+      act(() => stop());
+      await advance(10000);
+
+      expect(poll).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not call onTimeout when the poll finished first", async () => {
+      const onTimeout = vi.fn();
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(() => true, {
+          intervalMs: 1000,
+          timeoutMs: 5000,
+          onTimeout,
+        });
+      });
+
+      await advance(10000);
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+
+    it("tolerates stopPolling when nothing is running", () => {
+      const { result } = renderHook(() => usePolling());
+
+      expect(() => {
+        act(() => {
+          result.current.stopPolling();
+          result.current.stopPolling();
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("run management", () => {
+    it("replaces a previous run instead of stacking a second loop", async () => {
+      const first = vi.fn(() => false);
+      const second = vi.fn(() => false);
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(first, { intervalMs: 1000 });
+      });
+      await advance(2000);
+
+      act(() => {
+        result.current.startPolling(second, { intervalMs: 1000 });
+      });
+      await advance(3000);
+
+      // A user double-clicking "Recalculate" must not end up with two loops.
+      expect(first).toHaveBeenCalledTimes(2);
+      expect(second).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not re-enter a tick that has not settled", async () => {
+      let settle;
+      const poll = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            settle = resolve;
+          }),
+      );
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, { intervalMs: 100 });
+      });
+
+      // Ten intervals elapse while the first request is still outstanding; a
+      // slow endpoint should degrade the rate, not stack ten requests.
+      await advance(1000);
+      expect(poll).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        settle(false);
+        await Promise.resolve();
+      });
+
+      await advance(100);
+      expect(poll).toHaveBeenCalledTimes(2);
+    });
+
+    it("runs one tick straight away when immediate is set", async () => {
+      const poll = vi.fn(() => false);
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, {
+          intervalMs: 5000,
+          immediate: true,
+        });
+      });
+
+      expect(poll).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits for the first interval by default", async () => {
+      const poll = vi.fn(() => false);
+      const { result } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(poll, { intervalMs: 5000 });
+      });
+
+      expect(poll).not.toHaveBeenCalled();
+      await advance(5000);
+      expect(poll).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports isPolling across the run", async () => {
+      const { result } = renderHook(() => usePolling());
+      expect(result.current.isPolling).toBe(false);
+
+      act(() => {
+        result.current.startPolling(() => false, { intervalMs: 1000 });
+      });
+      expect(result.current.isPolling).toBe(true);
+
+      act(() => result.current.stopPolling());
+      expect(result.current.isPolling).toBe(false);
+    });
+
+    it("rejects a non-function poll", () => {
+      const { result } = renderHook(() => usePolling());
+
+      expect(() => result.current.startPolling(null)).toThrow(TypeError);
+    });
+
+    it("exposes isActive so a caller can guard its own state updates", async () => {
+      const seen = [];
+      const { result, unmount } = renderHook(() => usePolling());
+
+      act(() => {
+        result.current.startPolling(
+          ({ isActive }) => {
+            seen.push(isActive());
+            return false;
+          },
+          { intervalMs: 1000 },
+        );
+      });
+
+      await advance(2000);
+      expect(seen).toEqual([true, true]);
+
+      unmount();
+    });
+  });
+});

--- a/client/src/hooks/usePolling.js
+++ b/client/src/hooks/usePolling.js
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Owns the lifetime of a "poll until done or give up" loop (Issue #1455).
+ *
+ * ─── What this replaces ──────────────────────────────────────────────────────
+ *
+ * Five places started a poll from an event handler and kept the timer id in a
+ * `const` scoped to that handler:
+ *
+ *     const pollInterval = setInterval(async () => {
+ *       ...
+ *       if (done) clearInterval(pollInterval);
+ *     }, 2000);
+ *
+ *     setTimeout(() => { clearInterval(pollInterval); }, 30000);
+ *
+ * Nothing outside the handler could reach that id, so nothing on the unmount
+ * path could clear it. Navigating away mid-poll left the interval running:
+ * still fetching, still calling `setState` on an unmounted component, once
+ * every 2–5 seconds for the full deadline. The deadline `setTimeout` was
+ * untracked too, so it also fired after unmount.
+ *
+ * The two calendar-OAuth cases in `Settings.jsx` were worse. They polled
+ * `authWindow.closed` with no deadline at all, and `window.open` returns `null`
+ * when a popup blocker intervenes — which is the common case for a popup opened
+ * after an `await`, because the user-gesture token is already spent. With
+ * `authWindow === null`, `authWindow.closed` threw a `TypeError` twice a second
+ * forever, since the only `clearInterval` sat inside the branch that had just
+ * thrown.
+ *
+ * ─── What this guarantees ────────────────────────────────────────────────────
+ *
+ *   1. **Unmount stops everything.** The interval, the deadline, and any
+ *      in-flight request are all torn down by one effect cleanup.
+ *   2. **A throwing poll cannot become an infinite error loop.** `onError` is
+ *      called and polling continues, but the deadline is always armed, so the
+ *      loop is bounded by construction.
+ *   3. **Ticks never overlap.** A tick that is still awaiting is not re-entered
+ *      when the next interval fires; a slow endpoint degrades the polling rate
+ *      instead of stacking requests.
+ *   4. **No state updates after unmount.** Callers get an `AbortSignal` and can
+ *      also check `isActive()`.
+ *
+ * ─── Usage ───────────────────────────────────────────────────────────────────
+ *
+ *     const { startPolling, stopPolling, isPolling } = usePolling();
+ *
+ *     startPolling(
+ *       async ({ signal }) => {
+ *         const res = await fetch(url, { signal });
+ *         const data = await res.json();
+ *         if (data.status === "completed") { apply(data); return true; }
+ *         return false;                       // keep going
+ *       },
+ *       {
+ *         intervalMs: 2000,
+ *         timeoutMs: 30000,
+ *         onTimeout: () => setCalculating(false),
+ *         onError: (err) => console.error(err),
+ *       },
+ *     );
+ *
+ * Returning a truthy value from the poll function stops the loop. That is the
+ * whole protocol — callers never touch a timer id.
+ */
+
+/** Interval used when a caller does not specify one. */
+export const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+/** Deadline used when a caller does not specify one. */
+export const DEFAULT_POLL_TIMEOUT_MS = 60000;
+
+export const usePolling = () => {
+  /** Everything belonging to the current run; null when idle. */
+  const runRef = useRef(null);
+
+  /** False from the unmount cleanup onwards, so late callbacks can bail. */
+  const mountedRef = useRef(true);
+
+  const [isPolling, setIsPolling] = useState(false);
+
+  /**
+   * Tears the current run down.
+   *
+   * Safe to call at any time and any number of times — from a poll function,
+   * from a deadline, from unmount, or from a caller that changed its mind.
+   *
+   * @param {object} [options]
+   * @param {boolean} [options.timedOut] whether to invoke the run's `onTimeout`
+   */
+  const stopPolling = useCallback(({ timedOut = false } = {}) => {
+    const run = runRef.current;
+    if (!run) return;
+
+    runRef.current = null;
+
+    clearInterval(run.intervalId);
+    clearTimeout(run.timeoutId);
+    run.controller.abort();
+
+    // Only touch React state if the component is still around. Setting it
+    // during the unmount cleanup is exactly the warning this hook exists to
+    // remove.
+    if (mountedRef.current) setIsPolling(false);
+
+    if (timedOut && mountedRef.current) {
+      try {
+        run.onTimeout?.();
+      } catch (error) {
+        console.error("Polling onTimeout handler failed:", error);
+      }
+    }
+  }, []);
+
+  /**
+   * Starts polling. Any run already in progress is stopped first, so a caller
+   * that fires the same action twice cannot end up with two loops.
+   *
+   * @param {(ctx: {signal: AbortSignal, isActive: () => boolean}) => unknown} pollFn
+   *   Called on every tick. Return truthy — or a promise resolving truthy — to
+   *   stop. May be synchronous.
+   * @param {object} [options]
+   * @param {number} [options.intervalMs=DEFAULT_POLL_INTERVAL_MS]
+   * @param {number} [options.timeoutMs=DEFAULT_POLL_TIMEOUT_MS]
+   * @param {() => void} [options.onTimeout] runs if the deadline is reached
+   * @param {(error: unknown) => void} [options.onError] runs per failed tick
+   * @param {boolean} [options.immediate=false] run one tick before the first
+   *   interval elapses
+   * @returns {() => void} a stop function for this run
+   */
+  const startPolling = useCallback(
+    (
+      pollFn,
+      {
+        intervalMs = DEFAULT_POLL_INTERVAL_MS,
+        timeoutMs = DEFAULT_POLL_TIMEOUT_MS,
+        onTimeout,
+        onError,
+        immediate = false,
+      } = {},
+    ) => {
+      if (typeof pollFn !== "function") {
+        throw new TypeError("usePolling: pollFn must be a function");
+      }
+
+      stopPolling();
+
+      if (!mountedRef.current) return () => {};
+
+      const run = {
+        controller: new AbortController(),
+        onTimeout,
+        // Guards against re-entering a tick that has not settled yet.
+        inFlight: false,
+        intervalId: null,
+        timeoutId: null,
+      };
+
+      const isActive = () => runRef.current === run && mountedRef.current;
+
+      const tick = async () => {
+        if (!isActive() || run.inFlight) return;
+        run.inFlight = true;
+
+        try {
+          const done = await pollFn({
+            signal: run.controller.signal,
+            isActive,
+          });
+
+          // `isActive()` is re-checked *after* the await: the component may
+          // have unmounted while the request was in flight, and acting on the
+          // result then is the state-update-after-unmount warning.
+          if (done && isActive()) stopPolling();
+        } catch (error) {
+          // An aborted request is the expected consequence of stopping, not a
+          // failure worth reporting.
+          const aborted =
+            error?.name === "AbortError" ||
+            error?.name === "CanceledError" ||
+            error?.code === "ERR_CANCELED";
+
+          if (!aborted && isActive()) {
+            try {
+              onError?.(error);
+            } catch (handlerError) {
+              console.error("Polling onError handler failed:", handlerError);
+            }
+          }
+        } finally {
+          run.inFlight = false;
+        }
+      };
+
+      run.intervalId = setInterval(tick, intervalMs);
+
+      // The deadline is armed unconditionally. It is what makes a poll function
+      // that always throws terminate instead of looping forever.
+      if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+        run.timeoutId = setTimeout(() => {
+          if (runRef.current === run) stopPolling({ timedOut: true });
+        }, timeoutMs);
+      }
+
+      runRef.current = run;
+      setIsPolling(true);
+
+      if (immediate) tick();
+
+      return () => {
+        if (runRef.current === run) stopPolling();
+      };
+    },
+    [stopPolling],
+  );
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      stopPolling();
+    },
+    [stopPolling],
+  );
+
+  return { startPolling, stopPolling, isPolling };
+};
+
+export default usePolling;

--- a/client/src/pages/MeetingAnalytics.jsx
+++ b/client/src/pages/MeetingAnalytics.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import AppContent from "../context/AppContent";
+import { usePolling } from "../hooks/usePolling.js";
 import Navbar from "../components/Navbar.jsx";
 import {
   BarChart,
@@ -42,6 +43,9 @@ const MeetingAnalytics = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [analyzing, setAnalyzing] = useState(false);
+
+  // Owns the completion poll below, including its teardown on unmount (#1455).
+  const { startPolling } = usePolling();
 
   const fetchAnalytics = useCallback(async () => {
     try {
@@ -96,37 +100,42 @@ const MeetingAnalytics = () => {
 
       toast.info("Analysis started. This may take up to 60 seconds.");
 
-      // Poll for completion
-      const pollInterval = setInterval(async () => {
-        try {
+      // Poll for completion. The interval and its 2-minute deadline used to be
+      // plain `const`s inside this handler, so nothing on the unmount path
+      // could clear them and navigating away left the poll running (#1455).
+      startPolling(
+        async ({ signal }) => {
           const checkResponse = await fetch(
             `${backendUrl}/api/analytics/meetings/${meetingId}`,
-            { credentials: "include" },
+            { credentials: "include", signal },
           );
 
-          if (checkResponse.ok) {
-            const data = await checkResponse.json();
-            if (data.status === "completed") {
-              clearInterval(pollInterval);
-              setAnalytics(data);
-              setAnalyzing(false);
-              toast.success("Analysis completed!");
-            } else if (data.status === "failed") {
-              clearInterval(pollInterval);
-              setAnalyzing(false);
-              toast.error("Analysis failed");
-            }
-          }
-        } catch (err) {
-          console.error("Error polling:", err);
-        }
-      }, 5000);
+          if (!checkResponse.ok) return false;
 
-      // Stop polling after 2 minutes
-      setTimeout(() => {
-        clearInterval(pollInterval);
-        setAnalyzing(false);
-      }, 120000);
+          const data = await checkResponse.json();
+
+          if (data.status === "completed") {
+            setAnalytics(data);
+            setAnalyzing(false);
+            toast.success("Analysis completed!");
+            return true;
+          }
+
+          if (data.status === "failed") {
+            setAnalyzing(false);
+            toast.error("Analysis failed");
+            return true;
+          }
+
+          return false;
+        },
+        {
+          intervalMs: 5000,
+          timeoutMs: 120000,
+          onTimeout: () => setAnalyzing(false),
+          onError: (err) => console.error("Error polling:", err),
+        },
+      );
     } catch (err) {
       console.error("Error triggering analysis:", err);
       toast.error("Failed to start analysis");

--- a/client/src/pages/MeetingQuality.jsx
+++ b/client/src/pages/MeetingQuality.jsx
@@ -621,18 +621,29 @@ const MeetingQuality = () => {
   );
 };
 
-const MetricCard = ({ Icon, label, value }) => (
-  <div className="bg-slate-50 dark:bg-slate-800 rounded-xl p-4">
-    <div className="flex items-center gap-2 mb-2">
-      <Icon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-      <span className="text-sm text-slate-600 dark:text-slate-400">
-        {label}
-      </span>
+const MetricCard = (props) => {
+  // `Icon` is destructured in the body rather than in the parameter list on
+  // purpose. The shared ESLint config does not include `react/jsx-uses-vars`,
+  // so it cannot see that `<Icon />` below is a use; it works around that with
+  // `varsIgnorePattern: "^[A-Z_]"`, which covers variables but not destructured
+  // parameters. Binding it here therefore satisfies the rule without disabling
+  // it. This is a latent error that only surfaced once this file was touched,
+  // because `lint:changed` lints changed files only.
+  const { Icon, label, value } = props;
+
+  return (
+    <div className="bg-slate-50 dark:bg-slate-800 rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+        <span className="text-sm text-slate-600 dark:text-slate-400">
+          {label}
+        </span>
+      </div>
+      <div className="text-2xl font-bold text-slate-900 dark:text-white">
+        {value}
+      </div>
     </div>
-    <div className="text-2xl font-bold text-slate-900 dark:text-white">
-      {value}
-    </div>
-  </div>
-);
+  );
+};
 
 export default MeetingQuality;

--- a/client/src/pages/MeetingQuality.jsx
+++ b/client/src/pages/MeetingQuality.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import AppContent from "../context/AppContent";
+import { usePolling } from "../hooks/usePolling.js";
 import Navbar from "../components/Navbar.jsx";
 import {
   BarChart,
@@ -51,6 +52,9 @@ const MeetingQuality = () => {
   const [calculating, setCalculating] = useState(false);
   const [recommendations, setRecommendations] = useState(null);
 
+  // Owns the completion poll below, including its teardown on unmount (#1455).
+  const { startPolling } = usePolling();
+
   const fetchRecommendations = useCallback(async () => {
     try {
       const response = await fetch(
@@ -82,44 +86,49 @@ const MeetingQuality = () => {
 
       toast.info("Quality calculation started. This may take up to 5 seconds.");
 
-      // Poll for completion
-      const pollInterval = setInterval(async () => {
-        try {
+      // Poll for completion. The interval and its 30 s deadline used to be
+      // plain `const`s inside this handler, so nothing on the unmount path
+      // could clear them and navigating away left the poll running (#1455).
+      startPolling(
+        async ({ signal }) => {
           const checkResponse = await fetch(
             `${backendUrl}/api/quality/meeting/${meetingId}`,
-            { credentials: "include" },
+            { credentials: "include", signal },
           );
 
-          if (checkResponse.ok) {
-            const data = await checkResponse.json();
-            if (data.status === "completed") {
-              clearInterval(pollInterval);
-              setQualityData(data);
-              setCalculating(false);
-              toast.success("Quality score calculated!");
-              fetchRecommendations();
-            } else if (data.status === "failed") {
-              clearInterval(pollInterval);
-              setCalculating(false);
-              toast.error("Quality calculation failed");
-            }
-          }
-        } catch (err) {
-          console.error("Poll error:", err);
-        }
-      }, 2000);
+          if (!checkResponse.ok) return false;
 
-      // Stop polling after 30 seconds
-      setTimeout(() => {
-        clearInterval(pollInterval);
-        setCalculating(false);
-      }, 30000);
+          const data = await checkResponse.json();
+
+          if (data.status === "completed") {
+            setQualityData(data);
+            setCalculating(false);
+            toast.success("Quality score calculated!");
+            fetchRecommendations();
+            return true;
+          }
+
+          if (data.status === "failed") {
+            setCalculating(false);
+            toast.error("Quality calculation failed");
+            return true;
+          }
+
+          return false;
+        },
+        {
+          intervalMs: 2000,
+          timeoutMs: 30000,
+          onTimeout: () => setCalculating(false),
+          onError: (err) => console.error("Poll error:", err),
+        },
+      );
     } catch (error) {
       console.error("Error triggering calculation:", error);
       toast.error("Failed to start calculation");
       setCalculating(false);
     }
-  }, [backendUrl, meetingId, fetchRecommendations]);
+  }, [backendUrl, meetingId, fetchRecommendations, startPolling]);
 
   const fetchQualityData = useCallback(async () => {
     try {

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -36,8 +36,18 @@ import {
   CALENDAR_OAUTH_FALLBACK_PATH,
 } from "../utils/validateCalendarOAuthRedirect.js";
 import { validateRedirect } from "../utils/validateRedirect.js";
+import { usePolling } from "../hooks/usePolling.js";
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+/**
+ * How long to watch a calendar OAuth popup before giving up (Issue #1455).
+ *
+ * Generous, because the user is working through a consent screen — but not
+ * unbounded, so a popup left open and forgotten cannot poll for the lifetime
+ * of the tab. The previous code had no deadline at all.
+ */
+const CALENDAR_OAUTH_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Map NotificationPreference document fields → Settings toggle keys. */
 const prefsFromApi = (preferences, emailDigestEnabled) => ({
@@ -80,6 +90,9 @@ const Settings = () => {
     microsoft: null,
   });
   const [calendarLoading, setCalendarLoading] = useState(false);
+
+  // Owns the OAuth popup watcher, including its teardown on unmount (#1455).
+  const { startPolling } = usePolling();
 
   const [notificationPrefs, setNotificationPrefs] = useState({
     meetingNotifications: true,
@@ -247,82 +260,90 @@ const Settings = () => {
     }
   };
 
+  /**
+   * Opens a provider's OAuth popup and waits for the user to finish with it.
+   *
+   * The Google and Microsoft handlers were identical apart from three strings,
+   * and both carried the same two defects (Issue #1455):
+   *
+   *   - `window.open` returns `null` when a popup blocker intervenes, which is
+   *     the common case here because the popup is opened *after* an `await` and
+   *     the user-gesture token has already been spent on the auth-url request.
+   *     `authWindow.closed` then threw a TypeError — and the only
+   *     `clearInterval` sat inside the branch that had just thrown, so it threw
+   *     again every 500 ms for the rest of the session, with the spinner stuck
+   *     on because `setCalendarLoading(false)` was in that same branch.
+   *
+   *   - There was no deadline and no unmount teardown, so even a successful
+   *     flow left a timer running if the user navigated away first.
+   *
+   * The blocked-popup case is now detected before any timer exists, and
+   * `usePolling` owns the rest.
+   *
+   * @param {"google"|"microsoft"} provider
+   * @param {string} label human-readable name used in messages
+   */
+  const connectCalendarProvider = async (provider, label) => {
+    try {
+      setCalendarLoading(true);
+      const response = await apiClient.get(
+        `/api/calendar/${provider}/auth-url`,
+      );
+      const safeAuthUrl = validateCalendarOAuthAuthUrl(response.data.authUrl);
+
+      if (!safeAuthUrl) {
+        toast.error(`Invalid ${label} Calendar authorization URL`);
+        setCalendarLoading(false);
+        window.location.assign(
+          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
+        );
+        return;
+      }
+
+      // Open OAuth popup
+      const authWindow = window.open(
+        safeAuthUrl,
+        "_blank",
+        "width=500,height=600",
+      );
+
+      if (!authWindow) {
+        toast.error(
+          `Could not open the ${label} sign-in window. Please allow pop-ups for this site and try again.`,
+        );
+        setCalendarLoading(false);
+        return;
+      }
+
+      // Poll until the user closes the popup. The deadline is long because the
+      // user is filling in a consent screen, but it exists so a popup left open
+      // and forgotten does not poll for the lifetime of the tab.
+      startPolling(
+        () => {
+          if (!authWindow.closed) return false;
+
+          setCalendarLoading(false);
+          fetchCalendarStatus();
+          return true;
+        },
+        {
+          intervalMs: 500,
+          timeoutMs: CALENDAR_OAUTH_POLL_TIMEOUT_MS,
+          onTimeout: () => setCalendarLoading(false),
+        },
+      );
+    } catch (error) {
+      console.error(`Error connecting ${label} Calendar:`, error);
+      toast.error(`Failed to connect ${label} Calendar`);
+      setCalendarLoading(false);
+    }
+  };
+
   // Calendar connection handlers
-  const handleConnectGoogle = async () => {
-    try {
-      setCalendarLoading(true);
-      const response = await apiClient.get("/api/calendar/google/auth-url");
-      const safeAuthUrl = validateCalendarOAuthAuthUrl(response.data.authUrl);
+  const handleConnectGoogle = () => connectCalendarProvider("google", "Google");
 
-      if (!safeAuthUrl) {
-        toast.error("Invalid Google Calendar authorization URL");
-        setCalendarLoading(false);
-        window.location.assign(
-          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
-        );
-        return;
-      }
-
-      // Open OAuth popup
-      const authWindow = window.open(
-        safeAuthUrl,
-        "_blank",
-        "width=500,height=600",
-      );
-
-      // Poll for callback (in production, use a proper OAuth flow with redirect)
-      const pollForCallback = setInterval(() => {
-        if (authWindow.closed) {
-          clearInterval(pollForCallback);
-          setCalendarLoading(false);
-          // Refresh status
-          fetchCalendarStatus();
-        }
-      }, 500);
-    } catch (error) {
-      console.error("Error connecting Google Calendar:", error);
-      toast.error("Failed to connect Google Calendar");
-      setCalendarLoading(false);
-    }
-  };
-
-  const handleConnectMicrosoft = async () => {
-    try {
-      setCalendarLoading(true);
-      const response = await apiClient.get("/api/calendar/microsoft/auth-url");
-      const safeAuthUrl = validateCalendarOAuthAuthUrl(response.data.authUrl);
-
-      if (!safeAuthUrl) {
-        toast.error("Invalid Microsoft Calendar authorization URL");
-        setCalendarLoading(false);
-        window.location.assign(
-          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
-        );
-        return;
-      }
-
-      // Open OAuth popup
-      const authWindow = window.open(
-        safeAuthUrl,
-        "_blank",
-        "width=500,height=600",
-      );
-
-      // Poll for callback
-      const pollForCallback = setInterval(() => {
-        if (authWindow.closed) {
-          clearInterval(pollForCallback);
-          setCalendarLoading(false);
-          // Refresh status
-          fetchCalendarStatus();
-        }
-      }, 500);
-    } catch (error) {
-      console.error("Error connecting Microsoft Calendar:", error);
-      toast.error("Failed to connect Microsoft Calendar");
-      setCalendarLoading(false);
-    }
-  };
+  const handleConnectMicrosoft = () =>
+    connectCalendarProvider("microsoft", "Microsoft");
 
   const handleDisconnect = async (provider) => {
     try {


### PR DESCRIPTION
# Pull Request

## Description

Five call sites started a poll from an event handler and kept the interval id in a `const` scoped to that handler:

```js
const pollInterval = setInterval(async () => {
  ...
  if (done) clearInterval(pollInterval);
}, 2000);

setTimeout(() => { clearInterval(pollInterval); }, 30000);
```

Nothing outside the handler could reach that id, so nothing on the unmount path could clear it. Navigating away mid-poll left the interval fetching and calling `setState` on an unmounted component for the full deadline — and the deadline `setTimeout` was untracked too, so it also fired after unmount.

**The two calendar handlers in `Settings.jsx` were worse.** They polled `authWindow.closed` with no deadline at all:

```js
const authWindow = window.open(safeAuthUrl, "_blank", "width=500,height=600");

const pollForCallback = setInterval(() => {
  if (authWindow.closed) {          // TypeError when authWindow is null
    clearInterval(pollForCallback); // ...so this line is never reached
    setCalendarLoading(false);      // ...and neither is this
  }
}, 500);
```

`window.open` returns `null` when a popup blocker intervenes — the common case here, because the popup opens *after* an `await` and the user-gesture token has already been spent on the auth-url request. With a null window, `authWindow.closed` threw a `TypeError` twice a second **forever**, since the only `clearInterval` sat inside the branch that had just thrown. The spinner stayed on for the same reason, and the errors continued after navigating away from Settings.

## Approach

Five hand-rolled copies of "poll until done or give up" is the underlying problem. `client/src/hooks/usePolling.js` owns the interval, the deadline, an `AbortController` and the unmount teardown; all five sites are converted:

| Call site | Interval / deadline before | After |
|---|---|---|
| `pages/MeetingQuality.jsx` | 2 s, 30 s untracked | 2 s / 30 s, owned |
| `pages/MeetingAnalytics.jsx` | 5 s, 120 s untracked | 5 s / 120 s, owned |
| `pages/Settings.jsx` (Google) | 500 ms, **no deadline** | 500 ms / 5 min, owned |
| `pages/Settings.jsx` (Microsoft) | 500 ms, **no deadline** | 500 ms / 5 min, owned |
| `components/meeting-details/MeetingActions.jsx` | 5 s, **no deadline** | 5 s / 10 min, owned |

Returning truthy from the poll function stops the loop — that is the whole protocol, and callers never touch a timer id.

Beyond the teardown, the hook adds three things the inline versions could not do:

- **The deadline is armed unconditionally**, so a poll function that throws on every tick terminates instead of looping forever. That is what makes the popup-blocked case bounded even if the null check were missed.
- **Ticks do not overlap.** A tick that is still awaiting is not re-entered, so a slow endpoint degrades the polling rate instead of stacking requests.
- **`isActive()` is re-checked after the `await`**, so a response arriving post-unmount is not acted on.

The blocked-popup case is now detected *before any timer exists*, with a message telling the user to allow pop-ups. The two `Settings.jsx` handlers were identical apart from three strings and are now one `connectCalendarProvider(provider, label)` function, so this fix cannot be applied to one and missed on the other.

`MeetingActions`' sibling `recordingIntervalRef` already had proper unmount cleanup and is unchanged — only the transcription poll next to it was leaking.

## Type of Change

- [x] Bug Fix
- [x] Performance Improvement

## Related Issue

Closes #1455

## Testing

New suite `client/src/hooks/__tests__/usePolling.test.jsx` — 19 tests, organised around the two failures actually observed in the app rather than around the hook's API surface.

*The leak:* polling stops on unmount; the deadline timer is cleared on unmount; the in-flight request's `AbortSignal` is aborted on unmount; a result resolving after unmount is not acted on.

*The infinite error loop:* a poll that throws every tick keeps going but **stops at the deadline** (the popup-blocked case, asserted with the real `TypeError: Cannot read properties of null (reading 'closed')` message); an abort caused by stopping is not reported as an error; a throwing `onError` handler does not take the loop down.

*Run management:* starting twice replaces the run rather than stacking a second loop (a user double-clicking "Recalculate"); ten elapsed intervals during one outstanding request produce one call, not ten.

```
$ npx vitest run src/hooks/__tests__/usePolling.test.jsx
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Full client suite and build:

```
$ npx vitest run
 Test Files  7 failed | 79 passed (86)
      Tests  8 failed | 400 passed (408)

$ npm run build
 ✓ built in 9.72s
```

The 7 failing files (`App.test.jsx`, `AiSearch.test.jsx`, `MeetingRoomRebinding.test.jsx`, `PresentMode.a11y.test.jsx`, `NavbarDashboardNav.test.jsx`, `ProtectedRoute.test.jsx`, `rbacPermissions.test.js`) fail identically on `main` — same 7 files, same 8 tests — and none are touched by this PR. Verified by stashing these changes and re-running.

Lint is clean on the changed code. `MeetingQuality.jsx`'s `'Icon' is defined but never used` error and `Settings.jsx`'s `exhaustive-deps` warning both pre-date this branch (confirmed on `main` at the same code, different line numbers).

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

n/a — the visible effects are a console that no longer fills with `TypeError` when pop-ups are blocked, and a spinner that clears instead of hanging.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
