### PR TITLE
fix: correct meeting checklist API routes

### DIFF
--- a/client/src/services/__tests__/meetingChecklistApi.test.js
+++ b/client/src/services/__tests__/meetingChecklistApi.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../apiClient", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import api from "../apiClient";
+import { meetingChecklistApi } from "../meetingChecklistApi";
+
+describe("meetingChecklistApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the canonical /api prefix for get", async () => {
+    await meetingChecklistApi.getChecklist("meeting-1");
+    expect(api.get).toHaveBeenCalledWith("/api/meetings/meeting-1/checklist");
+  });
+
+  it("uses the canonical /api prefix for create", async () => {
+    const data = { items: [{ text: "Prepare agenda" }] };
+    await meetingChecklistApi.createChecklist("meeting-1", data);
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/meetings/meeting-1/checklist",
+      data,
+    );
+  });
+
+  it("uses the canonical /api prefix for update", async () => {
+    const data = { items: [{ text: "Updated agenda" }] };
+    await meetingChecklistApi.updateChecklist("meeting-1", data);
+    expect(api.put).toHaveBeenCalledWith(
+      "/api/meetings/meeting-1/checklist",
+      data,
+    );
+  });
+
+  it("uses the canonical /api prefix for delete", async () => {
+    await meetingChecklistApi.deleteChecklist("meeting-1");
+    expect(api.delete).toHaveBeenCalledWith(
+      "/api/meetings/meeting-1/checklist",
+    );
+  });
+
+  it("uses the canonical /api prefix for toggle", async () => {
+    await meetingChecklistApi.toggleItem("meeting-1", 2);
+    expect(api.patch).toHaveBeenCalledWith(
+      "/api/meetings/meeting-1/checklist/toggle",
+      { itemIndex: 2 },
+    );
+  });
+
+  it("uses the canonical /api prefix for readiness", async () => {
+    await meetingChecklistApi.getReadiness("meeting-1");
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/meetings/meeting-1/checklist/readiness",
+    );
+  });
+
+  it("never produces a duplicated /api/api path", async () => {
+    await meetingChecklistApi.getChecklist("meeting-2");
+    await meetingChecklistApi.createChecklist("meeting-2", {
+      items: [{ text: "Review notes" }],
+    });
+    await meetingChecklistApi.updateChecklist("meeting-2", {
+      items: [{ text: "Review notes" }],
+    });
+    await meetingChecklistApi.deleteChecklist("meeting-2");
+    await meetingChecklistApi.toggleItem("meeting-2", 0);
+    await meetingChecklistApi.getReadiness("meeting-2");
+
+    const calls = [
+      ...api.get.mock.calls,
+      ...api.post.mock.calls,
+      ...api.put.mock.calls,
+      ...api.delete.mock.calls,
+      ...api.patch.mock.calls,
+    ];
+
+    for (const [path] of calls) {
+      expect(path).not.toContain("/api/api/");
+    }
+  });
+});

--- a/client/src/services/meetingChecklistApi.js
+++ b/client/src/services/meetingChecklistApi.js
@@ -1,26 +1,36 @@
 import api from "./apiClient";
 
 const getChecklist = async (meetingId) => {
-  return await api.get(`/meetings/${meetingId}/checklist`);
+  return await api.get(`/api/meetings/${meetingId}/checklist`);
 };
 
 const createChecklist = async (meetingId, checklistData) => {
-  return await api.post(`/meetings/${meetingId}/checklist`, checklistData);
+  return await api.post(`/api/meetings/${meetingId}/checklist`, checklistData);
+};
+
+const updateChecklist = async (meetingId, checklistData) => {
+  return await api.put(`/api/meetings/${meetingId}/checklist`, checklistData);
+};
+
+const deleteChecklist = async (meetingId) => {
+  return await api.delete(`/api/meetings/${meetingId}/checklist`);
 };
 
 const toggleItem = async (meetingId, itemIndex) => {
-  return await api.patch(`/meetings/${meetingId}/checklist/toggle`, {
+  return await api.patch(`/api/meetings/${meetingId}/checklist/toggle`, {
     itemIndex,
   });
 };
 
 const getReadiness = async (meetingId) => {
-  return await api.get(`/meetings/${meetingId}/checklist/readiness`);
+  return await api.get(`/api/meetings/${meetingId}/checklist/readiness`);
 };
 
 export const meetingChecklistApi = {
   getChecklist,
   createChecklist,
+  updateChecklist,
+  deleteChecklist,
   toggleItem,
   getReadiness,
 };

--- a/server/controllers/meetingChecklistController.js
+++ b/server/controllers/meetingChecklistController.js
@@ -8,21 +8,36 @@ import {
 } from "../utils/errors.js";
 import { sendSuccess } from "../utils/responseHandler.js";
 
+const checklistItemSchema = z.object({
+  text: z.string().min(1, "Item text is required"),
+  description: z.string().optional(),
+  required: z.boolean().optional(),
+});
+
 const createChecklistSchema = z.object({
-  items: z
-    .array(
-      z.object({
-        text: z.string().min(1, "Item text is required"),
-        description: z.string().optional(),
-        required: z.boolean().optional(),
-      }),
-    )
-    .min(1, "At least one item is required"),
+  items: z.array(checklistItemSchema).min(1, "At least one item is required"),
 });
 
 const toggleItemSchema = z.object({
   itemIndex: z.number().int().min(0),
 });
+
+const canManageChecklist = (meeting, req) =>
+  meeting.uploadedBy.toString() === req.user.id || req.user.role === "admin";
+
+const requireMeetingOwner = (meeting, req, message) => {
+  if (!canManageChecklist(meeting, req)) {
+    throw new UnauthorizedError(message);
+  }
+};
+
+const findMeetingOrThrow = async (meetingId) => {
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    throw new NotFoundError("Meeting not found");
+  }
+  return meeting;
+};
 
 export const createChecklist = async (req, res, next) => {
   try {
@@ -30,16 +45,12 @@ export const createChecklist = async (req, res, next) => {
     const { items } = createChecklistSchema.parse(req.body);
     const userId = req.user.id;
 
-    const meeting = await Meeting.findById(meetingId);
-    if (!meeting) {
-      throw new NotFoundError("Meeting not found");
-    }
-
-    if (meeting.uploadedBy.toString() !== userId && req.user.role !== "admin") {
-      throw new UnauthorizedError(
-        "Only the meeting owner can create a checklist",
-      );
-    }
+    const meeting = await findMeetingOrThrow(meetingId);
+    requireMeetingOwner(
+      meeting,
+      req,
+      "Only the meeting owner can create a checklist",
+    );
 
     const existingChecklist = await MeetingChecklist.findOne({ meetingId });
     if (existingChecklist) {
@@ -63,14 +74,64 @@ export const createChecklist = async (req, res, next) => {
 export const getChecklist = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
-
     const checklist = await MeetingChecklist.findOne({ meetingId });
+
     if (!checklist) {
-      // It's okay if a meeting doesn't have a checklist yet
       return sendSuccess(res, { checklist: null }, "No checklist found");
     }
 
     sendSuccess(res, { checklist }, "Checklist retrieved successfully");
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateChecklist = async (req, res, next) => {
+  try {
+    const { meetingId } = req.params;
+    const { items } = createChecklistSchema.parse(req.body);
+
+    const meeting = await findMeetingOrThrow(meetingId);
+    requireMeetingOwner(
+      meeting,
+      req,
+      "Only the meeting owner can update a checklist",
+    );
+
+    const checklist = await MeetingChecklist.findOne({ meetingId });
+    if (!checklist) {
+      throw new NotFoundError("Checklist not found");
+    }
+
+    checklist.items = items;
+    // Item indexes can change when the checklist is edited, so completions
+    // cannot safely be carried over to the new item ordering.
+    checklist.completions = [];
+    await checklist.save();
+
+    sendSuccess(res, { checklist }, "Checklist updated successfully");
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteChecklist = async (req, res, next) => {
+  try {
+    const { meetingId } = req.params;
+
+    const meeting = await findMeetingOrThrow(meetingId);
+    requireMeetingOwner(
+      meeting,
+      req,
+      "Only the meeting owner can delete a checklist",
+    );
+
+    const checklist = await MeetingChecklist.findOneAndDelete({ meetingId });
+    if (!checklist) {
+      throw new NotFoundError("Checklist not found");
+    }
+
+    sendSuccess(res, { checklist }, "Checklist deleted successfully");
   } catch (error) {
     next(error);
   }
@@ -97,14 +158,12 @@ export const toggleItem = async (req, res, next) => {
 
     let updatedChecklist;
     if (completionIndex > -1) {
-      // Remove completion
       updatedChecklist = await MeetingChecklist.findOneAndUpdate(
         { meetingId },
         { $pull: { completions: { itemIndex, userId } } },
         { new: true },
       );
     } else {
-      // Add completion
       updatedChecklist = await MeetingChecklist.findOneAndUpdate(
         { meetingId },
         { $push: { completions: { itemIndex, userId } } },
@@ -127,24 +186,19 @@ export const getReadiness = async (req, res, next) => {
     const { meetingId } = req.params;
     const userId = req.user.id;
 
-    const meeting = await Meeting.findById(meetingId);
-    if (!meeting) {
-      throw new NotFoundError("Meeting not found");
-    }
-
-    if (meeting.uploadedBy.toString() !== userId && req.user.role !== "admin") {
-      throw new UnauthorizedError("Only the meeting owner can view readiness");
-    }
+    const meeting = await findMeetingOrThrow(meetingId);
+    requireMeetingOwner(
+      meeting,
+      req,
+      "Only the meeting owner can view readiness",
+    );
 
     const checklist = await MeetingChecklist.findOne({ meetingId });
     if (!checklist) {
       return sendSuccess(res, { readiness: [] }, "No checklist found");
     }
 
-    // Calculate readiness per participant
     const totalItems = checklist.items.length;
-
-    // Group completions by user
     const userCompletions = checklist.completions.reduce((acc, comp) => {
       const uid = comp.userId.toString();
       if (!acc[uid]) acc[uid] = 0;
@@ -159,6 +213,7 @@ export const getReadiness = async (req, res, next) => {
         p._id?.toString() ||
         p.id?.toString();
       const completedCount = uid ? userCompletions[uid] || 0 : 0;
+
       return {
         userId: p.user || p.userId || p._id || p.id,
         name: p.name || p.email || "Unknown",

--- a/server/routes/meetingChecklistRoutes.js
+++ b/server/routes/meetingChecklistRoutes.js
@@ -9,6 +9,8 @@ router.use(userAuth);
 
 router.post("/", meetingChecklistController.createChecklist);
 router.get("/", meetingChecklistController.getChecklist);
+router.put("/", meetingChecklistController.updateChecklist);
+router.delete("/", meetingChecklistController.deleteChecklist);
 router.patch("/toggle", meetingChecklistController.toggleItem);
 router.get("/readiness", meetingChecklistController.getReadiness);
 


### PR DESCRIPTION
## Summary

Fixes the Meeting Checklist API route prefix mismatch and completes the checklist API contract required by #1549.

## Related Issue

Closes #1549

## What changed?

- Updated all Meeting Checklist frontend requests to use the `/api` prefix.
- Added frontend update and delete API methods.
- Added backend PUT checklist support.
- Added backend DELETE checklist support.
- Preserved the existing authentication middleware.
- Preserved owner/admin authorization for checklist management.
- Added regression coverage for all checklist API paths.
- Added protection against accidentally generating `/api/api/...` URLs.

## API Contract

- `GET /api/meetings/:meetingId/checklist`
- `POST /api/meetings/:meetingId/checklist`
- `PUT /api/meetings/:meetingId/checklist`
- `DELETE /api/meetings/:meetingId/checklist`
- `PATCH /api/meetings/:meetingId/checklist/toggle`
- `GET /api/meetings/:meetingId/checklist/readiness`

## Authorization

All checklist routes remain protected by `userAuth`.

Create, update, delete, and readiness operations remain restricted to the meeting owner or an administrator.

## Testing

- [x] Meeting Checklist API regression tests
- [x] Verified `/api` prefix
- [x] Verified no `/api/api/...` paths
- [x] Client lint
- [x] Client build
- [x] Server lint
- [x] Server tests
- [x] `git diff --check`

## Scope

This PR is limited to the Meeting Checklist API contract and its regression coverage.

## Screenshots
<img width="1176" height="338" alt="Screenshot 2026-08-14 215149" src="https://github.com/user-attachments/assets/298872f4-2807-4520-ad3e-8004202dea8d" />
