### PR TITLE
fix: authorize reaction socket room access

### DIFF
--- a/server/socket/reactionSocket.js
+++ b/server/socket/reactionSocket.js
@@ -1,5 +1,5 @@
 import Reaction from "../models/reactionModel.js";
-import { verifyMeetingSocketAccess } from "../utils/meetingSocketAccess.js";
+import { resolveMeetingSocketAccess } from "../utils/meetingSocketAccess.js";
 
 /**
  * Rate limiting store, keyed on the authenticated user (Issue #1564).
@@ -50,60 +50,105 @@ const consumeRateLimit = (userId, now) => {
   return true;
 };
 
-const validEmojis = ["👍", "❤️", "😂", "🎉", "🤔", "👏"];
+const VALID_EMOJIS = new Set(["👍", "❤️", "😂", "🎉", "🤔", "👏"]);
+
+/**
+ * Validate reaction:send payload shape before any persistence (#1385).
+ * Client-supplied identity fields (userId, etc.) are intentionally ignored.
+ */
+const validateReactionPayload = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, message: "Invalid reaction payload" };
+  }
+
+  const { roomId, emoji, transcriptSegmentIndex } = payload;
+
+  if (!roomId || typeof roomId !== "string") {
+    return { ok: false, message: "roomId is required" };
+  }
+
+  if (!emoji || typeof emoji !== "string" || !VALID_EMOJIS.has(emoji)) {
+    return { ok: false, message: "Invalid reaction emoji" };
+  }
+
+  if (
+    transcriptSegmentIndex !== undefined &&
+    transcriptSegmentIndex !== null &&
+    (typeof transcriptSegmentIndex !== "number" ||
+      !Number.isFinite(transcriptSegmentIndex) ||
+      transcriptSegmentIndex < 0)
+  ) {
+    return { ok: false, message: "Invalid transcriptSegmentIndex" };
+  }
+
+  return {
+    ok: true,
+    roomId,
+    emoji,
+    transcriptSegmentIndex:
+      typeof transcriptSegmentIndex === "number"
+        ? transcriptSegmentIndex
+        : undefined,
+  };
+};
 
 export default (io) => {
   io.on("connection", (socket) => {
+    // Issue #1385: authorize roomId → meeting on EVERY reaction:send.
+    // Never trust handshake.auth.userId, payload.userId, or prior socket.join.
     socket.on("reaction:send", async (payload) => {
       try {
-        const { roomId, emoji, transcriptSegmentIndex } = payload || {};
-
-        if (!roomId || !emoji || !validEmojis.includes(emoji)) {
+        const validated = validateReactionPayload(payload);
+        if (!validated.ok) {
+          socket.emit("reaction:error", { message: validated.message });
           return;
         }
 
-        // Must be authenticated via the middleware in meetingSocket.js
+        // Identity comes only from Clerk-authenticated socket context.
         if (!socket.userId) {
-          return;
-        }
-
-        // `roomId` comes straight from the client. Authorize it before anything
-        // is broadcast or written — the previous order emitted to the room and
-        // created the Reaction first, so a caller from another organization
-        // could inject reactions into any meeting by id, and the injected row
-        // then surfaced (with their name and email) through the properly
-        // guarded reaction timeline endpoint.
-        const authorized = await verifyMeetingSocketAccess(roomId, socket);
-        if (!authorized) {
           socket.emit("reaction:error", {
-            message: "Forbidden: You don't have access to this meeting",
+            message: "Unauthorized: Authentication required",
           });
           return;
         }
 
-        if (!consumeRateLimit(socket.userId.toString(), Date.now())) {
+        const access = await resolveMeetingSocketAccess(
+          validated.roomId,
+          socket,
+        );
+        if (!access.authorized) {
+          socket.emit("reaction:error", {
+            message:
+              access.message ||
+              "Forbidden: You don't have access to this meeting",
+          });
+          return;
+        }
+
+        const authenticatedUserId = access.user._id.toString();
+        if (!consumeRateLimit(authenticatedUserId, Date.now())) {
           socket.emit("reaction:error", {
             message: "Rate limit exceeded. Try again later.",
           });
           return;
         }
 
-        // Persist first so a broadcast never advertises a reaction that failed
-        // to save — an invalid payload used to emit anyway and swallow the
-        // write error into console.error.
+        // Persist against the server-resolved meeting id and authenticated user.
+        const authorizedMeetingId = access.meeting._id;
         await Reaction.create({
-          meeting: roomId,
-          user: socket.userId,
-          emoji,
+          meeting: authorizedMeetingId,
+          user: authenticatedUserId,
+          emoji: validated.emoji,
           timestamp: new Date(),
-          transcriptSegmentIndex,
+          transcriptSegmentIndex: validated.transcriptSegmentIndex,
         });
 
-        socket.to(roomId).emit("reaction:new", {
-          userId: socket.userId,
-          emoji,
+        const roomKey = authorizedMeetingId.toString();
+        socket.to(roomKey).emit("reaction:new", {
+          userId: authenticatedUserId,
+          emoji: validated.emoji,
           timestamp: new Date().toISOString(),
-          transcriptSegmentIndex,
+          transcriptSegmentIndex: validated.transcriptSegmentIndex,
         });
       } catch (error) {
         console.error("Error handling reaction:", error);

--- a/server/tests/reactionSocketAuthorization.test.js
+++ b/server/tests/reactionSocketAuthorization.test.js
@@ -8,14 +8,20 @@ vi.mock("../models/meetingModel.js", () => ({
   default: { findById: vi.fn() },
 }));
 
+vi.mock("../models/userModel.js", () => ({
+  default: { findById: vi.fn() },
+}));
+
 import reactionSocket from "../socket/reactionSocket.js";
 import Reaction from "../models/reactionModel.js";
 import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
 
 const ORG_A = "507f1f77bcf86cd799439011";
 const ORG_B = "507f1f77bcf86cd799439012";
 const MEETING_ID = "507f1f77bcf86cd799439031";
 const OTHER_USER_ID = "507f1f77bcf86cd799439022";
+const SPOOFED_USER_ID = "507f1f77bcf86cd799439099";
 
 /**
  * The rate-limit budget lives in module scope and is deliberately no longer
@@ -27,16 +33,34 @@ let userCounter = 0;
 const nextUserId = () =>
   `507f1f77bcf86cd7994400${(userCounter++).toString().padStart(2, "0")}`;
 
-describe("reaction:send meeting authorization (#1564)", () => {
+describe("reaction:send meeting authorization (#1564 / #1385)", () => {
   let connectionCallback;
   let mockIo;
   let roomEmit;
   let USER_ID;
 
   /** Makes Meeting.findById resolve to a meeting owned by `org`/`uploader`. */
-  const meetingOwnedBy = (org, uploadedBy = OTHER_USER_ID) =>
+  const meetingOwnedBy = (org, uploadedBy = OTHER_USER_ID, participants = []) =>
     Meeting.findById.mockReturnValue({
-      select: vi.fn().mockResolvedValue({ organization: org, uploadedBy }),
+      select: vi.fn().mockResolvedValue({
+        _id: MEETING_ID,
+        organization: org,
+        uploadedBy,
+        participants,
+      }),
+    });
+
+  /** Fresh MongoDB user used by resolveMeetingSocketAccess on every send. */
+  const userInDb = (overrides = {}) =>
+    User.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        _id: USER_ID,
+        organization: ORG_A,
+        email: "react@example.com",
+        name: "Reactor",
+        role: "member",
+        ...overrides,
+      }),
     });
 
   const createSocket = (overrides = {}) => {
@@ -65,6 +89,7 @@ describe("reaction:send meeting authorization (#1564)", () => {
     roomEmit = vi.fn();
     Reaction.create.mockResolvedValue({ _id: "reaction_1" });
     meetingOwnedBy(ORG_A);
+    userInDb();
 
     mockIo = {
       on: vi.fn((event, cb) => {
@@ -78,8 +103,8 @@ describe("reaction:send meeting authorization (#1564)", () => {
     vi.useRealTimers();
   });
 
-  describe("same-organization reactions still work", () => {
-    it("persists and broadcasts a valid reaction", async () => {
+  describe("authorized reactions (#1385)", () => {
+    it("persists and broadcasts when same-org member reacts", async () => {
       const socket = createSocket();
 
       await socket.send({
@@ -88,6 +113,7 @@ describe("reaction:send meeting authorization (#1564)", () => {
         transcriptSegmentIndex: 3,
       });
 
+      expect(User.findById).toHaveBeenCalledWith(USER_ID);
       expect(Reaction.create).toHaveBeenCalledWith(
         expect.objectContaining({
           meeting: MEETING_ID,
@@ -113,6 +139,7 @@ describe("reaction:send meeting authorization (#1564)", () => {
 
     it("allows the meeting owner even from a different organization", async () => {
       meetingOwnedBy(ORG_B, USER_ID);
+      userInDb({ organization: ORG_A });
       const socket = createSocket({ userOrganization: ORG_A });
 
       await socket.send({ roomId: MEETING_ID, emoji: "🎉" });
@@ -120,9 +147,37 @@ describe("reaction:send meeting authorization (#1564)", () => {
       expect(Reaction.create).toHaveBeenCalled();
       expect(roomEmit).toHaveBeenCalled();
     });
+
+    it("allows a listed participant outside the meeting organization", async () => {
+      meetingOwnedBy(ORG_B, OTHER_USER_ID, [{ user: USER_ID }]);
+      userInDb({ organization: ORG_A });
+      const socket = createSocket();
+
+      await socket.send({ roomId: MEETING_ID, emoji: "👏" });
+
+      expect(Reaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meeting: MEETING_ID,
+          user: USER_ID,
+          emoji: "👏",
+        }),
+      );
+      expect(roomEmit).toHaveBeenCalled();
+    });
+
+    it("allows a participant matched by email", async () => {
+      meetingOwnedBy(ORG_B, OTHER_USER_ID, [{ email: "react@example.com" }]);
+      userInDb({ organization: ORG_A, email: "react@example.com" });
+      const socket = createSocket();
+
+      await socket.send({ roomId: MEETING_ID, emoji: "❤️" });
+
+      expect(Reaction.create).toHaveBeenCalled();
+      expect(roomEmit).toHaveBeenCalled();
+    });
   });
 
-  describe("cross-organization reactions are rejected", () => {
+  describe("unauthorized reactions are rejected (#1385)", () => {
     it("neither broadcasts nor writes for another organization's meeting", async () => {
       meetingOwnedBy(ORG_B);
       const socket = createSocket();
@@ -137,6 +192,17 @@ describe("reaction:send meeting authorization (#1564)", () => {
       });
     });
 
+    it("rejects a non-participant with no org overlap", async () => {
+      meetingOwnedBy(ORG_B, OTHER_USER_ID, [{ user: OTHER_USER_ID }]);
+      userInDb({ organization: ORG_A });
+      const socket = createSocket();
+
+      await socket.send({ roomId: MEETING_ID, emoji: "👍" });
+
+      expect(Reaction.create).not.toHaveBeenCalled();
+      expect(roomEmit).not.toHaveBeenCalled();
+    });
+
     it("rejects when the meeting does not exist", async () => {
       Meeting.findById.mockReturnValue({
         select: vi.fn().mockResolvedValue(null),
@@ -147,9 +213,13 @@ describe("reaction:send meeting authorization (#1564)", () => {
 
       expect(Reaction.create).not.toHaveBeenCalled();
       expect(roomEmit).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Meeting not found",
+      });
     });
 
-    it("rejects a caller with no organization", async () => {
+    it("rejects a caller with no organization and no participant listing", async () => {
+      userInDb({ organization: undefined });
       const socket = createSocket({ userOrganization: undefined });
 
       await socket.send({ roomId: MEETING_ID, emoji: "👍" });
@@ -159,6 +229,7 @@ describe("reaction:send meeting authorization (#1564)", () => {
     });
 
     it("rejects a caller whose role cannot view meetings", async () => {
+      userInDb({ role: undefined });
       const socket = createSocket({ userRole: undefined });
 
       await socket.send({ roomId: MEETING_ID, emoji: "👍" });
@@ -172,8 +243,68 @@ describe("reaction:send meeting authorization (#1564)", () => {
 
       await socket.send({ roomId: MEETING_ID, emoji: "👍" });
 
+      expect(User.findById).not.toHaveBeenCalled();
       expect(Meeting.findById).not.toHaveBeenCalled();
       expect(Reaction.create).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Unauthorized: Authentication required",
+      });
+    });
+
+    it("revalidates membership on every event after org removal", async () => {
+      const socket = createSocket({ userOrganization: ORG_A });
+
+      await socket.send({ roomId: MEETING_ID, emoji: "👍" });
+      expect(Reaction.create).toHaveBeenCalledTimes(1);
+
+      // Stale socket.userOrganization still says ORG_A, but DB says removed.
+      userInDb({ organization: ORG_B });
+      await socket.send({ roomId: MEETING_ID, emoji: "👍" });
+
+      expect(Reaction.create).toHaveBeenCalledTimes(1);
+      expect(roomEmit).toHaveBeenCalledTimes(1);
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Forbidden: You don't have access to this meeting",
+      });
+    });
+  });
+
+  describe("identity spoofing is ignored (#1385)", () => {
+    it("ignores payload.userId and persists as the authenticated user", async () => {
+      const socket = createSocket();
+
+      await socket.send({
+        roomId: MEETING_ID,
+        emoji: "👍",
+        userId: SPOOFED_USER_ID,
+      });
+
+      expect(Reaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: USER_ID,
+          meeting: MEETING_ID,
+        }),
+      );
+      expect(Reaction.create).not.toHaveBeenCalledWith(
+        expect.objectContaining({ user: SPOOFED_USER_ID }),
+      );
+      expect(roomEmit).toHaveBeenCalledWith(
+        "reaction:new",
+        expect.objectContaining({ userId: USER_ID }),
+      );
+    });
+
+    it("does not trust handshake.auth.userId over socket.userId", async () => {
+      const socket = createSocket({
+        handshake: { auth: { userId: SPOOFED_USER_ID } },
+      });
+
+      await socket.send({ roomId: MEETING_ID, emoji: "😂" });
+
+      expect(User.findById).toHaveBeenCalledWith(USER_ID);
+      expect(Reaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({ user: USER_ID }),
+      );
     });
   });
 
@@ -183,7 +314,6 @@ describe("reaction:send meeting authorization (#1564)", () => {
 
       await socket.send({ roomId: "not-an-id", emoji: "👍" });
 
-      // The old handler broadcast first and only failed on the write.
       expect(roomEmit).not.toHaveBeenCalled();
       expect(Reaction.create).not.toHaveBeenCalled();
       expect(socket.emit).toHaveBeenCalledWith(
@@ -192,22 +322,44 @@ describe("reaction:send meeting authorization (#1564)", () => {
       );
     });
 
-    it("ignores an emoji outside the allow list", async () => {
+    it("rejects an emoji outside the allow list with an error", async () => {
       const socket = createSocket();
 
       await socket.send({ roomId: MEETING_ID, emoji: "💀" });
 
+      expect(User.findById).not.toHaveBeenCalled();
       expect(Meeting.findById).not.toHaveBeenCalled();
       expect(Reaction.create).not.toHaveBeenCalled();
       expect(roomEmit).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Invalid reaction emoji",
+      });
     });
 
-    it("ignores a missing payload", async () => {
+    it("rejects a missing payload with an error", async () => {
       const socket = createSocket();
 
       await socket.send(undefined);
 
       expect(Reaction.create).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Invalid reaction payload",
+      });
+    });
+
+    it("rejects an invalid transcriptSegmentIndex", async () => {
+      const socket = createSocket();
+
+      await socket.send({
+        roomId: MEETING_ID,
+        emoji: "👍",
+        transcriptSegmentIndex: -1,
+      });
+
+      expect(Reaction.create).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith("reaction:error", {
+        message: "Invalid transcriptSegmentIndex",
+      });
     });
 
     it("does not broadcast when the write fails", async () => {
@@ -247,8 +399,6 @@ describe("reaction:send meeting authorization (#1564)", () => {
       }
       expect(Reaction.create).toHaveBeenCalledTimes(5);
 
-      // Same user, brand new connection: the old socket.id-keyed store handed
-      // out a fresh allowance here.
       const reconnected = createSocket({ id: "socket_456" });
       await reconnected.send({ roomId: MEETING_ID, emoji: "👍" });
 
@@ -264,6 +414,7 @@ describe("reaction:send meeting authorization (#1564)", () => {
         await first.send({ roomId: MEETING_ID, emoji: "👍" });
       }
 
+      userInDb({ _id: OTHER_USER_ID, organization: ORG_A });
       const other = createSocket({ id: "socket_789", userId: OTHER_USER_ID });
       await other.send({ roomId: MEETING_ID, emoji: "👍" });
 

--- a/server/utils/meetingSocketAccess.js
+++ b/server/utils/meetingSocketAccess.js
@@ -1,53 +1,143 @@
-import mongoose from "mongoose";
-import Meeting from "../models/meetingModel.js";
-import { hasPermission } from "./rbacPermissions.js";
-
 /**
- * Meeting access check for socket event handlers (Issue #1564).
+ * Meeting access check for socket event handlers (Issues #1564 / #1385).
  *
  * Socket handlers receive the meeting/room id in the event payload, which is
  * entirely client-controlled — there is no router to hang `requireOrgAccess`
- * off, so the check has to happen inside the handler. `socket/reactionSocket.js`
- * had no check at all and would broadcast into, and write a Reaction document
- * against, any meeting id a signed-in client cared to send.
+ * off, so the check has to happen inside the handler.
  *
- * The rule matches the one already enforced over HTTP by
- * `requireOrgAccess(Meeting)` in `routes/meetingRoutes.js`, and the one
- * `socket/translationSocket.js` implements inline: the caller must be
- * authenticated, hold the `meetings:view` permission for their role, and either
- * own the meeting or belong to its organization.
+ * Authorization is revalidated on every call against the current MongoDB user
+ * and meeting documents. Never trust:
+ * - client-supplied userId fields
+ * - socket.rooms / prior join state
+ * - stale socket.userOrganization from connection time alone
  *
- * @param {string} meetingId  id from the event payload — never trusted
- * @param {object} socket     an authenticated socket (see middleware/socketAuth.js)
- * @returns {Promise<boolean>} true when the caller may act on the meeting
+ * Access rule (aligned with collaborativeDocAccess / requireOrgAccess):
+ * - authenticated Clerk → MongoDB user
+ * - meetings:view permission
+ * - owner OR same organization OR listed participant
  */
-export const verifyMeetingSocketAccess = async (meetingId, socket) => {
-  if (!meetingId || !mongoose.isValidObjectId(meetingId)) {
-    return false;
+
+import mongoose from "mongoose";
+import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
+import { hasPermission } from "./rbacPermissions.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+
+/**
+ * @typedef {object} MeetingSocketAccessResult
+ * @property {boolean} authorized
+ * @property {string} [code]
+ * @property {string} [message]
+ * @property {object} [meeting]
+ * @property {object} [user]
+ */
+
+/**
+ * Resolve and authorize a client-supplied meeting/room id for a socket user.
+ *
+ * @param {string} meetingId
+ * @param {object} socket - authenticated socket (middleware/socketAuth.js)
+ * @returns {Promise<MeetingSocketAccessResult>}
+ */
+export const resolveMeetingSocketAccess = async (meetingId, socket) => {
+  if (!socket?.userId) {
+    return {
+      authorized: false,
+      code: "unauthenticated",
+      message: "Unauthorized: Authentication required",
+    };
   }
 
-  if (!socket?.userId || !socket?.userRole) {
-    return false;
+  if (!meetingId || !mongoose.isValidObjectId(String(meetingId))) {
+    return {
+      authorized: false,
+      code: "invalid_meeting",
+      message: "Invalid meeting ID",
+    };
   }
 
-  if (!hasPermission(socket.userRole, "meetings", "view")) {
-    return false;
+  // Fresh user load so org/role removals take effect immediately (#1385).
+  const user = await User.findById(socket.userId).select(
+    "organization email name role",
+  );
+
+  if (!user) {
+    return {
+      authorized: false,
+      code: "unauthenticated",
+      message: "Unauthorized: User not found",
+    };
+  }
+
+  const userRole = user.role || socket.userRole;
+  if (!userRole || !hasPermission(userRole, "meetings", "view")) {
+    return {
+      authorized: false,
+      code: "forbidden",
+      message: "Forbidden: You don't have permission to view this meeting",
+    };
   }
 
   const meeting = await Meeting.findById(meetingId).select(
-    "organization uploadedBy",
+    "organization uploadedBy participants",
   );
+
   if (!meeting) {
-    return false;
+    return {
+      authorized: false,
+      code: "not_found",
+      message: "Meeting not found",
+    };
   }
 
-  const isOwner = meeting.uploadedBy?.toString() === socket.userId.toString();
-  const isInSameOrg =
-    meeting.organization &&
-    socket.userOrganization &&
-    meeting.organization.toString() === socket.userOrganization.toString();
+  const authUser = {
+    _id: user._id,
+    organization: user.organization,
+    email: user.email,
+    name: user.name,
+    role: userRole,
+  };
 
-  return Boolean(isOwner || isInSameOrg);
+  if (canAccessMeetingDoc(meeting, authUser)) {
+    return { authorized: true, meeting, user: authUser };
+  }
+
+  const authenticatedUserId = authUser._id.toString();
+  const authenticatedEmail = authUser.email?.toLowerCase?.() || "";
+
+  const isParticipant = (meeting.participants || []).some((p) => {
+    if (p.user && p.user.toString() === authenticatedUserId) return true;
+    if (
+      authenticatedEmail &&
+      p.email &&
+      p.email.toLowerCase() === authenticatedEmail
+    ) {
+      return true;
+    }
+    return false;
+  });
+
+  if (isParticipant) {
+    return { authorized: true, meeting, user: authUser };
+  }
+
+  return {
+    authorized: false,
+    code: "forbidden",
+    message: "Forbidden: You don't have access to this meeting",
+  };
 };
 
-export default { verifyMeetingSocketAccess };
+/**
+ * Boolean wrapper kept for call sites that only need a yes/no answer.
+ * Prefer `resolveMeetingSocketAccess` when the authorized meeting id is needed.
+ */
+export const verifyMeetingSocketAccess = async (meetingId, socket) => {
+  const result = await resolveMeetingSocketAccess(meetingId, socket);
+  return result.authorized;
+};
+
+export default {
+  verifyMeetingSocketAccess,
+  resolveMeetingSocketAccess,
+};


### PR DESCRIPTION
## Summary

Fixes #1385

Enforces meeting-level authorization for reaction socket events before reactions are persisted or broadcast.

This prevents users from sending reactions to arbitrary meetings by supplying unauthorized `roomId` values and ensures all reaction activity is scoped to meetings the authenticated user can access.

---

## Problem

The reaction socket authenticated users but did not fully revalidate authorization for the supplied `roomId` before persisting reactions.

A malicious client could potentially target meetings outside their authorized scope by submitting reactions to arbitrary room identifiers.

---

## Root Cause

Authorization relied on connection-time context and client-supplied room identifiers.

Meeting access was not consistently revalidated using fresh membership data before persistence.

This created a risk where:

- Cross-organization reactions could be attempted
- Removed users could retain access during an active session
- Client-supplied identity fields could influence authorization behavior

---

## Changes Made

### Authorization Flow

```text
Clerk JWT
    ↓
Socket Authentication
    ↓
Validate Payload
    ↓
Resolve Meeting Access
    ↓
Reload MongoDB User
    ↓
Verify Organization / Participant Access
    ↓
Persist Reaction
    ↓
Broadcast reaction:new
```

### Access Validation

- Revalidates authorization on every `reaction:send`
- Uses fresh database membership checks
- Supports authorized owners, organization members, and participants
- Ignores spoofed identity fields from clients

### Persistence Hardening

Reactions are now persisted using:

- Server-resolved meeting IDs
- Authenticated socket user identity

Unauthorized requests never reach persistence.

---

## Files Changed

- `server/socket/reactionSocket.js`
- `server/utils/meetingSocketAccess.js`
- `server/tests/reactionSocketAuthorization.test.js`

---

## Security Improvements

- Blocks cross-organization reactions
- Rejects unauthorized room access
- Ignores spoofed `userId` values
- Revalidates authorization for every reaction event
- Prevents persistence and broadcasting on authorization failure
- Honors membership changes during active sessions

---

## Tests Added

Added regression coverage for:

- Same-org authorized reactions
- Meeting owner access
- Participant access
- Cross-org denial
- Non-participant denial
- Invalid room IDs
- Missing meetings
- Unauthenticated sockets
- Membership removal after connection
- Spoofed identity attempts
- No persistence/broadcast when denied

---

## Expected Behavior

| Scenario | Result |
|----------|---------|
| Authorized member sends reaction | Success |
| Meeting owner sends reaction | Success |
| Authorized participant sends reaction | Success |
| Cross-org non-participant | Rejected |
| Invalid roomId | Rejected |
| Missing meeting | Rejected |
| Unauthenticated socket | Rejected |
| Spoofed userId | Ignored |

---

## Security Impact

This change closes a socket authorization gap by ensuring reaction persistence and broadcasting occur only after server-side meeting authorization succeeds.

The fix prevents:

- Unauthorized reactions
- Cross-organization room access
- Identity spoofing attempts
- Persistence without authorization

while preserving existing real-time reaction functionality.

---

## Manual Verification

- [ ] Authorized member can send reactions
- [ ] Meeting owner can send reactions
- [ ] Participant can send reactions
- [ ] Cross-org unauthorized users are denied
- [ ] Invalid room IDs are rejected
- [ ] Unauthenticated sockets are rejected
- [ ] Spoofed userId values are ignored
- [ ] Unauthorized reactions are not persisted
- [ ] Unauthorized reactions are not broadcast
- [ ] Membership removal immediately revokes access