### PR TITLE
feat(ui): add dark mode support for automation rules

### DIFF
--- a/client/src/pages/AutomationRules.jsx
+++ b/client/src/pages/AutomationRules.jsx
@@ -1,17 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { toast } from "react-toastify";
-import {
-  Plus,
-  Trash2,
-  Power,
-  PowerOff,
-  Activity,
-  Sliders,
-  ChevronDown,
-  ChevronUp,
-} from "lucide-react";
+import { Plus, Trash2, Power, PowerOff, Activity, Sliders } from "lucide-react";
 import * as api from "../services/automationRuleApi";
 import ConfirmModal from "../components/ConfirmModal.jsx";
+
+/** Shared field styles — light + dark (Issue #1371). */
+const FIELD_CLASS =
+  "w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 focus:border-indigo-500 dark:focus:border-indigo-400";
+
+const LABEL_CLASS =
+  "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1";
 
 const AutomationRules = () => {
   const [rules, setRules] = useState([]);
@@ -113,317 +111,325 @@ const AutomationRules = () => {
   };
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-6xl">
-      <div className="flex justify-between items-center mb-8">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-            Automation Rules
-          </h1>
-          <p className="text-gray-500 mt-2">
-            Automate your organization's workflows.
-          </p>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors">
+      <div className="container mx-auto px-4 py-8 max-w-6xl">
+        <div className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              Automation Rules
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-2">
+              Automate your organization's workflows.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowBuilder(!showBuilder)}
+            className="bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white px-4 py-2 rounded-lg flex items-center transition-colors shadow-sm cursor-pointer"
+          >
+            {showBuilder ? (
+              "Cancel"
+            ) : (
+              <>
+                <Plus size={18} className="mr-2" /> New Rule
+              </>
+            )}
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowBuilder(!showBuilder)}
-          className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg flex items-center transition-colors shadow-sm cursor-pointer"
-        >
-          {showBuilder ? (
-            "Cancel"
-          ) : (
-            <>
-              <Plus size={18} className="mr-2" /> New Rule
-            </>
-          )}
-        </button>
-      </div>
 
-      {showBuilder && (
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 mb-8 border border-gray-100 dark:border-gray-700">
-          <h2 className="text-xl font-semibold mb-6 text-gray-800 dark:text-gray-200">
-            Create New Rule
-          </h2>
-          <form onSubmit={handleCreate} className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Rule Name
-                </label>
-                <input
-                  type="text"
-                  required
-                  className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                  value={newRule.name}
-                  onChange={(e) =>
-                    setNewRule({ ...newRule, name: e.target.value })
-                  }
-                  placeholder="e.g. Notify Slack on new meeting"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Description
-                </label>
-                <input
-                  type="text"
-                  className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                  value={newRule.description}
-                  onChange={(e) =>
-                    setNewRule({ ...newRule, description: e.target.value })
-                  }
-                  placeholder="Optional description"
-                />
-              </div>
-            </div>
-
-            {/* Trigger Config */}
-            <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-              <h3 className="text-md font-semibold text-gray-800 dark:text-gray-200 mb-4 flex items-center">
-                <Activity size={18} className="mr-2 text-indigo-500" /> When
-                this happens... (Trigger)
-              </h3>
+        {showBuilder && (
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 mb-8 border border-gray-200 dark:border-gray-700">
+            <h2 className="text-xl font-semibold mb-6 text-gray-800 dark:text-gray-100">
+              Create New Rule
+            </h2>
+            <form onSubmit={handleCreate} className="space-y-6">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Event Type
-                  </label>
-                  <select
-                    className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                    value={newRule.trigger.event}
+                  <label className={LABEL_CLASS}>Rule Name</label>
+                  <input
+                    type="text"
+                    required
+                    className={FIELD_CLASS}
+                    value={newRule.name}
                     onChange={(e) =>
-                      setNewRule({
-                        ...newRule,
-                        trigger: { ...newRule.trigger, event: e.target.value },
-                      })
+                      setNewRule({ ...newRule, name: e.target.value })
                     }
-                  >
-                    <option value="meeting.created">Meeting Created</option>
-                    <option value="transcript.processed">
-                      Transcript Processed
-                    </option>
-                    <option value="action_item.assigned">
-                      Action Item Assigned
-                    </option>
-                  </select>
+                    placeholder="e.g. Notify Slack on new meeting"
+                  />
                 </div>
-
-                {newRule.trigger.event === "meeting.created" && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Filter by Tag (Optional)
-                    </label>
-                    <input
-                      type="text"
-                      className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                      placeholder="e.g. urgent"
-                      onChange={(e) =>
-                        handleFilterChange("tag", e.target.value)
-                      }
-                    />
-                  </div>
-                )}
+                <div>
+                  <label className={LABEL_CLASS}>Description</label>
+                  <input
+                    type="text"
+                    className={FIELD_CLASS}
+                    value={newRule.description}
+                    onChange={(e) =>
+                      setNewRule({ ...newRule, description: e.target.value })
+                    }
+                    placeholder="Optional description"
+                  />
+                </div>
               </div>
-            </div>
 
-            {/* Actions Config */}
-            <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
-              <h3 className="text-md font-semibold text-gray-800 dark:text-gray-200 mb-4 flex items-center">
-                <Sliders size={18} className="mr-2 text-indigo-500" /> Do
-                this... (Actions)
-              </h3>
-              {newRule.actions.map((action, index) => (
-                <div
-                  key={index}
-                  className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 bg-gray-50 dark:bg-gray-750 p-4 rounded-lg"
-                >
+              {/* Trigger Config */}
+              <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+                <h3 className="text-md font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
+                  <Activity
+                    size={18}
+                    className="mr-2 text-indigo-500 dark:text-indigo-400"
+                  />{" "}
+                  When this happens... (Trigger)
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      Action Type
-                    </label>
+                    <label className={LABEL_CLASS}>Event Type</label>
                     <select
-                      className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                      value={action.type}
+                      className={FIELD_CLASS}
+                      value={newRule.trigger.event}
                       onChange={(e) =>
-                        handleActionChange(index, "type", e.target.value)
+                        setNewRule({
+                          ...newRule,
+                          trigger: {
+                            ...newRule.trigger,
+                            event: e.target.value,
+                          },
+                        })
                       }
                     >
-                      <option value="slack">Send Slack Notification</option>
-                      <option value="email">Send Email</option>
-                      <option value="webhook">Trigger Webhook</option>
+                      <option value="meeting.created">Meeting Created</option>
+                      <option value="transcript.processed">
+                        Transcript Processed
+                      </option>
+                      <option value="action_item.assigned">
+                        Action Item Assigned
+                      </option>
                     </select>
                   </div>
 
-                  {action.type === "slack" && (
+                  {newRule.trigger.event === "meeting.created" && (
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                        Channel ID
+                      <label className={LABEL_CLASS}>
+                        Filter by Tag (Optional)
                       </label>
                       <input
                         type="text"
-                        required
-                        className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                        placeholder="e.g. #general"
-                        value={action.config.channelId || ""}
+                        className={FIELD_CLASS}
+                        placeholder="e.g. urgent"
                         onChange={(e) =>
-                          handleActionChange(index, "channelId", e.target.value)
-                        }
-                      />
-                    </div>
-                  )}
-
-                  {action.type === "email" && (
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                        Recipient Email
-                      </label>
-                      <input
-                        type="email"
-                        required
-                        className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                        placeholder="user@example.com"
-                        value={action.config.email || ""}
-                        onChange={(e) =>
-                          handleActionChange(index, "email", e.target.value)
-                        }
-                      />
-                    </div>
-                  )}
-
-                  {action.type === "webhook" && (
-                    <div className="md:col-span-2">
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                        Webhook URL
-                      </label>
-                      <input
-                        type="url"
-                        required
-                        className="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600"
-                        placeholder="https://api.example.com/webhook"
-                        value={action.config.url || ""}
-                        onChange={(e) =>
-                          handleActionChange(index, "url", e.target.value)
+                          handleFilterChange("tag", e.target.value)
                         }
                       />
                     </div>
                   )}
                 </div>
-              ))}
-            </div>
+              </div>
 
-            <div className="flex justify-end space-x-4">
-              <button
-                type="button"
-                onClick={() => setShowBuilder(false)}
-                className="px-4 py-2 border rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-2 rounded-lg font-medium shadow-sm transition-colors cursor-pointer"
-              >
-                Save Rule
-              </button>
-            </div>
-          </form>
-        </div>
-      )}
-
-      {/* Rules List */}
-      {loading ? (
-        <div className="text-center py-12 text-gray-500">Loading rules...</div>
-      ) : rules.length === 0 ? (
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-12 text-center border border-gray-100 dark:border-gray-700">
-          <Sliders className="mx-auto h-12 w-12 text-gray-400 mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-            No automation rules yet
-          </h3>
-          <p className="text-gray-500 mt-1 mb-6">
-            Get started by creating a new rule above.
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {rules.map((rule) => (
-            <div
-              key={rule._id}
-              className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 border border-gray-100 dark:border-gray-700 flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-md"
-            >
-              <div className="flex-1">
-                <div className="flex items-center space-x-3">
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                    {rule.name}
-                  </h3>
-                  <span
-                    className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                      rule.isActive
-                        ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                        : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
-                    }`}
+              {/* Actions Config */}
+              <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+                <h3 className="text-md font-semibold text-gray-800 dark:text-gray-100 mb-4 flex items-center">
+                  <Sliders
+                    size={18}
+                    className="mr-2 text-indigo-500 dark:text-indigo-400"
+                  />{" "}
+                  Do this... (Actions)
+                </h3>
+                {newRule.actions.map((action, index) => (
+                  <div
+                    key={index}
+                    className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4 bg-gray-50 dark:bg-gray-900/50 p-4 rounded-lg border border-transparent dark:border-gray-700"
                   >
-                    {rule.isActive ? "Active" : "Disabled"}
-                  </span>
-                </div>
-                {rule.description && (
-                  <p className="text-gray-500 text-sm mt-1">
-                    {rule.description}
-                  </p>
-                )}
+                    <div>
+                      <label className={LABEL_CLASS}>Action Type</label>
+                      <select
+                        className={FIELD_CLASS}
+                        value={action.type}
+                        onChange={(e) =>
+                          handleActionChange(index, "type", e.target.value)
+                        }
+                      >
+                        <option value="slack">Send Slack Notification</option>
+                        <option value="email">Send Email</option>
+                        <option value="webhook">Trigger Webhook</option>
+                      </select>
+                    </div>
 
-                <div className="flex items-center space-x-4 mt-3 text-xs text-gray-500 dark:text-gray-400">
-                  <div>
-                    <span className="font-semibold text-gray-700 dark:text-gray-300">
-                      Trigger:
-                    </span>{" "}
-                    {rule.trigger?.event}
+                    {action.type === "slack" && (
+                      <div>
+                        <label className={LABEL_CLASS}>Channel ID</label>
+                        <input
+                          type="text"
+                          required
+                          className={FIELD_CLASS}
+                          placeholder="e.g. #general"
+                          value={action.config.channelId || ""}
+                          onChange={(e) =>
+                            handleActionChange(
+                              index,
+                              "channelId",
+                              e.target.value,
+                            )
+                          }
+                        />
+                      </div>
+                    )}
+
+                    {action.type === "email" && (
+                      <div>
+                        <label className={LABEL_CLASS}>Recipient Email</label>
+                        <input
+                          type="email"
+                          required
+                          className={FIELD_CLASS}
+                          placeholder="user@example.com"
+                          value={action.config.email || ""}
+                          onChange={(e) =>
+                            handleActionChange(index, "email", e.target.value)
+                          }
+                        />
+                      </div>
+                    )}
+
+                    {action.type === "webhook" && (
+                      <div className="md:col-span-2">
+                        <label className={LABEL_CLASS}>Webhook URL</label>
+                        <input
+                          type="url"
+                          required
+                          className={FIELD_CLASS}
+                          placeholder="https://api.example.com/webhook"
+                          value={action.config.url || ""}
+                          onChange={(e) =>
+                            handleActionChange(index, "url", e.target.value)
+                          }
+                        />
+                      </div>
+                    )}
                   </div>
-                  <div>
-                    <span className="font-semibold text-gray-700 dark:text-gray-300">
-                      Actions:
-                    </span>{" "}
-                    {rule.actions?.map((a) => a.type).join(", ")}
-                  </div>
-                </div>
+                ))}
               </div>
 
-              <div className="flex items-center space-x-3 self-end md:self-center">
+              <div className="flex justify-end space-x-4">
                 <button
                   type="button"
-                  onClick={() => handleToggle(rule._id, rule.isActive)}
-                  className={`p-2 rounded-lg transition-colors cursor-pointer ${
-                    rule.isActive
-                      ? "text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20"
-                      : "text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                  }`}
-                  title={rule.isActive ? "Disable Rule" : "Enable Rule"}
+                  onClick={() => setShowBuilder(false)}
+                  className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer transition-colors"
                 >
-                  {rule.isActive ? <Power size={20} /> : <PowerOff size={20} />}
+                  Cancel
                 </button>
                 <button
-                  type="button"
-                  onClick={() => setDeleteTarget(rule)}
-                  className="p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors cursor-pointer"
-                  title="Delete Rule"
+                  type="submit"
+                  className="bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white px-6 py-2 rounded-lg font-medium shadow-sm transition-colors cursor-pointer"
                 >
-                  <Trash2 size={20} />
+                  Save Rule
                 </button>
               </div>
-            </div>
-          ))}
-        </div>
-      )}
+            </form>
+          </div>
+        )}
 
-      {/* Confirmation Modal (#1369) */}
-      <ConfirmModal
-        isOpen={Boolean(deleteTarget)}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={handleDeleteConfirm}
-        title="Delete Automation Rule"
-        message={`Are you sure you want to delete "${deleteTarget?.name || "this automation rule"}"? This action cannot be undone.`}
-        confirmText="Delete Rule"
-        variant="danger"
-        isLoading={deleteLoading}
-      />
+        {/* Rules List */}
+        {loading ? (
+          <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+            Loading rules...
+          </div>
+        ) : rules.length === 0 ? (
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-12 text-center border border-gray-200 dark:border-gray-700">
+            <Sliders className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500 mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+              No automation rules yet
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400 mt-1 mb-6">
+              Get started by creating a new rule above.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {rules.map((rule) => (
+              <div
+                key={rule._id}
+                data-testid="automation-rule-card"
+                className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 border border-gray-200 dark:border-gray-700 flex flex-col md:flex-row justify-between items-start md:items-center gap-4 transition-all hover:shadow-md dark:hover:border-gray-600"
+              >
+                <div className="flex-1">
+                  <div className="flex items-center space-x-3">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      {rule.name}
+                    </h3>
+                    <span
+                      className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        rule.isActive
+                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                          : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+                      }`}
+                    >
+                      {rule.isActive ? "Active" : "Disabled"}
+                    </span>
+                  </div>
+                  {rule.description && (
+                    <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">
+                      {rule.description}
+                    </p>
+                  )}
+
+                  <div className="flex items-center space-x-4 mt-3 text-xs text-gray-500 dark:text-gray-400">
+                    <div>
+                      <span className="font-semibold text-gray-700 dark:text-gray-300">
+                        Trigger:
+                      </span>{" "}
+                      {rule.trigger?.event}
+                    </div>
+                    <div>
+                      <span className="font-semibold text-gray-700 dark:text-gray-300">
+                        Actions:
+                      </span>{" "}
+                      {rule.actions?.map((a) => a.type).join(", ")}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center space-x-3 self-end md:self-center">
+                  <button
+                    type="button"
+                    onClick={() => handleToggle(rule._id, rule.isActive)}
+                    className={`p-2 rounded-lg transition-colors cursor-pointer ${
+                      rule.isActive
+                        ? "text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20"
+                        : "text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    }`}
+                    title={rule.isActive ? "Disable Rule" : "Enable Rule"}
+                  >
+                    {rule.isActive ? (
+                      <Power size={20} />
+                    ) : (
+                      <PowerOff size={20} />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDeleteTarget(rule)}
+                    className="p-2 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors cursor-pointer"
+                    title="Delete Rule"
+                  >
+                    <Trash2 size={20} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Confirmation Modal (#1369) */}
+        <ConfirmModal
+          isOpen={Boolean(deleteTarget)}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={handleDeleteConfirm}
+          title="Delete Automation Rule"
+          message={`Are you sure you want to delete "${deleteTarget?.name || "this automation rule"}"? This action cannot be undone.`}
+          confirmText="Delete Rule"
+          variant="danger"
+          isLoading={deleteLoading}
+        />
+      </div>
     </div>
   );
 };

--- a/client/src/pages/__tests__/AutomationRulesDarkMode.test.jsx
+++ b/client/src/pages/__tests__/AutomationRulesDarkMode.test.jsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import AutomationRules from "../AutomationRules.jsx";
+import * as api from "../../services/automationRuleApi.js";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/automationRuleApi.js", () => ({
+  fetchRules: vi.fn(),
+  toggleRuleStatus: vi.fn(),
+  deleteRule: vi.fn(),
+  createRule: vi.fn(),
+}));
+
+describe("AutomationRules Dark Mode (#1371)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the page container with dark-mode background and text classes", async () => {
+    api.fetchRules.mockResolvedValue([]);
+
+    const { container } = render(<AutomationRules />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no automation rules yet/i)).toBeInTheDocument();
+    });
+
+    const root = container.firstChild;
+    expect(root.className).toContain("dark:bg-gray-900");
+    expect(root.className).toContain("dark:text-gray-100");
+    expect(root.className).toContain("bg-gray-50");
+  });
+
+  it("renders empty-state card with dark-mode surface classes", async () => {
+    api.fetchRules.mockResolvedValue([]);
+
+    render(<AutomationRules />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no automation rules yet/i)).toBeInTheDocument();
+    });
+
+    const emptyTitle = screen.getByText(/no automation rules yet/i);
+    const emptyCard = emptyTitle.closest("div.rounded-xl");
+    expect(emptyCard.className).toContain("dark:bg-gray-800");
+    expect(emptyCard.className).toContain("dark:border-gray-700");
+    expect(emptyTitle.className).toContain("dark:text-white");
+  });
+
+  it("renders rule cards with dark-mode classes", async () => {
+    api.fetchRules.mockResolvedValue([
+      {
+        _id: "rule-1",
+        name: "Notify Slack on meeting creation",
+        description: "Posts to #general",
+        isActive: true,
+        trigger: { event: "meeting.created" },
+        actions: [{ type: "slack" }],
+      },
+      {
+        _id: "rule-2",
+        name: "Disabled webhook rule",
+        isActive: false,
+        trigger: { event: "transcript.processed" },
+        actions: [{ type: "webhook" }],
+      },
+    ]);
+
+    render(<AutomationRules />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Notify Slack on meeting creation"),
+      ).toBeInTheDocument();
+    });
+
+    const cards = screen.getAllByTestId("automation-rule-card");
+    expect(cards).toHaveLength(2);
+    cards.forEach((card) => {
+      expect(card.className).toContain("dark:bg-gray-800");
+      expect(card.className).toContain("dark:border-gray-700");
+    });
+
+    const activeBadge = screen.getByText("Active");
+    expect(activeBadge.className).toContain("dark:bg-green-900/30");
+    expect(activeBadge.className).toContain("dark:text-green-400");
+
+    const disabledBadge = screen.getByText("Disabled");
+    expect(disabledBadge.className).toContain("dark:bg-gray-700");
+    expect(disabledBadge.className).toContain("dark:text-gray-300");
+  });
+
+  it("renders builder form inputs and buttons with dark-mode classes", async () => {
+    api.fetchRules.mockResolvedValue([]);
+
+    render(<AutomationRules />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no automation rules yet/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /new rule/i }));
+
+    expect(screen.getByText(/create new rule/i)).toBeInTheDocument();
+
+    const nameInput = screen.getByPlaceholderText(
+      /notify slack on new meeting/i,
+    );
+    expect(nameInput.className).toContain("dark:bg-gray-700");
+    expect(nameInput.className).toContain("dark:border-gray-600");
+    expect(nameInput.className).toContain("dark:text-white");
+    expect(nameInput.className).toContain("dark:placeholder-gray-400");
+
+    const eventSelect = screen.getByDisplayValue("Meeting Created");
+    expect(eventSelect.className).toContain("dark:bg-gray-700");
+    expect(eventSelect.className).toContain("dark:text-white");
+
+    const cancelButtons = screen.getAllByRole("button", { name: /^cancel$/i });
+    expect(cancelButtons.length).toBeGreaterThanOrEqual(1);
+    const formCancel = cancelButtons.find((btn) =>
+      btn.className.includes("dark:border-gray-600"),
+    );
+    expect(formCancel).toBeTruthy();
+    expect(formCancel.className).toContain("dark:text-gray-300");
+    expect(formCancel.className).toContain("dark:hover:bg-gray-700");
+
+    const saveButton = screen.getByRole("button", { name: /save rule/i });
+    expect(saveButton.className).toContain("dark:bg-indigo-500");
+    expect(saveButton.className).toContain("dark:hover:bg-indigo-600");
+  });
+
+  it("renders action and delete controls with dark-mode hover classes", async () => {
+    api.fetchRules.mockResolvedValue([
+      {
+        _id: "rule-1",
+        name: "Notify Slack on meeting creation",
+        isActive: true,
+        trigger: { event: "meeting.created" },
+        actions: [{ type: "slack" }],
+      },
+    ]);
+
+    render(<AutomationRules />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Notify Slack on meeting creation"),
+      ).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTitle("Disable Rule");
+    expect(toggle.className).toContain("dark:text-green-400");
+    expect(toggle.className).toContain("dark:hover:bg-green-900/20");
+
+    const deleteButton = screen.getByTitle("Delete Rule");
+    expect(deleteButton.className).toContain("dark:text-red-400");
+    expect(deleteButton.className).toContain("dark:hover:bg-red-900/20");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1371

Adds complete dark-mode support to the Automation Rules page to ensure visual consistency, accessibility, and proper contrast across all UI elements.

## Changes Made

### UI Improvements

Enhanced dark theme support throughout `AutomationRules.jsx` including:

- Page-level background containers
- Rule builder sections
- Rule cards
- Form labels
- Inputs
- Select controls
- Action panels
- Status badges
- Toggle controls
- Delete buttons
- Empty states
- Secondary action buttons

### Dark Theme Consistency

Added or improved:

- `dark:bg-*`
- `dark:border-*`
- `dark:text-*`
- `dark:hover:*`
- `dark:focus:*`

classes across the page.

### Accessibility Improvements

- Improved text contrast in dark mode
- Improved placeholder visibility
- Improved focus-ring visibility
- Improved hover-state contrast
- Improved readability for status badges and controls

### Code Cleanup

- Introduced shared styling constants for form fields and labels
- Removed unused imports
- Replaced invalid Tailwind class:

```diff
-dark:bg-gray-750
+dark:bg-gray-900/50