### PR TITLE
fix(security): enforce meeting authorization on personal note retrieval

### DIFF
--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -3,6 +3,7 @@ import { z } from "zod";
 import PersonalNote from "../models/personalNoteModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
 
 /**
  * Maximum character limits for note fields
@@ -59,13 +60,16 @@ const annotationSchema = z.object({
 });
 
 /**
- * Resolve and validate meeting access for a user
+ * Resolve and validate meeting access for a user.
+ * Uses the shared `canAccessMeetingDoc` predicate (same rule as requireOrgAccess)
+ * so personal-note reads/writes stay aligned with meeting-scoped authorization
+ * (Issue #1389).
  *
  * @param {string} meetingId - Meeting ID to check
  * @param {Object} user - User object from request
  * @returns {Promise<Object>} Access result with meeting or error
  */
-const resolveAccessibleMeeting = async (meetingId, user) => {
+export const resolveAccessibleMeeting = async (meetingId, user) => {
   // Validate meeting ID format
   if (!mongoose.isValidObjectId(meetingId)) {
     return {
@@ -76,7 +80,7 @@ const resolveAccessibleMeeting = async (meetingId, user) => {
     };
   }
 
-  // Fetch meeting from database
+  // Fetch meeting from database — never trust the client id alone
   const meeting = await Meeting.findById(meetingId);
   if (!meeting) {
     return {
@@ -87,17 +91,7 @@ const resolveAccessibleMeeting = async (meetingId, user) => {
     };
   }
 
-  // Check if user is the meeting owner
-  const isOwner = meeting.uploadedBy?.toString() === user._id.toString();
-
-  // Check if user belongs to the same organization
-  const isInSameOrg =
-    meeting.organization &&
-    user.organization &&
-    meeting.organization.toString() === user.organization.toString();
-
-  // User must be owner OR in same organization
-  if (!isOwner && !isInSameOrg) {
+  if (!canAccessMeetingDoc(meeting, user)) {
     return {
       error: {
         status: 403,
@@ -130,8 +124,16 @@ const getAccessibleMeetingIds = async (user) => {
 // @desc Get personal note for a specific meeting
 // @route GET /api/personal-notes/:meetingId
 // @access Private
+// Issue #1389: meeting access MUST be resolved before any note query.
 export const getNoteByMeetingId = async (req, res) => {
   try {
+    if (!req.user?._id) {
+      return res.status(401).json({
+        success: false,
+        message: "Unauthorized",
+      });
+    }
+
     const { meetingId } = req.params;
     const userId = req.user._id;
 
@@ -146,7 +148,7 @@ export const getNoteByMeetingId = async (req, res) => {
       });
     }
 
-    // Verify user has access to this meeting
+    // Same meeting authorization path as note write operations
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
       return res
@@ -154,8 +156,12 @@ export const getNoteByMeetingId = async (req, res) => {
         .json({ success: false, message: access.error.message });
     }
 
-    // Fetch note for this user and meeting
-    let note = await PersonalNote.findOne({ userId, meetingId });
+    // Query with the server-resolved meeting id — never the raw path param alone
+    const authorizedMeetingId = access.meeting._id;
+    let note = await PersonalNote.findOne({
+      userId,
+      meetingId: authorizedMeetingId,
+    });
 
     if (note && note.userId.toString() !== userId.toString()) {
       return res.status(403).json({

--- a/server/tests/personalNote.test.js
+++ b/server/tests/personalNote.test.js
@@ -155,6 +155,80 @@ describe("PersonalNote API", () => {
     expect(res.body.success).toBe(false);
   });
 
+  it("denies GET retrieval for a meeting the user cannot access (#1389)", async () => {
+    const otherUser = await User.create({
+      name: "Foreign Owner",
+      email: "foreignowner@test.com",
+      password: "password123",
+      role: "member",
+    });
+    const foreignMeeting = await Meeting.create({
+      title: "Inaccessible Meeting",
+      date: new Date(),
+      uploadedBy: otherUser._id,
+      organization: new mongoose.Types.ObjectId(),
+      participants: [],
+    });
+
+    // Even if a note somehow exists for this user+meeting, retrieval must 403
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: foreignMeeting._id,
+      content: "should not be readable without meeting access",
+    });
+
+    const res = await request(app)
+      .get(`/api/personal-notes/${foreignMeeting._id}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/access/i);
+    expect(res.body.note).toBeUndefined();
+  });
+
+  it("allows owner GET retrieval for an accessible meeting (#1389)", async () => {
+    await PersonalNote.create({
+      userId: user._id,
+      meetingId: meeting._id,
+      content: "owner readable note",
+      title: "Mine",
+    });
+
+    const res = await request(app)
+      .get(`/api/personal-notes/${meeting._id}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.note.content).toBe("owner readable note");
+  });
+
+  it("rejects GET with an invalid meeting id (#1389)", async () => {
+    const res = await request(app)
+      .get(`/api/personal-notes/not-an-object-id`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("returns 404 on GET when the meeting does not exist (#1389)", async () => {
+    const missingId = "5f9f1b9b9c9d440000000000";
+    const res = await request(app)
+      .get(`/api/personal-notes/${missingId}`)
+      .set(authHeader(token));
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("rejects unauthenticated GET retrieval (#1389)", async () => {
+    const res = await request(app).get(`/api/personal-notes/${meeting._id}`);
+
+    expect(res.statusCode).toBe(401);
+  });
+
   it("rejects content over the max length with 400", async () => {
     const res = await request(app)
       .post(`/api/personal-notes/${meeting._id}`)

--- a/server/tests/personalNoteRetrievalAuthorization.test.js
+++ b/server/tests/personalNoteRetrievalAuthorization.test.js
@@ -1,0 +1,312 @@
+/**
+ * Issue #1389 — Personal note retrieval by meetingId must use
+ * resolveAccessibleMeeting before any PersonalNote query.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+const findByIdSpy = jest.fn();
+const findOneSpy = jest.fn();
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: {
+    findById: (...args) => findByIdSpy(...args),
+    find: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("../models/personalNoteModel.js", () => ({
+  default: {
+    findOne: (...args) => findOneSpy(...args),
+    find: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+const { getNoteByMeetingId, resolveAccessibleMeeting } =
+  await import("../controllers/personalNoteController.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const MEETING_A = new mongoose.Types.ObjectId();
+const MEETING_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+const USER_B = new mongoose.Types.ObjectId();
+const OWNER_ID = new mongoose.Types.ObjectId();
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("resolveAccessibleMeeting (#1389)", () => {
+  beforeEach(() => {
+    findByIdSpy.mockReset();
+    findOneSpy.mockReset();
+  });
+
+  it("allows the meeting owner", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: ORG_A,
+    });
+
+    const result = await resolveAccessibleMeeting(MEETING_A.toString(), {
+      _id: OWNER_ID,
+      organization: ORG_B,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.meeting._id).toEqual(MEETING_A);
+  });
+
+  it("allows an authorized same-organization member", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: ORG_A,
+    });
+
+    const result = await resolveAccessibleMeeting(MEETING_A.toString(), {
+      _id: USER_A,
+      organization: ORG_A,
+    });
+
+    expect(result.error).toBeUndefined();
+  });
+
+  it("denies cross-organization access", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: ORG_A,
+    });
+
+    const result = await resolveAccessibleMeeting(MEETING_A.toString(), {
+      _id: USER_B,
+      organization: ORG_B,
+    });
+
+    expect(result.error).toMatchObject({
+      status: 403,
+      message: expect.stringMatching(/access/i),
+    });
+  });
+
+  it("rejects invalid meeting ids", async () => {
+    const result = await resolveAccessibleMeeting("not-valid", {
+      _id: USER_A,
+      organization: ORG_A,
+    });
+
+    expect(result.error.status).toBe(400);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing meetings", async () => {
+    findByIdSpy.mockResolvedValue(null);
+
+    const result = await resolveAccessibleMeeting(MEETING_A.toString(), {
+      _id: USER_A,
+      organization: ORG_A,
+    });
+
+    expect(result.error.status).toBe(404);
+  });
+});
+
+describe("GET personal note retrieval authorization (#1389)", () => {
+  beforeEach(() => {
+    findByIdSpy.mockReset();
+    findOneSpy.mockReset();
+  });
+
+  it("returns the owner's note for an accessible meeting", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: USER_A,
+      organization: ORG_A,
+    });
+    findOneSpy.mockResolvedValue({
+      userId: USER_A,
+      meetingId: MEETING_A,
+      content: "my private note",
+      title: "Title",
+      annotations: [],
+      isPinned: false,
+      toObject() {
+        return {
+          userId: USER_A,
+          meetingId: MEETING_A,
+          content: "my private note",
+          title: "Title",
+          annotations: [],
+          isPinned: false,
+        };
+      },
+    });
+
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: { _id: USER_A, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(findByIdSpy).toHaveBeenCalledWith(MEETING_A.toString());
+    expect(findOneSpy).toHaveBeenCalledWith({
+      userId: USER_A,
+      meetingId: MEETING_A,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        note: expect.objectContaining({ content: "my private note" }),
+      }),
+    );
+  });
+
+  it("allows an authorized org participant to retrieve their own empty note shell", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: ORG_A,
+    });
+    findOneSpy.mockResolvedValue(null);
+
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: { _id: USER_A, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(findOneSpy).toHaveBeenCalledWith({
+      userId: USER_A,
+      meetingId: MEETING_A,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        note: expect.objectContaining({ content: "" }),
+      }),
+    );
+  });
+
+  it("denies cross-organization retrieval and does not query notes", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_B,
+      uploadedBy: OWNER_ID,
+      organization: ORG_B,
+    });
+
+    const req = {
+      params: { meetingId: MEETING_B.toString() },
+      user: { _id: USER_A, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("denies unauthorized users for inaccessible meetings without querying notes", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: null,
+    });
+
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: { _id: USER_B, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles invalid meeting ids without querying notes", async () => {
+    const req = {
+      params: { meetingId: "bad-id" },
+      user: { _id: USER_A, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles missing meetings without querying notes", async () => {
+    findByIdSpy.mockResolvedValue(null);
+
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: { _id: USER_A, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("denies unauthenticated requests before meeting/note lookups", async () => {
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: null,
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+    expect(findOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("never returns another user's note for an accessible meeting", async () => {
+    findByIdSpy.mockResolvedValue({
+      _id: MEETING_A,
+      uploadedBy: OWNER_ID,
+      organization: ORG_A,
+    });
+    // findOne is scoped by userId — simulate no note for USER_B
+    findOneSpy.mockResolvedValue(null);
+
+    const req = {
+      params: { meetingId: MEETING_A.toString() },
+      user: { _id: USER_B, organization: ORG_A, role: "member" },
+    };
+    const res = mockRes();
+
+    await getNoteByMeetingId(req, res);
+
+    expect(findOneSpy).toHaveBeenCalledWith({
+      userId: USER_B,
+      meetingId: MEETING_A,
+    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        note: expect.objectContaining({ content: "" }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1389

Enforces meeting authorization on personal note retrieval by reusing the existing `resolveAccessibleMeeting` flow before any note lookup occurs.

This prevents unauthorized users from accessing notes through client-supplied meeting IDs and aligns retrieval authorization with existing write operations.

## Changes Made

- Reused `resolveAccessibleMeeting` for note retrieval authorization
- Reused `canAccessMeetingDoc` for meeting access validation
- Scoped note queries to the resolved authorized meeting
- Added an early authentication check before note retrieval
- Added regression tests for authorization and cross-organization access

## Files Changed

- `server/controllers/personalNoteController.js`
- `server/tests/personalNote.test.js`
- `server/tests/personalNoteRetrievalAuthorization.test.js` (new)

## Security Improvements

- Blocks cross-organization note access
- Prevents retrieval using inaccessible meeting IDs
- Ensures note queries only run after authorization succeeds
- Preserves note ownership and privacy

## Tests Added

- Authorized owner access
- Authorized participant access
- Cross-organization access denial
- Unauthorized meeting access denial
- Invalid/missing meeting handling
- Unauthenticated request handling

## Expected Behavior

| Scenario | Result |
|----------|--------|
| Authorized user retrieves notes | 200 OK |
| Cross-organization access | 403 Forbidden |
| Invalid meeting ID | 400 Bad Request |
| Missing meeting | 404 Not Found |
| Unauthenticated request | 401 Unauthorized |

## Checklist

- [x] Reused `resolveAccessibleMeeting`
- [x] Enforced meeting authorization before retrieval
- [x] Blocked cross-organization access
- [x] Preserved note ownership
- [x] Added regression tests
- [x] Preserved existing authorized functionality