### PR TITLE
fix: handle glossary loading errors with retry

### DIFF
--- a/client/src/pages/Glossary.jsx
+++ b/client/src/pages/Glossary.jsx
@@ -10,8 +10,8 @@ import ConfirmModal from "../components/ConfirmModal.jsx";
 const Glossary = () => {
   const [terms, setTerms] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [searchTerm, setSearchTerm] = useState("");
-
   // New term form state
   const [showAddForm, setShowAddForm] = useState(false);
   const [newTerm, setNewTerm] = useState({
@@ -28,10 +28,12 @@ const Glossary = () => {
   const loadTerms = useCallback(async () => {
     try {
       setLoading(true);
+      setError(null);
       const data = await fetchTerms({ search: searchTerm });
       setTerms(data || []);
-    } catch (error) {
-      console.error("Failed to load glossary terms:", error);
+    } catch (loadError) {
+      console.error("Failed to load glossary terms:", loadError);
+      setError("We couldn't load the glossary right now. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -68,8 +70,8 @@ const Glossary = () => {
       setShowAddForm(false);
       setNewTerm({ term: "", definition: "", aliases: "", category: "" });
       loadTerms();
-    } catch (error) {
-      console.error("Failed to add term:", error);
+    } catch (submitError) {
+      console.error("Failed to add term:", submitError);
       alert("Failed to add term");
     }
   };
@@ -81,8 +83,8 @@ const Glossary = () => {
       await deleteTerm(deleteTarget._id);
       setDeleteTarget(null);
       loadTerms();
-    } catch (error) {
-      console.error("Failed to delete term:", error);
+    } catch (deleteError) {
+      console.error("Failed to delete term:", deleteError);
       alert("Failed to delete term");
     } finally {
       setDeleteLoading(false);
@@ -93,8 +95,8 @@ const Glossary = () => {
     try {
       await approveTerm(id);
       loadTerms();
-    } catch (error) {
-      console.error("Failed to approve term:", error);
+    } catch (approveError) {
+      console.error("Failed to approve term:", approveError);
       alert("Failed to approve term");
     }
   };
@@ -166,7 +168,6 @@ const Glossary = () => {
                 />
               </div>
             </div>
-
             <div>
               <label className="block text-sm font-medium text-gray-700">
                 Definition
@@ -182,7 +183,6 @@ const Glossary = () => {
                 placeholder="Definition of the term"
               />
             </div>
-
             <div>
               <label className="block text-sm font-medium text-gray-700">
                 Aliases (comma separated)
@@ -197,7 +197,6 @@ const Glossary = () => {
                 placeholder="Return on Investment"
               />
             </div>
-
             <button
               type="submit"
               className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer"
@@ -231,7 +230,6 @@ const Glossary = () => {
                     {term.category}
                   </span>
                 )}
-
                 <div className="mt-4 flex space-x-2">
                   <button
                     type="button"
@@ -270,6 +268,20 @@ const Glossary = () => {
 
         {loading ? (
           <p className="text-gray-500">Loading terms...</p>
+        ) : error ? (
+          <div
+            role="alert"
+            className="rounded-md border border-red-200 bg-red-50 p-4"
+          >
+            <p className="text-sm text-red-700">{error}</p>
+            <button
+              type="button"
+              onClick={loadTerms}
+              className="mt-3 inline-flex items-center rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700 cursor-pointer"
+            >
+              Retry
+            </button>
+          </div>
         ) : approvedTerms.length === 0 ? (
           <p className="text-gray-500">No approved terms found.</p>
         ) : (

--- a/client/src/pages/__tests__/GlossaryAccessibility.test.jsx
+++ b/client/src/pages/__tests__/GlossaryAccessibility.test.jsx
@@ -37,13 +37,56 @@ describe("Glossary Accessibility (#1491)", () => {
 
     const addButton = screen.getByRole("button", { name: /add term/i });
     fireEvent.click(addButton);
-
     expect(screen.getByRole("dialog")).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "Escape" });
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows a user-friendly error state when glossary loading fails", async () => {
+    api.fetchTerms.mockRejectedValueOnce(
+      new Error("Request failed: 500 Internal Server Error"),
+    );
+
+    render(<Glossary />);
+
+    const alert = await screen.findByRole("alert");
+
+    expect(alert).toHaveTextContent(
+      "We couldn't load the glossary right now. Please try again.",
+    );
+    expect(alert).not.toHaveTextContent("500");
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText("No approved terms found."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("retries glossary loading and clears the error after success", async () => {
+    api.fetchTerms
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValueOnce([
+        {
+          _id: "term-1",
+          term: "ROI",
+          definition: "Return on Investment",
+          approvalStatus: "approved",
+        },
+      ]);
+
+    render(<Glossary />);
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(api.fetchTerms).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("ROI")).toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Improves the Organization Glossary error handling so users receive a clear
error state when glossary terms cannot be loaded instead of seeing an
incorrect empty-state message.

## Related Issue

Closes #1523

## What changed?

- Added explicit glossary loading error state.
- Added a user-friendly error message when fetching terms fails.
- Added an accessible Retry button.
- Retry reuses the existing glossary loading flow.
- Clears stale errors before subsequent requests.
- Clears the error after a successful retry.
- Prevents the empty-state message from appearing while an error is active.
- Added tests covering glossary load failures and successful retry recovery.

## Testing

- [x] Glossary accessibility tests
- [x] Client lint
- [x] Client build
- [x] PR validation
- [x] `git diff --check`

## User Impact

Users now receive actionable feedback when the glossary cannot be loaded,
including a Retry action, instead of being incorrectly told that no approved
terms exist.

## Scope

This PR is intentionally limited to the Organization Glossary loading/error
experience and its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Glossary loading failures now display a clear error alert with a Retry option.
  - Empty-state messaging is hidden while an error is shown.
  - Retrying successfully reloads glossary content and dismisses the error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->