### PR TITLE
refactor: enforce authorization on meeting feedback endpoints (#1405)

### DIFF
--- a/server/controllers/meetingFeedbackController.js
+++ b/server/controllers/meetingFeedbackController.js
@@ -20,12 +20,30 @@ export const submitFeedback = async (req, res, next) => {
     const validatedData = feedbackSchema.parse(req.body);
     const userId = req.user._id;
 
+    if (!mongoose.isValidObjectId(validatedData.meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID" });
+    }
+
     // Verify meeting exists and user is a participant or organizer
     const meeting = await Meeting.findById(validatedData.meetingId);
     if (!meeting) {
       return res
         .status(404)
         .json({ success: false, message: "Meeting not found" });
+    }
+
+    // Organization Isolation Check
+    if (
+      meeting.organization &&
+      (!req.user.organization ||
+        meeting.organization.toString() !== req.user.organization.toString())
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Meeting belongs to another organization",
+      });
     }
 
     // Check if user is participant or the owner
@@ -95,6 +113,18 @@ export const getFeedbackForMeeting = async (req, res) => {
         .json({ success: false, message: "Meeting not found" });
     }
 
+    // Organization Isolation Check
+    if (
+      meeting.organization &&
+      (!req.user.organization ||
+        meeting.organization.toString() !== req.user.organization.toString())
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Meeting belongs to another organization",
+      });
+    }
+
     const isOwner = meeting.uploadedBy.toString() === userId.toString();
     const isParticipant = meeting.participants?.some(
       (p) => p.user?.toString() === userId.toString(),
@@ -133,6 +163,38 @@ export const getUserFeedbackForMeeting = async (req, res) => {
       return res
         .status(400)
         .json({ success: false, message: "Invalid meeting ID" });
+    }
+
+    const meeting = await Meeting.findById(meetingId);
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Meeting not found" });
+    }
+
+    // Organization Isolation Check
+    if (
+      meeting.organization &&
+      (!req.user.organization ||
+        meeting.organization.toString() !== req.user.organization.toString())
+    ) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Meeting belongs to another organization",
+      });
+    }
+
+    // User Access Check
+    const isOwner = meeting.uploadedBy.toString() === userId.toString();
+    const isParticipant = meeting.participants?.some(
+      (p) => p.user?.toString() === userId.toString(),
+    );
+
+    if (!isOwner && !isParticipant) {
+      return res.status(403).json({
+        success: false,
+        message: "Not authorized to view feedback for this meeting",
+      });
     }
 
     const feedback = await MeetingFeedback.findOne({ meetingId, userId });
@@ -226,6 +288,21 @@ export const deleteFeedback = async (req, res) => {
       return res
         .status(404)
         .json({ success: false, message: "Feedback not found" });
+    }
+
+    // Check meeting organization isolation if meeting exists
+    const meeting = await Meeting.findById(feedback.meetingId);
+    if (meeting) {
+      if (
+        meeting.organization &&
+        (!req.user.organization ||
+          meeting.organization.toString() !== req.user.organization.toString())
+      ) {
+        return res.status(403).json({
+          success: false,
+          message: "Forbidden: Meeting belongs to another organization",
+        });
+      }
     }
 
     if (feedback.userId.toString() !== req.user._id.toString()) {

--- a/server/tests/meetingFeedback.test.js
+++ b/server/tests/meetingFeedback.test.js
@@ -3,6 +3,7 @@ import {
   getAggregateFeedback,
   deleteFeedback,
   getFeedbackForMeeting,
+  getUserFeedbackForMeeting,
 } from "../controllers/meetingFeedbackController.js";
 import MeetingFeedback from "../models/meetingFeedbackModel.js";
 import Meeting from "../models/meetingModel.js";
@@ -90,6 +91,52 @@ describe("Meeting Feedback Controller", () => {
         expect.objectContaining({ success: false }),
       );
     });
+
+    it("should fail if meeting belongs to a different organization", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.body = {
+        meetingId,
+        overallRating: 5,
+        summaryAccuracy: 5,
+        transcriptQuality: 5,
+      };
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        organization: new mongoose.Types.ObjectId().toString(), // different org
+        participants: [{ user: req.user._id }],
+      });
+
+      await submitFeedback(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: Meeting belongs to another organization",
+        }),
+      );
+    });
+
+    it("should return 400 for invalid meeting ID", async () => {
+      req.body = {
+        meetingId: "invalid-id",
+        overallRating: 5,
+        summaryAccuracy: 5,
+        transcriptQuality: 5,
+      };
+
+      await submitFeedback(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Invalid meeting ID",
+        }),
+      );
+    });
   });
 
   describe("getAggregateFeedback", () => {
@@ -149,6 +196,30 @@ describe("Meeting Feedback Controller", () => {
       expect(findSpy).not.toHaveBeenCalled();
     });
 
+    it("returns 403 when the meeting belongs to a different organization", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        organization: new mongoose.Types.ObjectId().toString(), // different org
+        participants: [{ user: req.user._id }],
+      });
+      const findSpy = jest.spyOn(MeetingFeedback, "find");
+
+      await getFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: Meeting belongs to another organization",
+        }),
+      );
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
     it("returns 404 when the meeting does not exist", async () => {
       req.params.meetingId = new mongoose.Types.ObjectId().toString();
       jest.spyOn(Meeting, "findById").mockResolvedValue(null);
@@ -183,9 +254,15 @@ describe("Meeting Feedback Controller", () => {
   });
 
   describe("getUserFeedbackForMeeting", () => {
-    it("returns user feedback when found", async () => {
+    it("returns user feedback when found and authorized", async () => {
       const meetingId = new mongoose.Types.ObjectId().toString();
       req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: req.user._id,
+        participants: [],
+      });
 
       jest.spyOn(MeetingFeedback, "findOne").mockResolvedValue({
         _id: "f1",
@@ -194,8 +271,6 @@ describe("Meeting Feedback Controller", () => {
         overallRating: 4,
       });
 
-      const { getUserFeedbackForMeeting } =
-        await import("../controllers/meetingFeedbackController.js");
       await getUserFeedbackForMeeting(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
@@ -206,24 +281,106 @@ describe("Meeting Feedback Controller", () => {
         }),
       );
     });
+
+    it("returns 404 if meeting does not exist", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue(null);
+
+      await getUserFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("returns 403 if meeting belongs to a different organization", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        organization: new mongoose.Types.ObjectId().toString(),
+        participants: [{ user: req.user._id }],
+      });
+
+      await getUserFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: Meeting belongs to another organization",
+        }),
+      );
+    });
+
+    it("returns 403 if user is not participant or owner", async () => {
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.meetingId = meetingId;
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        participants: [],
+      });
+
+      await getUserFeedbackForMeeting(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
   });
 
   describe("deleteFeedback", () => {
-    it("should delete feedback if owned by user", async () => {
+    it("should delete feedback if owned by user and authorized", async () => {
       const feedbackId = new mongoose.Types.ObjectId().toString();
+      const meetingId = new mongoose.Types.ObjectId().toString();
       req.params.id = feedbackId;
 
       const mockDeleteOne = jest.fn();
       jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
         _id: feedbackId,
+        meetingId,
         userId: req.user._id,
         deleteOne: mockDeleteOne,
+      });
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        organization: req.user.organization,
       });
 
       await deleteFeedback(req, res);
 
       expect(mockDeleteOne).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should fail to delete if the associated meeting belongs to a different organization", async () => {
+      const feedbackId = new mongoose.Types.ObjectId().toString();
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.id = feedbackId;
+
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: feedbackId,
+        meetingId,
+        userId: req.user._id,
+      });
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        organization: new mongoose.Types.ObjectId().toString(),
+      });
+
+      await deleteFeedback(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Forbidden: Meeting belongs to another organization",
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
## 📝 Summary
This PR implements server-side authorization checks and organization boundaries on all Meeting Feedback endpoints (`/api/feedback/*`). It enforces that users can only submit, view, retrieve, or delete feedback for meetings they own, participate in, and belong to within their active organization.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1405

---

## ✨ Changes Made
- **Hardened Controller Access Controls**:
  - Modified `server/controllers/meetingFeedbackController.js` to validate `meetingId` formats and enforce organization boundary checks on `submitFeedback` and `getFeedbackForMeeting`.
  - Added full meeting lookups and participant/owner verification inside `getUserFeedbackForMeeting` and `deleteFeedback`.
- **Expanded Test Coverage**:
  - Updated `server/tests/meetingFeedback.test.js` to cover organization boundary mismatches, invalid meeting IDs, and unauthorized attempts to view or delete feedback.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests locally using Jest:
```bash
cd server
npm run test tests/meetingFeedback.test.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent feedback submissions for invalid or missing meetings.
  * Strengthened organization and access checks when submitting, viewing, or deleting meeting feedback.
  * Prevented unauthorized users from accessing feedback for meetings they do not own or participate in.
  * Blocked cross-organization feedback access and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->