### PR TITLE
fix: replace recap retry alerts with inline feedback

### DIFF
--- a/client/src/pages/RecapScheduleDashboard.jsx
+++ b/client/src/pages/RecapScheduleDashboard.jsx
@@ -13,10 +13,11 @@ import {
   Calendar,
 } from "lucide-react";
 
+const RETRY_FEEDBACK_TIMEOUT = 3000;
+
 const RecapScheduleDashboard = () => {
   const { userData } = useContext(AppContent);
   const organizationId = userData?.organization?._id || userData?.organization;
-
   const [schedule, setSchedule] = useState({
     scheduleType: "immediate",
     deliveryChannel: "email",
@@ -28,7 +29,9 @@ const RecapScheduleDashboard = () => {
   const [history, setHistory] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [retryingDeliveryId, setRetryingDeliveryId] = useState(null);
   const [saveMessage, setSaveMessage] = useState({ type: "", text: "" });
+  const [retryMessage, setRetryMessage] = useState({ type: "", text: "" });
 
   useEffect(() => {
     const fetchData = async () => {
@@ -38,7 +41,6 @@ const RecapScheduleDashboard = () => {
           recapScheduleApi.getSchedule(organizationId),
           recapScheduleApi.getDeliveryHistory(),
         ]);
-
         if (scheduleRes.status === "fulfilled" && scheduleRes.value.data) {
           const data = scheduleRes.value.data;
           setSchedule({
@@ -54,64 +56,47 @@ const RecapScheduleDashboard = () => {
               : "",
           });
         }
-
-        if (historyRes.status === "fulfilled" && historyRes.value.data) {
+        if (historyRes.status === "fulfilled" && historyRes.value.data)
           setHistory(historyRes.value.data);
-        }
       } catch (error) {
         console.error("Failed to fetch dashboard data:", error);
       } finally {
         setIsLoading(false);
       }
     };
-
-    if (organizationId) {
-      fetchData();
-    }
+    if (organizationId) fetchData();
   }, [organizationId]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setSchedule((prev) => ({ ...prev, [name]: value }));
-    if (saveMessage.type === "error") {
-      setSaveMessage({ type: "", text: "" });
-    }
+    if (saveMessage.type === "error") setSaveMessage({ type: "", text: "" });
   };
 
   const validateSchedule = () => {
-    if (!schedule.timezone || !schedule.timezone.trim()) {
+    if (!schedule.timezone || !schedule.timezone.trim())
       return "Timezone cannot be empty.";
-    }
-
     const todayStr = new Date().toISOString().slice(0, 10);
-
-    if (schedule.startDate && schedule.startDate < todayStr) {
+    if (schedule.startDate && schedule.startDate < todayStr)
       return "Start date cannot be in the past.";
-    }
-
     if (
       schedule.startDate &&
       schedule.endDate &&
       schedule.endDate < schedule.startDate
-    ) {
+    )
       return "End date must be on or after start date.";
-    }
-
     return null;
   };
 
   const handleSave = async (e) => {
     e.preventDefault();
-
     const validationError = validateSchedule();
     if (validationError) {
       setSaveMessage({ type: "error", text: validationError });
       return;
     }
-
     setIsSaving(true);
     setSaveMessage({ type: "", text: "" });
-
     try {
       await recapScheduleApi.upsertSchedule(organizationId, schedule);
       setSaveMessage({
@@ -128,12 +113,26 @@ const RecapScheduleDashboard = () => {
   };
 
   const handleRetry = async (deliveryId) => {
+    setRetryingDeliveryId(deliveryId);
+    setRetryMessage({ type: "", text: "" });
     try {
       await recapScheduleApi.retryDelivery(deliveryId);
-      alert("Retry enqueued successfully!");
+      setRetryMessage({
+        type: "success",
+        text: "Retry enqueued successfully.",
+      });
+      setTimeout(
+        () => setRetryMessage({ type: "", text: "" }),
+        RETRY_FEEDBACK_TIMEOUT,
+      );
     } catch (error) {
       console.error("Retry failed:", error);
-      alert("Failed to enqueue retry.");
+      setRetryMessage({
+        type: "error",
+        text: "We couldn't enqueue the retry. Please try again.",
+      });
+    } finally {
+      setRetryingDeliveryId(null);
     }
   };
 
@@ -150,21 +149,18 @@ const RecapScheduleDashboard = () => {
             history.
           </p>
         </div>
-
         {isLoading ? (
           <div className="flex justify-center items-center py-20">
             <RefreshCw className="h-8 w-8 text-blue-600 animate-spin" />
           </div>
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            {/* Configuration Form */}
             <div className="lg:col-span-1">
               <div className="bg-white dark:bg-gray-800 shadow rounded-xl p-6 border border-slate-200 dark:border-gray-700">
                 <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2 mb-4">
                   <Clock className="w-5 h-5 text-blue-600" />
                   Schedule Settings
                 </h2>
-
                 <form noValidate onSubmit={handleSave} className="space-y-4">
                   <div>
                     <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
@@ -181,7 +177,6 @@ const RecapScheduleDashboard = () => {
                       <option value="weekly">Weekly</option>
                     </select>
                   </div>
-
                   <div>
                     <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
                       Delivery Channel
@@ -197,7 +192,6 @@ const RecapScheduleDashboard = () => {
                       <option value="webhook">Webhook</option>
                     </select>
                   </div>
-
                   {schedule.scheduleType !== "immediate" && (
                     <div>
                       <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
@@ -212,7 +206,6 @@ const RecapScheduleDashboard = () => {
                       />
                     </div>
                   )}
-
                   <div>
                     <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
                       Timezone
@@ -226,8 +219,6 @@ const RecapScheduleDashboard = () => {
                       className="w-full rounded-lg border-slate-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-blue-500 focus:ring-blue-500"
                     />
                   </div>
-
-                  {/* Date Range Validation Fields (#1308) */}
                   <div className="grid grid-cols-2 gap-2">
                     <div>
                       <label
@@ -262,7 +253,6 @@ const RecapScheduleDashboard = () => {
                       />
                     </div>
                   </div>
-
                   <button
                     type="submit"
                     disabled={isSaving}
@@ -275,15 +265,10 @@ const RecapScheduleDashboard = () => {
                     )}
                     {isSaving ? "Saving..." : "Save Preferences"}
                   </button>
-
                   {saveMessage.text && (
                     <div
                       role="alert"
-                      className={`p-3 rounded-md flex items-center gap-2 text-sm ${
-                        saveMessage.type === "success"
-                          ? "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                          : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400"
-                      }`}
+                      className={`p-3 rounded-md flex items-center gap-2 text-sm ${saveMessage.type === "success" ? "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400" : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400"}`}
                     >
                       {saveMessage.type === "success" ? (
                         <CheckCircle2 className="w-4 h-4" />
@@ -296,8 +281,6 @@ const RecapScheduleDashboard = () => {
                 </form>
               </div>
             </div>
-
-            {/* Delivery History */}
             <div className="lg:col-span-2">
               <div className="bg-white dark:bg-gray-800 shadow rounded-xl border border-slate-200 dark:border-gray-700 flex flex-col h-full">
                 <div className="p-6 border-b border-slate-200 dark:border-gray-700">
@@ -306,8 +289,21 @@ const RecapScheduleDashboard = () => {
                     Delivery History
                   </h2>
                 </div>
-
                 <div className="p-0 overflow-x-auto">
+                  {retryMessage.text && (
+                    <div
+                      role="alert"
+                      aria-live="polite"
+                      className={`m-4 p-3 rounded-md flex items-center gap-2 text-sm ${retryMessage.type === "success" ? "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400" : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400"}`}
+                    >
+                      {retryMessage.type === "success" ? (
+                        <CheckCircle2 className="w-4 h-4" aria-hidden="true" />
+                      ) : (
+                        <AlertCircle className="w-4 h-4" aria-hidden="true" />
+                      )}
+                      <span>{retryMessage.text}</span>
+                    </div>
+                  )}
                   <table className="w-full text-left border-collapse">
                     <thead>
                       <tr className="bg-slate-50 dark:bg-gray-900/50 text-slate-500 dark:text-gray-400 text-sm">
@@ -344,9 +340,21 @@ const RecapScheduleDashboard = () => {
                               <button
                                 type="button"
                                 onClick={() => handleRetry(delivery._id)}
-                                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 font-medium cursor-pointer"
+                                disabled={retryingDeliveryId === delivery._id}
+                                aria-label={`Retry delivery for ${delivery.meetingId?.title || "Unknown Meeting"}`}
+                                className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 font-medium cursor-pointer disabled:opacity-60 disabled:cursor-wait"
                               >
-                                Retry
+                                {retryingDeliveryId === delivery._id ? (
+                                  <span className="inline-flex items-center gap-1">
+                                    <RefreshCw
+                                      className="w-3.5 h-3.5 animate-spin"
+                                      aria-hidden="true"
+                                    />
+                                    Retrying...
+                                  </span>
+                                ) : (
+                                  "Retry"
+                                )}
                               </button>
                             </td>
                           </tr>

--- a/client/src/pages/__tests__/RecapScheduleValidation.test.jsx
+++ b/client/src/pages/__tests__/RecapScheduleValidation.test.jsx
@@ -12,14 +12,9 @@ vi.mock("@clerk/clerk-react", () => ({
   useUser: () => ({ user: null }),
   useClerk: () => ({ signOut: vi.fn() }),
 }));
-
 vi.mock("react-toastify", () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
-
 vi.mock("../../services/recapScheduleApi.js", () => ({
   recapScheduleApi: {
     getSchedule: vi
@@ -27,43 +22,46 @@ vi.mock("../../services/recapScheduleApi.js", () => ({
       .mockResolvedValue({ data: { scheduleType: "daily", timezone: "UTC" } }),
     getDeliveryHistory: vi.fn().mockResolvedValue({ data: [] }),
     upsertSchedule: vi.fn(),
+    retryDelivery: vi.fn(),
   },
 }));
 
 const mockUserData = {
   organization: { _id: "org-123", name: "Engineering Org" },
 };
+const renderDashboard = () =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <AppContent.Provider value={{ userData: mockUserData }}>
+          <RBACProvider>
+            <RecapScheduleDashboard />
+          </RBACProvider>
+        </AppContent.Provider>
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
 
 describe("RecapScheduleDashboard Date & Timezone Validation (#1308)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    recapScheduleApi.getSchedule.mockResolvedValue({
+      data: { scheduleType: "daily", timezone: "UTC" },
+    });
+    recapScheduleApi.getDeliveryHistory.mockResolvedValue({ data: [] });
   });
 
   it("prevents submission when start date is set in the past", async () => {
-    render(
-      <MemoryRouter>
-        <ThemeProvider>
-          <AppContent.Provider value={{ userData: mockUserData }}>
-            <RBACProvider>
-              <RecapScheduleDashboard />
-            </RBACProvider>
-          </AppContent.Provider>
-        </ThemeProvider>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
+    renderDashboard();
+    await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /save preferences/i }),
-      ).toBeInTheDocument();
+      ).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByLabelText(/start date/i), {
+      target: { value: "2020-01-01" },
     });
-
-    const startDateInput = screen.getByLabelText(/start date/i);
-    fireEvent.change(startDateInput, { target: { value: "2020-01-01" } });
-
-    const saveBtn = screen.getByRole("button", { name: /save preferences/i });
-    fireEvent.click(saveBtn);
-
+    fireEvent.click(screen.getByRole("button", { name: /save preferences/i }));
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Start date cannot be in the past.",
     );
@@ -71,36 +69,133 @@ describe("RecapScheduleDashboard Date & Timezone Validation (#1308)", () => {
   });
 
   it("prevents submission when end date is before start date", async () => {
-    render(
-      <MemoryRouter>
-        <ThemeProvider>
-          <AppContent.Provider value={{ userData: mockUserData }}>
-            <RBACProvider>
-              <RecapScheduleDashboard />
-            </RBACProvider>
-          </AppContent.Provider>
-        </ThemeProvider>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
+    renderDashboard();
+    await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /save preferences/i }),
-      ).toBeInTheDocument();
+      ).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByLabelText(/start date/i), {
+      target: { value: "2026-12-10" },
     });
-
-    const startDateInput = screen.getByLabelText(/start date/i);
-    const endDateInput = screen.getByLabelText(/end date/i);
-
-    fireEvent.change(startDateInput, { target: { value: "2026-12-10" } });
-    fireEvent.change(endDateInput, { target: { value: "2026-12-01" } });
-
-    const saveBtn = screen.getByRole("button", { name: /save preferences/i });
-    fireEvent.click(saveBtn);
-
+    fireEvent.change(screen.getByLabelText(/end date/i), {
+      target: { value: "2026-12-01" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save preferences/i }));
     expect(screen.getByRole("alert")).toHaveTextContent(
       "End date must be on or after start date.",
     );
     expect(recapScheduleApi.upsertSchedule).not.toHaveBeenCalled();
+  });
+});
+
+describe("RecapScheduleDashboard Retry Feedback (#1524)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recapScheduleApi.getSchedule.mockResolvedValue({
+      data: { scheduleType: "daily", timezone: "UTC" },
+    });
+  });
+
+  it("shows inline success feedback when a retry is enqueued", async () => {
+    recapScheduleApi.getDeliveryHistory.mockResolvedValue({
+      data: [
+        {
+          _id: "delivery-1",
+          deliveredAt: "2026-08-14T10:00:00.000Z",
+          meetingId: { title: "Weekly Sync" },
+        },
+      ],
+    });
+    recapScheduleApi.retryDelivery.mockResolvedValue({
+      data: { queued: true },
+    });
+    const alertSpy = vi.spyOn(window, "alert");
+    renderDashboard();
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /retry delivery for weekly sync/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(recapScheduleApi.retryDelivery).toHaveBeenCalledWith("delivery-1");
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Retry enqueued successfully.",
+      );
+    });
+    expect(alertSpy).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  it("shows a friendly inline error without exposing the backend error", async () => {
+    recapScheduleApi.getDeliveryHistory.mockResolvedValue({
+      data: [
+        {
+          _id: "delivery-2",
+          deliveredAt: "2026-08-14T10:00:00.000Z",
+          meetingId: { title: "Planning Review" },
+        },
+      ],
+    });
+    recapScheduleApi.retryDelivery.mockRejectedValue(
+      new Error("500: queue connection failed; internal token=secret"),
+    );
+    const alertSpy = vi.spyOn(window, "alert");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderDashboard();
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /retry delivery for planning review/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "We couldn't enqueue the retry. Please try again.",
+      ),
+    );
+    expect(screen.getByRole("alert")).not.toHaveTextContent(
+      "queue connection failed",
+    );
+    expect(screen.getByRole("alert")).not.toHaveTextContent("secret");
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    alertSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("disables the retry action while the request is pending", async () => {
+    let resolveRetry;
+    recapScheduleApi.getDeliveryHistory.mockResolvedValue({
+      data: [
+        {
+          _id: "delivery-3",
+          deliveredAt: "2026-08-14T10:00:00.000Z",
+          meetingId: { title: "Standup" },
+        },
+      ],
+    });
+    recapScheduleApi.retryDelivery.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    renderDashboard();
+    const retryButton = await screen.findByRole("button", {
+      name: /retry delivery for standup/i,
+    });
+    fireEvent.click(retryButton);
+    await waitFor(() => {
+      expect(recapScheduleApi.retryDelivery).toHaveBeenCalledTimes(1);
+      expect(retryButton).toBeDisabled();
+      expect(retryButton).toHaveTextContent("Retrying...");
+    });
+    resolveRetry({ data: { queued: true } });
+    await waitFor(() => {
+      expect(retryButton).not.toBeDisabled();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Retry enqueued successfully.",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Replaces native browser alerts in the recap delivery retry flow with accessible inline feedback.

## Related Issue

Closes #1524

## What changed?

- Replaced native `alert()` calls in the recap retry flow with inline feedback.
- Added success and failure retry feedback.
- Prevented raw backend error details from being displayed to users.
- Added retry loading/disabled state.
- Preserved the existing retry API behavior.
- Kept schedule-save feedback independent from retry feedback.
- Added automated coverage for successful and failed retry attempts.
- Verified that retry failures do not invoke `window.alert`.

## Validation

- [x] Prettier
- [x] ESLint
- [x] Targeted Vitest tests
- [x] Client PR validation
- [x] Production build

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation