### PR TITLE
fix: scope recap preview by organization

### DIFF
--- a/server/controllers/recapPreferenceController.js
+++ b/server/controllers/recapPreferenceController.js
@@ -74,7 +74,10 @@ export const previewRecapEmail = async (req, res) => {
 
     // Find a recent completed meeting to use as preview data,
     // or fallback to a dummy object if none exists.
-    let meeting = await Meeting.findOne({ status: "completed" }).sort({
+    let meeting = await Meeting.findOne({
+      status: "completed",
+      organization: req.user.organization,
+    }).sort({
       date: -1,
     });
 


### PR DESCRIPTION
## Summary

Fixes #1382 by ensuring the recap email preview only uses completed meetings belonging to the authenticated user's organization.

## Changes

- Scoped the preview meeting query by `req.user.organization`.
- Prevents the recap preview from selecting a completed meeting from another organization.
- Preserves the existing latest-meeting selection and fallback preview behavior.

## Implementation

Updated `previewRecapEmail` in:

`server/controllers/recapPreferenceController.js`

The meeting lookup now filters by:

- `status: "completed"`
- `organization: req.user.organization`

## Testing

Ran:

```bash
npm test -- --runInBand tests/recapEmailService.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recap email previews now use the most recent completed meeting from the authenticated user’s organization.
  - Prevents previews from displaying content from unrelated meetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->