### PR TITLE
fix: prevent duplicate template actions

### DIFF
--- a/client/src/pages/TemplateLibrary.jsx
+++ b/client/src/pages/TemplateLibrary.jsx
@@ -16,6 +16,8 @@ const TemplateLibrary = () => {
   const [selectedTemplate, setSelectedTemplate] = useState(null);
   const [ratingInput, setRatingInput] = useState(5);
   const [reviewInput, setReviewInput] = useState("");
+  const [cloningTemplateId, setCloningTemplateId] = useState(null);
+  const [ratingTemplateId, setRatingTemplateId] = useState(null);
 
   const fetchTemplates = async () => {
     setLoading(true);
@@ -39,16 +41,24 @@ const TemplateLibrary = () => {
   }, [categoryFilter, sortOption]);
 
   const handleClone = async (templateId) => {
+    if (cloningTemplateId) return;
+
+    setCloningTemplateId(templateId);
     try {
       await cloneTemplate(templateId);
       alert("Template cloned successfully!");
-      fetchTemplates(); // Refresh to update clone count
+      await fetchTemplates();
     } catch {
       alert("Failed to clone template");
+    } finally {
+      setCloningTemplateId(null);
     }
   };
 
   const handleRate = async (templateId) => {
+    if (ratingTemplateId) return;
+
+    setRatingTemplateId(templateId);
     try {
       await rateTemplate(templateId, {
         rating: ratingInput,
@@ -57,10 +67,12 @@ const TemplateLibrary = () => {
       alert("Rating submitted successfully!");
       setRatingInput(5);
       setReviewInput("");
-      fetchTemplates(); // Refresh to update rating
-      setSelectedTemplate(null); // Close modal
+      await fetchTemplates();
+      setSelectedTemplate(null);
     } catch {
       alert("Failed to submit rating");
+    } finally {
+      setRatingTemplateId(null);
     }
   };
 
@@ -158,7 +170,6 @@ const TemplateLibrary = () => {
         )}
       </div>
 
-      {/* Modal */}
       {selectedTemplate && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-800 rounded-xl max-w-lg w-full p-6">
@@ -168,6 +179,7 @@ const TemplateLibrary = () => {
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
               {selectedTemplate.description}
             </p>
+
             <div className="mb-6">
               <h4 className="font-semibold text-gray-700 dark:text-gray-300 mb-2">
                 Agenda Blocks
@@ -184,10 +196,14 @@ const TemplateLibrary = () => {
             <div className="flex gap-4 mb-6">
               <button
                 onClick={() => handleClone(selectedTemplate._id)}
-                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-lg font-medium transition flex items-center justify-center"
+                disabled={cloningTemplateId === selectedTemplate._id}
+                aria-busy={cloningTemplateId === selectedTemplate._id}
+                className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed text-white py-2 px-4 rounded-lg font-medium transition flex items-center justify-center"
               >
                 <CopyPlus className="w-5 h-5 mr-2" />
-                Clone Template
+                {cloningTemplateId === selectedTemplate._id
+                  ? "Cloning..."
+                  : "Clone Template"}
               </button>
             </div>
 
@@ -206,7 +222,9 @@ const TemplateLibrary = () => {
                         ? "text-yellow-400 fill-current"
                         : "text-gray-300"
                     }`}
-                    onClick={() => setRatingInput(star)}
+                    onClick={() => {
+                      if (!ratingTemplateId) setRatingInput(star);
+                    }}
                   />
                 ))}
               </div>
@@ -214,21 +232,27 @@ const TemplateLibrary = () => {
                 value={reviewInput}
                 onChange={(e) => setReviewInput(e.target.value)}
                 placeholder="Leave a review..."
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-2 text-sm mb-2 dark:bg-gray-700 dark:text-white"
+                disabled={ratingTemplateId === selectedTemplate._id}
+                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-2 text-sm mb-2 dark:bg-gray-700 dark:text-white disabled:opacity-60"
                 rows="3"
               />
               <div className="flex justify-end gap-2">
                 <button
                   onClick={() => setSelectedTemplate(null)}
-                  className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition"
+                  disabled={Boolean(ratingTemplateId)}
+                  className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={() => handleRate(selectedTemplate._id)}
-                  className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition"
+                  disabled={ratingTemplateId === selectedTemplate._id}
+                  aria-busy={ratingTemplateId === selectedTemplate._id}
+                  className="px-4 py-2 bg-green-600 hover:bg-green-700 disabled:opacity-60 disabled:cursor-not-allowed text-white rounded-lg transition"
                 >
-                  Submit Rating
+                  {ratingTemplateId === selectedTemplate._id
+                    ? "Submitting..."
+                    : "Submit Rating"}
                 </button>
               </div>
             </div>

--- a/client/src/pages/__tests__/TemplateLibraryDuplicateSubmission.test.jsx
+++ b/client/src/pages/__tests__/TemplateLibraryDuplicateSubmission.test.jsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TemplateLibrary from "../TemplateLibrary.jsx";
+import {
+  browseTemplates,
+  cloneTemplate,
+  rateTemplate,
+} from "../../services/templateLibraryApi";
+
+vi.mock("../components/Navbar.jsx", () => ({
+  default: () => <nav>Navbar</nav>,
+}));
+
+vi.mock("lucide-react", () => ({
+  CopyPlus: () => <span />,
+  Star: () => <span />,
+  ChevronDown: () => <span />,
+  Filter: () => <span />,
+}));
+
+vi.mock("../../services/templateLibraryApi", () => ({
+  browseTemplates: vi.fn(),
+  cloneTemplate: vi.fn(),
+  rateTemplate: vi.fn(),
+}));
+
+const template = {
+  _id: "template-1",
+  name: "Weekly Sync",
+  category: "Engineering",
+  description: "A weekly engineering sync",
+  cloneCount: 3,
+  averageRating: 4.5,
+  agendaBlocks: [{ title: "Updates", duration: 15 }],
+};
+
+const otherTemplate = {
+  ...template,
+  _id: "template-2",
+  name: "Planning Session",
+};
+
+describe("TemplateLibrary duplicate-submission protection (#1525)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    browseTemplates.mockResolvedValue({
+      templates: [template, otherTemplate],
+    });
+    cloneTemplate.mockResolvedValue({});
+    rateTemplate.mockResolvedValue({});
+  });
+
+  it("disables only the active clone operation while it is pending", async () => {
+    let resolveClone;
+    cloneTemplate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveClone = resolve;
+        }),
+    );
+
+    render(<TemplateLibrary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly Sync")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Weekly Sync"));
+
+    const cloneButton = screen.getByRole("button", { name: "Clone Template" });
+    fireEvent.click(cloneButton);
+
+    expect(screen.getByRole("button", { name: "Cloning..." })).toBeDisabled();
+    expect(cloneTemplate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cloning..." }));
+    expect(cloneTemplate).toHaveBeenCalledTimes(1);
+
+    resolveClone({});
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Clone Template" }),
+      ).toBeEnabled();
+    });
+  });
+
+  it("restores clone interaction after a failed request", async () => {
+    let rejectClone;
+    cloneTemplate.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectClone = reject;
+        }),
+    );
+
+    render(<TemplateLibrary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly Sync")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Weekly Sync"));
+    fireEvent.click(screen.getByRole("button", { name: "Clone Template" }));
+
+    expect(screen.getByRole("button", { name: "Cloning..." })).toBeDisabled();
+
+    rejectClone(new Error("clone failed"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Clone Template" }),
+      ).toBeEnabled();
+    });
+  });
+
+  it("prevents duplicate rating submissions while the request is pending", async () => {
+    let resolveRating;
+    rateTemplate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRating = resolve;
+        }),
+    );
+
+    render(<TemplateLibrary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly Sync")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Weekly Sync"));
+
+    const submitButton = screen.getByRole("button", { name: "Submit Rating" });
+    fireEvent.click(submitButton);
+
+    expect(
+      screen.getByRole("button", { name: "Submitting..." }),
+    ).toBeDisabled();
+    expect(rateTemplate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Submitting..." }));
+    expect(rateTemplate).toHaveBeenCalledTimes(1);
+
+    resolveRating({});
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Submitting..." }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("restores rating interaction after a failed request", async () => {
+    let rejectRating;
+    rateTemplate.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectRating = reject;
+        }),
+    );
+
+    render(<TemplateLibrary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly Sync")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Weekly Sync"));
+    fireEvent.click(screen.getByRole("button", { name: "Submit Rating" }));
+
+    expect(
+      screen.getByRole("button", { name: "Submitting..." }),
+    ).toBeDisabled();
+
+    rejectRating(new Error("rating failed"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Submit Rating" }),
+      ).toBeEnabled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds operation-specific loading and disabled states to Template Library clone and rating actions to prevent accidental duplicate submissions.

## Related Issue

Closes #1525

## What changed?

- Track the template currently being cloned.
- Disable the active clone action while the request is pending.
- Show `Cloning...` while cloning.
- Prevent repeated clone submissions.
- Track the active rating submission.
- Disable the rating submit action while the request is pending.
- Show `Submitting...` while rating.
- Restore controls after success or failure.
- Keep unrelated template actions interactive.
- Preserve existing clone and rating API behavior.
- Preserve existing success and error feedback.
- Add tests for duplicate-click prevention and state restoration.

## Testing

- [x] Prettier
- [x] ESLint
- [x] Targeted Vitest test
- [x] `npm run validate:pr`
- [x] `npm run build`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation