### PR TITLE
feat(bot): update issue and PR automation

### DIFF
--- a/.github/scripts/comments.js
+++ b/.github/scripts/comments.js
@@ -1,4 +1,10 @@
-import { AUTOMATION, COMMANDS, reminderMarker } from "./constants.js";
+import {
+  AUTOMATION,
+  COMMANDS,
+  LIMITS,
+  TIMERS,
+  reminderMarker,
+} from "./constants.js";
 
 import { withMarker } from "./utils.js";
 
@@ -10,7 +16,7 @@ export const comments = {
         `Issue #${issueNumber} is now officially assigned to you.\n\n` +
         `💬 Welcome! For faster communication and project updates, please join our Discord community:\nhttps://discord.gg/c29cwdVMG\n\n` +
         `Before you dive in, please take a moment to review **CONTRIBUTING.md**, and try to keep your PR focused on this issue so it's easy to review.\n\n` +
-        `⏳ Please open your PR within **48 hours**. If you need a bit more time, no worries — just leave a quick progress update here and you're good to continue.\n\n` +
+        `⏳ Please open your PR within **${TIMERS.expirationHours} hours**. If you need a bit more time, no worries — just leave a quick progress update here and you're good to continue.\n\n` +
         `Excited to see what you build. Happy coding! 🚀`,
     ),
 
@@ -21,7 +27,7 @@ export const comments = {
 
   maxIssueLimitReached: ({ user, activeCount }) =>
     `Hi @${user}, thanks for your enthusiasm — it does not go unnoticed! 🌟\n\n` +
-    `You currently have **${activeCount} active assigned issues**, and our current limit is **4** at a time, just so everyone gets a fair shot at contributing.\n\n` +
+    `You currently have **${activeCount} active assigned issues**, and our current limit is **${LIMITS.maxActiveAssignedIssues}** at a time, just so everyone gets a fair shot at contributing.\n\n` +
     `Please complete or release one of your active issues with \`${COMMANDS.unclaim}\`, and then you're welcome to claim another right away.`,
 
   invalidClaim: ({ user }) =>
@@ -61,7 +67,7 @@ export const comments = {
     withMarker(
       AUTOMATION.assignmentWelcomeMarker,
       `Hi @${assignee}, welcome aboard! 🎉\n\n` +
-        `You are now assigned to issue #${issueNumber}. Please follow **CONTRIBUTING.md**, keep your PR focused on this issue, and aim to open it within **48 hours**.\n\n` +
+        `You are now assigned to issue #${issueNumber}. Please follow **CONTRIBUTING.md**, keep your PR focused on this issue, and aim to open it within **${TIMERS.expirationHours} hours**.\n\n` +
         `If anything blocks you along the way, just leave a short update here — we're happy to help. Looking forward to your contribution! 🚀`,
     ),
 
@@ -91,7 +97,7 @@ export const comments = {
     withMarker(
       AUTOMATION.expiredMarker,
       `Hi @${assignee}, thank you again for your interest in this issue! 🙏\n\n` +
-        `Since there was no activity within the **48-hour** claim window, the issue has been released so other contributors can get a chance to work on it.\n\n` +
+        `Since there was no activity within the **${TIMERS.expirationHours}-hour** claim window, the issue has been released so other contributors can get a chance to work on it.\n\n` +
         `If it's still available and you'd like to continue, you're more than welcome to claim it again — we'd love to see you back! 😊`,
     ),
 
@@ -185,5 +191,36 @@ export const comments = {
       AUTOMATION.ciValidationMarker,
       `### ✅ Automated PR Validation Passed\n\n` +
         `Hi @${user}, all required checks are now passing. The earlier automated "Request Changes" review has been dismissed, and this PR is ready for maintainer review. Thanks for the fix! 🎉`,
+    ),
+
+  prAutoClosed: ({ user, prNumber, hoursOpen }) =>
+    withMarker(
+      AUTOMATION.prAutoClosedMarker,
+      `Hi @${user}, thank you for your contribution! 🙏\n\n` +
+        `Pull request #${prNumber} has been automatically closed because it remained open for more than **${hoursOpen} hours** without being merged.\n\n` +
+        `Please address any required changes or check failures, then reopen this PR or open a new one following **CONTRIBUTING.md**. We'd love to review your updates! 🚀`,
+    ),
+
+  prChangesRequestedReminder: ({ user }) =>
+    withMarker(
+      AUTOMATION.prChangesRequestedReminderMarker,
+      `Hi @${user}, friendly reminder! 👋\n\n` +
+        `A reviewer has requested changes on this pull request. Please address the feedback when you can so we can keep moving toward review.\n\n` +
+        `Thank you for your contribution! 💪`,
+    ),
+
+  prFailedChecksReminder: ({ user, failedRuns }) =>
+    withMarker(
+      AUTOMATION.prFailedChecksReminderMarker,
+      `Hi @${user}, friendly reminder! 👋\n\n` +
+        `One or more required CI checks are failing on this pull request. Please review the workflow logs, fix the reported issues, and push an update.\n\n` +
+        `**Failed Checks**\n\n` +
+        failedRuns
+          .map(
+            (run) =>
+              `- ❌ [${run.name}](${run.html_url || run.details_url || "#"})`,
+          )
+          .join("\n") +
+        `\n\nOnce all required checks pass, this PR will be ready for maintainer review. Thanks! 🚀`,
     ),
 };

--- a/.github/scripts/constants.js
+++ b/.github/scripts/constants.js
@@ -13,6 +13,9 @@ export const AUTOMATION = Object.freeze({
   guidanceMarker: "mom:claim-guidance",
   overrideMarker: "mom:maintainer-override",
   ciValidationMarker: "mom:ci-validation",
+  prAutoClosedMarker: "mom:pr-auto-closed",
+  prChangesRequestedReminderMarker: "mom:pr-changes-requested-reminder",
+  prFailedChecksReminderMarker: "mom:pr-failed-checks-reminder",
 });
 
 export const COMMANDS = Object.freeze({
@@ -21,16 +24,18 @@ export const COMMANDS = Object.freeze({
 });
 
 export const LIMITS = Object.freeze({
-  maxActiveAssignedIssues: 4,
+  maxActiveAssignedIssues: 5,
   guidanceCooldownHours: 12,
 });
 
 export const TIMERS = Object.freeze({
-  // Reminders every 8 hours until the 48-hour claim window expires.
-  reminderHours: Object.freeze([8, 16, 24, 32, 40]),
-  expirationHours: 48,
+  // Reminders every 6 hours until the 24-hour claim window expires.
+  reminderHours: Object.freeze([6, 12, 18]),
+  expirationHours: 24,
   // Contributor-authored issues: exclusive claim window for the author.
   authorPriorityHours: 48,
+  // Close open PRs strictly after this many hours (uses PR created_at).
+  prAutoCloseHours: 48,
 });
 
 export function reminderMarker(hours) {

--- a/.github/scripts/helpers.js
+++ b/.github/scripts/helpers.js
@@ -198,6 +198,22 @@ export async function listOpenAssignedIssues(github, context, core) {
   );
 }
 
+export async function listOpenPullRequests(github, context, core) {
+  const records = await safeCall(
+    core,
+    "pulls.list(open)",
+    () =>
+      github.paginate(github.rest.pulls.list, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        state: "open",
+        per_page: 100,
+      }),
+    [],
+  );
+  return records || [];
+}
+
 /**
  * Find OPEN PRs (including drafts) that link to the given issue number.
  * Uses a scoped search + body/title parse to avoid listing every PR.

--- a/.github/scripts/index.js
+++ b/.github/scripts/index.js
@@ -5,6 +5,7 @@ export {
   processPrMerged,
   processPrValidation,
   processFirstContributorWelcome,
+  processPrAutomation,
 } from "./pr.js";
 export { processIssueCommentGuidance } from "./issue-comments.js";
 export { processIssueLifecycle } from "./lifecycle.js";

--- a/.github/scripts/pr.js
+++ b/.github/scripts/pr.js
@@ -5,8 +5,9 @@ import {
   findCommentByMarker,
   getIssue,
   isExpectedRepository,
+  listOpenPullRequests,
+  listReviews,
   safeCall,
-  summarizeCheckStates,
   summarizeRequiredCheckStates,
 } from "./helpers.js";
 import { processPrActivityRefresh } from "./activity.js";
@@ -15,7 +16,9 @@ import {
   AUTOMATION,
   ALLOWED_BRANCH_PREFIXES,
   REQUIRED_CHECK_NAMES,
+  TIMERS,
 } from "./constants.js";
+import { hoursSince, isIgnoredBotUser } from "./utils.js";
 
 function isMeaningfulDescription(text) {
   const value = String(text || "").trim();
@@ -289,4 +292,142 @@ export async function processFirstContributorWelcome({
     pr.number,
     comments.firstContributorWelcome({ user: pr.user.login }),
   );
+}
+
+function getLatestHumanReview(reviews) {
+  return (
+    (reviews || [])
+      .filter(
+        (review) =>
+          !isIgnoredBotUser(review.user) &&
+          !hasMarker(review.body, AUTOMATION.ciValidationMarker),
+      )
+      .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))[0] ||
+    null
+  );
+}
+
+async function closeStalePullRequest({ github, context, core, pr }) {
+  const prAuthor = pr.user?.login;
+  if (!prAuthor) return;
+
+  const existingCloseComment = await findCommentByMarker(
+    github,
+    context,
+    core,
+    pr.number,
+    AUTOMATION.prAutoClosedMarker,
+  );
+
+  const closeResult = await safeCall(core, "pulls.update(close stale PR)", () =>
+    github.rest.pulls.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: pr.number,
+      state: "closed",
+    }),
+  );
+
+  // Never leave a marker when close fails — the next hourly run must retry.
+  if (!closeResult) return;
+
+  if (existingCloseComment) return;
+
+  await createComment(
+    github,
+    context,
+    core,
+    pr.number,
+    comments.prAutoClosed({
+      user: prAuthor,
+      prNumber: pr.number,
+      hoursOpen: TIMERS.prAutoCloseHours,
+    }),
+  );
+}
+
+async function remindChangesRequested({ github, context, core, pr }) {
+  const prAuthor = pr.user?.login;
+  if (!prAuthor || pr.draft) return;
+
+  const reviews = await listReviews(github, context, core, pr.number);
+  const latestReview = getLatestHumanReview(reviews);
+  if (!latestReview || latestReview.state !== "CHANGES_REQUESTED") return;
+
+  const existingReminder = await findCommentByMarker(
+    github,
+    context,
+    core,
+    pr.number,
+    AUTOMATION.prChangesRequestedReminderMarker,
+  );
+  if (
+    existingReminder &&
+    new Date(latestReview.submitted_at) <=
+      new Date(existingReminder.created_at || existingReminder.updated_at || 0)
+  ) {
+    return;
+  }
+
+  await createOrUpdateMarkerComment(
+    github,
+    context,
+    core,
+    pr.number,
+    AUTOMATION.prChangesRequestedReminderMarker,
+    comments.prChangesRequestedReminder({ user: prAuthor }),
+  );
+}
+
+async function remindFailedChecks({ github, context, core, pr }) {
+  const prAuthor = pr.user?.login;
+  if (!prAuthor || pr.draft) return;
+
+  const checkRunsResponse = await safeCall(
+    core,
+    "checks.listForRef(PR reminders)",
+    () =>
+      github.rest.checks.listForRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: pr.head?.sha,
+        per_page: 100,
+      }),
+    { data: { check_runs: [] } },
+  );
+  const summary = summarizeRequiredCheckStates(
+    checkRunsResponse?.data?.check_runs || [],
+    REQUIRED_CHECK_NAMES,
+  );
+
+  if (!summary.allCompleted || summary.failedCount === 0) return;
+
+  await createOrUpdateMarkerComment(
+    github,
+    context,
+    core,
+    pr.number,
+    AUTOMATION.prFailedChecksReminderMarker,
+    comments.prFailedChecksReminder({
+      user: prAuthor,
+      failedRuns: summary.failedRuns,
+    }),
+  );
+}
+
+export async function processPrAutomation({ github, context, core }) {
+  if (!isExpectedRepository(context)) return;
+
+  const openPullRequests = await listOpenPullRequests(github, context, core);
+
+  for (const pr of openPullRequests) {
+    const openHours = hoursSince(pr.created_at);
+    if (openHours > TIMERS.prAutoCloseHours) {
+      await closeStalePullRequest({ github, context, core, pr });
+      continue;
+    }
+
+    await remindChangesRequested({ github, context, core, pr });
+    await remindFailedChecks({ github, context, core, pr });
+  }
 }

--- a/.github/scripts/tests/automation.test.js
+++ b/.github/scripts/tests/automation.test.js
@@ -7,6 +7,7 @@ import {
   processPrValidation,
   processPrMerged,
   processFirstContributorWelcome,
+  processPrAutomation,
 } from "../pr.js";
 import { processIssueLifecycle } from "../lifecycle.js";
 import { processClaimExpiration } from "../expiration.js";
@@ -22,6 +23,8 @@ function createGithub(issueFactory) {
     assignees: {},
     issues: {},
     openPullRequests: [],
+    reviews: [],
+    closedPullRequests: [],
   };
   return {
     state,
@@ -70,6 +73,9 @@ function createGithub(issueFactory) {
         async listComments() {
           return { data: state.comments };
         },
+        async listForRepo() {
+          return { data: [] };
+        },
         async addLabels() {
           return { data: [] };
         },
@@ -89,6 +95,24 @@ function createGithub(issueFactory) {
         async get({ pull_number }) {
           return { data: { number: pull_number } };
         },
+        async update({ pull_number, state: prState }) {
+          const pr = state.openPullRequests.find(
+            (p) => p.number === pull_number,
+          );
+          if (pr) pr.state = prState;
+          return { data: { number: pull_number, state: prState } };
+        },
+        async listReviews() {
+          return { data: state.reviews || [] };
+        },
+        async list() {
+          return { data: state.openPullRequests };
+        },
+      },
+      checks: {
+        async listForRef() {
+          return { data: { check_runs: state.checkRuns || [] } };
+        },
       },
       search: {
         async issuesAndPullRequests() {
@@ -101,13 +125,29 @@ function createGithub(issueFactory) {
         return this.rest.issues.listComments(args).then((r) => r.data);
       if (apiMethod === this.rest.search.issuesAndPullRequests)
         return state.openPullRequests;
+      if (apiMethod === this.rest.pulls.list) return state.openPullRequests;
+      if (apiMethod === this.rest.pulls.listReviews)
+        return this.rest.pulls.listReviews(args).then((r) => r.data);
       if (args.assignee) {
-        return new Array(args.assignee === "busy-user" ? 4 : 1)
+        return new Array(
+          args.assignee === "busy-user"
+            ? 5
+            : args.assignee === "four-user"
+              ? 4
+              : 1,
+        )
           .fill(0)
           .map((_, i) => ({
             number: i + 1,
             title: `Issue ${i + 1}`,
           }));
+      }
+      if (apiMethod === this.rest.issues.listForRepo) {
+        return Object.keys(state.assignees).map((n) => ({
+          number: Number(n),
+          state: "open",
+          assignees: [{ login: state.assignees[n] }],
+        }));
       }
       return Object.keys(state.assignees).map((n) => ({
         number: Number(n),
@@ -184,7 +224,7 @@ test("claim: already assigned", async () => {
   );
 });
 
-test("claim: max 4 active issues", async () => {
+test("claim: max 5 active issues", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
   const github = createGithub(issueFactory);
   const context = baseContext();
@@ -196,7 +236,26 @@ test("claim: max 4 active issues", async () => {
   };
   await processClaim({ github, context, core: createCore() });
   assert.ok(
-    github.state.comments.some((c) => c.body.includes("limit is **4**")),
+    github.state.comments.some((c) => c.body.includes("limit is **5**")),
+  );
+});
+
+test("claim: allows fifth claim when four active", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  const context = baseContext();
+  context.payload.comment.user.login = "four-user";
+  context.payload.issue.user.login = "four-user";
+  github.state.issues[10] = {
+    user: { login: "four-user" },
+    author_association: "CONTRIBUTOR",
+  };
+  await processClaim({ github, context, core: createCore() });
+  assert.equal(github.state.assignees[10], "four-user");
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("limit is **5**"))
+      .length,
+    0,
   );
 });
 
@@ -339,9 +398,9 @@ test("issue lifecycle close clears metadata and preserves assignees", async () =
   assert.equal(github.state.assignees[10], "assigned-user");
 });
 
-test("expiration: expires after 48 inactive hours", async () => {
+test("expiration: expires after 24 inactive hours", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
-  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
       body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}"}\n<!-- mom:metadata:end -->`,
@@ -358,15 +417,17 @@ test("expiration: expires after 48 inactive hours", async () => {
   assert.ok(
     github.state.comments.some((c) => c.body.includes("mom:claim-expired")),
   );
-  assert.ok(github.state.comments.some((c) => c.body.includes("48-hour")));
+  assert.ok(github.state.comments.some((c) => c.body.includes("24-hour")));
 });
 
-test("expiration: does not expire before 48 hours", async () => {
+test("expiration: does not expire before 24 hours", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
-  const oldDate = new Date(Date.now() - 47 * 60 * 60 * 1000).toISOString();
+  const oldDate = new Date(
+    Date.now() - (24 * 60 * 60 * 1000 - 60 * 1000),
+  ).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
-      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}","16":"${oldDate}","24":"${oldDate}","32":"${oldDate}","40":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"6":"${oldDate}","12":"${oldDate}","18":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
     }),
   );
   github.state.assignees[51] = "assigned-user";
@@ -384,9 +445,9 @@ test("expiration: does not expire before 48 hours", async () => {
   );
 });
 
-test("expiration: posts 8-hour interval reminders without duplicates", async () => {
+test("expiration: posts 6-hour interval reminders without duplicates", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
-  const oldDate = new Date(Date.now() - 9 * 60 * 60 * 1000).toISOString();
+  const oldDate = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
       body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{}}\n<!-- mom:metadata:end -->`,
@@ -403,16 +464,41 @@ test("expiration: posts 8-hour interval reminders without duplicates", async () 
   await processClaimExpiration({ github, context, core: createCore() });
 
   const reminderComments = github.state.comments.filter((c) =>
-    c.body.includes("mom:reminder-8h"),
+    c.body.includes("mom:reminder-6h"),
   );
   assert.equal(reminderComments.length, 1);
-  assert.ok(reminderComments[0].body.includes("**8 hours**"));
+  assert.ok(reminderComments[0].body.includes("**6 hours**"));
   assert.equal(github.state.assignees[52], "assigned-user");
 });
 
-test("expiration: sends highest due reminder for 8h cadence", async () => {
+test("expiration: no reminder before 6 inactive hours", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
-  const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+  const oldDate = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString();
+  const github = createGithub((number, state) =>
+    issueFactory(number, state, {
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{}}\n<!-- mom:metadata:end -->`,
+    }),
+  );
+  github.state.assignees[54] = "assigned-user";
+  await processClaimExpiration({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-"))
+      .length,
+    0,
+  );
+});
+
+test("expiration: sends highest due reminder for 6h cadence", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 19 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
       body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{}}\n<!-- mom:metadata:end -->`,
@@ -428,17 +514,17 @@ test("expiration: sends highest due reminder for 8h cadence", async () => {
   await processClaimExpiration({ github, context, core: createCore() });
 
   assert.equal(
-    github.state.comments.filter((c) => c.body.includes("mom:reminder-24h"))
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-18h"))
       .length,
     1,
   );
   assert.equal(
-    github.state.comments.filter((c) => c.body.includes("mom:reminder-8h"))
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-6h"))
       .length,
     0,
   );
   assert.equal(
-    github.state.comments.filter((c) => c.body.includes("mom:reminder-16h"))
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-12h"))
       .length,
     0,
   );
@@ -830,7 +916,7 @@ test("activity: PR synchronize refreshes linked issue", async () => {
   const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
-      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"6":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
       assignees: [{ login: "assigned-user" }],
     }),
   );
@@ -864,7 +950,7 @@ test("activity: issue comment from assignee refreshes", async () => {
   const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
-      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"6":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
     }),
   );
   github.state.assignees[71] = "assigned-user";
@@ -898,7 +984,7 @@ test("activity: bot comments do not refresh", async () => {
   const oldDate = new Date(Date.now() - 40 * 60 * 60 * 1000).toISOString();
   const github = createGithub((number, state) =>
     issueFactory(number, state, {
-      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"8":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
+      body: `<!-- mom:metadata:start -->\n{"assignedAt":"${oldDate}","lastActivityAt":"${oldDate}","remindersSentAt":{"6":"${oldDate}"}}\n<!-- mom:metadata:end -->`,
     }),
   );
   github.state.assignees[72] = "assigned-user";
@@ -941,6 +1027,308 @@ test("metadata: legacy body without new fields remains compatible", async () => 
   assert.equal(isManualAssignment(meta), true);
 });
 
+test("pr automation: closes PR open more than 48 hours without merge", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub(issueFactory);
+  github.state.openPullRequests = [
+    {
+      number: 300,
+      state: "open",
+      created_at: oldDate,
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  await processPrAutomation({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.openPullRequests[0].state, "closed");
+  assert.ok(
+    github.state.comments.some((c) => c.body.includes("mom:pr-auto-closed")),
+  );
+  assert.ok(
+    github.state.comments.some((c) =>
+      c.body.includes("more than **48 hours**"),
+    ),
+  );
+});
+
+test("pr automation: does not close PR at exactly 48 hours", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const createdAt = new Date(
+    Date.now() - 48 * 60 * 60 * 1000 + 1000,
+  ).toISOString();
+  const github = createGithub(issueFactory);
+  github.state.openPullRequests = [
+    {
+      number: 301,
+      state: "open",
+      created_at: createdAt,
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  await processPrAutomation({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(github.state.openPullRequests[0].state, "open");
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:pr-auto-closed"))
+      .length,
+    0,
+  );
+});
+
+test("pr automation: reminds on human changes requested without duplicates", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  github.state.openPullRequests = [
+    {
+      number: 302,
+      state: "open",
+      created_at: new Date().toISOString(),
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  github.state.reviews = [
+    {
+      state: "CHANGES_REQUESTED",
+      user: { login: "reviewer", type: "User" },
+      submitted_at: new Date().toISOString(),
+      body: "Please fix tests",
+    },
+  ];
+  const context = {
+    eventName: "schedule",
+    repo: { owner: "org", repo: "repo" },
+    payload: {},
+  };
+  await processPrAutomation({ github, context, core: createCore() });
+  await processPrAutomation({ github, context, core: createCore() });
+  assert.equal(
+    github.state.comments.filter((c) =>
+      c.body.includes("mom:pr-changes-requested-reminder"),
+    ).length,
+    1,
+  );
+});
+
+test("pr automation: skips reminder when latest human review is approved", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  const older = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+  const newer = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+  github.state.openPullRequests = [
+    {
+      number: 305,
+      state: "open",
+      created_at: new Date().toISOString(),
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  github.state.reviews = [
+    {
+      state: "CHANGES_REQUESTED",
+      user: { login: "reviewer", type: "User" },
+      submitted_at: older,
+      body: "Please fix tests",
+    },
+    {
+      state: "APPROVED",
+      user: { login: "reviewer", type: "User" },
+      submitted_at: newer,
+      body: "Looks good now",
+    },
+  ];
+  await processPrAutomation({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(
+    github.state.comments.filter((c) =>
+      c.body.includes("mom:pr-changes-requested-reminder"),
+    ).length,
+    0,
+  );
+});
+
+test("pr automation: retries close after API failure without leaving marker", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const oldDate = new Date(Date.now() - 49 * 60 * 60 * 1000).toISOString();
+  const github = createGithub(issueFactory);
+  let closeAttempts = 0;
+  github.rest.pulls.update = async ({ pull_number, state: prState }) => {
+    closeAttempts += 1;
+    if (closeAttempts === 1) {
+      throw new Error("temporary GitHub API failure");
+    }
+    const pr = github.state.openPullRequests.find(
+      (p) => p.number === pull_number,
+    );
+    if (pr) pr.state = prState;
+    return { data: { number: pull_number, state: prState } };
+  };
+  github.state.openPullRequests = [
+    {
+      number: 306,
+      state: "open",
+      created_at: oldDate,
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  const context = {
+    eventName: "schedule",
+    repo: { owner: "org", repo: "repo" },
+    payload: {},
+  };
+  const core = {
+    info() {},
+    warning() {},
+    error() {},
+  };
+
+  await processPrAutomation({ github, context, core });
+  assert.equal(github.state.openPullRequests[0].state, "open");
+  assert.equal(closeAttempts, 1);
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:pr-auto-closed"))
+      .length,
+    0,
+  );
+
+  await processPrAutomation({ github, context, core });
+  assert.equal(github.state.openPullRequests[0].state, "closed");
+  assert.equal(closeAttempts, 2);
+  assert.equal(
+    github.state.comments.filter((c) => c.body.includes("mom:pr-auto-closed"))
+      .length,
+    1,
+  );
+});
+
+test("pr automation: reminds on failed required checks only when completed", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  github.state.openPullRequests = [
+    {
+      number: 303,
+      state: "open",
+      created_at: new Date().toISOString(),
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  github.state.checkRuns = [
+    {
+      name: "Code Quality",
+      status: "completed",
+      conclusion: "failure",
+      html_url: "https://example.com/check",
+    },
+    {
+      name: "Backend Validation",
+      status: "completed",
+      conclusion: "success",
+    },
+    {
+      name: "Frontend Validation",
+      status: "completed",
+      conclusion: "success",
+    },
+    {
+      name: "Integration Tests",
+      status: "completed",
+      conclusion: "success",
+    },
+  ];
+  await processPrAutomation({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.ok(
+    github.state.comments.some((c) =>
+      c.body.includes("mom:pr-failed-checks-reminder"),
+    ),
+  );
+});
+
+test("pr automation: skips failed-check reminder while checks pending", async () => {
+  process.env.GITHUB_REPOSITORY = "org/repo";
+  const github = createGithub(issueFactory);
+  github.state.openPullRequests = [
+    {
+      number: 304,
+      state: "open",
+      created_at: new Date().toISOString(),
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+    },
+  ];
+  github.state.checkRuns = [
+    {
+      name: "Code Quality",
+      status: "in_progress",
+      conclusion: null,
+    },
+    {
+      name: "Backend Validation",
+      status: "completed",
+      conclusion: "success",
+    },
+    {
+      name: "Frontend Validation",
+      status: "completed",
+      conclusion: "success",
+    },
+    {
+      name: "Integration Tests",
+      status: "completed",
+      conclusion: "success",
+    },
+  ];
+  await processPrAutomation({
+    github,
+    context: {
+      eventName: "schedule",
+      repo: { owner: "org", repo: "repo" },
+      payload: {},
+    },
+    core: createCore(),
+  });
+  assert.equal(
+    github.state.comments.filter((c) =>
+      c.body.includes("mom:pr-failed-checks-reminder"),
+    ).length,
+    0,
+  );
+});
+
 test("manual assignment: sets manualAssignment metadata", async () => {
   process.env.GITHUB_REPOSITORY = "org/repo";
   const github = createGithub(issueFactory);
@@ -980,7 +1368,7 @@ test("expiration: duplicate workflow run does not duplicate reminders", async ()
   await processClaimExpiration({ github, context, core: createCore() });
   await processClaimExpiration({ github, context, core: createCore() });
   assert.equal(
-    github.state.comments.filter((c) => c.body.includes("mom:reminder-8h"))
+    github.state.comments.filter((c) => c.body.includes("mom:reminder-6h"))
       .length,
     1,
   );

--- a/.github/workflows/04-claim-expiration.yml
+++ b/.github/workflows/04-claim-expiration.yml
@@ -7,7 +7,9 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
   contents: read
+  checks: read
 
 concurrency:
   group: expiration-${{ github.repository }}
@@ -19,9 +21,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Process claim expiration
+      - name: Process claim expiration and PR automation
         uses: actions/github-script@v8
         with:
           script: |
             const { processClaimExpiration } = await import(`${process.cwd()}/.github/scripts/expiration.js`);
+            const { processPrAutomation } = await import(`${process.cwd()}/.github/scripts/pr.js`);
             await processClaimExpiration({ github, context, core });
+            await processPrAutomation({ github, context, core });


### PR DESCRIPTION
## Summary

Updates the GitHub Actions contributor-management bot with the requested issue assignment, claim-limit, reminder, and PR automation improvements.

## Changes

### Issue automation

- Reduced issue assignment expiration window from 48 hours to 24 hours.
- Changed contributor inactivity reminders from every 8 hours to every 6 hours.
- Updated the reminder schedule to 6h, 12h, and 18h within the 24-hour assignment window.
- Increased the maximum number of simultaneously claimed issues from 4 to 5.

### PR automation

- Automatically closes open PRs that remain open for more than 48 hours.
- Uses the PR `created_at` timestamp for stale-PR detection.
- Stale PR automation only closes PRs and never merges them.
- Added contributor reminders when the latest human review requests changes.
- Excludes ignored/bot CI reviews from changes-requested reminders.
- Added contributor reminders when all required checks have completed and one or more required checks have failed.
- Uses marker-based comments to prevent reminder spam.

### Reliability fixes

During the production audit, two edge-case bugs were identified and fixed:

1. **Stale PR close retry**
   - Previously, the auto-close marker could be created before the PR was actually closed.
   - A transient GitHub API failure could therefore prevent future retry attempts.
   - The implementation now closes the PR first and posts the informational comment only after successful closure.

2. **Stale changes-requested reminder**
   - Previously, an older `CHANGES_REQUESTED` review could continue triggering reminders after a newer human review approved the PR.
   - The implementation now evaluates the latest human review state and only reminds when that latest review is `CHANGES_REQUESTED`.

## Validation

- `node --test .github/scripts/tests/automation.test.js`
  - 45/45 tests passed
- `node --check .github/scripts/pr.js`
- `node --check .github/scripts/helpers.js`
- `node --check .github/scripts/expiration.js`
- `node --check .github/scripts/constants.js`
- `node --check .github/scripts/comments.js`
- `git diff --check`
  - Passed with no whitespace errors

## Regression coverage

Added/updated tests for:

- 5th claim allowed / 6th claim rejected
- 23h59m assignment expiration boundary
- 6h reminder boundary
- 48h PR age boundary
- stale PR close retry after API failure
- approved latest review preventing stale changes-requested reminders

## Scope

No unrelated workflows, dependencies, runtime versions, or existing contributor flows were changed.

Existing `/claim`, `/unclaim`, manual assignment, activity refresh, PR validation, CI validation, merge handling, labels, markers, and workflow scheduling remain intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically closes stale, unmerged pull requests after 48 hours.
  * Sends reminders for requested changes and failed required checks, including links to failed checks.
  * Refreshes reminders to reflect newer review activity.

* **Improvements**
  * Increased the active issue assignment limit from 4 to 5.
  * Updated reminders to occur at 6, 12, and 18 hours, with expiration after 24 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->