### PR TITLE
fix: correct parking lot API route prefix

### DIFF
--- a/client/src/services/__tests__/parkingLotApi.test.js
+++ b/client/src/services/__tests__/parkingLotApi.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import apiClient from "../apiClient";
+import { parkingLotApi } from "../parkingLotApi";
+
+vi.mock("../apiClient", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("parkingLotApi endpoint contract (#1548)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the canonical /api prefix when creating a parking-lot topic", () => {
+    parkingLotApi.addTopic({ title: "Follow up" });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/api/parking-lot", {
+      title: "Follow up",
+    });
+  });
+
+  it("uses the canonical /api prefix when listing an organization's parking lot", () => {
+    parkingLotApi.getOrganizationParkingLot("org-123", { status: "open" });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/parking-lot/organization/org-123",
+      { params: { status: "open" } },
+    );
+  });
+
+  it("uses the canonical /api prefix when updating topic status", () => {
+    parkingLotApi.updateTopicStatus("topic-123", { status: "resolved" });
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      "/api/parking-lot/topic-123/status",
+      { status: "resolved" },
+    );
+  });
+
+  it("uses the canonical /api prefix when assigning topics", () => {
+    parkingLotApi.assignTopics({ topicIds: ["topic-1", "topic-2"] });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/api/parking-lot/assign", {
+      topicIds: ["topic-1", "topic-2"],
+    });
+  });
+
+  it("never generates a duplicate /api/api prefix", () => {
+    parkingLotApi.addTopic({ title: "No duplicate prefix" });
+    parkingLotApi.getOrganizationParkingLot("org-123");
+    parkingLotApi.updateTopicStatus("topic-123", { status: "open" });
+    parkingLotApi.assignTopics({ topicIds: ["topic-1"] });
+
+    const requestedPaths = [
+      ...apiClient.post.mock.calls.map(([path]) => path),
+      ...apiClient.get.mock.calls.map(([path]) => path),
+      ...apiClient.patch.mock.calls.map(([path]) => path),
+    ];
+
+    expect(requestedPaths).toHaveLength(4);
+    expect(requestedPaths.every((path) => !path.includes("/api/api/"))).toBe(
+      true,
+    );
+    expect(requestedPaths.every((path) => path.startsWith("/api/"))).toBe(true);
+  });
+});

--- a/client/src/services/parkingLotApi.js
+++ b/client/src/services/parkingLotApi.js
@@ -1,10 +1,16 @@
 import apiClient from "./apiClient";
 
+const PARKING_LOT_BASE_PATH = "/api/parking-lot";
+
 export const parkingLotApi = {
-  addTopic: (data) => apiClient.post("/parking-lot", data),
+  addTopic: (data) => apiClient.post(PARKING_LOT_BASE_PATH, data),
+
   getOrganizationParkingLot: (orgId, params) =>
-    apiClient.get(`/parking-lot/organization/${orgId}`, { params }),
+    apiClient.get(`${PARKING_LOT_BASE_PATH}/organization/${orgId}`, { params }),
+
   updateTopicStatus: (id, data) =>
-    apiClient.patch(`/parking-lot/${id}/status`, data),
-  assignTopics: (data) => apiClient.post("/parking-lot/assign", data),
+    apiClient.patch(`${PARKING_LOT_BASE_PATH}/${id}/status`, data),
+
+  assignTopics: (data) =>
+    apiClient.post(`${PARKING_LOT_BASE_PATH}/assign`, data),
 };


### PR DESCRIPTION
## Summary

Fixes the Parking Lot frontend API route prefix mismatch.

## Related Issue

Closes #1548

## What changed?

- Updated Parking Lot API requests to use the canonical `/api/parking-lot` prefix.
- Kept the shared API client's backend base URL unchanged.
- Added regression tests for all currently exposed Parking Lot operations.
- Added coverage preventing accidental `/api/api/...` URLs.

## Verified operations

- Create parking-lot topic
- List an organization's parking lot
- Update topic status
- Assign topics

## Testing

- [x] Parking Lot API regression tests
- [x] Client ESLint
- [x] Client production build
- [x] `git diff --check`

## Scope

This PR is intentionally limited to the Parking Lot API client route contract and its regression tests.

## Screenshots
<img width="1162" height="300" alt="Screenshot 2026-08-14 214723" src="https://github.com/user-attachments/assets/4596562d-f3ce-41c9-bd3c-a9a070359aec" />
