### PR TITLE
fix: prevent cross-organization access in meeting health trends

### DIFF
--- a/server/controllers/meetingHealthController.js
+++ b/server/controllers/meetingHealthController.js
@@ -3,7 +3,7 @@ import { calculateMeetingHealth } from "../services/meetingHealthService.js";
 
 // @desc    Get health score for a meeting
 // @route   GET /api/meeting-health/:meetingId
-// @access  Private
+// @access  Private (org membership + meetings.view — enforced in routes)
 export const getMeetingHealth = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
@@ -11,7 +11,7 @@ export const getMeetingHealth = async (req, res, next) => {
     // First try to find existing record
     let healthRecord = await MeetingHealth.findOne({ meetingId });
 
-    // If not found, compute it on the fly
+    // If not found, compute it on the fly (meeting already authorized via middleware)
     if (!healthRecord) {
       healthRecord = await calculateMeetingHealth(meetingId);
     }
@@ -27,12 +27,23 @@ export const getMeetingHealth = async (req, res, next) => {
 
 // @desc    Get organization health trends
 // @route   GET /api/meeting-health/trends/:organizationId
-// @access  Private
+// @access  Private (membership + role + org match — enforced in routes)
 export const getOrganizationHealthTrends = async (req, res, next) => {
   try {
-    const { organizationId } = req.params;
+    // Issue #1380: never query with the client-supplied path param.
+    // requireOrganizationParamMatch sets the server-trusted membership org.
+    const organizationId =
+      req.authorizedOrganizationId ||
+      (req.user?.organization?._id || req.user?.organization)?.toString();
 
-    // Get last 30 meetings health for trends
+    if (!organizationId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    // Get last 30 meetings health for trends — scoped to authorized org only
     const trends = await MeetingHealth.find({ organization: organizationId })
       .sort({ createdAt: 1 }) // Chronological order
       .limit(30)

--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -347,3 +347,59 @@ export const requireMinimumRole = (minimumRole) => {
     next();
   };
 };
+
+/**
+ * Ensures a client-supplied organization path/query param matches the
+ * authenticated user's membership organization (Issue #1380).
+ *
+ * Cross-tenant IDOR pattern this closes: authorize the user, then still query
+ * with an untrusted `:organizationId` from the URL. After this middleware runs,
+ * handlers MUST scope queries with `req.authorizedOrganizationId` (the
+ * server-resolved membership org), never the raw path parameter.
+ *
+ * @param {string} [paramName="organizationId"]
+ */
+export const requireOrganizationParamMatch = (paramName = "organizationId") => {
+  return (req, res, next) => {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    if (!req.user.organization) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    const requestedId = req.params?.[paramName] ?? req.query?.[paramName];
+    if (!requestedId) {
+      return res.status(400).json({
+        success: false,
+        message: "Organization ID required",
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(requestedId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid organization ID",
+      });
+    }
+
+    // Support populated organization refs and raw ObjectIds.
+    const userOrgId = (
+      req.user.organization._id || req.user.organization
+    ).toString();
+
+    if (userOrgId !== String(requestedId)) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You don't have access to this resource",
+      });
+    }
+
+    req.authorizedOrganizationId = userOrgId;
+    next();
+  };
+};

--- a/server/routes/meetingHealthRoutes.js
+++ b/server/routes/meetingHealthRoutes.js
@@ -1,25 +1,44 @@
 import express from "express";
+import Meeting from "../models/meetingModel.js";
 import {
   getMeetingHealth,
   getOrganizationHealthTrends,
 } from "../controllers/meetingHealthController.js";
 import userAuth from "../middleware/userAuth.js";
-import { requireRole } from "../middleware/rbac.js";
+import {
+  requireOrgAccess,
+  requireOrgMembership,
+  requireOrganizationParamMatch,
+  requirePermission,
+  requireRole,
+} from "../middleware/rbac.js";
 
 const router = express.Router();
 
 // Require authentication for all routes
 router.use(userAuth);
 
-// Get health score for a specific meeting
-router.get("/:meetingId", getMeetingHealth);
-
-// Get organization-wide trends
-// Require admin or manager roles for org-wide insights
+// Organization-wide trends MUST be registered before "/:meetingId"
+// so "trends" is not captured as a meeting id.
+//
+// Issue #1380 authorization chain:
+//   userAuth → org membership → admin/manager role → path org matches membership
+// Controllers then query with req.authorizedOrganizationId only.
 router.get(
   "/trends/:organizationId",
+  requireOrgMembership,
   requireRole(["admin", "manager"]),
+  requireOrganizationParamMatch("organizationId"),
   getOrganizationHealthTrends,
+);
+
+// Issue #1379: resolve the meeting server-side and enforce org membership
+// before any health read/calculation. Never trust meetingId alone.
+router.get(
+  "/:meetingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  getMeetingHealth,
 );
 
 export default router;

--- a/server/tests/meetingHealthTrendsAuthorization.test.js
+++ b/server/tests/meetingHealthTrendsAuthorization.test.js
@@ -1,0 +1,286 @@
+/**
+ * Issue #1380 — Meeting Health Trends must never query with a client-supplied
+ * organizationId. Cross-org URL manipulation must not leak another tenant's
+ * metrics.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+import { requireOrganizationParamMatch } from "../middleware/rbac.js";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const findSpy = jest.fn();
+
+jest.unstable_mockModule("../models/meetingHealthModel.js", () => ({
+  default: {
+    find: (...args) => findSpy(...args),
+    findOne: jest.fn(),
+  },
+}));
+
+const { default: meetingHealthRoutes } =
+  await import("../routes/meetingHealthRoutes.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const aliceAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+
+const aliceManager = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "manager",
+};
+
+const aliceMember = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const malloryAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noOrgAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "admin",
+};
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use("/api/meeting-health", meetingHealthRoutes);
+});
+
+beforeEach(() => {
+  currentUser = aliceAdmin;
+  findSpy.mockReset();
+  findSpy.mockReturnValue({
+    sort: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        populate: jest.fn().mockResolvedValue([]),
+      }),
+    }),
+  });
+});
+
+describe("requireOrganizationParamMatch (#1380)", () => {
+  const mockRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("sets authorizedOrganizationId from membership when path org matches", () => {
+    const middleware = requireOrganizationParamMatch("organizationId");
+    const req = {
+      user: { organization: ORG_A, role: "admin" },
+      params: { organizationId: ORG_A.toString() },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.authorizedOrganizationId).toBe(ORG_A.toString());
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-organization path parameters", () => {
+    const middleware = requireOrganizationParamMatch("organizationId");
+    const req = {
+      user: { organization: ORG_A, role: "admin" },
+      params: { organizationId: ORG_B.toString() },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(req.authorizedOrganizationId).toBeUndefined();
+  });
+
+  it("rejects missing organization membership", () => {
+    const middleware = requireOrganizationParamMatch("organizationId");
+    const req = {
+      user: { organization: null, role: "admin" },
+      params: { organizationId: ORG_A.toString() },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("rejects invalid organization ids", () => {
+    const middleware = requireOrganizationParamMatch("organizationId");
+    const req = {
+      user: { organization: ORG_A, role: "admin" },
+      params: { organizationId: "not-valid" },
+    };
+    const res = mockRes();
+    const next = jest.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe("GET /api/meeting-health/trends/:organizationId (#1380)", () => {
+  it("allows admin access for their own organization", async () => {
+    currentUser = aliceAdmin;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(findSpy).toHaveBeenCalledWith({
+      organization: ORG_A.toString(),
+    });
+  });
+
+  it("allows manager access for their own organization", async () => {
+    currentUser = aliceManager;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(findSpy).toHaveBeenCalledWith({
+      organization: ORG_A.toString(),
+    });
+  });
+
+  it("denies cross-organization trend access and does not query foreign org", async () => {
+    currentUser = aliceAdmin;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_B}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/access/i);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("denies members without admin/manager role", async () => {
+    currentUser = aliceMember;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+    expect(res.status).toBe(403);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("denies users with no organization membership", async () => {
+    currentUser = noOrgAdmin;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/organization membership/i);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid organization ids", async () => {
+    currentUser = aliceAdmin;
+
+    const res = await request(app).get(
+      "/api/meeting-health/trends/not-a-valid-id",
+    );
+
+    expect(res.status).toBe(400);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    currentUser = null;
+
+    const res = await request(app).get(`/api/meeting-health/trends/${ORG_A}`);
+
+    expect(res.status).toBe(401);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("scopes queries to the authorized org even when path and membership match", async () => {
+    currentUser = malloryAdmin;
+
+    const foreignTrend = {
+      organization: ORG_A,
+      compositeScore: 99,
+      factors: {
+        agendaCoverage: 99,
+        timeAdherence: 99,
+        engagement: 99,
+        actionItemClarity: 99,
+        sentiment: 99,
+      },
+    };
+
+    findSpy.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          populate: jest.fn().mockResolvedValue([foreignTrend]),
+        }),
+      }),
+    });
+
+    // Mallory (ORG_B) must not be able to pull ORG_A trends via URL.
+    const denied = await request(app).get(
+      `/api/meeting-health/trends/${ORG_A}`,
+    );
+    expect(denied.status).toBe(403);
+    expect(findSpy).not.toHaveBeenCalled();
+
+    // Own-org request queries only ORG_B.
+    findSpy.mockClear();
+    findSpy.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          populate: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+
+    const allowed = await request(app).get(
+      `/api/meeting-health/trends/${ORG_B}`,
+    );
+    expect(allowed.status).toBe(200);
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(findSpy).toHaveBeenCalledWith({
+      organization: ORG_B.toString(),
+    });
+    expect(findSpy.mock.calls[0][0].organization).not.toBe(ORG_A.toString());
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1380

Prevents cross-organization data exposure in Meeting Health Trends by enforcing server-side organization authorization and ensuring database queries are scoped only to the authenticated user's authorized organization.

## Problem

The trends endpoint validated authentication and role permissions but still relied on the client-supplied `:organizationId` when querying organization health data.

This created a potential cross-tenant vulnerability where a user could attempt to access another organization's health trends by manipulating the URL parameter.

## Changes Made

### Authorization Hardening

- Added centralized organization validation middleware:
  - `requireOrganizationParamMatch("organizationId")`
- Verifies:
  - Authenticated Clerk identity
  - MongoDB user
  - Organization membership
  - Requested organization ID matches authorized organization
  - Required role permissions

### Query Scoping

- Removed dependency on `req.params.organizationId` for database queries.
- Queries are now scoped exclusively using:
  - `req.authorizedOrganizationId`

### Route Protection

Updated Meeting Health Trends authorization flow:

```text
userAuth
→ requireOrgMembership
→ requireRole(["admin", "manager"])
→ requireOrganizationParamMatch("organizationId")
→ controller