### PR TITLE
fix: enforce organization membership on recap schedule operations

### DIFF
--- a/server/controllers/recapScheduleController.js
+++ b/server/controllers/recapScheduleController.js
@@ -10,10 +10,25 @@ const scheduleSchema = z.object({
   timezone: z.string().optional(),
 });
 
+/**
+ * Server-resolved org from requireOrganizationParamMatch, with membership fallback.
+ * Never use req.params.organizationId for queries (Issue #1381).
+ */
+const resolveAuthorizedOrganizationId = (req) =>
+  req.authorizedOrganizationId ||
+  (req.user?.organization?._id || req.user?.organization)?.toString();
+
 export const upsertSchedule = async (req, res) => {
   try {
-    const { organizationId } = req.params;
+    const organizationId = resolveAuthorizedOrganizationId(req);
     const userId = req.user._id;
+
+    if (!organizationId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
 
     const parsedData = scheduleSchema.parse(req.body);
 
@@ -35,8 +50,15 @@ export const upsertSchedule = async (req, res) => {
 
 export const getSchedule = async (req, res) => {
   try {
-    const { organizationId } = req.params;
+    const organizationId = resolveAuthorizedOrganizationId(req);
     const userId = req.user._id;
+
+    if (!organizationId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
 
     const schedule = await RecapSchedule.findOne({ organizationId, userId });
     if (!schedule) {

--- a/server/routes/recapScheduleRoutes.js
+++ b/server/routes/recapScheduleRoutes.js
@@ -1,6 +1,10 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
 import {
+  requireOrgMembership,
+  requireOrganizationParamMatch,
+} from "../middleware/rbac.js";
+import {
   upsertSchedule,
   getSchedule,
   getDeliveryHistory,
@@ -9,19 +13,27 @@ import {
 
 const router = express.Router();
 
-// All routes require authentication
+// Issue #1381 authorization chain:
+//   userAuth → org membership → (for :organizationId) path org matches membership
+// Controllers then query with req.authorizedOrganizationId only.
 router.use(userAuth);
+router.use(requireOrgMembership);
 
-// Get schedule for an organization
-router.get("/:organizationId", getSchedule);
-
-// Create or update schedule for an organization
-router.put("/:organizationId", upsertSchedule);
-
-// Get delivery history (per user)
+// Static paths MUST be registered before "/:organizationId"
+// so "history" / "retry" are not captured as organization ids.
 router.get("/history/deliveries", getDeliveryHistory);
-
-// Retry a delivery
 router.post("/retry/:deliveryId", retryDelivery);
+
+router.get(
+  "/:organizationId",
+  requireOrganizationParamMatch("organizationId"),
+  getSchedule,
+);
+
+router.put(
+  "/:organizationId",
+  requireOrganizationParamMatch("organizationId"),
+  upsertSchedule,
+);
 
 export default router;

--- a/server/tests/recapSchedule.test.js
+++ b/server/tests/recapSchedule.test.js
@@ -1,11 +1,19 @@
 import { jest } from "@jest/globals";
 import request from "supertest";
 import express from "express";
+import mongoose from "mongoose";
 
-// Mock middleware
+const ORG_ID = new mongoose.Types.ObjectId();
+const USER_ID = new mongoose.Types.ObjectId();
+
+// Mock middleware — authenticated org member (Issue #1381 requires membership)
 jest.unstable_mockModule("../middleware/userAuth.js", () => ({
   default: (req, res, next) => {
-    req.user = { _id: "user-1" };
+    req.user = {
+      _id: USER_ID,
+      organization: ORG_ID,
+      role: "member",
+    };
     next();
   },
 }));
@@ -32,7 +40,6 @@ jest.unstable_mockModule("../services/queueService.js", () => ({
   },
 }));
 
-// Now dynamically import the routes and controllers after mocks
 const { default: recapScheduleRoutes } =
   await import("../routes/recapScheduleRoutes.js");
 const { default: RecapSchedule } =
@@ -42,11 +49,6 @@ const { default: RecapDelivery } =
 
 const app = express();
 app.use(express.json());
-// Inject mock requireAuth manually for the tests in case the import one is skipped
-app.use((req, res, next) => {
-  req.user = { _id: "user-1" };
-  next();
-});
 app.use("/api/recap-schedule", recapScheduleRoutes);
 
 describe("Recap Schedule API", () => {
@@ -57,8 +59,8 @@ describe("Recap Schedule API", () => {
   describe("PUT /api/recap-schedule/:organizationId", () => {
     it("should create or update a schedule successfully", async () => {
       const mockSchedule = {
-        organizationId: "org-1",
-        userId: "user-1",
+        organizationId: ORG_ID.toString(),
+        userId: USER_ID.toString(),
         scheduleType: "daily",
         deliveryChannel: "email",
         preferredTime: "10:00",
@@ -67,7 +69,7 @@ describe("Recap Schedule API", () => {
 
       RecapSchedule.findOneAndUpdate.mockResolvedValue(mockSchedule);
 
-      const res = await request(app).put("/api/recap-schedule/org-1").send({
+      const res = await request(app).put(`/api/recap-schedule/${ORG_ID}`).send({
         scheduleType: "daily",
         deliveryChannel: "email",
         preferredTime: "10:00",
@@ -77,14 +79,14 @@ describe("Recap Schedule API", () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual(mockSchedule);
       expect(RecapSchedule.findOneAndUpdate).toHaveBeenCalledWith(
-        { organizationId: "org-1", userId: "user-1" },
+        { organizationId: ORG_ID.toString(), userId: USER_ID },
         expect.any(Object),
         { new: true, upsert: true },
       );
     });
 
     it("should return 400 for invalid data", async () => {
-      const res = await request(app).put("/api/recap-schedule/org-1").send({
+      const res = await request(app).put(`/api/recap-schedule/${ORG_ID}`).send({
         scheduleType: "invalid_type", // Invalid enum
       });
 
@@ -97,7 +99,7 @@ describe("Recap Schedule API", () => {
       const mockSchedule = { scheduleType: "weekly" };
       RecapSchedule.findOne.mockResolvedValue(mockSchedule);
 
-      const res = await request(app).get("/api/recap-schedule/org-1");
+      const res = await request(app).get(`/api/recap-schedule/${ORG_ID}`);
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual(mockSchedule);
@@ -106,7 +108,7 @@ describe("Recap Schedule API", () => {
     it("should return 404 if schedule not found", async () => {
       RecapSchedule.findOne.mockResolvedValue(null);
 
-      const res = await request(app).get("/api/recap-schedule/org-1");
+      const res = await request(app).get(`/api/recap-schedule/${ORG_ID}`);
 
       expect(res.status).toBe(404);
     });
@@ -139,7 +141,7 @@ describe("Recap Schedule API", () => {
       RecapDelivery.findOne.mockResolvedValue({
         _id: "del-1",
         meetingId: "meet-1",
-        userId: "user-1",
+        userId: USER_ID,
       });
 
       const res = await request(app).post("/api/recap-schedule/retry/del-1");

--- a/server/tests/recapScheduleAuthorization.test.js
+++ b/server/tests/recapScheduleAuthorization.test.js
@@ -1,0 +1,391 @@
+/**
+ * Issue #1381 — Recap schedule operations must never trust a client-supplied
+ * organizationId. Cross-org URL manipulation must not create/read/update
+ * another tenant's schedules.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const findOneAndUpdateSpy = jest.fn();
+const findOneSpy = jest.fn();
+const deliveryFindSpy = jest.fn();
+const deliveryFindOneSpy = jest.fn();
+const queueAddSpy = jest.fn();
+
+jest.unstable_mockModule("../models/recapScheduleModel.js", () => ({
+  default: {
+    findOneAndUpdate: (...args) => findOneAndUpdateSpy(...args),
+    findOne: (...args) => findOneSpy(...args),
+  },
+}));
+
+jest.unstable_mockModule("../models/recapDeliveryModel.js", () => ({
+  default: {
+    find: (...args) => deliveryFindSpy(...args),
+    findOne: (...args) => deliveryFindOneSpy(...args),
+  },
+}));
+
+jest.unstable_mockModule("../services/queueService.js", () => ({
+  recapDeliveryQueue: {
+    isActive: true,
+    add: (...args) => queueAddSpy(...args),
+  },
+}));
+
+const { default: recapScheduleRoutes } =
+  await import("../routes/recapScheduleRoutes.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+const DELIVERY_ID = new mongoose.Types.ObjectId();
+
+const aliceMember = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: "member",
+};
+
+const aliceAdmin = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: "admin",
+};
+
+const malloryAdmin = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noOrgUser = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "member",
+};
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use("/api/recap-schedule", recapScheduleRoutes);
+});
+
+beforeEach(() => {
+  currentUser = aliceMember;
+  findOneAndUpdateSpy.mockReset();
+  findOneSpy.mockReset();
+  deliveryFindSpy.mockReset();
+  deliveryFindOneSpy.mockReset();
+  queueAddSpy.mockReset();
+
+  findOneAndUpdateSpy.mockResolvedValue({
+    organizationId: ORG_A.toString(),
+    userId: USER_A.toString(),
+    scheduleType: "daily",
+  });
+  findOneSpy.mockResolvedValue({
+    organizationId: ORG_A.toString(),
+    userId: USER_A.toString(),
+    scheduleType: "weekly",
+  });
+  deliveryFindSpy.mockReturnValue({
+    populate: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockResolvedValue([{ _id: DELIVERY_ID }]),
+      }),
+    }),
+  });
+  deliveryFindOneSpy.mockResolvedValue({
+    _id: DELIVERY_ID,
+    meetingId: new mongoose.Types.ObjectId(),
+    userId: USER_A,
+  });
+});
+
+describe("Recap schedule organization authorization (#1381)", () => {
+  describe("GET /api/recap-schedule/:organizationId", () => {
+    it("allows same-organization access and scopes the query", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(res.status).toBe(200);
+      expect(findOneSpy).toHaveBeenCalledWith({
+        organizationId: ORG_A.toString(),
+        userId: USER_A,
+      });
+    });
+
+    it("allows admin access for their own organization", async () => {
+      currentUser = aliceAdmin;
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(res.status).toBe(200);
+      expect(findOneSpy).toHaveBeenCalledWith({
+        organizationId: ORG_A.toString(),
+        userId: USER_A,
+      });
+    });
+
+    it("denies cross-organization access and does not query", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_B}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/access/i);
+      expect(findOneSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies users with no organization membership", async () => {
+      currentUser = noOrgUser;
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/organization membership/i);
+      expect(findOneSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid organization ids", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app).get("/api/recap-schedule/not-a-valid-id");
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/invalid organization/i);
+      expect(findOneSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when schedule is missing in the authorized org", async () => {
+      currentUser = aliceMember;
+      findOneSpy.mockResolvedValue(null);
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(res.status).toBe(404);
+      expect(findOneSpy).toHaveBeenCalledWith({
+        organizationId: ORG_A.toString(),
+        userId: USER_A,
+      });
+    });
+
+    it("denies unauthenticated requests", async () => {
+      currentUser = null;
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(res.status).toBe(401);
+      expect(findOneSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PUT /api/recap-schedule/:organizationId (create/update)", () => {
+    const payload = {
+      scheduleType: "daily",
+      deliveryChannel: "email",
+      preferredTime: "10:00",
+      timezone: "UTC",
+    };
+
+    it("creates/updates schedule for the authorized organization only", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app)
+        .put(`/api/recap-schedule/${ORG_A}`)
+        .send(payload);
+
+      expect(res.status).toBe(200);
+      expect(findOneAndUpdateSpy).toHaveBeenCalledWith(
+        { organizationId: ORG_A.toString(), userId: USER_A },
+        expect.objectContaining({
+          organizationId: ORG_A.toString(),
+          userId: USER_A,
+          scheduleType: "daily",
+        }),
+        { new: true, upsert: true },
+      );
+    });
+
+    it("denies cross-organization create/update and does not write", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app)
+        .put(`/api/recap-schedule/${ORG_B}`)
+        .send(payload);
+
+      expect(res.status).toBe(403);
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies foreign-org admin writing into another tenant", async () => {
+      currentUser = malloryAdmin;
+
+      const res = await request(app)
+        .put(`/api/recap-schedule/${ORG_A}`)
+        .send(payload);
+
+      expect(res.status).toBe(403);
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid organization ids before write", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app)
+        .put("/api/recap-schedule/not-valid")
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies missing organization membership before write", async () => {
+      currentUser = noOrgUser;
+
+      const res = await request(app)
+        .put(`/api/recap-schedule/${ORG_A}`)
+        .send(payload);
+
+      expect(res.status).toBe(403);
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies unauthenticated create/update", async () => {
+      currentUser = null;
+
+      const res = await request(app)
+        .put(`/api/recap-schedule/${ORG_A}`)
+        .send(payload);
+
+      expect(res.status).toBe(401);
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/recap-schedule/history/deliveries", () => {
+    it("allows org members to list their delivery history", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app).get(
+        "/api/recap-schedule/history/deliveries",
+      );
+
+      expect(res.status).toBe(200);
+      expect(deliveryFindSpy).toHaveBeenCalledWith({ userId: USER_A });
+    });
+
+    it("denies users without organization membership", async () => {
+      currentUser = noOrgUser;
+
+      const res = await request(app).get(
+        "/api/recap-schedule/history/deliveries",
+      );
+
+      expect(res.status).toBe(403);
+      expect(deliveryFindSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies unauthenticated list requests", async () => {
+      currentUser = null;
+
+      const res = await request(app).get(
+        "/api/recap-schedule/history/deliveries",
+      );
+
+      expect(res.status).toBe(401);
+      expect(deliveryFindSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/recap-schedule/retry/:deliveryId", () => {
+    it("allows org members to retry their own delivery", async () => {
+      currentUser = aliceMember;
+
+      const res = await request(app).post(
+        `/api/recap-schedule/retry/${DELIVERY_ID}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(deliveryFindOneSpy).toHaveBeenCalledWith({
+        _id: DELIVERY_ID.toString(),
+        userId: USER_A,
+      });
+      expect(queueAddSpy).toHaveBeenCalled();
+    });
+
+    it("denies users without organization membership", async () => {
+      currentUser = noOrgUser;
+
+      const res = await request(app).post(
+        `/api/recap-schedule/retry/${DELIVERY_ID}`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(deliveryFindOneSpy).not.toHaveBeenCalled();
+      expect(queueAddSpy).not.toHaveBeenCalled();
+    });
+
+    it("denies unauthenticated retry", async () => {
+      currentUser = null;
+
+      const res = await request(app).post(
+        `/api/recap-schedule/retry/${DELIVERY_ID}`,
+      );
+
+      expect(res.status).toBe(401);
+      expect(deliveryFindOneSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cross-tenant query scoping", () => {
+    it("never queries with a foreign organizationId even when path differs from membership", async () => {
+      currentUser = {
+        _id: USER_A,
+        organization: { _id: ORG_A },
+        role: "member",
+      };
+
+      const res = await request(app).get(`/api/recap-schedule/${ORG_B}`);
+
+      expect(res.status).toBe(403);
+      expect(findOneSpy).not.toHaveBeenCalled();
+      expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it("uses authorized membership org id (not raw path) on successful read", async () => {
+      currentUser = {
+        _id: USER_A,
+        organization: { _id: ORG_A },
+        role: "member",
+      };
+
+      await request(app).get(`/api/recap-schedule/${ORG_A}`);
+
+      expect(findOneSpy).toHaveBeenCalledTimes(1);
+      expect(findOneSpy.mock.calls[0][0].organizationId).toBe(ORG_A.toString());
+      expect(findOneSpy.mock.calls[0][0].organizationId).not.toBe(
+        ORG_B.toString(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1381

Enforces organization membership validation and organization-scoped authorization across recap schedule operations to prevent cross-organization access and modification.

## Problem

Recap schedule endpoints accepted an `organizationId` from the request path and relied primarily on authentication.

This created a potential authorization bypass where an authenticated user could access or modify recap schedules belonging to another organization by changing the URL parameter.

## Root Cause

The controller trusted the client-supplied `organizationId` for database queries after authentication.

Authorization checks did not consistently verify:

- Organization membership
- Authorized organization scope
- Organization ownership requirements

Additionally, static routes such as `history` and `retry` were registered after parameterized routes, creating potential routing ambiguity.

## Changes Made

### Authorization Enforcement

Added organization membership validation before recap schedule operations.

Authorization flow:

```text
userAuth
→ requireOrgMembership
→ requireOrganizationParamMatch("organizationId")
→ controller
→ organization-scoped query
```

### Organization Scoping

Recap schedule reads and writes now use:

```js
req.authorizedOrganizationId
```

instead of directly trusting:

```js
req.params.organizationId
```

### Route Hardening

Updated route ordering to ensure:

- Static routes are evaluated before parameterized routes
- History and retry endpoints are not interpreted as organization IDs
- Authorization middleware executes before controller logic

### Security Improvements

- Prevents cross-organization schedule access
- Prevents cross-organization schedule creation
- Prevents cross-organization schedule modification
- Prevents unauthorized schedule retrieval
- Ensures database queries are scoped to authorized organizations only

## Files Changed

- `server/controllers/recapScheduleController.js`
- `server/routes/recapScheduleRoutes.js`
- `server/tests/recapSchedule.test.js`
- `server/tests/recapScheduleAuthorization.test.js`

## Tests Added

Added authorization regression coverage for:

- Same-organization access
- Cross-organization access denial
- Unauthenticated requests
- Missing organization membership
- Invalid organization IDs
- Organization-scoped query enforcement
- History endpoint authorization
- Retry endpoint authorization

## Expected Behavior

| Scenario | Result |
|-----------|---------|
| Member accessing own organization schedule | 200 OK |
| Admin accessing own organization schedule | 200 OK |
| User accessing another organization's schedule | 403 Forbidden |
| User without organization membership | 403 Forbidden |
| Invalid organization ID | 400 Bad Request |
| Unauthenticated request | 401 Unauthorized |

## Security Impact

This change closes a cross-organization authorization vulnerability by ensuring recap schedule operations are restricted to authorized organization members and all database access is scoped to a server-validated organization.

## Manual Verification

- [ ] GET own organization recap schedule returns `200`
- [ ] PUT own organization recap schedule returns `200`
- [ ] Cross-organization GET returns `403`
- [ ] Cross-organization PUT returns `403`
- [ ] Invalid organization ID returns `400`
- [ ] Unauthenticated requests return `401`
- [ ] History endpoint remains functional for authorized members
- [ ] Retry endpoint remains functional for authorized members
- [ ] No cross-organization database writes occur

## Checklist

- [x] Organization membership validation added
- [x] Organization-scoped queries enforced
- [x] Cross-organization access blocked
- [x] Route ordering hardened
- [x] Regression tests added
- [x] Existing authorized functionality preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Recap schedule operations now require authentication and authorized organization membership.
  * Requests targeting another organization or lacking membership are denied.
  * Schedule and delivery history actions are scoped to the authorized organization.
  * Invalid organization identifiers and unauthorized retry attempts are handled safely.

* **Tests**
  * Added comprehensive coverage for authorization, tenant isolation, authentication, and organization-scoped access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->