### PR TITLE
fix(validation): enforce strict schema validation and character limits in topicController

### DIFF
--- a/server/controllers/__tests__/topicValidation.test.js
+++ b/server/controllers/__tests__/topicValidation.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renameCluster } from "../topicController.js";
+import TopicCluster from "../../models/topicClusterModel.js";
+
+vi.mock("../../models/topicClusterModel.js");
+
+describe("Topic Controller Schema Validation (#1490)", () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      params: { clusterId: "507f1f77bcf86cd799439011" },
+      body: {},
+      user: { organization: "org123" },
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("returns 400 Bad Request when label is empty or missing", async () => {
+    req.body = { label: "   " };
+
+    await renameCluster(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: expect.any(String) }),
+    );
+  });
+
+  it("returns 400 Bad Request when label exceeds 120 characters", async () => {
+    req.body = { label: "a".repeat(121) };
+
+    await renameCluster(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: expect.stringMatching(/120 characters/i),
+      }),
+    );
+  });
+
+  it("renames cluster successfully with valid label", async () => {
+    req.body = { label: "Engineering Updates" };
+    const mockCluster = {
+      label: "Old Label",
+      isUserRenamed: false,
+      save: vi.fn().mockResolvedValue(true),
+    };
+    TopicCluster.findOne.mockResolvedValue(mockCluster);
+
+    await renameCluster(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockCluster.label).toBe("Engineering Updates");
+    expect(mockCluster.isUserRenamed).toBe(true);
+    expect(mockCluster.save).toHaveBeenCalled();
+  });
+});

--- a/server/controllers/topicController.js
+++ b/server/controllers/topicController.js
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { z } from "zod";
 import * as topicExtractionService from "../services/topicExtractionService.js";
 import MeetingTopic from "../models/meetingTopicModel.js";
 import TopicCluster from "../models/topicClusterModel.js";
@@ -8,6 +9,17 @@ import { AppError } from "../utils/errors.js";
 
 /** Cluster labels appear in chart axes and legends; long ones break the view. */
 const MAX_CLUSTER_LABEL_LENGTH = 120;
+
+const renameClusterSchema = z.object({
+  label: z
+    .string()
+    .trim()
+    .min(1, "Label is required")
+    .max(
+      MAX_CLUSTER_LABEL_LENGTH,
+      `Label cannot exceed ${MAX_CLUSTER_LABEL_LENGTH} characters`,
+    ),
+});
 
 const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
 
@@ -150,7 +162,6 @@ export const getTopicClusters = async (req, res) => {
 export const renameCluster = async (req, res) => {
   try {
     const { clusterId } = req.params;
-    const { label } = req.body;
 
     if (!isValidId(clusterId)) {
       return res
@@ -158,19 +169,15 @@ export const renameCluster = async (req, res) => {
         .json({ success: false, error: "Invalid cluster ID" });
     }
 
-    // `if (!label)` accepted any truthy value, so a number or an object reached
-    // `cluster.label = label` and was coerced on save.
-    if (typeof label !== "string" || label.trim().length === 0) {
-      return res
-        .status(400)
-        .json({ success: false, error: "Label is required" });
-    }
-    if (label.trim().length > MAX_CLUSTER_LABEL_LENGTH) {
+    const parsed = renameClusterSchema.safeParse(req.body);
+    if (!parsed.success) {
       return res.status(400).json({
         success: false,
-        error: `Label cannot exceed ${MAX_CLUSTER_LABEL_LENGTH} characters`,
+        error: parsed.error.issues[0]?.message || "Validation error",
       });
     }
+
+    const { label } = parsed.data;
 
     // Scope the lookup (Issue #1276).
     //


### PR DESCRIPTION
Fixes #1490

## Description
This PR enforces Zod schema validation on cluster renaming in 	opicController.js, validating label strings and enforcing a 120-character maximum limit.

## Proposed Changes
- **Zod Schema Validation**: Applied enameClusterSchema to validate label inputs, rejecting empty or oversized labels with HTTP 400 Bad Request.
- **Unit Test Coverage**: Added Vitest test suite (	opicValidation.test.js) verifying label validation, 120-character max limit, and successful cluster rename operations.

## Checklist
- [x] Related Issue is linked (Fixes #1490).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.