### PR TITLE
fix: enforce meeting health access controls

### DIFF
--- a/server/controllers/meetingHealthController.js
+++ b/server/controllers/meetingHealthController.js
@@ -1,9 +1,10 @@
+import mongoose from "mongoose";
 import MeetingHealth from "../models/meetingHealthModel.js";
 import { calculateMeetingHealth } from "../services/meetingHealthService.js";
 
 // @desc    Get health score for a meeting
 // @route   GET /api/meeting-health/:meetingId
-// @access  Private
+// @access  Private (org membership + meetings.view — enforced in routes)
 export const getMeetingHealth = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
@@ -11,7 +12,7 @@ export const getMeetingHealth = async (req, res, next) => {
     // First try to find existing record
     let healthRecord = await MeetingHealth.findOne({ meetingId });
 
-    // If not found, compute it on the fly
+    // If not found, compute it on the fly (meeting already authorized via middleware)
     if (!healthRecord) {
       healthRecord = await calculateMeetingHealth(meetingId);
     }
@@ -27,10 +28,32 @@ export const getMeetingHealth = async (req, res, next) => {
 
 // @desc    Get organization health trends
 // @route   GET /api/meeting-health/trends/:organizationId
-// @access  Private
+// @access  Private (role + org scope — enforced here and in routes)
 export const getOrganizationHealthTrends = async (req, res, next) => {
   try {
     const { organizationId } = req.params;
+
+    if (!req.user?.organization) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(organizationId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid organization ID",
+      });
+    }
+
+    // Issue #1379: never trust client-supplied organizationId for trends
+    if (req.user.organization.toString() !== String(organizationId)) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You don't have access to this resource",
+      });
+    }
 
     // Get last 30 meetings health for trends
     const trends = await MeetingHealth.find({ organization: organizationId })

--- a/server/routes/meetingHealthRoutes.js
+++ b/server/routes/meetingHealthRoutes.js
@@ -1,25 +1,38 @@
 import express from "express";
+import Meeting from "../models/meetingModel.js";
 import {
   getMeetingHealth,
   getOrganizationHealthTrends,
 } from "../controllers/meetingHealthController.js";
 import userAuth from "../middleware/userAuth.js";
-import { requireRole } from "../middleware/rbac.js";
+import {
+  requireOrgAccess,
+  requirePermission,
+  requireRole,
+} from "../middleware/rbac.js";
 
 const router = express.Router();
 
 // Require authentication for all routes
 router.use(userAuth);
 
-// Get health score for a specific meeting
-router.get("/:meetingId", getMeetingHealth);
-
-// Get organization-wide trends
-// Require admin or manager roles for org-wide insights
+// Organization-wide trends MUST be registered before "/:meetingId"
+// so "trends" is not captured as a meeting id.
+// Preserve existing admin/manager role gate; org scoping is enforced in the
+// controller (Issue #1379).
 router.get(
   "/trends/:organizationId",
   requireRole(["admin", "manager"]),
   getOrganizationHealthTrends,
+);
+
+// Issue #1379: resolve the meeting server-side and enforce org membership
+// before any health read/calculation. Never trust meetingId alone.
+router.get(
+  "/:meetingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  getMeetingHealth,
 );
 
 export default router;

--- a/server/tests/meetingHealthAuthorization.test.js
+++ b/server/tests/meetingHealthAuthorization.test.js
@@ -1,0 +1,254 @@
+/**
+ * Issue #1379 — meeting health endpoints must resolve the meeting and enforce
+ * organization access before any health read/calculation. Cross-org callers
+ * must not retrieve or trigger health computation for another tenant's meeting.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const mockCalculateMeetingHealth = jest.fn();
+
+jest.unstable_mockModule("../services/meetingHealthService.js", () => ({
+  calculateMeetingHealth: (...args) => mockCalculateMeetingHealth(...args),
+}));
+
+const { default: meetingHealthRoutes } =
+  await import("../routes/meetingHealthRoutes.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: MeetingHealth } =
+  await import("../models/meetingHealthModel.js");
+
+await import("../models/userModel.js");
+await import("../models/organizationModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const aliceAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noOrgUser = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "member",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/meeting-health", meetingHealthRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+  mockCalculateMeetingHealth.mockReset();
+  mockCalculateMeetingHealth.mockResolvedValue({
+    compositeScore: 80,
+    factors: {
+      agendaCoverage: 80,
+      timeAdherence: 80,
+      engagement: 80,
+      actionItemClarity: 80,
+      sentiment: 80,
+    },
+    recommendations: [],
+  });
+});
+
+const seedMeeting = async ({
+  organization,
+  uploadedBy,
+  title = "Health Meeting",
+} = {}) => {
+  return Meeting.create({
+    uploadedBy,
+    organization,
+    title,
+    date: new Date(),
+  });
+};
+
+describe("Meeting health authorization (#1379)", () => {
+  describe("GET /api/meeting-health/:meetingId", () => {
+    it("allows a same-org member to read meeting health", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      await MeetingHealth.create({
+        meetingId: meeting._id,
+        organization: ORG_A,
+        compositeScore: 72,
+        factors: {
+          agendaCoverage: 70,
+          timeAdherence: 70,
+          engagement: 70,
+          actionItemClarity: 70,
+          sentiment: 80,
+        },
+        recommendations: [],
+      });
+
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.compositeScore).toBe(72);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("calculates health for authorized users when no cached record exists", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(mockCalculateMeetingHealth).toHaveBeenCalledWith(
+        meeting._id.toString(),
+      );
+    });
+
+    it("returns 403 for cross-organization access and never calculates health", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: mallory._id,
+        title: "Confidential",
+      });
+
+      currentUser = alice;
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/access/i);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the user has no organization", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = noOrgUser;
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/organization membership/i);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for an unknown meeting", async () => {
+      const missingId = new mongoose.Types.ObjectId();
+      const res = await request(app).get(`/api/meeting-health/${missingId}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for an invalid meeting id", async () => {
+      const res = await request(app).get("/api/meeting-health/not-a-valid-id");
+
+      expect(res.status).toBe(400);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when unauthenticated", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_A,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = null;
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      expect(res.status).toBe(401);
+      expect(mockCalculateMeetingHealth).not.toHaveBeenCalled();
+    });
+
+    it("allows the meeting uploader even when org fields differ (ownership)", async () => {
+      const meeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: alice._id,
+      });
+
+      currentUser = alice;
+      const res = await request(app).get(`/api/meeting-health/${meeting._id}`);
+
+      // canAccessMeetingDoc grants access to uploadedBy
+      expect(res.status).toBe(200);
+      expect(mockCalculateMeetingHealth).toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/meeting-health/trends/:organizationId", () => {
+    it("allows an admin to read trends for their own organization", async () => {
+      currentUser = aliceAdmin;
+
+      const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.trends).toEqual([]);
+    });
+
+    it("returns 403 when an admin requests another organization's trends", async () => {
+      currentUser = aliceAdmin;
+
+      const res = await request(app).get(`/api/meeting-health/trends/${ORG_B}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/access/i);
+    });
+
+    it("returns 403 for members without the admin/manager role", async () => {
+      currentUser = alice;
+
+      const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1379

Fixes an IDOR vulnerability in the meeting health endpoints by enforcing organization membership, meeting access validation, and RBAC authorization before health data can be accessed or calculated.

## Problem

Meeting health endpoints relied primarily on authentication and did not consistently verify whether the authenticated user was authorized to access the target meeting.

A user with knowledge of another meeting's ID could potentially retrieve or trigger health calculations for meetings outside their organization.

## Changes Made

### Authorization Enforcement

Added access validation before any meeting health logic executes.

Authorization flow now:

1. Authenticate user
2. Resolve meeting from database
3. Verify meeting access
4. Verify organization membership
5. Verify required permissions
6. Execute health calculation/read

### Reused Existing Security Infrastructure

Integrated existing authorization mechanisms already used elsewhere in the application:

- `userAuth`
- `requireOrgAccess(Meeting)`
- `canAccessMeetingDoc`
- `requirePermission("meetings", "view")`

This keeps meeting health authorization consistent with:

- Transcript endpoints
- Speaker mapping endpoints
- Other meeting-scoped resources

### Route Improvements

Corrected route ordering to prevent route conflicts.

- Registered `/trends` routes before `/:meetingId`
- Prevents accidental matching of trends requests as meeting IDs

### Trends Endpoint Hardening

Added organization validation for trends endpoints.

Users can now only request trends data for organizations they are authorized to access.

## Security Improvements

### Protected Scenarios

- Cross-organization meeting access
- Unauthorized health calculations
- Meeting ID enumeration attempts
- Unauthorized organization trend access

### Preserved Access

Authorized users continue to access meeting health data without behavioral changes.

Uploader access remains supported through existing access-control logic.

## Response Behavior

| Scenario | Status |
|-----------|----------|
| Unauthenticated | 401 |
| Unauthorized | 403 |
| Meeting Not Found | 404 |
| Invalid Meeting ID | 400 |

Response handling follows existing project conventions.

## Tests Added

### meetingHealthAuthorization.test.js

Added coverage for:

#### Authorized Access

- Same-org user can access meeting health
- Authorized users can trigger health calculation
- Meeting uploader retains access

#### Unauthorized Access

- Cross-org access denied
- No-organization user denied
- User without permissions denied
- Trends access denied for unauthorized organizations

#### Validation

- Invalid ObjectId returns 400
- Missing meeting returns 404
- Unauthenticated request returns 401

#### Security Regression

- Health calculation never executes for unauthorized requests
- Cross-org meeting IDs cannot expose health data

## Files Changed

### Modified

- `server/controllers/meetingHealthController.js`
- `server/routes/meetingHealthRoutes.js`

### Added

- `server/tests/meetingHealthAuthorization.test.js`

## Manual Verification

- [ ] Same-org user can retrieve meeting health
- [ ] Same-org user can trigger health calculation
- [ ] Cross-org user receives 403
- [ ] Invalid meeting ID returns 400
- [ ] Missing meeting returns 404
- [ ] Unauthenticated requests return 401
- [ ] Trends endpoint works for authorized orgs
- [ ] Trends endpoint rejects unauthorized orgs
- [ ] Health calculations are not executed for unauthorized requests

## Notes

- No changes to health calculation logic.
- No changes to health scoring behavior.
- No database schema changes.
- Fix is limited to authorization and route protection.
- Existing authorized functionality remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access controls for meeting health data and organization trends.
  * Blocked invalid, unknown, cross-organization, and unauthenticated requests.
  * Enforced required meeting-view permissions and role restrictions.
  * Preserved valid access for authorized members and meeting owners.

* **Tests**
  * Added comprehensive coverage for authorization, organization membership, cached results, calculations, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->