### PR TITLE
feat(ui): add confirmation modal prior to deleting glossary terms in Glossary

### DIFF
--- a/client/src/pages/Glossary.jsx
+++ b/client/src/pages/Glossary.jsx
@@ -5,6 +5,7 @@ import {
   deleteTerm,
   approveTerm,
 } from "../services/glossaryApi";
+import ConfirmModal from "../components/ConfirmModal.jsx";
 
 const Glossary = () => {
   const [terms, setTerms] = useState([]);
@@ -19,6 +20,10 @@ const Glossary = () => {
     aliases: "",
     category: "",
   });
+
+  // Confirmation modal state (#1489)
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
 
   const loadTerms = useCallback(async () => {
     try {
@@ -58,14 +63,18 @@ const Glossary = () => {
     }
   };
 
-  const handleDelete = async (id) => {
-    if (!window.confirm("Are you sure you want to delete this term?")) return;
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setDeleteLoading(true);
     try {
-      await deleteTerm(id);
+      await deleteTerm(deleteTarget._id);
+      setDeleteTarget(null);
       loadTerms();
     } catch (error) {
       console.error("Failed to delete term:", error);
       alert("Failed to delete term");
+    } finally {
+      setDeleteLoading(false);
     }
   };
 
@@ -92,8 +101,9 @@ const Glossary = () => {
         </div>
         <div className="mt-4 flex md:mt-0 md:ml-4">
           <button
+            type="button"
             onClick={() => setShowAddForm(!showAddForm)}
-            className="ml-3 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+            className="ml-3 inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 cursor-pointer"
           >
             {showAddForm ? "Cancel" : "Add Term"}
           </button>
@@ -149,8 +159,9 @@ const Glossary = () => {
                   setNewTerm({ ...newTerm, definition: e.target.value })
                 }
                 className="mt-1 block w-full border-gray-300 rounded-md shadow-sm p-2 border"
-                rows="2"
-              ></textarea>
+                rows={3}
+                placeholder="Definition of the term"
+              />
             </div>
 
             <div>
@@ -170,7 +181,7 @@ const Glossary = () => {
 
             <button
               type="submit"
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer"
             >
               Save Term
             </button>
@@ -204,14 +215,16 @@ const Glossary = () => {
 
                 <div className="mt-4 flex space-x-2">
                   <button
+                    type="button"
                     onClick={() => handleApprove(term._id)}
-                    className="flex-1 bg-green-600 text-white py-1 rounded text-sm hover:bg-green-700"
+                    className="flex-1 bg-green-600 text-white py-1 rounded text-sm hover:bg-green-700 cursor-pointer"
                   >
                     Approve
                   </button>
                   <button
-                    onClick={() => handleDelete(term._id)}
-                    className="flex-1 bg-red-100 text-red-700 py-1 rounded text-sm hover:bg-red-200"
+                    type="button"
+                    onClick={() => setDeleteTarget(term)}
+                    className="flex-1 bg-red-100 text-red-700 py-1 rounded text-sm hover:bg-red-200 cursor-pointer"
                   >
                     Reject
                   </button>
@@ -265,8 +278,9 @@ const Glossary = () => {
                       )}
                     </div>
                     <button
-                      onClick={() => handleDelete(term._id)}
-                      className="text-red-500 hover:text-red-700"
+                      type="button"
+                      onClick={() => setDeleteTarget(term)}
+                      className="text-red-500 hover:text-red-700 cursor-pointer"
                     >
                       Delete
                     </button>
@@ -277,6 +291,18 @@ const Glossary = () => {
           </div>
         )}
       </div>
+
+      {/* Deletion Confirmation Modal (#1489) */}
+      <ConfirmModal
+        isOpen={Boolean(deleteTarget)}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete Glossary Term"
+        message={`Are you sure you want to delete term "${deleteTarget?.term || "this term"}"? This action cannot be undone.`}
+        confirmText="Delete Term"
+        variant="danger"
+        isLoading={deleteLoading}
+      />
     </div>
   );
 };

--- a/client/src/pages/__tests__/GlossaryConfirmModal.test.jsx
+++ b/client/src/pages/__tests__/GlossaryConfirmModal.test.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Glossary from "../Glossary.jsx";
+import * as api from "../../services/glossaryApi.js";
+
+vi.mock("../../services/glossaryApi.js", () => ({
+  fetchTerms: vi.fn(),
+  createTerm: vi.fn(),
+  deleteTerm: vi.fn(),
+  approveTerm: vi.fn(),
+}));
+
+describe("Glossary Confirmation Modal (#1489)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens deletion confirmation modal and deletes term on confirm", async () => {
+    api.fetchTerms.mockResolvedValue([
+      {
+        _id: "term-1",
+        term: "ROI",
+        definition: "Return on Investment",
+        approvalStatus: "approved",
+      },
+    ]);
+    api.deleteTerm.mockResolvedValue({ success: true });
+
+    render(<Glossary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ROI")).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole("button", { name: /^delete$/i });
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/delete glossary term/i)).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", {
+      name: /delete term/i,
+    });
+    const confirmButton = confirmButtons[confirmButtons.length - 1];
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(api.deleteTerm).toHaveBeenCalledWith("term-1");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1489

## Description
This PR replaces native window.confirm calls in Glossary.jsx with accessible ConfirmModal.jsx popups before executing glossary term deletions.

## Proposed Changes
- **Accessible Deletion Confirmation**: Prompted users with ConfirmModal.jsx before deleting or rejecting glossary terms.
- **State Management**: Added deleteTarget and deleteLoading state properties to prevent duplicate deletion calls.
- **Unit Test Coverage**: Added Vitest test suite (GlossaryConfirmModal.test.jsx) verifying deletion confirmation modal rendering and deletion API invocation.

## Checklist
- [x] Related Issue is linked (Fixes #1489).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.