### PR TITLE
feat: add production testimonials and public rating system

### DIFF
--- a/client/src/components/ScrollNavigator.jsx
+++ b/client/src/components/ScrollNavigator.jsx
@@ -6,6 +6,7 @@ const SECTIONS = [
   { id: "features", label: "Features" },
   { id: "how-it-works", label: "How It Works" },
   { id: "about", label: "About" },
+  { id: "testimonials", label: "Testimonials" },
   { id: "faq", label: "FAQ" },
 ];
 

--- a/client/src/components/TestimonialsSection.jsx
+++ b/client/src/components/TestimonialsSection.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+import apiClient from "../services/apiClient.js";
+import TestimonialsCarousel from "./testimonials/TestimonialsCarousel.jsx";
+
+const useIntersectionFade = (threshold = 0.15) => {
+  const ref = useRef(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add("visible");
+          observer.unobserve(el);
+        }
+      },
+      { threshold },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+  return ref;
+};
+
+export default function TestimonialsSection() {
+  const navigate = useNavigate();
+  const headingRef = useIntersectionFade();
+  const [testimonials, setTestimonials] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const { data } = await apiClient.get("/api/testimonials", {
+          params: { limit: 12, page: 1 },
+        });
+        if (!cancelled) {
+          setTestimonials(data.testimonials || []);
+        }
+      } catch {
+        if (!cancelled) {
+          setError("Unable to load testimonials right now.");
+          setTestimonials([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section
+      id="testimonials"
+      className="py-24 bg-white dark:bg-gray-900"
+      aria-labelledby="testimonials-heading"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-10">
+        <div
+          ref={headingRef}
+          className="fade-in-up text-center max-w-3xl mx-auto mb-12"
+        >
+          <span className="inline-flex items-center px-4 py-1 rounded-full text-xs font-semibold tracking-wider uppercase bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700">
+            Testimonials
+          </span>
+          <h2
+            id="testimonials-heading"
+            className="text-3xl sm:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 mt-5 leading-tight"
+          >
+            Trusted by teams who{" "}
+            <span className="bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 bg-clip-text text-transparent">
+              remember what matters
+            </span>
+          </h2>
+          <p className="mt-5 text-base sm:text-lg text-gray-600 dark:text-gray-300 leading-relaxed">
+            Real feedback from people using MeetOnMemory to keep decisions and
+            action items clear.
+          </p>
+        </div>
+
+        {loading ? (
+          <div
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+            aria-busy="true"
+            aria-label="Loading testimonials"
+          >
+            {[1, 2, 3].map((key) => (
+              <div
+                key={key}
+                className="h-48 rounded-2xl border border-slate-200 dark:border-gray-700 bg-slate-100 dark:bg-gray-800 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 px-6 py-10 text-center text-sm text-rose-700 dark:text-rose-300">
+            {error}
+          </div>
+        ) : (
+          <TestimonialsCarousel testimonials={testimonials} />
+        )}
+
+        <div className="text-center mt-12">
+          <button
+            type="button"
+            onClick={() => navigate("/testimonials")}
+            className="group inline-flex items-center gap-2 px-8 py-3.5 bg-linear-to-r from-blue-600 to-violet-600 text-white rounded-xl font-semibold hover:shadow-xl hover:shadow-blue-500/30 hover:scale-105 active:scale-100 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 cursor-pointer"
+          >
+            Share Your Experience
+            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform duration-300" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/admin/TestimonialsModeration.jsx
+++ b/client/src/components/admin/TestimonialsModeration.jsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import apiClient from "../../services/apiClient.js";
+import StarRating from "../testimonials/StarRating.jsx";
+
+const STATUS_FILTERS = ["pending", "approved", "rejected", "all"];
+
+export default function TestimonialsModeration() {
+  const [status, setStatus] = useState("pending");
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [busyId, setBusyId] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError("");
+      const params = { page: 1, limit: 50 };
+      if (status !== "all") params.status = status;
+      const { data } = await apiClient.get("/api/admin/testimonials", {
+        params,
+      });
+      setItems(data.testimonials || []);
+    } catch {
+      setError("Unable to load testimonials for moderation.");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const updateStatus = async (id, nextStatus) => {
+    setBusyId(id);
+    try {
+      await apiClient.patch(`/api/admin/testimonials/${id}/status`, {
+        status: nextStatus,
+      });
+      toast.success(`Marked as ${nextStatus}`);
+      await load();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to update moderation status",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const remove = async (id) => {
+    if (!window.confirm("Remove this testimonial permanently?")) return;
+    setBusyId(id);
+    try {
+      await apiClient.delete(`/api/admin/testimonials/${id}`);
+      toast.success("Testimonial removed");
+      await load();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to remove testimonial",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="flex flex-wrap gap-2"
+        role="tablist"
+        aria-label="Filter by status"
+      >
+        {STATUS_FILTERS.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setStatus(value)}
+            className={`px-3 py-1.5 rounded-full text-xs font-semibold capitalize cursor-pointer ${
+              status === value
+                ? "bg-blue-600 text-white"
+                : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300"
+            }`}
+          >
+            {value}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3" aria-busy="true">
+          {[1, 2, 3].map((k) => (
+            <div
+              key={k}
+              className="h-24 rounded-xl bg-slate-100 dark:bg-slate-800 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-sm text-rose-600" role="alert">
+          {error}
+        </p>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-200 dark:border-slate-700 px-4 py-10 text-center text-sm text-slate-500">
+          No testimonials in this filter.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-2">
+                    <StarRating value={item.rating} readOnly size="sm" />
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      {item.status}
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-800 dark:text-slate-200">
+                    &ldquo;{item.comment}&rdquo;
+                  </p>
+                  <p className="mt-2 text-xs text-slate-500">
+                    {item.user?.name || "Unknown user"}
+                    {item.organization?.name
+                      ? ` · ${item.organization.name}`
+                      : ""}
+                    {item.createdAt
+                      ? ` · ${new Date(item.createdAt).toLocaleString()}`
+                      : ""}
+                  </p>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {item.status !== "approved" ? (
+                    <button
+                      type="button"
+                      disabled={busyId === item.id}
+                      onClick={() => updateStatus(item.id, "approved")}
+                      className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-emerald-600 text-white disabled:opacity-50 cursor-pointer"
+                    >
+                      Approve
+                    </button>
+                  ) : null}
+                  {item.status !== "rejected" ? (
+                    <button
+                      type="button"
+                      disabled={busyId === item.id}
+                      onClick={() => updateStatus(item.id, "rejected")}
+                      className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-amber-500 text-white disabled:opacity-50 cursor-pointer"
+                    >
+                      Reject
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={busyId === item.id}
+                    onClick={() => remove(item.id)}
+                    className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-rose-600 text-white disabled:opacity-50 cursor-pointer"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/testimonials/StarRating.jsx
+++ b/client/src/components/testimonials/StarRating.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Star } from "lucide-react";
+
+/**
+ * Interactive or read-only 1–5 star rating control.
+ */
+export default function StarRating({
+  value = 0,
+  onChange,
+  readOnly = false,
+  size = "md",
+  label = "Rating",
+}) {
+  const sizeClass = size === "sm" ? "w-4 h-4" : "w-6 h-6";
+  const stars = [1, 2, 3, 4, 5];
+
+  if (readOnly) {
+    return (
+      <div
+        className="inline-flex items-center gap-0.5"
+        role="img"
+        aria-label={`${value} out of 5 stars`}
+      >
+        {stars.map((star) => (
+          <Star
+            key={star}
+            aria-hidden="true"
+            className={`${sizeClass} ${
+              star <= value
+                ? "fill-amber-400 text-amber-400"
+                : "fill-transparent text-slate-300 dark:text-slate-600"
+            }`}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="inline-flex items-center gap-1"
+      role="radiogroup"
+      aria-label={label}
+    >
+      {stars.map((star) => {
+        const selected = star <= value;
+        return (
+          <button
+            key={star}
+            type="button"
+            role="radio"
+            aria-checked={value === star}
+            aria-label={`${star} star${star === 1 ? "" : "s"}`}
+            onClick={() => onChange?.(star)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+                e.preventDefault();
+                onChange?.(Math.min(5, value + 1 || 1));
+              }
+              if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+                e.preventDefault();
+                onChange?.(Math.max(1, (value || 1) - 1));
+              }
+            }}
+            className="p-0.5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 cursor-pointer"
+          >
+            <Star
+              aria-hidden="true"
+              className={`${sizeClass} transition-colors ${
+                selected
+                  ? "fill-amber-400 text-amber-400"
+                  : "fill-transparent text-slate-300 dark:text-slate-600 hover:text-amber-300"
+              }`}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/testimonials/TestimonialCard.jsx
+++ b/client/src/components/testimonials/TestimonialCard.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import StarRating from "./StarRating.jsx";
+
+const initials = (name = "") => {
+  const parts = String(name).trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+};
+
+export default function TestimonialCard({ testimonial, compact = false }) {
+  const name = testimonial?.user?.name || "Anonymous";
+  const profilePic = testimonial?.user?.profilePic || "";
+  const orgName = testimonial?.organization?.name;
+  const role = testimonial?.user?.role;
+  const subtitle = [role, orgName].filter(Boolean).join(" · ");
+
+  return (
+    <article
+      className={`h-full flex flex-col bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm ${
+        compact ? "p-5" : "p-6 sm:p-7"
+      }`}
+    >
+      <StarRating value={testimonial?.rating || 0} readOnly size="sm" />
+
+      <blockquote className="mt-4 flex-1">
+        <p
+          className={`text-gray-700 dark:text-gray-200 leading-relaxed ${
+            compact
+              ? "text-sm line-clamp-3"
+              : "text-sm sm:text-base line-clamp-4"
+          }`}
+        >
+          &ldquo;{testimonial?.comment || ""}&rdquo;
+        </p>
+      </blockquote>
+
+      <div className="mt-5 flex items-center gap-3">
+        {profilePic ? (
+          <img
+            src={profilePic}
+            alt=""
+            className="w-10 h-10 rounded-full object-cover border border-gray-200 dark:border-gray-600"
+          />
+        ) : (
+          <div
+            className="w-10 h-10 rounded-full bg-linear-to-br from-blue-600 to-indigo-600 text-white text-xs font-semibold flex items-center justify-center"
+            aria-hidden="true"
+          >
+            {initials(name)}
+          </div>
+        )}
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {name}
+          </p>
+          {subtitle ? (
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate capitalize">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/client/src/components/testimonials/TestimonialsCarousel.jsx
+++ b/client/src/components/testimonials/TestimonialsCarousel.jsx
@@ -1,0 +1,231 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight, Pause, Play } from "lucide-react";
+import TestimonialCard from "./TestimonialCard.jsx";
+
+const AUTO_INTERVAL_MS = 5500;
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+}
+
+function useVisibleCards() {
+  const [count, setCount] = useState(1);
+  useEffect(() => {
+    const update = () => {
+      if (window.innerWidth >= 1024) setCount(3);
+      else if (window.innerWidth >= 768) setCount(2);
+      else setCount(1);
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+  return count;
+}
+
+export default function TestimonialsCarousel({ testimonials = [] }) {
+  const reducedMotion = usePrefersReducedMotion();
+  const visibleCount = useVisibleCards();
+  const [index, setIndex] = useState(0);
+  const [playing, setPlaying] = useState(true);
+  const [userPaused, setUserPaused] = useState(false);
+  const sectionVisible = useRef(true);
+  const tabVisible = useRef(true);
+  const touchStartX = useRef(null);
+  const containerRef = useRef(null);
+
+  const total = testimonials.length;
+  const maxIndex = Math.max(0, total - visibleCount);
+
+  useEffect(() => {
+    setIndex((prev) => Math.min(prev, maxIndex));
+  }, [maxIndex]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        sectionVisible.current = entry.isIntersecting;
+      },
+      { threshold: 0.2 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const onVisibility = () => {
+      tabVisible.current = document.visibilityState === "visible";
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
+  const goNext = useCallback(() => {
+    setIndex((prev) => (prev >= maxIndex ? 0 : prev + 1));
+  }, [maxIndex]);
+
+  const goPrev = useCallback(() => {
+    setIndex((prev) => (prev <= 0 ? maxIndex : prev - 1));
+  }, [maxIndex]);
+
+  useEffect(() => {
+    if (reducedMotion || !playing || userPaused || total <= visibleCount) {
+      return undefined;
+    }
+
+    const timer = setInterval(() => {
+      if (!sectionVisible.current || !tabVisible.current) return;
+      goNext();
+    }, AUTO_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [reducedMotion, playing, userPaused, total, visibleCount, goNext]);
+
+  const pauseForInteraction = () => {
+    setUserPaused(true);
+    setPlaying(false);
+  };
+
+  const onTouchStart = (e) => {
+    touchStartX.current = e.changedTouches[0]?.clientX ?? null;
+  };
+
+  const onTouchEnd = (e) => {
+    if (touchStartX.current == null) return;
+    const dx = e.changedTouches[0].clientX - touchStartX.current;
+    touchStartX.current = null;
+    if (Math.abs(dx) < 40) return;
+    pauseForInteraction();
+    if (dx < 0) goNext();
+    else goPrev();
+  };
+
+  if (total === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 dark:border-gray-700 px-6 py-12 text-center">
+        <p className="text-gray-600 dark:text-gray-300 font-medium">
+          No testimonials yet.
+        </p>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Be the first to share your experience.
+        </p>
+      </div>
+    );
+  }
+
+  const pageCount = maxIndex + 1;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div
+        className="overflow-hidden"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onMouseEnter={() => setUserPaused(true)}
+        onMouseLeave={() => {
+          if (playing) setUserPaused(false);
+        }}
+      >
+        <div
+          className={`flex gap-4 ${
+            reducedMotion ? "" : "transition-transform duration-500 ease-out"
+          }`}
+          style={{
+            transform: `translateX(-${(index * 100) / visibleCount}%)`,
+          }}
+        >
+          {testimonials.map((item) => (
+            <div
+              key={item.id}
+              className="shrink-0"
+              style={{
+                width: `calc((100% - ${(visibleCount - 1) * 1}rem) / ${visibleCount})`,
+              }}
+            >
+              <TestimonialCard testimonial={item} compact />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            pauseForInteraction();
+            goPrev();
+          }}
+          className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-slate-600 dark:text-slate-300 hover:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+          aria-label="Previous testimonials"
+        >
+          <ChevronLeft className="w-5 h-5" aria-hidden="true" />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            const next = !playing;
+            setPlaying(next);
+            setUserPaused(!next);
+          }}
+          className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-slate-600 dark:text-slate-300 hover:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+          aria-label={playing ? "Pause carousel" : "Play carousel"}
+        >
+          {playing ? (
+            <Pause className="w-4 h-4" aria-hidden="true" />
+          ) : (
+            <Play className="w-4 h-4" aria-hidden="true" />
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            pauseForInteraction();
+            goNext();
+          }}
+          className="inline-flex items-center justify-center w-10 h-10 rounded-xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-slate-600 dark:text-slate-300 hover:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+          aria-label="Next testimonials"
+        >
+          <ChevronRight className="w-5 h-5" aria-hidden="true" />
+        </button>
+
+        <div
+          className="flex items-center gap-2 ml-2"
+          role="tablist"
+          aria-label="Testimonial pages"
+        >
+          {Array.from({ length: pageCount }).map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              role="tab"
+              aria-selected={i === index}
+              aria-label={`Go to page ${i + 1}`}
+              onClick={() => {
+                pauseForInteraction();
+                setIndex(i);
+              }}
+              className={`h-2.5 rounded-full transition-all cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                i === index
+                  ? "w-6 bg-blue-600"
+                  : "w-2.5 bg-slate-300 dark:bg-slate-600 hover:bg-slate-400"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx
+++ b/client/src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TestimonialsSection from "../../TestimonialsSection.jsx";
+import TestimonialsCarousel from "../TestimonialsCarousel.jsx";
+import StarRating from "../StarRating.jsx";
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import apiClient from "../../../services/apiClient.js";
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const sample = [
+  {
+    id: "1",
+    rating: 5,
+    comment: "MeetOnMemory made tracking decisions easy for our team.",
+    user: { name: "John Doe", profilePic: "", role: "member" },
+    organization: { name: "Engineering Team" },
+  },
+  {
+    id: "2",
+    rating: 4,
+    comment: "Action items finally stay visible after every meeting.",
+    user: { name: "Jane Doe", profilePic: "", role: "admin" },
+    organization: null,
+  },
+];
+
+describe("StarRating", () => {
+  it("exposes accessible rating value when read-only", () => {
+    render(<StarRating value={4} readOnly />);
+    expect(screen.getByRole("img", { name: "4 out of 5 stars" })).toBeTruthy();
+  });
+
+  it("allows selecting a rating interactively", () => {
+    const onChange = vi.fn();
+    render(<StarRating value={0} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: "5 stars" }));
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+});
+
+describe("TestimonialsCarousel", () => {
+  it("shows empty state when there are no testimonials", () => {
+    render(<TestimonialsCarousel testimonials={[]} />);
+    expect(screen.getByText("No testimonials yet.")).toBeTruthy();
+  });
+
+  it("renders comments in quotation marks and supports next navigation", () => {
+    render(<TestimonialsCarousel testimonials={sample} />);
+    expect(
+      screen.getByText((text) =>
+        text.includes(
+          "MeetOnMemory made tracking decisions easy for our team.",
+        ),
+      ),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByLabelText("Next testimonials"));
+    expect(screen.getByLabelText("Previous testimonials")).toBeTruthy();
+  });
+
+  it("toggles play and pause", () => {
+    render(<TestimonialsCarousel testimonials={sample} />);
+    const pause = screen.getByLabelText("Pause carousel");
+    fireEvent.click(pause);
+    expect(screen.getByLabelText("Play carousel")).toBeTruthy();
+  });
+});
+
+describe("TestimonialsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads testimonials from the API", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { testimonials: sample, pagination: { total: 2 } },
+    });
+
+    render(
+      <MemoryRouter>
+        <TestimonialsSection />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/api/testimonials", {
+        params: { limit: 12, page: 1 },
+      });
+    });
+
+    expect(await screen.findByText("Share Your Experience")).toBeTruthy();
+    expect(
+      await screen.findByText((text) =>
+        text.includes(
+          "MeetOnMemory made tracking decisions easy for our team.",
+        ),
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows empty messaging when API returns no testimonials", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { testimonials: [], pagination: { total: 0 } },
+    });
+
+    render(
+      <MemoryRouter>
+        <TestimonialsSection />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("No testimonials yet.")).toBeTruthy();
+  });
+
+  it("shows an error state when the API fails", async () => {
+    apiClient.get.mockRejectedValue(new Error("network"));
+
+    render(
+      <MemoryRouter>
+        <TestimonialsSection />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("Unable to load testimonials right now."),
+    ).toBeTruthy();
+  });
+});

--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -14,9 +14,11 @@ import {
   X,
   Sparkles,
   ClipboardList,
+  MessageSquareQuote,
 } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import TemplateBuilder from "../components/admin/TemplateBuilder.jsx";
+import TestimonialsModeration from "../components/admin/TestimonialsModeration.jsx";
 
 const MODULES = [
   {
@@ -66,6 +68,14 @@ const MODULES = [
     icon: ClipboardList,
     iconBg: "bg-fuchsia-50 dark:bg-fuchsia-900/30",
     iconColor: "text-fuchsia-600 dark:text-fuchsia-400",
+  },
+  {
+    id: "testimonials",
+    labelKey: "Testimonials",
+    descriptionKey: "Moderate public product ratings and comments",
+    icon: MessageSquareQuote,
+    iconBg: "bg-sky-50 dark:bg-sky-900/30",
+    iconColor: "text-sky-600 dark:text-sky-400",
   },
   {
     id: "policies",
@@ -275,6 +285,8 @@ const AdminPanel = () => {
             </div>
           ) : activeModule === "templates" ? (
             <TemplateBuilder />
+          ) : activeModule === "testimonials" ? (
+            <TestimonialsModeration />
           ) : (
             <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-8 shadow-sm text-center">
               <div

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import Navbar from "../components/Navbar";
 import Hero from "../components/Hero";
 import HowItWorks from "../components/HowItWorks";
 import About from "../components/About";
+import TestimonialsSection from "../components/TestimonialsSection";
 import FAQ from "../components/FAQ";
 import Features from "../components/Features";
 
@@ -19,6 +20,7 @@ const Home = () => {
       <Features />
       <HowItWorks />
       <About />
+      <TestimonialsSection />
       <FAQ />
     </div>
   );

--- a/client/src/pages/Testimonials.jsx
+++ b/client/src/pages/Testimonials.jsx
@@ -1,0 +1,371 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import Navbar from "../components/Navbar.jsx";
+import StarRating from "../components/testimonials/StarRating.jsx";
+import TestimonialCard from "../components/testimonials/TestimonialCard.jsx";
+import apiClient from "../services/apiClient.js";
+import AppContent from "../context/AppContent.js";
+
+const COMMENT_MIN = 10;
+const COMMENT_MAX = 500;
+
+export default function Testimonials() {
+  const navigate = useNavigate();
+  const { isLoggedin } = useContext(AppContent) || {};
+
+  const [stats, setStats] = useState(null);
+  const [testimonials, setTestimonials] = useState([]);
+  const [mine, setMine] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState(null);
+
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const loadPublic = useCallback(async () => {
+    const [statsRes, listRes] = await Promise.all([
+      apiClient.get("/api/testimonials/stats"),
+      apiClient.get("/api/testimonials", { params: { page: 1, limit: 24 } }),
+    ]);
+    setStats(statsRes.data.stats || null);
+    setTestimonials(listRes.data.testimonials || []);
+  }, []);
+
+  const loadMine = useCallback(async () => {
+    if (!isLoggedin) {
+      setMine(null);
+      return;
+    }
+    try {
+      const { data } = await apiClient.get("/api/testimonials/me");
+      setMine(data.testimonial || null);
+      if (data.testimonial) {
+        setRating(data.testimonial.rating);
+        setComment(data.testimonial.comment);
+      }
+    } catch {
+      setMine(null);
+    }
+  }, [isLoggedin]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setListError(null);
+        await loadPublic();
+        if (!cancelled) await loadMine();
+      } catch {
+        if (!cancelled) {
+          setListError("Unable to load testimonials right now.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPublic, loadMine]);
+
+  const validate = () => {
+    const trimmed = comment.trim();
+    if (!rating || rating < 1 || rating > 5) {
+      return "Please select a rating between 1 and 5 stars.";
+    }
+    if (trimmed.length < COMMENT_MIN) {
+      return `Comment must be at least ${COMMENT_MIN} characters.`;
+    }
+    if (trimmed.length > COMMENT_MAX) {
+      return `Comment must be at most ${COMMENT_MAX} characters.`;
+    }
+    return "";
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!isLoggedin) {
+      navigate("/login");
+      return;
+    }
+
+    const validationError = validate();
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError("");
+    try {
+      const payload = { rating, comment: comment.trim() };
+      let response;
+      if (mine?.id && editing) {
+        response = await apiClient.put(`/api/testimonials/${mine.id}`, payload);
+      } else if (!mine) {
+        response = await apiClient.post("/api/testimonials", payload);
+      } else {
+        setEditing(true);
+        setSubmitting(false);
+        return;
+      }
+
+      setMine(response.data.testimonial);
+      setEditing(false);
+      toast.success(
+        response.data.message ||
+          "Your review has been submitted and is awaiting approval.",
+      );
+      await loadPublic();
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        "Unable to save your review. Please try again.";
+      setFormError(message);
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const startEdit = () => {
+    if (!mine) return;
+    setRating(mine.rating);
+    setComment(mine.comment);
+    setEditing(true);
+    setFormError("");
+  };
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-white to-slate-50 dark:from-gray-950 dark:to-gray-900">
+      <Navbar />
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
+        <div className="text-center mb-10">
+          <p className="text-xs font-semibold uppercase tracking-wider text-blue-600 dark:text-blue-400">
+            Community feedback
+          </p>
+          <h1 className="mt-3 text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">
+            Testimonials
+          </h1>
+          <p className="mt-3 text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+            See what others are saying, and share your own experience with
+            MeetOnMemory.
+          </p>
+        </div>
+
+        {loading ? (
+          <div
+            className="space-y-4"
+            aria-busy="true"
+            aria-label="Loading testimonials"
+          >
+            <div className="h-28 rounded-2xl bg-slate-100 dark:bg-gray-800 animate-pulse" />
+            <div className="h-40 rounded-2xl bg-slate-100 dark:bg-gray-800 animate-pulse" />
+          </div>
+        ) : listError ? (
+          <div className="rounded-2xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 px-6 py-8 text-center text-sm text-rose-700 dark:text-rose-300">
+            {listError}
+          </div>
+        ) : (
+          <>
+            <section
+              className="rounded-2xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 sm:p-8 mb-8"
+              aria-labelledby="rating-overview"
+            >
+              <h2
+                id="rating-overview"
+                className="text-lg font-semibold text-gray-900 dark:text-white mb-4"
+              >
+                Rating overview
+              </h2>
+              <div className="flex flex-col sm:flex-row gap-8">
+                <div className="text-center sm:text-left">
+                  <p className="text-4xl font-extrabold text-gray-900 dark:text-white">
+                    {stats?.averageRating?.toFixed?.(1) ?? "0.0"}
+                    <span className="text-lg font-semibold text-gray-500">
+                      {" "}
+                      / 5
+                    </span>
+                  </p>
+                  <div className="mt-2 flex justify-center sm:justify-start">
+                    <StarRating
+                      value={Math.round(stats?.averageRating || 0)}
+                      readOnly
+                    />
+                  </div>
+                  <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                    Based on {stats?.total || 0} review
+                    {(stats?.total || 0) === 1 ? "" : "s"}
+                  </p>
+                </div>
+
+                <div
+                  className="flex-1 space-y-2"
+                  aria-label="Rating distribution"
+                >
+                  {(stats?.distribution || []).map((row) => (
+                    <div key={row.stars} className="flex items-center gap-3">
+                      <span className="w-12 text-xs font-medium text-gray-600 dark:text-gray-300">
+                        {row.stars}★
+                      </span>
+                      <div className="flex-1 h-2 rounded-full bg-slate-100 dark:bg-gray-800 overflow-hidden">
+                        <div
+                          className="h-full bg-amber-400 rounded-full"
+                          style={{ width: `${row.percent}%` }}
+                        />
+                      </div>
+                      <span className="w-10 text-right text-xs text-gray-500">
+                        {row.percent}%
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section
+              className="rounded-2xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 sm:p-8 mb-10"
+              aria-labelledby="your-review"
+            >
+              <h2
+                id="your-review"
+                className="text-lg font-semibold text-gray-900 dark:text-white mb-4"
+              >
+                {mine && !editing ? "Your review" : "Share your experience"}
+              </h2>
+
+              {!isLoggedin ? (
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  Please{" "}
+                  <Link
+                    to="/login"
+                    className="text-blue-600 dark:text-blue-400 font-semibold underline-offset-2 hover:underline"
+                  >
+                    sign in
+                  </Link>{" "}
+                  to submit a rating.
+                </p>
+              ) : mine && !editing ? (
+                <div className="space-y-4">
+                  <StarRating value={mine.rating} readOnly />
+                  <p className="text-gray-700 dark:text-gray-200">
+                    &ldquo;{mine.comment}&rdquo;
+                  </p>
+                  <p className="text-xs text-gray-500 capitalize">
+                    Status: {mine.status}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={startEdit}
+                    className="inline-flex items-center px-4 py-2 rounded-xl bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+                  >
+                    Edit Review
+                  </button>
+                </div>
+              ) : (
+                <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Rating
+                    </label>
+                    <StarRating value={rating} onChange={setRating} />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="testimonial-comment"
+                      className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+                    >
+                      Comment
+                    </label>
+                    <textarea
+                      id="testimonial-comment"
+                      value={comment}
+                      onChange={(e) => setComment(e.target.value)}
+                      rows={3}
+                      maxLength={COMMENT_MAX}
+                      className="w-full rounded-xl border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-950 px-4 py-3 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      placeholder="Share what stood out about MeetOnMemory (1–3 short lines)."
+                      required
+                    />
+                    <p className="mt-1 text-xs text-gray-500">
+                      {comment.trim().length}/{COMMENT_MAX} characters
+                    </p>
+                  </div>
+
+                  {formError ? (
+                    <p
+                      className="text-sm text-rose-600 dark:text-rose-400"
+                      role="alert"
+                    >
+                      {formError}
+                    </p>
+                  ) : null}
+
+                  <div className="flex flex-wrap gap-3">
+                    <button
+                      type="submit"
+                      disabled={submitting}
+                      className="inline-flex items-center px-5 py-2.5 rounded-xl bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
+                    >
+                      {submitting
+                        ? "Saving…"
+                        : mine
+                          ? "Update review"
+                          : "Submit review"}
+                    </button>
+                    {editing ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditing(false);
+                          setRating(mine.rating);
+                          setComment(mine.comment);
+                          setFormError("");
+                        }}
+                        className="inline-flex items-center px-5 py-2.5 rounded-xl border border-slate-200 dark:border-gray-700 text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                    ) : null}
+                  </div>
+                </form>
+              )}
+            </section>
+
+            <section aria-labelledby="all-testimonials">
+              <h2
+                id="all-testimonials"
+                className="text-lg font-semibold text-gray-900 dark:text-white mb-4"
+              >
+                Community testimonials
+              </h2>
+              {testimonials.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-slate-200 dark:border-gray-700 px-6 py-12 text-center">
+                  <p className="text-gray-600 dark:text-gray-300 font-medium">
+                    No testimonials yet.
+                  </p>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Be the first to share your experience.
+                  </p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {testimonials.map((item) => (
+                    <TestimonialCard key={item.id} testimonial={item} />
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/client/src/routes/PublicRoutes.jsx
+++ b/client/src/routes/PublicRoutes.jsx
@@ -18,10 +18,12 @@ import PublicSharedView from "../pages/PublicSharedView.jsx";
 import DeveloperDocs from "../pages/DeveloperDocs.jsx";
 import AcceptInvite from "../pages/AcceptInvite.jsx";
 import MeetingInviteJoin from "../pages/MeetingInviteJoin.jsx";
+import Testimonials from "../pages/Testimonials.jsx";
 
 const PublicRoutes = (
   <React.Fragment>
     <Route path="/" element={<Home />} />
+    <Route path="/testimonials" element={<Testimonials />} />
     {/* Clerk path-based auth (supports /login/factor-password, SSO callbacks, etc.) */}
     <Route path="/login/*" element={<Login />} />
     <Route path="/signup/*" element={<SignUp />} />

--- a/server/controllers/testimonialController.js
+++ b/server/controllers/testimonialController.js
@@ -1,0 +1,470 @@
+import { z } from "zod";
+import mongoose from "mongoose";
+import Testimonial, {
+  TESTIMONIAL_COMMENT_MAX_LENGTH,
+} from "../models/testimonialModel.js";
+
+const commentSchema = z
+  .string()
+  .trim()
+  .min(10, "Comment must be at least 10 characters")
+  .max(
+    TESTIMONIAL_COMMENT_MAX_LENGTH,
+    `Comment must be at most ${TESTIMONIAL_COMMENT_MAX_LENGTH} characters`,
+  );
+
+const testimonialBodySchema = z.object({
+  rating: z.coerce.number().int().min(1).max(5),
+  comment: commentSchema,
+});
+
+const statusSchema = z.object({
+  status: z.enum(["pending", "approved", "rejected"]),
+});
+
+const PUBLIC_USER_SELECT = "name profilePic role organization";
+const PUBLIC_ORG_SELECT = "name";
+
+const toPublicTestimonial = (doc) => {
+  const user = doc.user || {};
+  const organization = doc.organization || null;
+
+  return {
+    id: doc._id,
+    rating: doc.rating,
+    comment: doc.comment,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt,
+    user: {
+      name: user.name || "Anonymous",
+      profilePic: user.profilePic || "",
+      role: user.role || null,
+    },
+    organization: organization ? { name: organization.name || null } : null,
+  };
+};
+
+const toOwnerTestimonial = (doc) => ({
+  ...toPublicTestimonial(doc),
+  status: doc.status,
+});
+
+const toAdminTestimonial = (doc) => ({
+  ...toOwnerTestimonial(doc),
+  userId: doc.user?._id || doc.user,
+  moderatedAt: doc.moderatedAt,
+  moderatedBy: doc.moderatedBy,
+});
+
+const populatePublic = (query) =>
+  query
+    .populate("user", PUBLIC_USER_SELECT)
+    .populate("organization", PUBLIC_ORG_SELECT);
+
+/**
+ * GET /api/testimonials
+ * Public list of approved testimonials (paginated).
+ */
+export const listApprovedTestimonials = async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(
+      50,
+      Math.max(1, parseInt(req.query.limit, 10) || 12),
+    );
+    const skip = (page - 1) * limit;
+
+    const filter = { status: "approved" };
+    const [items, total] = await Promise.all([
+      populatePublic(
+        Testimonial.find(filter)
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(limit),
+      ).lean(),
+      Testimonial.countDocuments(filter),
+    ]);
+
+    return res.status(200).json({
+      success: true,
+      testimonials: items.map(toPublicTestimonial),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 0,
+      },
+    });
+  } catch (error) {
+    console.error("Error listing testimonials:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load testimonials",
+    });
+  }
+};
+
+/**
+ * GET /api/testimonials/stats
+ * Aggregate stats from approved testimonials only.
+ */
+export const getTestimonialStats = async (req, res) => {
+  try {
+    const [stats] = await Testimonial.aggregate([
+      { $match: { status: "approved" } },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: 1 },
+          averageRating: { $avg: "$rating" },
+          star1: { $sum: { $cond: [{ $eq: ["$rating", 1] }, 1, 0] } },
+          star2: { $sum: { $cond: [{ $eq: ["$rating", 2] }, 1, 0] } },
+          star3: { $sum: { $cond: [{ $eq: ["$rating", 3] }, 1, 0] } },
+          star4: { $sum: { $cond: [{ $eq: ["$rating", 4] }, 1, 0] } },
+          star5: { $sum: { $cond: [{ $eq: ["$rating", 5] }, 1, 0] } },
+        },
+      },
+    ]);
+
+    const total = stats?.total || 0;
+    const averageRating = total
+      ? Math.round((stats.averageRating + Number.EPSILON) * 10) / 10
+      : 0;
+
+    const distribution = [5, 4, 3, 2, 1].map((stars) => {
+      const count = stats?.[`star${stars}`] || 0;
+      const percent = total ? Math.round((count / total) * 100) : 0;
+      return { stars, count, percent };
+    });
+
+    return res.status(200).json({
+      success: true,
+      stats: {
+        total,
+        averageRating,
+        distribution,
+      },
+    });
+  } catch (error) {
+    console.error("Error computing testimonial stats:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load rating statistics",
+    });
+  }
+};
+
+/**
+ * GET /api/testimonials/me
+ */
+export const getMyTestimonial = async (req, res) => {
+  try {
+    const userId = req.user._id || req.user.id;
+    const doc = await populatePublic(
+      Testimonial.findOne({ user: userId }),
+    ).lean();
+
+    return res.status(200).json({
+      success: true,
+      testimonial: doc ? toOwnerTestimonial(doc) : null,
+    });
+  } catch (error) {
+    console.error("Error fetching own testimonial:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load your review",
+    });
+  }
+};
+
+/**
+ * POST /api/testimonials
+ */
+export const createTestimonial = async (req, res) => {
+  try {
+    const parsed = testimonialBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: parsed.error.issues[0]?.message || "Invalid testimonial data",
+      });
+    }
+
+    const userId = req.user._id || req.user.id;
+    const existing = await Testimonial.findOne({ user: userId }).lean();
+    if (existing) {
+      return res.status(409).json({
+        success: false,
+        message:
+          "You have already submitted a review. Edit your existing review instead.",
+      });
+    }
+
+    const created = await Testimonial.create({
+      user: userId,
+      organization: req.user.organization || null,
+      rating: parsed.data.rating,
+      comment: parsed.data.comment,
+      status: "pending",
+    });
+
+    const doc = await populatePublic(Testimonial.findById(created._id)).lean();
+
+    return res.status(201).json({
+      success: true,
+      message: "Your review has been submitted and is awaiting approval.",
+      testimonial: toOwnerTestimonial(doc),
+    });
+  } catch (error) {
+    if (error?.code === 11000) {
+      return res.status(409).json({
+        success: false,
+        message:
+          "You have already submitted a review. Edit your existing review instead.",
+      });
+    }
+    console.error("Error creating testimonial:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to submit review",
+    });
+  }
+};
+
+/**
+ * PUT /api/testimonials/:id
+ */
+export const updateTestimonial = async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid testimonial id",
+      });
+    }
+
+    const parsed = testimonialBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: parsed.error.issues[0]?.message || "Invalid testimonial data",
+      });
+    }
+
+    const userId = req.user._id || req.user.id;
+    const existing = await Testimonial.findById(id);
+    if (!existing) {
+      return res.status(404).json({
+        success: false,
+        message: "Testimonial not found",
+      });
+    }
+
+    if (existing.user.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "You can only edit your own review",
+      });
+    }
+
+    existing.rating = parsed.data.rating;
+    existing.comment = parsed.data.comment;
+    // Re-moderate after edits so pending/rejected content is not auto-published
+    existing.status = "pending";
+    existing.moderatedAt = null;
+    existing.moderatedBy = null;
+    await existing.save();
+
+    const doc = await populatePublic(Testimonial.findById(existing._id)).lean();
+
+    return res.status(200).json({
+      success: true,
+      message: "Your review has been updated and is awaiting approval.",
+      testimonial: toOwnerTestimonial(doc),
+    });
+  } catch (error) {
+    console.error("Error updating testimonial:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update review",
+    });
+  }
+};
+
+/**
+ * DELETE /api/testimonials/:id
+ */
+export const deleteOwnTestimonial = async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid testimonial id",
+      });
+    }
+
+    const userId = req.user._id || req.user.id;
+    const existing = await Testimonial.findById(id);
+    if (!existing) {
+      return res.status(404).json({
+        success: false,
+        message: "Testimonial not found",
+      });
+    }
+
+    if (existing.user.toString() !== userId.toString()) {
+      return res.status(403).json({
+        success: false,
+        message: "You can only delete your own review",
+      });
+    }
+
+    await existing.deleteOne();
+
+    return res.status(200).json({
+      success: true,
+      message: "Your review has been deleted",
+    });
+  } catch (error) {
+    console.error("Error deleting testimonial:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to delete review",
+    });
+  }
+};
+
+/**
+ * GET /api/admin/testimonials
+ */
+export const listAdminTestimonials = async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(
+      50,
+      Math.max(1, parseInt(req.query.limit, 10) || 20),
+    );
+    const skip = (page - 1) * limit;
+    const status = req.query.status;
+
+    const filter = {};
+    if (status && ["pending", "approved", "rejected"].includes(status)) {
+      filter.status = status;
+    }
+
+    const [items, total] = await Promise.all([
+      populatePublic(
+        Testimonial.find(filter)
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(limit),
+      ).lean(),
+      Testimonial.countDocuments(filter),
+    ]);
+
+    return res.status(200).json({
+      success: true,
+      testimonials: items.map(toAdminTestimonial),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 0,
+      },
+    });
+  } catch (error) {
+    console.error("Error listing admin testimonials:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load testimonials for moderation",
+    });
+  }
+};
+
+/**
+ * PATCH /api/admin/testimonials/:id/status
+ */
+export const updateTestimonialStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid testimonial id",
+      });
+    }
+
+    const parsed = statusSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: "Status must be pending, approved, or rejected",
+      });
+    }
+
+    const existing = await Testimonial.findById(id);
+    if (!existing) {
+      return res.status(404).json({
+        success: false,
+        message: "Testimonial not found",
+      });
+    }
+
+    existing.status = parsed.data.status;
+    existing.moderatedBy = req.user._id || req.user.id;
+    existing.moderatedAt = new Date();
+    await existing.save();
+
+    const doc = await populatePublic(Testimonial.findById(existing._id)).lean();
+
+    return res.status(200).json({
+      success: true,
+      message: `Testimonial marked as ${parsed.data.status}`,
+      testimonial: toAdminTestimonial(doc),
+    });
+  } catch (error) {
+    console.error("Error updating testimonial status:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update moderation status",
+    });
+  }
+};
+
+/**
+ * DELETE /api/admin/testimonials/:id
+ */
+export const adminDeleteTestimonial = async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid testimonial id",
+      });
+    }
+
+    const existing = await Testimonial.findById(id);
+    if (!existing) {
+      return res.status(404).json({
+        success: false,
+        message: "Testimonial not found",
+      });
+    }
+
+    await existing.deleteOne();
+
+    return res.status(200).json({
+      success: true,
+      message: "Testimonial removed",
+    });
+  } catch (error) {
+    console.error("Error admin-deleting testimonial:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to remove testimonial",
+    });
+  }
+};

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -266,3 +266,26 @@ export const createInvitationCreateLimiter = (overrides = {}) =>
   });
 
 export const invitationCreateLimiter = createInvitationCreateLimiter();
+
+/**
+ * Per-user limiter for public product testimonial submissions (Issue #1572).
+ * Caps abuse while allowing legitimate create/update retries.
+ */
+export const createTestimonialSubmitLimiter = (overrides = {}) =>
+  rateLimit({
+    ...baseOptions,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 10,
+    keyGenerator: (req) => {
+      const userId = req.user?._id || req.user?.id;
+      return userId ? `user:${userId}` : `ip:${getClientIp(req)}`;
+    },
+    message: {
+      success: false,
+      message: "Too many testimonial submissions. Please try again later.",
+    },
+    store: createStore("rl:testimonial_submit:"),
+    ...overrides,
+  });
+
+export const testimonialSubmitLimiter = createTestimonialSubmitLimiter();

--- a/server/models/testimonialModel.js
+++ b/server/models/testimonialModel.js
@@ -1,0 +1,54 @@
+import mongoose from "mongoose";
+
+const COMMENT_MAX_LENGTH = 500;
+
+const testimonialSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      default: null,
+    },
+    rating: {
+      type: Number,
+      required: true,
+      min: 1,
+      max: 5,
+    },
+    comment: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: COMMENT_MAX_LENGTH,
+    },
+    status: {
+      type: String,
+      enum: ["pending", "approved", "rejected"],
+      default: "pending",
+      index: true,
+    },
+    moderatedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+    },
+    moderatedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true },
+);
+
+// One active review per user
+testimonialSchema.index({ user: 1 }, { unique: true });
+testimonialSchema.index({ status: 1, createdAt: -1 });
+
+export const TESTIMONIAL_COMMENT_MAX_LENGTH = COMMENT_MAX_LENGTH;
+
+export default mongoose.model("Testimonial", testimonialSchema);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -60,6 +60,9 @@ import actionItemDependencyRoutes from "./actionItemDependencyRoutes.js";
 import parkingLotRoutes from "./parkingLotRoutes.js";
 import sentimentTimelineRoutes from "./sentimentTimelineRoutes.js";
 import meetingRsvpRoutes from "./meetingRsvpRoutes.js";
+import testimonialRoutes, {
+  adminTestimonialRouter,
+} from "./testimonialRoutes.js";
 
 import calendarRoutes from "./calendarRoutes.js";
 import assistantRoutes from "./assistantRoutes.js";
@@ -157,5 +160,7 @@ router.use("/api/action-item-dependencies", actionItemDependencyRoutes);
 router.use("/api/parking-lot", parkingLotRoutes);
 router.use("/api/sentiment-timeline", sentimentTimelineRoutes);
 router.use("/api/rsvps", meetingRsvpRoutes);
+router.use("/api/testimonials", testimonialRoutes);
+router.use("/api/admin/testimonials", adminTestimonialRouter);
 
 export default router;

--- a/server/routes/testimonialRoutes.js
+++ b/server/routes/testimonialRoutes.js
@@ -1,0 +1,36 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import { requireAdminOrOwner } from "../middleware/rbac.js";
+import { testimonialSubmitLimiter } from "../middleware/rateLimiter.js";
+import {
+  listApprovedTestimonials,
+  getTestimonialStats,
+  getMyTestimonial,
+  createTestimonial,
+  updateTestimonial,
+  deleteOwnTestimonial,
+  listAdminTestimonials,
+  updateTestimonialStatus,
+  adminDeleteTestimonial,
+} from "../controllers/testimonialController.js";
+
+const router = express.Router();
+
+// Public
+router.get("/", listApprovedTestimonials);
+router.get("/stats", getTestimonialStats);
+
+// Authenticated user
+router.get("/me", userAuth, getMyTestimonial);
+router.post("/", userAuth, testimonialSubmitLimiter, createTestimonial);
+router.put("/:id", userAuth, testimonialSubmitLimiter, updateTestimonial);
+router.delete("/:id", userAuth, deleteOwnTestimonial);
+
+export default router;
+
+export const adminTestimonialRouter = express.Router();
+
+adminTestimonialRouter.use(userAuth, requireAdminOrOwner);
+adminTestimonialRouter.get("/", listAdminTestimonials);
+adminTestimonialRouter.patch("/:id/status", updateTestimonialStatus);
+adminTestimonialRouter.delete("/:id", adminDeleteTestimonial);

--- a/server/tests/routeRegistration.test.js
+++ b/server/tests/routeRegistration.test.js
@@ -72,6 +72,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/ai-summary-templates",
       "/api/topics",
       "/api/quality",
+      "/api/testimonials",
     ];
 
     for (const prefix of standaloneRoutePrefixes) {
@@ -144,6 +145,8 @@ describe("Route Consolidation and Registration", () => {
       "/api/workspace",
       "/api/recap",
       "/api/quality",
+      "/api/testimonials",
+      "/api/admin/testimonials",
     ];
 
     for (const routePath of expectedRoutes) {

--- a/server/tests/testimonialController.test.js
+++ b/server/tests/testimonialController.test.js
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  listApprovedTestimonials,
+  getTestimonialStats,
+  createTestimonial,
+  updateTestimonial,
+  deleteOwnTestimonial,
+  updateTestimonialStatus,
+} from "../controllers/testimonialController.js";
+import Testimonial from "../models/testimonialModel.js";
+
+vi.mock("../models/testimonialModel.js", () => {
+  const Model = {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findById: vi.fn(),
+    countDocuments: vi.fn(),
+    create: vi.fn(),
+    aggregate: vi.fn(),
+  };
+  return {
+    default: Model,
+    TESTIMONIAL_COMMENT_MAX_LENGTH: 500,
+  };
+});
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+};
+
+const chainFind = (docs) => {
+  const chain = {
+    sort: vi.fn().mockReturnThis(),
+    skip: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    populate: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(docs),
+  };
+  return chain;
+};
+
+describe("testimonialController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists only approved testimonials publicly", async () => {
+    const docs = [
+      {
+        _id: "t1",
+        rating: 5,
+        comment: "Great product for meeting notes",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { name: "Ada", profilePic: "", role: "member" },
+        organization: { name: "Acme" },
+      },
+    ];
+    Testimonial.find.mockReturnValue(chainFind(docs));
+    Testimonial.countDocuments.mockResolvedValue(1);
+
+    const req = { query: {} };
+    const res = mockRes();
+    await listApprovedTestimonials(req, res);
+
+    expect(Testimonial.find).toHaveBeenCalledWith({ status: "approved" });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        testimonials: [
+          expect.objectContaining({
+            rating: 5,
+            comment: "Great product for meeting notes",
+            user: expect.objectContaining({ name: "Ada" }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("computes stats from approved testimonials only", async () => {
+    Testimonial.aggregate.mockResolvedValue([
+      {
+        total: 2,
+        averageRating: 4.5,
+        star1: 0,
+        star2: 0,
+        star3: 0,
+        star4: 1,
+        star5: 1,
+      },
+    ]);
+
+    const res = mockRes();
+    await getTestimonialStats({}, res);
+
+    expect(Testimonial.aggregate).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      stats: {
+        total: 2,
+        averageRating: 4.5,
+        distribution: [
+          { stars: 5, count: 1, percent: 50 },
+          { stars: 4, count: 1, percent: 50 },
+          { stars: 3, count: 0, percent: 0 },
+          { stars: 2, count: 0, percent: 0 },
+          { stars: 1, count: 0, percent: 0 },
+        ],
+      },
+    });
+  });
+
+  it("rejects invalid ratings on create", async () => {
+    const req = {
+      user: { _id: "u1", organization: null },
+      body: { rating: 6, comment: "This is a valid length comment" },
+    };
+    const res = mockRes();
+    await createTestimonial(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(Testimonial.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only comments", async () => {
+    const req = {
+      user: { _id: "u1" },
+      body: { rating: 5, comment: "     " },
+    };
+    const res = mockRes();
+    await createTestimonial(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("prevents duplicate submissions for the same user", async () => {
+    Testimonial.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ _id: "existing" }),
+    });
+
+    const req = {
+      user: { _id: "u1", organization: null },
+      body: {
+        rating: 5,
+        comment: "Another thoughtful review about the product",
+      },
+    };
+    const res = mockRes();
+    await createTestimonial(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(Testimonial.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a pending testimonial for authenticated users", async () => {
+    Testimonial.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue(null),
+    });
+    Testimonial.create.mockResolvedValue({ _id: "t1" });
+    Testimonial.findById.mockReturnValue(
+      chainFind({
+        _id: "t1",
+        rating: 5,
+        comment: "Another thoughtful review about the product",
+        status: "pending",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { name: "Ada", profilePic: "", role: "member" },
+        organization: null,
+      }),
+    );
+
+    // findById after create uses populate chain differently - fix mock
+    const populateChain = {
+      populate: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue({
+        _id: "t1",
+        rating: 5,
+        comment: "Another thoughtful review about the product",
+        status: "pending",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        user: { name: "Ada", profilePic: "", role: "member" },
+        organization: null,
+      }),
+    };
+    populateChain.populate.mockReturnValue(populateChain);
+    Testimonial.findById.mockReturnValue(populateChain);
+
+    const req = {
+      user: { _id: "u1", organization: "org1" },
+      body: {
+        rating: 5,
+        comment: "Another thoughtful review about the product",
+      },
+    };
+    const res = mockRes();
+    await createTestimonial(req, res);
+
+    expect(Testimonial.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: "u1",
+        status: "pending",
+        rating: 5,
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("blocks editing another user's testimonial", async () => {
+    Testimonial.findById.mockResolvedValue({
+      user: { toString: () => "owner-id" },
+    });
+
+    const req = {
+      user: { _id: "other-user" },
+      params: { id: "507f1f77bcf86cd799439011" },
+      body: {
+        rating: 4,
+        comment: "Trying to edit someone else's review text",
+      },
+    };
+    const res = mockRes();
+    await updateTestimonial(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("allows owners to update and resets status to pending", async () => {
+    const existing = {
+      user: { toString: () => "u1" },
+      _id: "507f1f77bcf86cd799439011",
+      rating: 3,
+      comment: "old",
+      status: "approved",
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    Testimonial.findById.mockResolvedValueOnce(existing).mockReturnValueOnce(
+      (() => {
+        const chain = {
+          populate: vi.fn().mockReturnThis(),
+          lean: vi.fn().mockResolvedValue({
+            _id: existing._id,
+            rating: 4,
+            comment: "Updated thoughtful review about the product",
+            status: "pending",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            user: { name: "Ada", profilePic: "", role: "member" },
+            organization: null,
+          }),
+        };
+        chain.populate.mockReturnValue(chain);
+        return chain;
+      })(),
+    );
+
+    const req = {
+      user: { _id: "u1" },
+      params: { id: "507f1f77bcf86cd799439011" },
+      body: {
+        rating: 4,
+        comment: "Updated thoughtful review about the product",
+      },
+    };
+    const res = mockRes();
+    await updateTestimonial(req, res);
+
+    expect(existing.status).toBe("pending");
+    expect(existing.save).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("blocks deleting another user's testimonial", async () => {
+    Testimonial.findById.mockResolvedValue({
+      user: { toString: () => "owner-id" },
+      deleteOne: vi.fn(),
+    });
+
+    const req = {
+      user: { _id: "other" },
+      params: { id: "507f1f77bcf86cd799439011" },
+    };
+    const res = mockRes();
+    await deleteOwnTestimonial(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("allows admins to approve testimonials", async () => {
+    const existing = {
+      _id: "507f1f77bcf86cd799439011",
+      status: "pending",
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    Testimonial.findById.mockResolvedValueOnce(existing).mockReturnValueOnce(
+      (() => {
+        const chain = {
+          populate: vi.fn().mockReturnThis(),
+          lean: vi.fn().mockResolvedValue({
+            _id: existing._id,
+            rating: 5,
+            comment: "Approved review content here",
+            status: "approved",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            user: { _id: "u1", name: "Ada", profilePic: "", role: "member" },
+            organization: null,
+            moderatedAt: new Date(),
+            moderatedBy: "admin1",
+          }),
+        };
+        chain.populate.mockReturnValue(chain);
+        return chain;
+      })(),
+    );
+
+    const req = {
+      user: { _id: "admin1", role: "admin" },
+      params: { id: "507f1f77bcf86cd799439011" },
+      body: { status: "approved" },
+    };
+    const res = mockRes();
+    await updateTestimonialStatus(req, res);
+
+    expect(existing.status).toBe("approved");
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1572
- Adds database-backed testimonials with pending/approved/rejected moderation
- Homepage carousel (before FAQ) + `/testimonials` page for stats/submit/edit
- Admin Panel moderation using existing admin/owner RBAC
## Test plan
- [ ] `npm run lint:changed --prefix client && npm run format:check:changed --prefix client`
- [ ] `npm run lint:changed --prefix server && npm run format:check:changed --prefix server`
- [ ] `cd server && npx vitest run tests/testimonialController.test.js`
- [ ] `cd client && npx vitest run src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx`
- [ ] Homepage shows Testimonials section before FAQ; CTA opens `/testimonials`
- [ ] Signed-in user can submit/edit one review (starts as pending)
- [ ] Only approved reviews appear publicly; admin can approve/reject/remove
