### PR TITLE
refactor: fix live transcript socket Clerk authentication (#1406)

### DIFF
--- a/client/src/components/LiveTranscriptPanel.jsx
+++ b/client/src/components/LiveTranscriptPanel.jsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState, useRef } from "react";
 import { io } from "socket.io-client";
 import { toast } from "react-toastify";
 import { Loader2, Mic, AlertCircle } from "lucide-react";
-import { createClerkSocketOptions } from "../services/apiClient.js";
+import { useAuth } from "@clerk/clerk-react";
+import {
+  createClerkSocketOptions,
+  getClerkBearerToken,
+} from "../services/apiClient.js";
+import { getBackendUrl } from "../config/backendConfig.js";
 
 const LiveTranscriptPanel = ({ meetingId }) => {
   const [segments, setSegments] = useState([]);
@@ -10,9 +15,14 @@ const LiveTranscriptPanel = ({ meetingId }) => {
   const [error, setError] = useState(null);
   const socketRef = useRef(null);
   const transcriptEndRef = useRef(null);
+  const { isSignedIn, isLoaded } = useAuth();
 
   useEffect(() => {
     if (!meetingId) return;
+    if (!isLoaded || !isSignedIn) {
+      setStatus("disconnected");
+      return;
+    }
 
     let cancelled = false;
 
@@ -22,8 +32,22 @@ const LiveTranscriptPanel = ({ meetingId }) => {
       });
       if (cancelled) return;
 
-      // Initialize socket connection
-      socketRef.current = io("/", opts);
+      // Initialize socket connection using backendUrl
+      const backendUrl = getBackendUrl();
+      socketRef.current = io(backendUrl, opts);
+
+      socketRef.current.on("reconnect_attempt", async () => {
+        try {
+          const token = await getClerkBearerToken();
+          if (socketRef.current.auth) {
+            socketRef.current.auth.token = token;
+          } else {
+            socketRef.current.auth = { token };
+          }
+        } catch (error) {
+          console.error("Failed to refresh token on reconnect:", error);
+        }
+      });
 
       socketRef.current.on("connect", () => {
         console.log("Connected to transcript socket");
@@ -87,7 +111,7 @@ const LiveTranscriptPanel = ({ meetingId }) => {
         socketRef.current.disconnect();
       }
     };
-  }, [meetingId]);
+  }, [meetingId, isLoaded, isSignedIn]);
 
   const formatTime = (seconds) => {
     const mins = Math.floor(seconds / 60);

--- a/client/src/components/__tests__/LiveTranscriptPanelAuth.test.jsx
+++ b/client/src/components/__tests__/LiveTranscriptPanelAuth.test.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import LiveTranscriptPanel from "../LiveTranscriptPanel.jsx";
+
+// Mock Clerk auth state
+let mockIsSignedIn = true;
+let mockIsLoaded = true;
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    isSignedIn: mockIsSignedIn,
+    isLoaded: mockIsLoaded,
+  }),
+}));
+
+// Mock socket.io-client
+const mockSocketInstances = [];
+const mockIo = vi.fn((url, options) => {
+  const listeners = {};
+  const socket = {
+    id: `socket_${mockSocketInstances.length + 1}`,
+    auth: options?.auth || {},
+    on: vi.fn((event, cb) => {
+      listeners[event] = cb;
+    }),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+    // Helper to fire events locally in tests
+    fireEvent: (event, data) => {
+      if (listeners[event]) {
+        listeners[event](data);
+      }
+    },
+  };
+  mockSocketInstances.push(socket);
+  return socket;
+});
+
+vi.mock("socket.io-client", () => ({
+  io: mockIo,
+}));
+
+let mockToken = "initial_clerk_token";
+
+vi.mock("../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async (extra) => ({
+    auth: { token: mockToken },
+    ...extra,
+  })),
+  getClerkBearerToken: vi.fn(async () => mockToken),
+}));
+
+vi.mock("../../config/backendConfig.js", () => ({
+  getBackendUrl: vi.fn(() => "http://localhost:5000"),
+}));
+
+describe("LiveTranscriptPanel Clerk Auth and Reconnection Lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocketInstances.length = 0;
+    mockIsSignedIn = true;
+    mockIsLoaded = true;
+    mockToken = "initial_clerk_token";
+  });
+
+  it("should not establish socket connection if Clerk is not loaded", async () => {
+    mockIsLoaded = false;
+    mockIsSignedIn = false;
+
+    render(<LiveTranscriptPanel meetingId="meeting-123" />);
+
+    // Wait a brief tick
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockIo).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/connecting to transcript service/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should not establish socket connection if user is not signed in", async () => {
+    mockIsLoaded = true;
+    mockIsSignedIn = false;
+
+    render(<LiveTranscriptPanel meetingId="meeting-123" />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockIo).not.toHaveBeenCalled();
+  });
+
+  it("should connect socket with token when Clerk is ready and signed in", async () => {
+    render(<LiveTranscriptPanel meetingId="meeting-123" />);
+
+    // Wait for the async connection logic inside useEffect
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockIo).toHaveBeenCalledTimes(1);
+    expect(mockIo).toHaveBeenCalledWith(
+      "http://localhost:5000",
+      expect.objectContaining({
+        auth: { token: "initial_clerk_token" },
+      }),
+    );
+
+    const socket = mockSocketInstances[0];
+    expect(socket.on).toHaveBeenCalledWith("connect", expect.any(Function));
+  });
+
+  it("should disconnect socket cleanly when session is signed out", async () => {
+    const { rerender } = render(
+      <LiveTranscriptPanel meetingId="meeting-123" />,
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockSocketInstances).toHaveLength(1);
+    const socket = mockSocketInstances[0];
+
+    // Simulate signout
+    mockIsSignedIn = false;
+
+    await act(async () => {
+      rerender(<LiveTranscriptPanel meetingId="meeting-123" />);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(socket.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fetch a fresh token dynamically during socket reconnect_attempt event", async () => {
+    render(<LiveTranscriptPanel meetingId="meeting-123" />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(mockSocketInstances).toHaveLength(1);
+    const socket = mockSocketInstances[0];
+
+    // Change the mock token to simulate token rotation
+    mockToken = "refreshed_clerk_token";
+
+    // Simulate the socket firing reconnect_attempt
+    await act(async () => {
+      await socket.fireEvent("reconnect_attempt");
+    });
+
+    expect(socket.auth.token).toBe("refreshed_clerk_token");
+  });
+});

--- a/client/src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx
+++ b/client/src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx
@@ -11,8 +11,20 @@ vi.mock("socket.io-client", () => ({
   })),
 }));
 
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    isSignedIn: true,
+    isLoaded: true,
+  }),
+}));
+
+vi.mock("../config/backendConfig.js", () => ({
+  getBackendUrl: vi.fn(() => "http://localhost:5000"),
+}));
+
 vi.mock("../services/apiClient.js", () => ({
   createClerkSocketOptions: vi.fn().mockResolvedValue({}),
+  getClerkBearerToken: vi.fn().mockResolvedValue("mock_token"),
 }));
 
 describe("LiveTranscriptPanel Dark Mode (#1340)", () => {


### PR DESCRIPTION
## 📝 Summary
This PR integrates Clerk session-token authentication and active reconnection handlers inside the `LiveTranscriptPanel` Socket.IO client connection. It ensures connections are only made once Clerk is ready/signed in, disposes connections cleanly on logout, and pulls fresh tokens during reconnect retries.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1406

---

## ✨ Changes Made
- **Hardened Connection Lifecycle**:
  - Refactored `client/src/components/LiveTranscriptPanel.jsx` to block connection setup if Clerk is loading or signed out (`!isLoaded || !isSignedIn`).
  - Pass the dynamic backend URL to the `io(...)` constructor instead of `"/"`.
  - Added a `reconnect_attempt` socket listener that calls `getClerkBearerToken()` dynamically before retrying connection.
  - Sockets cleanly disconnect inside the `useEffect` cleanup block whenever the session shifts or becomes unsigned.
- **Added Automated Integration Tests**:
  - Created `client/src/components/__tests__/LiveTranscriptPanelAuth.test.jsx` verifying connection blocks, successful auth logins, dynamic reconnect tokens, and signout disconnections.
  - Mocked Clerk hooks and the backend configuration inside `client/src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx` to align with the new auth requirements and prevent regressions.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests locally using Vitest:
```bash
cd client
npm run test src/components/__tests__/LiveTranscriptPanelAuth.test.jsx src/components/__tests__/LiveTranscriptPanelDarkMode.test.jsx
