### PR TITLE
fix(security): authenticate workspace socket identity via Clerk

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -7,6 +7,7 @@ import documentSync from "../socket/documentSync.js";
 import transcriptSocket from "../socket/transcriptSocket.js";
 import reactionSocket from "../socket/reactionSocket.js";
 import translationSocket from "../socket/translationSocket.js";
+import { initWorkspaceSocket } from "../socket/workspaceSocket.js";
 import authenticateSocket from "../middleware/socketAuth.js";
 
 export function configureSocket(server, app) {
@@ -88,6 +89,7 @@ export function configureSocket(server, app) {
   transcriptSocket(io);
   reactionSocket(io);
   translationSocket(io);
+  initWorkspaceSocket(io);
 
   return io;
 }

--- a/server/socket/workspaceSocket.js
+++ b/server/socket/workspaceSocket.js
@@ -2,6 +2,7 @@
 import mongoose from "mongoose";
 import Meeting from "../models/meetingModel.js";
 import { workspaceSyncService } from "../services/workspaceSyncService.js";
+import authenticateSocket from "../middleware/socketAuth.js";
 
 /**
  * Throttle utility to prevent cursor movement spam over WebSockets
@@ -20,60 +21,75 @@ const throttle = (func, limit) => {
 };
 
 /**
+ * Authorize workspace access using the Clerk-authenticated MongoDB user only.
+ * Never trust handshake.auth.userId / query.userId (Issue #1386).
+ */
+const authorizeWorkspaceAccess = async (socket, next) => {
+  try {
+    if (!socket.userId) {
+      return next(new Error("Authentication error: User not found"));
+    }
+
+    const meetingId =
+      socket.handshake.auth?.meetingId || socket.handshake.query?.meetingId;
+
+    if (!meetingId) {
+      return next(new Error("Meeting ID missing"));
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return next(new Error("Invalid Meeting ID format"));
+    }
+
+    const meeting = await Meeting.findById(meetingId).select(
+      "organization participants uploadedBy",
+    );
+    if (!meeting) {
+      return next(new Error("Meeting not found"));
+    }
+
+    const authenticatedUserId = socket.userId.toString();
+    const authenticatedEmail = socket.user?.email;
+
+    const isParticipant = meeting.participants.some(
+      (p) =>
+        p.user?.toString() === authenticatedUserId ||
+        (authenticatedEmail &&
+          p.email &&
+          p.email.toLowerCase() === authenticatedEmail.toLowerCase()),
+    );
+    const isOwner = meeting.uploadedBy?.toString() === authenticatedUserId;
+
+    if (!isParticipant && !isOwner) {
+      return next(
+        new Error("Forbidden: You are not a participant of this meeting"),
+      );
+    }
+
+    // Identity is already set by authenticateSocket — never overwrite from client.
+    socket.meetingId = meetingId;
+    socket.userName =
+      socket.user?.name || socket.handshake.auth?.userName || "Anonymous";
+    socket.userColor = socket.handshake.auth?.userColor || "#6366f1";
+
+    next();
+  } catch (error) {
+    console.error("❌ Workspace Socket Auth Error:", error.message);
+    next(new Error("Authentication failed"));
+  }
+};
+
+/**
  * Initialize Workspace WebSocket events for the Collaborative War Room
  * @param {Object} io - Socket.IO server instance
  */
 export const initWorkspaceSocket = (io) => {
   const workspaceNsp = io.of("/workspace");
 
-  // Authentication & Authorization Middleware for Socket Connections
-  workspaceNsp.use(async (socket, next) => {
-    try {
-      const userId =
-        socket.handshake.auth?.userId || socket.handshake.query?.userId;
-      const meetingId =
-        socket.handshake.auth?.meetingId || socket.handshake.query?.meetingId;
-
-      if (!userId || !meetingId) {
-        return next(new Error("Authentication credentials missing"));
-      }
-
-      if (!mongoose.Types.ObjectId.isValid(meetingId)) {
-        return next(new Error("Invalid Meeting ID format"));
-      }
-
-      const meeting = await Meeting.findById(meetingId).select(
-        "organization participants uploadedBy",
-      );
-      if (!meeting) {
-        return next(new Error("Meeting not found"));
-      }
-
-      // Verify user is participant or owner
-      const isParticipant = meeting.participants.some(
-        (p) =>
-          p.user?.toString() === userId ||
-          p.email === socket.handshake.auth?.email,
-      );
-      const isOwner = meeting.uploadedBy?.toString() === userId;
-
-      if (!isParticipant && !isOwner) {
-        return next(
-          new Error("Forbidden: You are not a participant of this meeting"),
-        );
-      }
-
-      socket.userId = userId;
-      socket.meetingId = meetingId;
-      socket.userName = socket.handshake.auth?.userName || "Anonymous";
-      socket.userColor = socket.handshake.auth?.userColor || "#6366f1";
-
-      next();
-    } catch (error) {
-      console.error("❌ Workspace Socket Auth Error:", error.message);
-      next(new Error("Authentication failed"));
-    }
-  });
+  // Clerk JWT → MongoDB user (authoritative identity)
+  workspaceNsp.use(authenticateSocket);
+  // Meeting participant/owner check against authenticated user only
+  workspaceNsp.use(authorizeWorkspaceAccess);
 
   workspaceNsp.on("connection", (socket) => {
     const room = `meeting-war-room-${socket.meetingId}`;
@@ -195,3 +211,5 @@ export const initWorkspaceSocket = (io) => {
     });
   });
 };
+
+export { authorizeWorkspaceAccess };

--- a/server/tests/workspaceSocketAuthentication.test.js
+++ b/server/tests/workspaceSocketAuthentication.test.js
@@ -1,0 +1,409 @@
+/**
+ * Issue #1386 — Workspace socket must authenticate identity from Clerk only.
+ * Client-supplied handshake.auth.userId / query.userId must never authorize access.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { authenticateSocket } from "../middleware/socketAuth.js";
+import {
+  initWorkspaceSocket,
+  authorizeWorkspaceAccess,
+} from "../socket/workspaceSocket.js";
+import Meeting from "../models/meetingModel.js";
+import { verifyClerkSessionToken } from "../utils/authUtils.js";
+import { findUserByClerkId } from "../services/authLinkingService.js";
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findById: vi.fn(),
+  },
+}));
+
+vi.mock("../services/workspaceSyncService.js", () => ({
+  workspaceSyncService: {
+    persistCanvasElement: vi.fn().mockResolvedValue(undefined),
+    clearCanvas: vi.fn().mockResolvedValue(undefined),
+    reorderActionItem: vi.fn().mockResolvedValue({ movedItem: null }),
+    analyzeBottlenecks: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../utils/authUtils.js", () => ({
+  verifyClerkSessionToken: vi.fn(),
+}));
+
+vi.mock("../services/authLinkingService.js", () => ({
+  findUserByClerkId: vi.fn(),
+  provisionOrLinkClerkUser: vi.fn(),
+}));
+
+const USER_A_ID = new mongoose.Types.ObjectId("669bb3f78e472659c23b5bf5");
+const USER_B_ID = new mongoose.Types.ObjectId("669bb3f78e472659c23b5bf7");
+const MEETING_ID = new mongoose.Types.ObjectId("669bb3f78e472659c23b5bf8");
+const ORG_ID = new mongoose.Types.ObjectId("669bb3f78e472659c23b5bf6");
+
+describe("Workspace Socket Clerk Authentication (#1386)", () => {
+  let middlewares;
+  let connectionCallback;
+  let mockNsp;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    middlewares = [];
+    connectionCallback = null;
+    mockNsp = {
+      use: vi.fn((mw) => {
+        middlewares.push(mw);
+      }),
+      on: vi.fn((event, cb) => {
+        if (event === "connection") {
+          connectionCallback = cb;
+        }
+      }),
+    };
+    const mockIo = {
+      of: vi.fn((path) => {
+        expect(path).toBe("/workspace");
+        return mockNsp;
+      }),
+    };
+    initWorkspaceSocket(mockIo);
+  });
+
+  const createSocket = (overrides = {}) => {
+    const base = {
+      id: "socket_ws_1",
+      handshake: {
+        headers: { authorization: "Bearer valid_clerk_token" },
+        auth: {
+          meetingId: MEETING_ID.toString(),
+        },
+        query: {},
+      },
+      join: vi.fn(),
+      emit: vi.fn(),
+      to: vi.fn().mockReturnValue({ emit: vi.fn() }),
+      on: vi.fn(),
+      ...overrides,
+    };
+    if (overrides.handshake) {
+      base.handshake = {
+        headers: { authorization: "Bearer valid_clerk_token" },
+        auth: { meetingId: MEETING_ID.toString() },
+        query: {},
+        ...overrides.handshake,
+      };
+    }
+    return base;
+  };
+
+  const mockAuthorizedMeetingForUser = (userId, email) => {
+    Meeting.findById.mockResolvedValue({
+      _id: MEETING_ID,
+      uploadedBy: USER_B_ID,
+      organization: ORG_ID,
+      participants: [
+        { user: userId, email },
+        { user: USER_B_ID, email: "owner@example.com" },
+      ],
+    });
+  };
+
+  describe("Clerk identity resolution", () => {
+    it("allows a valid Clerk-authenticated user to connect", async () => {
+      const socket = createSocket();
+      const next = vi.fn();
+
+      verifyClerkSessionToken.mockResolvedValue({ sub: "clerk_user_a" });
+      findUserByClerkId.mockResolvedValue({
+        _id: USER_A_ID,
+        name: "Alice",
+        email: "alice@example.com",
+        role: "member",
+        organization: ORG_ID,
+      });
+
+      await authenticateSocket(socket, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(socket.userId).toBe(USER_A_ID.toString());
+      expect(socket.user.email).toBe("alice@example.com");
+    });
+
+    it("rejects an invalid Clerk token", async () => {
+      const socket = createSocket();
+      const next = vi.fn();
+
+      verifyClerkSessionToken.mockRejectedValue(new Error("bad token"));
+
+      await authenticateSocket(socket, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Authentication error: Invalid Clerk token",
+        }),
+      );
+      expect(socket.userId).toBeUndefined();
+    });
+
+    it("rejects a missing Clerk token", async () => {
+      const socket = createSocket({
+        handshake: { headers: {}, auth: { meetingId: MEETING_ID.toString() } },
+      });
+      const next = vi.fn();
+
+      await authenticateSocket(socket, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Authentication error: No token provided",
+        }),
+      );
+    });
+  });
+
+  describe("Namespace middleware wiring", () => {
+    it("registers authenticateSocket before workspace authorization", () => {
+      expect(middlewares.length).toBeGreaterThanOrEqual(2);
+      expect(middlewares[0]).toBe(authenticateSocket);
+      expect(middlewares[1]).toBe(authorizeWorkspaceAccess);
+    });
+  });
+
+  describe("Workspace participant authorization", () => {
+    it("joins workspace successfully when the authenticated user is a participant", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+      });
+      mockAuthorizedMeetingForUser(USER_A_ID, "alice@example.com");
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(socket.meetingId).toBe(MEETING_ID.toString());
+      expect(socket.userId).toBe(USER_A_ID.toString());
+
+      connectionCallback(socket);
+      expect(socket.join).toHaveBeenCalledWith(
+        `meeting-war-room-${MEETING_ID}`,
+      );
+      expect(socket.to).toHaveBeenCalledWith(`meeting-war-room-${MEETING_ID}`);
+    });
+
+    it("allows the meeting owner to connect", async () => {
+      const socket = createSocket({
+        userId: USER_B_ID.toString(),
+        user: {
+          _id: USER_B_ID,
+          name: "Owner",
+          email: "owner@example.com",
+        },
+      });
+      Meeting.findById.mockResolvedValue({
+        _id: MEETING_ID,
+        uploadedBy: USER_B_ID,
+        participants: [],
+      });
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(socket.userId).toBe(USER_B_ID.toString());
+    });
+
+    it("denies unauthorized workspace access", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+      });
+      Meeting.findById.mockResolvedValue({
+        _id: MEETING_ID,
+        uploadedBy: USER_B_ID,
+        participants: [{ user: USER_B_ID, email: "owner@example.com" }],
+      });
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Forbidden: You are not a participant of this meeting",
+        }),
+      );
+      expect(Meeting.findById).toHaveBeenCalled();
+    });
+  });
+
+  describe("Client identity spoofing defenses", () => {
+    it("ignores spoofed handshake.auth.userId and keeps Clerk-authenticated identity", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+        handshake: {
+          headers: { authorization: "Bearer valid_clerk_token" },
+          auth: {
+            meetingId: MEETING_ID.toString(),
+            userId: USER_B_ID.toString(), // spoofed
+            email: "owner@example.com", // spoofed email must not grant access alone
+          },
+          query: {},
+        },
+      });
+      // Alice is a participant; Bob is owner. Spoofed Bob id must not replace Alice.
+      mockAuthorizedMeetingForUser(USER_A_ID, "alice@example.com");
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(socket.userId).toBe(USER_A_ID.toString());
+      expect(socket.userId).not.toBe(USER_B_ID.toString());
+    });
+
+    it("prevents User A from impersonating User B via auth.userId", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+        handshake: {
+          headers: { authorization: "Bearer valid_clerk_token" },
+          auth: {
+            meetingId: MEETING_ID.toString(),
+            userId: USER_B_ID.toString(),
+          },
+          query: { userId: USER_B_ID.toString() },
+        },
+      });
+      // Meeting only allows Bob (owner). Spoofed Bob id must not authorize Alice.
+      Meeting.findById.mockResolvedValue({
+        _id: MEETING_ID,
+        uploadedBy: USER_B_ID,
+        participants: [{ user: USER_B_ID, email: "owner@example.com" }],
+      });
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Forbidden: You are not a participant of this meeting",
+        }),
+      );
+      expect(socket.userId).toBe(USER_A_ID.toString());
+    });
+
+    it("authorization uses authenticated MongoDB user only (not query.userId)", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+        handshake: {
+          headers: {},
+          auth: { meetingId: MEETING_ID.toString() },
+          query: { userId: USER_B_ID.toString() },
+        },
+      });
+      mockAuthorizedMeetingForUser(USER_A_ID, "alice@example.com");
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(socket.userId).toBe(USER_A_ID.toString());
+
+      const participantCheckArgs = Meeting.findById.mock.calls[0][0];
+      expect(participantCheckArgs).toBe(MEETING_ID.toString());
+    });
+
+    it("does not grant access via spoofed handshake.auth.email alone", async () => {
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+        handshake: {
+          headers: {},
+          auth: {
+            meetingId: MEETING_ID.toString(),
+            email: "owner@example.com",
+          },
+          query: {},
+        },
+      });
+      Meeting.findById.mockResolvedValue({
+        _id: MEETING_ID,
+        uploadedBy: USER_B_ID,
+        participants: [{ user: USER_B_ID, email: "owner@example.com" }],
+      });
+      const next = vi.fn();
+
+      await authorizeWorkspaceAccess(socket, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Forbidden: You are not a participant of this meeting",
+        }),
+      );
+    });
+  });
+
+  describe("Collaboration behavior after auth", () => {
+    it("broadcasts collaboration events with authenticated socket.userId", async () => {
+      const roomEmit = vi.fn();
+      const socket = createSocket({
+        userId: USER_A_ID.toString(),
+        meetingId: MEETING_ID.toString(),
+        userName: "Alice",
+        userColor: "#111111",
+        user: {
+          _id: USER_A_ID,
+          name: "Alice",
+          email: "alice@example.com",
+        },
+        to: vi.fn().mockReturnValue({ emit: roomEmit }),
+      });
+
+      connectionCallback(socket);
+
+      const voteHandler = socket.on.mock.calls.find(
+        (c) => c[0] === "workspace:vote-topic",
+      )?.[1];
+      expect(voteHandler).toBeTypeOf("function");
+
+      voteHandler({ topicId: "t1", voteType: "up" });
+
+      expect(roomEmit).toHaveBeenCalledWith(
+        "workspace:vote-topic",
+        expect.objectContaining({
+          userId: USER_A_ID.toString(),
+          topicId: "t1",
+          voteType: "up",
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1386

Replaces client-controlled workspace socket identity with authenticated Clerk-based identity and server-side authorization.

Workspace socket connections now derive identity exclusively from a verified Clerk JWT and authenticated MongoDB user instead of trusting client-supplied `userId` values.

## Problem

The workspace socket previously trusted values provided by the client:

```js
handshake.auth.userId
```

and related client-controlled identity fields.

This allowed a malicious client to impersonate another user by supplying a different user ID during socket connection and workspace authorization.

## Root Cause

Workspace authorization relied on identity information supplied by the client during the socket handshake.

The server did not consistently derive identity from:

```text
Clerk JWT
→ Verified Clerk Subject
→ MongoDB User
→ Workspace Authorization
```

As a result, client-controlled values could influence authorization decisions.

## Changes Made

### Clerk-Based Socket Authentication

Workspace sockets now authenticate using the existing Clerk-aware socket authentication middleware.

Authorization flow:

```text
Clerk JWT
→ authenticateSocket
→ Verified Clerk identity
→ MongoDB user lookup
→ Workspace authorization
→ Socket connection
```

### Removed Trust in Client Identity

The server no longer trusts:

```js
handshake.auth.userId
query.userId
auth.userId
```

for authorization decisions.

Any spoofed values are ignored.

### Server-Side Identity Resolution

Workspace participant authorization now uses:

```js
socket.user
socket.userId
```

populated by authenticated server-side middleware.

Authorization decisions are based only on verified user records.

### Socket Registration Updates

Updated socket initialization to ensure workspace sockets are registered using the authenticated socket infrastructure already present in the application.

## Security Improvements

- Prevents user impersonation through socket handshakes
- Prevents spoofed `userId` authorization bypasses
- Prevents spoofed email-based participant authorization
- Ensures authorization is derived from verified Clerk identities
- Enforces server-side identity ownership
- Preserves existing participant authorization behavior

## Files Changed

- `server/config/socket.js`
- `server/socket/workspaceSocket.js`
- `server/tests/workspaceSocketAuthentication.test.js`

## Tests Added

Added regression coverage for:

- Valid Clerk-authenticated socket connections
- Workspace participant authorization
- Workspace owner authorization
- Spoofed `handshake.auth.userId` values
- User impersonation attempts
- Invalid Clerk tokens
- Missing Clerk tokens
- Unauthorized workspace access
- Authenticated MongoDB user identity enforcement
- Collaboration event authorization

## Expected Behavior

| Scenario | Result |
|-----------|---------|
| Valid participant with Clerk token | Connection allowed |
| Valid owner with Clerk token | Connection allowed |
| Spoofed `auth.userId` | Ignored |
| User A impersonating User B | Rejected |
| Missing token | Rejected |
| Invalid token | Rejected |
| Unauthorized workspace access | Rejected |
| Collaboration events | Use authenticated identity |

## Security Impact

This change closes a socket-level identity spoofing vulnerability by ensuring workspace authorization is based exclusively on authenticated Clerk identities and server-resolved MongoDB users.

Client-controlled identity values can no longer be used to gain unauthorized workspace access.

## Manual Verification

- [ ] Connect to `/workspace` with a valid Clerk token and authorized meeting
- [ ] Verify workspace join succeeds for participants
- [ ] Verify workspace join succeeds for owners
- [ ] Connect with spoofed `auth.userId`
- [ ] Confirm authenticated identity is still used
- [ ] Connect with invalid Clerk token
- [ ] Confirm connection is rejected
- [ ] Connect without token
- [ ] Confirm connection is rejected
- [ ] Verify collaboration events broadcast authenticated user identity
- [ ] Verify non-participants cannot access workspace sockets

## Checklist

- [x] Clerk authentication enforced
- [x] Client-controlled identities removed from authorization
- [x] Server-side identity resolution implemented
- [x] User impersonation blocked
- [x] Workspace authorization preserved
- [x] Regression tests added
- [x] Existing collaboration functionality preserved