### PR TITLE
refactor: audit and migrate auth-critical pages away from raw fetch (#1408)

### DIFF
--- a/client/src/components/__tests__/ClerkSessionSyncAuth.test.jsx
+++ b/client/src/components/__tests__/ClerkSessionSyncAuth.test.jsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ClerkSessionSync } from "../ClerkSessionSync";
+import AppContent from "../../context/AppContent";
+import { authApi } from "../../services";
+
+vi.mock("../../services", () => ({
+  authApi: {
+    syncClerkUser: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+let mockGetToken = vi.fn();
+let mockSignOut = vi.fn();
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    getToken: mockGetToken,
+    isSignedIn: true,
+    isLoaded: true,
+    userId: "user_clerk_123",
+  }),
+  useUser: () => ({
+    user: {
+      primaryEmailAddress: { emailAddress: "user@example.com" },
+      fullName: "Test User",
+      imageUrl: "http://image.url",
+    },
+  }),
+  useClerk: () => ({
+    signOut: mockSignOut,
+  }),
+}));
+
+describe("ClerkSessionSync Auth & Bootstrap Requests", () => {
+  let contextValue;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "pk_test_123");
+
+    contextValue = {
+      initializeAuth: vi.fn().mockResolvedValue({ name: "Test User" }),
+      isLoggedin: false,
+      setIsLoggedin: vi.fn(),
+      setUserData: vi.fn(),
+      setLoading: vi.fn(),
+      userData: null,
+      getUserData: vi.fn().mockResolvedValue({ name: "Test User" }),
+    };
+
+    mockGetToken.mockResolvedValue("mock_jwt_token");
+  });
+
+  it("should retrieve token and call syncClerkUser and initializeAuth during bootstrap", async () => {
+    authApi.syncClerkUser.mockResolvedValue({ data: { success: true } });
+
+    render(
+      <AppContent.Provider value={contextValue}>
+        <ClerkSessionSync />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetToken).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(authApi.syncClerkUser).toHaveBeenCalledWith(
+        {
+          clerkUserId: "user_clerk_123",
+          email: "user@example.com",
+          name: "Test User",
+          profilePic: "http://image.url",
+        },
+        {
+          headers: { Authorization: "Bearer mock_jwt_token" },
+        },
+      );
+    });
+
+    await waitFor(() => {
+      expect(contextValue.initializeAuth).toHaveBeenCalledWith({
+        authorization: "Bearer mock_jwt_token",
+      });
+    });
+  });
+
+  it("should retry bootstrapping if syncClerkUser/initializeAuth fails initially", async () => {
+    // Fail first sync, then succeed
+    authApi.syncClerkUser
+      .mockRejectedValueOnce(new Error("Sync failed"))
+      .mockResolvedValue({ data: { success: true } });
+
+    render(
+      <AppContent.Provider value={contextValue}>
+        <ClerkSessionSync />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      // It should retry after failing initially
+      expect(authApi.syncClerkUser).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR covers the audit of authentication-critical frontend pages and flows to ensure raw `fetch()` calls are not used for authenticated application API endpoints. We verified all bootstrap, login, signup, and onboarding pages use Clerk SDK methods or the shared Clerk-aware `apiClient` wrapper, and added a regression test suite for `ClerkSessionSync`.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1408

---

## ✨ Changes Made
- **Audited Flows**: Verified `Login`, `SignUp`, `ClerkSessionSync`, `ProtectedRoute`, `CreateOrganizationPage`, `JoinOrganizationPage`, `AcceptInvite`, and `MeetingInviteJoin` are fully migrated to use Clerk-aware API services.
- **Added Automated Regression Tests**:
  - Created `client/src/components/__tests__/ClerkSessionSyncAuth.test.jsx` verifying Clerk token retrieval, `syncClerkUser` and `initializeAuth` header verification, and bootstrap retry thresholds.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests locally using Vitest:
```bash
cd client
npm run test src/components/__tests__/ClerkSessionSyncAuth.test.jsx
