### PR TITLE
fix: enforce participant authorization for workspace action items

### DIFF
--- a/server/controllers/workspaceController.js
+++ b/server/controllers/workspaceController.js
@@ -1,6 +1,6 @@
-// server/controllers/workspaceController.js
 import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
+import { canAccessWorkspaceMeeting } from "../utils/workspaceAuthorization.js";
 
 /**
  * @desc Get initial War Room state (Canvas + Action Board)
@@ -28,17 +28,10 @@ export const getWorkspaceState = async (req, res) => {
     }
 
     // Authorization check
-    const isParticipant = meeting.participants.some(
-      (p) =>
-        p.user?.toString() === req.user._id.toString() ||
-        p.email === req.user.email,
-    );
-    const isOwner = meeting.uploadedBy?.toString() === req.user._id.toString();
-
-    if (!isParticipant && !isOwner) {
+    if (!canAccessWorkspaceMeeting(meeting, req.user)) {
       return res.status(403).json({
         success: false,
-        message: "Forbidden: Not a meeting participant",
+        message: "Forbidden: Not authorized to access this meeting workspace",
       });
     }
 
@@ -90,6 +83,13 @@ export const addActionItem = async (req, res) => {
       return res
         .status(404)
         .json({ success: false, message: "Meeting not found" });
+
+    if (!canAccessWorkspaceMeeting(meeting, req.user)) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Not authorized to modify this meeting workspace",
+      });
+    }
 
     if (!meeting.warRoom) meeting.warRoom = { actionColumns: {} };
     if (!meeting.warRoom.actionColumns) meeting.warRoom.actionColumns = {};

--- a/server/tests/workspaceAuthorization.test.js
+++ b/server/tests/workspaceAuthorization.test.js
@@ -1,0 +1,176 @@
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: {
+    findById: jest.fn(),
+  },
+}));
+
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { addActionItem } =
+  await import("../controllers/workspaceController.js");
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+
+  return res;
+};
+
+describe("addActionItem authorization (#1383)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects a user who is not a meeting participant", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const ownerId = new mongoose.Types.ObjectId();
+
+    const meeting = {
+      participants: [],
+      uploadedBy: ownerId,
+      organization: new mongoose.Types.ObjectId(),
+      warRoom: {
+        actionColumns: {
+          backlog: [],
+        },
+      },
+      save: jest.fn(),
+      markModified: jest.fn(),
+    };
+
+    Meeting.findById.mockResolvedValue(meeting);
+
+    const req = {
+      params: {
+        meetingId: new mongoose.Types.ObjectId().toString(),
+      },
+      body: {
+        title: "Unauthorized action",
+      },
+      user: {
+        _id: userId,
+        email: "user@example.com",
+        organization: meeting.organization,
+      },
+    };
+
+    const res = createResponse();
+
+    await addActionItem(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+      }),
+    );
+    expect(meeting.save).not.toHaveBeenCalled();
+  });
+
+  it("rejects a participant from another organization", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const meetingOrg = new mongoose.Types.ObjectId();
+    const userOrg = new mongoose.Types.ObjectId();
+
+    const meeting = {
+      participants: [
+        {
+          user: userId,
+          email: "user@example.com",
+        },
+      ],
+      uploadedBy: new mongoose.Types.ObjectId(),
+      organization: meetingOrg,
+      warRoom: {
+        actionColumns: {
+          backlog: [],
+        },
+      },
+      save: jest.fn(),
+      markModified: jest.fn(),
+    };
+
+    Meeting.findById.mockResolvedValue(meeting);
+
+    const req = {
+      params: {
+        meetingId: new mongoose.Types.ObjectId().toString(),
+      },
+      body: {
+        title: "Cross organization action",
+      },
+      user: {
+        _id: userId,
+        email: "user@example.com",
+        organization: userOrg,
+      },
+    };
+
+    const res = createResponse();
+
+    await addActionItem(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(meeting.save).not.toHaveBeenCalled();
+  });
+
+  it("allows an authorized participant from the same organization", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const organization = new mongoose.Types.ObjectId();
+
+    const meeting = {
+      participants: [
+        {
+          user: userId,
+          email: "user@example.com",
+        },
+      ],
+      uploadedBy: new mongoose.Types.ObjectId(),
+      organization,
+      warRoom: {
+        actionColumns: {
+          backlog: [],
+        },
+      },
+      save: jest.fn(),
+      markModified: jest.fn(),
+    };
+
+    Meeting.findById.mockResolvedValue(meeting);
+
+    const req = {
+      params: {
+        meetingId: new mongoose.Types.ObjectId().toString(),
+      },
+      body: {
+        title: "Authorized action",
+        priority: "high",
+      },
+      user: {
+        _id: userId,
+        email: "user@example.com",
+        organization,
+      },
+    };
+
+    const res = createResponse();
+
+    await addActionItem(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+      }),
+    );
+    expect(meeting.save).toHaveBeenCalled();
+    expect(meeting.warRoom.actionColumns.backlog).toHaveLength(1);
+    expect(meeting.warRoom.actionColumns.backlog[0].title).toBe(
+      "Authorized action",
+    );
+  });
+});

--- a/server/utils/workspaceAuthorization.js
+++ b/server/utils/workspaceAuthorization.js
@@ -1,0 +1,32 @@
+import { isSameOrganization } from "./organizationScope.js";
+
+export const isWorkspaceMeetingParticipant = (meeting, user) => {
+  if (!meeting || !user) return false;
+
+  const userId = user._id?.toString();
+  const email = user.email;
+
+  const isParticipant = (meeting.participants || []).some(
+    (participant) =>
+      participant.user?.toString() === userId ||
+      (email && participant.email === email),
+  );
+
+  const isOwner = meeting.uploadedBy?.toString() === userId;
+
+  return isParticipant || isOwner;
+};
+
+export const canAccessWorkspaceMeeting = (meeting, user) => {
+  if (!isWorkspaceMeetingParticipant(meeting, user)) {
+    return false;
+  }
+
+  // Personal/legacy meetings without an organization retain
+  // the existing participant/owner authorization behavior.
+  if (!meeting.organization) {
+    return true;
+  }
+
+  return isSameOrganization(meeting.organization, user.organization);
+};


### PR DESCRIPTION
## Summary

Fixes #1383

This PR enforces authorization checks before users can add action items to a meeting workspace.

### Changes

- Added a shared `canAccessWorkspaceMeeting` authorization helper.
- Reused the helper in workspace state retrieval to avoid authorization logic drift.
- Added authorization checks before `addActionItem` mutates the workspace.
- Prevents unauthorized users from modifying another meeting's workspace.
- Prevents cross-organization workspace mutations.
- Added regression tests for:
  - Unauthorized/non-participant users
  - Participants from another organization
  - Authorized participants from the same organization

## Testing

### Targeted tests

- `npm test -- tests/workspaceAuthorization.test.js --runInBand` ✅
  - 3/3 tests passed
- `npm test -- tests/sourceActionItemLinks.test.js --runInBand` ✅
  - 5/5 tests passed

### Full test suite

The full test suite was also attempted. An unrelated existing failure occurs in:

`tests/webhook.test.js`

because `queueService.js` does not export `initAIWorker`.

## Issue

Closes #1383