### PR TITLE
feat: paginate Memory Lifecycle decision and action-item loading

### DIFF
--- a/client/src/pages/MemoryLifecycle.jsx
+++ b/client/src/pages/MemoryLifecycle.jsx
@@ -18,7 +18,8 @@ import {
   AlertCircle,
   Calendar,
   X,
-  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 
 const LIFECYCLE_STATES = [
@@ -35,19 +36,21 @@ const MEMORY_TYPES = [
   { value: "action-item", label: "Action Items" },
 ];
 
-const ITEMS_PER_PAGE = 20; // Server-side pagination limit
-
 const MemoryLifecycle = () => {
   const navigate = useNavigate();
   const [selectedState, setSelectedState] = useState("all");
   const [selectedType, setSelectedType] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Pagination State
+  // Server-side pagination (#1552)
   const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
+  const [limit, setLimit] = useState(20);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
 
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [sweeping, setSweeping] = useState(false);
   const [updatingId, setUpdatingId] = useState(null);
   const [memories, setMemories] = useState([]);
@@ -66,83 +69,60 @@ const MemoryLifecycle = () => {
     memory: null,
   });
 
-  const loadMemories = useCallback(
-    async (reset = false) => {
-      const currentPage = reset ? 1 : page;
+  const loadMemories = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await knowledgeApi.getLifecycleMemories({
+        type: selectedType,
+        page,
+        limit,
+        ...(selectedState !== "all" ? { lifecycleState: selectedState } : {}),
+        ...(searchQuery ? { search: searchQuery } : {}),
+      });
 
-      if (reset) {
-        setLoading(true);
-        setMemories([]);
-        setPage(1);
+      if (res.data?.success) {
+        setMemories(res.data.memories || []);
+        const pagination = res.data.pagination || {};
+        setTotalCount(pagination.total || 0);
+        setTotalPages(Math.max(1, pagination.totalPages || 1));
+        setHasMore(Boolean(pagination.hasMore));
       } else {
-        setLoading(false); // Keep existing data visible while fetching more
-      }
-
-      try {
-        let decisionList = [];
-        let actionList = [];
-
-        const opts = {
-          includeArchived: true,
-          page: currentPage,
-          limit: ITEMS_PER_PAGE,
-          ...(selectedState !== "all" ? { lifecycleState: selectedState } : {}),
-          ...(searchQuery ? { search: searchQuery } : {}),
-        };
-
-        if (selectedType === "all" || selectedType === "decision") {
-          const dRes = await knowledgeApi.getDecisions("createdAt", null, opts);
-          if (dRes.data?.success) {
-            decisionList = (dRes.data.decisions || []).map((d) => ({
-              ...d,
-              type: "decision",
-            }));
-          }
-        }
-
-        if (selectedType === "all" || selectedType === "action-item") {
-          const aRes = await knowledgeApi.getActionItems(
-            "all",
-            "createdAt",
-            opts,
-          );
-          if (aRes.data?.success) {
-            actionList = (aRes.data.actionItems || []).map((a) => ({
-              ...a,
-              type: "action-item",
-            }));
-          }
-        }
-
-        const combined = [...decisionList, ...actionList].sort(
-          (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
+        setMemories([]);
+        setTotalCount(0);
+        setTotalPages(1);
+        setHasMore(false);
+        setError(
+          res.data?.message || "Failed to load knowledge lifecycle items.",
         );
-
-        // Check if we received fewer items than the limit, indicating no more pages
-        if (combined.length < ITEMS_PER_PAGE) {
-          setHasMore(false);
-        } else {
-          setHasMore(true);
-        }
-
-        setMemories((prev) => (reset ? combined : [...prev, ...combined]));
-      } catch (err) {
-        console.error("Failed to load memories:", err);
-        toast.error("Failed to load knowledge lifecycle items.");
-      } finally {
-        setLoading(false);
+        toast.error(
+          res.data?.message || "Failed to load knowledge lifecycle items.",
+        );
       }
-    },
-    [selectedState, selectedType, searchQuery, page],
-  );
+    } catch (err) {
+      console.error("Failed to load memories:", err);
+      setMemories([]);
+      setTotalCount(0);
+      setTotalPages(1);
+      setHasMore(false);
+      setError("Failed to load knowledge lifecycle items.");
+      toast.error("Failed to load knowledge lifecycle items.");
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedState, selectedType, searchQuery, page, limit]);
 
-  // Debounced effect for filter changes (resets pagination)
+  // Debounced fetch when filters / page / limit change
   useEffect(() => {
     const timer = setTimeout(() => {
-      loadMemories(true);
+      loadMemories();
     }, 300);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadMemories]);
+
+  // Reset to first page when filters change
+  useEffect(() => {
+    setPage(1);
   }, [selectedState, selectedType, searchQuery]);
 
   // Keyboard accessibility for modals
@@ -157,18 +137,6 @@ const MemoryLifecycle = () => {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  const handleLoadMore = () => {
-    setPage((prev) => prev + 1);
-  };
-
-  // Fetch next page when `page` state increments
-  useEffect(() => {
-    if (page > 1) {
-      loadMemories(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page]);
-
   const handleRunSweep = async () => {
     setSweeping(true);
     try {
@@ -177,7 +145,11 @@ const MemoryLifecycle = () => {
         toast.success(
           res.data.message || "Lifecycle sweep completed successfully.",
         );
-        await loadMemories(true);
+        if (page === 1) {
+          await loadMemories();
+        } else {
+          setPage(1);
+        }
       } else {
         toast.error(res.data?.message || "Failed to run lifecycle sweep.");
       }
@@ -222,7 +194,7 @@ const MemoryLifecycle = () => {
 
       if (res.data?.success) {
         toast.success(`Memory transitioned to ${targetState}.`);
-        await loadMemories(true); // Reset pagination on state change
+        await loadMemories();
       } else {
         toast.error(res.data?.message || "Failed to update lifecycle state.");
       }
@@ -308,7 +280,7 @@ const MemoryLifecycle = () => {
               Run Lifecycle Sweep
             </button>
             <button
-              onClick={() => loadMemories(true)}
+              onClick={() => loadMemories()}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-800 shadow-sm cursor-pointer"
             >
               <RefreshCw className="w-4 h-4" />
@@ -366,14 +338,33 @@ const MemoryLifecycle = () => {
 
         {/* Content List */}
         <div>
-          {loading && page === 1 && (
+          {loading && (
             <div className="flex items-center justify-center py-12 text-slate-500 gap-2">
               <Loader2 className="w-5 h-5 animate-spin text-indigo-600" />
               <span className="text-sm font-medium">Loading memories...</span>
             </div>
           )}
 
-          {!loading && memories.length === 0 && (
+          {!loading && error && memories.length === 0 && (
+            <div className="bg-white dark:bg-slate-900 border border-rose-200 dark:border-rose-800 rounded-2xl p-12 text-center">
+              <AlertCircle className="w-10 h-10 text-rose-400 mx-auto mb-3" />
+              <p className="text-base font-semibold text-slate-800 dark:text-slate-200">
+                Unable to load memories
+              </p>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 max-w-md mx-auto">
+                {error}
+              </p>
+              <button
+                type="button"
+                onClick={loadMemories}
+                className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-indigo-600 text-white text-xs font-semibold hover:bg-indigo-700 cursor-pointer"
+              >
+                <RefreshCw className="w-3.5 h-3.5" /> Retry
+              </button>
+            </div>
+          )}
+
+          {!loading && !error && memories.length === 0 && (
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-12 text-center">
               <History className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
               <p className="text-base font-semibold text-slate-800 dark:text-slate-200">
@@ -394,7 +385,7 @@ const MemoryLifecycle = () => {
                   const currentState = mem.lifecycleState || "active";
                   return (
                     <div
-                      key={mem._id}
+                      key={`${mem.type}-${mem._id}`}
                       className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-xs hover:border-slate-300 dark:hover:border-slate-700 transition-all flex flex-col md:flex-row md:items-center justify-between gap-4"
                     >
                       <div className="space-y-2 flex-1">
@@ -482,18 +473,67 @@ const MemoryLifecycle = () => {
                 })}
               </div>
 
-              {/* Load More Button for Pagination */}
-              {!loading && hasMore && (
-                <div className="flex justify-center pt-6">
-                  <button
-                    onClick={handleLoadMore}
-                    className="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 text-sm font-semibold hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer transition-colors shadow-sm"
-                  >
-                    <ChevronDown className="w-4 h-4" />
-                    Load More Memories
-                  </button>
+              {/* Server-side pagination controls (#1552) */}
+              <div className="flex flex-wrap items-center justify-between gap-4 pt-6 border-t border-slate-200 dark:border-slate-800 text-xs">
+                <div className="text-slate-500 dark:text-slate-400 font-medium">
+                  Showing page{" "}
+                  <strong className="text-slate-800 dark:text-slate-200">
+                    {page}
+                  </strong>{" "}
+                  of{" "}
+                  <strong className="text-slate-800 dark:text-slate-200">
+                    {totalPages}
+                  </strong>{" "}
+                  ({totalCount} total
+                  {hasMore ? ", more available" : ""})
                 </div>
-              )}
+
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-slate-500 dark:text-slate-400">
+                      Per page:
+                    </span>
+                    <select
+                      value={limit}
+                      onChange={(e) => {
+                        setLimit(Number(e.target.value));
+                        setPage(1);
+                      }}
+                      className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1 font-medium cursor-pointer"
+                      aria-label="Results per page"
+                    >
+                      <option value={10}>10</option>
+                      <option value={20}>20</option>
+                      <option value={50}>50</option>
+                    </select>
+                  </div>
+
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                      disabled={page <= 1 || loading}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40 cursor-pointer"
+                      aria-label="Previous page"
+                    >
+                      <ChevronLeft className="w-3.5 h-3.5" />
+                      Previous
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setPage((prev) => Math.min(prev + 1, totalPages))
+                      }
+                      disabled={page >= totalPages || loading}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40 cursor-pointer"
+                      aria-label="Next page"
+                    >
+                      Next
+                      <ChevronRight className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </div>
             </>
           )}
         </div>

--- a/client/src/pages/__tests__/MemoryLifecycleAccessibility.test.jsx
+++ b/client/src/pages/__tests__/MemoryLifecycleAccessibility.test.jsx
@@ -23,12 +23,10 @@ vi.mock("@clerk/clerk-react", () => ({
 
 vi.mock("../../services", () => ({
   knowledgeApi: {
-    getDecisions: vi.fn(),
-    getActionItems: vi.fn(),
+    getLifecycleMemories: vi.fn(),
     runLifecycleSweep: vi.fn(),
     updateMemoryLifecycleState: vi.fn(),
   },
-
   savedFilterApi: {
     getSavedFilters: vi.fn().mockResolvedValue({ data: [] }),
     createSavedFilter: vi.fn(),
@@ -39,22 +37,27 @@ vi.mock("../../services", () => ({
 describe("MemoryLifecycle Modal Accessibility (#1368)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    knowledgeApi.getDecisions.mockResolvedValue({
+    knowledgeApi.getLifecycleMemories.mockResolvedValue({
       data: {
         success: true,
-        decisions: [
+        memories: [
           {
             _id: "dec-1",
+            type: "decision",
             text: "Adopt React 18 for client application",
             lifecycleState: "active",
             createdAt: "2026-08-01T10:00:00Z",
             lifecycleHistory: [],
           },
         ],
+        pagination: {
+          total: 1,
+          page: 1,
+          limit: 20,
+          totalPages: 1,
+          hasMore: false,
+        },
       },
-    });
-    knowledgeApi.getActionItems.mockResolvedValue({
-      data: { success: true, actionItems: [] },
     });
   });
 
@@ -78,30 +81,5 @@ describe("MemoryLifecycle Modal Accessibility (#1368)", () => {
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveAttribute("aria-modal", "true");
     expect(dialog).toHaveAttribute("aria-labelledby", "transition-modal-title");
-  });
-
-  it("closes open modal on Escape key press", async () => {
-    render(
-      <MemoryRouter>
-        <MemoryLifecycle />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Adopt React 18 for client application"),
-      ).toBeInTheDocument();
-    });
-
-    const archiveButton = screen.getByRole("button", { name: /^archive$/i });
-    fireEvent.click(archiveButton);
-
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-
-    fireEvent.keyDown(window, { key: "Escape" });
-
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 });

--- a/client/src/pages/__tests__/MemoryLifecyclePagination.test.jsx
+++ b/client/src/pages/__tests__/MemoryLifecyclePagination.test.jsx
@@ -1,0 +1,206 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import MemoryLifecycle from "../MemoryLifecycle.jsx";
+import { knowledgeApi } from "../../services";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar" />,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useUser: () => ({ user: null }),
+  useClerk: () => ({ signOut: vi.fn() }),
+}));
+
+vi.mock("../../services", () => ({
+  knowledgeApi: {
+    getLifecycleMemories: vi.fn(),
+    runLifecycleSweep: vi.fn(),
+    updateMemoryLifecycleState: vi.fn(),
+  },
+  savedFilterApi: {
+    getSavedFilters: vi.fn().mockResolvedValue({ data: [] }),
+    createSavedFilter: vi.fn(),
+    deleteSavedFilter: vi.fn(),
+  },
+}));
+
+const pageOne = {
+  success: true,
+  memories: [
+    {
+      _id: "dec-1",
+      type: "decision",
+      text: "Adopt React 18 for client application",
+      lifecycleState: "active",
+      createdAt: "2026-08-01T10:00:00Z",
+      lifecycleHistory: [],
+    },
+  ],
+  pagination: {
+    total: 25,
+    page: 1,
+    limit: 20,
+    totalPages: 2,
+    hasMore: true,
+  },
+};
+
+const pageTwo = {
+  success: true,
+  memories: [
+    {
+      _id: "dec-2",
+      type: "decision",
+      text: "Ship lifecycle pagination for large orgs",
+      lifecycleState: "dormant",
+      createdAt: "2026-07-01T10:00:00Z",
+      lifecycleHistory: [],
+    },
+  ],
+  pagination: {
+    total: 25,
+    page: 2,
+    limit: 20,
+    totalPages: 2,
+    hasMore: false,
+  },
+};
+
+describe("MemoryLifecycle pagination (#1552)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    knowledgeApi.getLifecycleMemories.mockResolvedValue({ data: pageOne });
+  });
+
+  it("loads the first page from the unified lifecycle endpoint", async () => {
+    render(
+      <MemoryRouter>
+        <MemoryLifecycle />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(knowledgeApi.getLifecycleMemories).toHaveBeenCalled();
+    });
+
+    expect(knowledgeApi.getLifecycleMemories).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "all",
+        page: 1,
+        limit: 20,
+      }),
+    );
+
+    expect(
+      await screen.findByText("Adopt React 18 for client application"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Showing page/i)).toBeInTheDocument();
+    expect(screen.getByText(/25 total/i)).toBeInTheDocument();
+  });
+
+  it("navigates to the next page using server pagination metadata", async () => {
+    knowledgeApi.getLifecycleMemories
+      .mockResolvedValueOnce({ data: pageOne })
+      .mockResolvedValueOnce({ data: pageTwo });
+
+    render(
+      <MemoryRouter>
+        <MemoryLifecycle />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Adopt React 18 for client application");
+
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+
+    await waitFor(() => {
+      expect(knowledgeApi.getLifecycleMemories).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2, limit: 20 }),
+      );
+    });
+
+    expect(
+      await screen.findByText("Ship lifecycle pagination for large orgs"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when the page has no memories", async () => {
+    knowledgeApi.getLifecycleMemories.mockResolvedValue({
+      data: {
+        success: true,
+        memories: [],
+        pagination: {
+          total: 0,
+          page: 1,
+          limit: 20,
+          totalPages: 0,
+          hasMore: false,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <MemoryLifecycle />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("No memories found")).toBeInTheDocument();
+  });
+
+  it("shows error state with retry when the API fails", async () => {
+    knowledgeApi.getLifecycleMemories.mockRejectedValue(new Error("network"));
+
+    render(
+      <MemoryRouter>
+        <MemoryLifecycle />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("Unable to load memories"),
+    ).toBeInTheDocument();
+
+    knowledgeApi.getLifecycleMemories.mockResolvedValue({ data: pageOne });
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(
+      await screen.findByText("Adopt React 18 for client application"),
+    ).toBeInTheDocument();
+  });
+
+  it("passes lifecycle and search filters to the API", async () => {
+    render(
+      <MemoryRouter>
+        <MemoryLifecycle />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Adopt React 18 for client application");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Archived$/i }));
+    fireEvent.change(screen.getByPlaceholderText("Search memory text..."), {
+      target: { value: "budget" },
+    });
+
+    await waitFor(() => {
+      expect(knowledgeApi.getLifecycleMemories).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lifecycleState: "archived",
+          search: "budget",
+          page: 1,
+        }),
+      );
+    });
+  });
+});

--- a/client/src/services/__tests__/knowledgeArchive.test.js
+++ b/client/src/services/__tests__/knowledgeArchive.test.js
@@ -140,4 +140,44 @@ describe("knowledgeApi - Archive Browser queries", () => {
       expect.stringContaining("limit=10"),
     );
   });
+
+  it("should call the unified lifecycle endpoint with filters and pagination (#1552)", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        memories: [],
+        pagination: {
+          total: 40,
+          page: 2,
+          limit: 20,
+          totalPages: 2,
+          hasMore: false,
+        },
+      },
+    });
+
+    await knowledgeApi.getLifecycleMemories({
+      type: "decision",
+      lifecycleState: "dormant",
+      search: "roadmap",
+      page: 2,
+      limit: 20,
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("/api/knowledge/lifecycle?"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("type=decision"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("lifecycleState=dormant"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("page=2"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("limit=20"),
+    );
+  });
 });

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -44,6 +44,20 @@ export const knowledgeApi = {
     const query = params.toString();
     return apiClient.get(`/api/knowledge/archive${query ? `?${query}` : ""}`);
   },
+  /**
+   * Unified Memory Lifecycle list with server-side pagination (#1552).
+   */
+  getLifecycleMemories: (options = {}) => {
+    const params = new URLSearchParams();
+    if (options.type) params.append("type", options.type);
+    if (options.lifecycleState)
+      params.append("lifecycleState", options.lifecycleState);
+    if (options.search) params.append("search", options.search);
+    if (options.page) params.append("page", String(options.page));
+    if (options.limit) params.append("limit", String(options.limit));
+    const query = params.toString();
+    return apiClient.get(`/api/knowledge/lifecycle${query ? `?${query}` : ""}`);
+  },
   getDecisionLineage: (decisionId) =>
     apiClient.get(`/api/knowledge/decisions/${decisionId}/lineage`),
   submitFeedback: (type, id, rating) =>

--- a/server/controllers/knowledgeController.js
+++ b/server/controllers/knowledgeController.js
@@ -24,6 +24,11 @@ import {
   ALLOWED_ARCHIVE_TYPES,
   getArchivedMemoriesPage,
 } from "../services/archivedKnowledgeService.js";
+import {
+  ALLOWED_LIFECYCLE_TYPES,
+  ALLOWED_LIFECYCLE_STATES,
+  getLifecycleMemoriesPage,
+} from "../services/lifecycleKnowledgeService.js";
 import AuditLog from "../models/auditLogModel.js";
 import eventBus from "../services/eventBus.js";
 import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
@@ -514,6 +519,62 @@ export const getArchivedMemories = async (req, res) => {
     }
     console.error("getArchivedMemories error:", error);
     sendError(res, 500, "Failed to fetch archived memories");
+  }
+};
+
+/**
+ * Unified Memory Lifecycle list with server-side pagination (Issue #1552).
+ * Unions decisions + action items before skip/limit so pages stay correct
+ * when filtering by type "all".
+ */
+export const getLifecycleMemories = async (req, res) => {
+  try {
+    const { type = "all", search, lifecycleState = "all" } = req.query || {};
+    const organization = sanitizeOrg(req.user?.organization);
+
+    if (!organization) {
+      return sendError(res, 400, "Organization required");
+    }
+
+    if (typeof type !== "string" || !ALLOWED_LIFECYCLE_TYPES.includes(type)) {
+      return sendError(
+        res,
+        400,
+        `Invalid type. Allowed values: ${ALLOWED_LIFECYCLE_TYPES.join(", ")}`,
+      );
+    }
+
+    if (
+      typeof lifecycleState !== "string" ||
+      !ALLOWED_LIFECYCLE_STATES.includes(lifecycleState)
+    ) {
+      return sendError(
+        res,
+        400,
+        `Invalid lifecycleState. Allowed values: ${ALLOWED_LIFECYCLE_STATES.join(", ")}`,
+      );
+    }
+
+    if (search !== undefined && search !== null && typeof search !== "string") {
+      return sendError(res, 400, "Invalid search");
+    }
+
+    const result = await getLifecycleMemoriesPage({
+      organization,
+      type,
+      lifecycleState,
+      search,
+      page: req.query.page,
+      limit: req.query.limit,
+    });
+
+    sendSuccess(res, result);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("getLifecycleMemories error:", error);
+    sendError(res, 500, "Failed to fetch lifecycle memories");
   }
 };
 

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -7,6 +7,7 @@ import {
   getOpenActionItems,
   getDecisions,
   getArchivedMemories,
+  getLifecycleMemories,
   submitMemoryFeedback,
   recalculateImportance,
   updateActionItemStatus,
@@ -123,7 +124,13 @@ router.post(
   recalculateImportance,
 );
 
-// --- Memory Lifecycle Management (#377) ---
+// --- Memory Lifecycle Management (#377, #1552) ---
+router.get(
+  "/lifecycle",
+  requireOrgMembership,
+  requirePermission("knowledge", "view"),
+  getLifecycleMemories,
+);
 router.post(
   "/lifecycle/run",
   writeLimiter,

--- a/server/services/lifecycleKnowledgeService.js
+++ b/server/services/lifecycleKnowledgeService.js
@@ -1,0 +1,189 @@
+import mongoose from "mongoose";
+import ActionItem from "../models/actionItemModel.js";
+import Decision from "../models/decisionModel.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
+import { literalContainsFilter } from "../utils/regexUtils.js";
+
+export const ALLOWED_LIFECYCLE_TYPES = ["all", "decision", "action-item"];
+
+export const ALLOWED_LIFECYCLE_STATES = [
+  "all",
+  "active",
+  "dormant",
+  "archived",
+  "expired",
+];
+
+const toObjectId = (value) => {
+  if (!value) return null;
+  if (value instanceof mongoose.Types.ObjectId) return value;
+  const asString = String(value);
+  return mongoose.Types.ObjectId.isValid(asString)
+    ? new mongoose.Types.ObjectId(asString)
+    : value;
+};
+
+/**
+ * Shared $match for Memory Lifecycle listings (Issue #1552).
+ * Filters by org, optional lifecycle state, and literal text search.
+ */
+export const buildLifecycleMatch = ({
+  organization,
+  search,
+  lifecycleState = "all",
+}) => {
+  const match = {
+    organization: toObjectId(organization),
+  };
+
+  if (
+    lifecycleState &&
+    lifecycleState !== "all" &&
+    ALLOWED_LIFECYCLE_STATES.includes(lifecycleState)
+  ) {
+    match.lifecycleState = lifecycleState;
+  }
+
+  const searchFilter = literalContainsFilter(search);
+  if (searchFilter) {
+    match.text = searchFilter;
+  }
+
+  return match;
+};
+
+const withType = (type) => ({
+  $addFields: { type },
+});
+
+const meetingLookupStages = [
+  {
+    $lookup: {
+      from: "meetings",
+      localField: "sourceMeetingId",
+      foreignField: "_id",
+      as: "_sourceMeeting",
+      pipeline: [{ $project: { title: 1, date: 1 } }],
+    },
+  },
+  {
+    $addFields: {
+      sourceMeetingId: { $arrayElemAt: ["$_sourceMeeting", 0] },
+    },
+  },
+  { $project: { _sourceMeeting: 0, embedding: 0 } },
+];
+
+/**
+ * Union + sort + facet pipeline so decisions and action items share one
+ * server-side page (avoids client merge of two independent pages).
+ */
+export const buildLifecyclePipeline = ({
+  type = "all",
+  organization,
+  search,
+  lifecycleState = "all",
+  skip = 0,
+  limit = 20,
+}) => {
+  const match = buildLifecycleMatch({
+    organization,
+    search,
+    lifecycleState,
+  });
+  const actionItemCollection = ActionItem.collection?.name || "actionitems";
+
+  const decisionBranch = [{ $match: match }, withType("decision")];
+
+  let prefix;
+  if (type === "decision") {
+    prefix = decisionBranch;
+  } else if (type === "action-item") {
+    prefix = [{ $match: match }, withType("action-item")];
+  } else {
+    prefix = [
+      ...decisionBranch,
+      {
+        $unionWith: {
+          coll: actionItemCollection,
+          pipeline: [{ $match: match }, withType("action-item")],
+        },
+      },
+    ];
+  }
+
+  return [
+    ...prefix,
+    { $sort: { createdAt: -1, _id: -1 } },
+    {
+      $facet: {
+        metadata: [{ $count: "total" }],
+        data: [{ $skip: skip }, { $limit: limit }, ...meetingLookupStages],
+      },
+    },
+  ];
+};
+
+/**
+ * One page of lifecycle memories with unified pagination metadata.
+ *
+ * @returns {{ memories: object[], pagination: object }}
+ */
+export const getLifecycleMemoriesPage = async ({
+  organization,
+  type = "all",
+  lifecycleState = "all",
+  search,
+  page,
+  limit,
+}) => {
+  if (!organization) {
+    const err = new Error("Organization required");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (!ALLOWED_LIFECYCLE_TYPES.includes(type)) {
+    const err = new Error(
+      `Invalid type. Allowed values: ${ALLOWED_LIFECYCLE_TYPES.join(", ")}`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (!ALLOWED_LIFECYCLE_STATES.includes(lifecycleState)) {
+    const err = new Error(
+      `Invalid lifecycleState. Allowed values: ${ALLOWED_LIFECYCLE_STATES.join(", ")}`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const pagination = parsePagination(
+    { page, limit },
+    { defaultLimit: 20, maxLimit: 100 },
+  );
+
+  const pipeline = buildLifecyclePipeline({
+    type,
+    organization,
+    search,
+    lifecycleState,
+    skip: pagination.skip,
+    limit: pagination.limit,
+  });
+
+  const Model = type === "action-item" ? ActionItem : Decision;
+  const [facet] = await Model.aggregate(pipeline);
+  const memories = facet?.data || [];
+  const total = facet?.metadata?.[0]?.total || 0;
+
+  return {
+    memories,
+    pagination: buildPaginationMeta({
+      total,
+      page: pagination.page,
+      limit: pagination.limit,
+    }),
+  };
+};

--- a/server/tests/lifecycleKnowledgeService.test.js
+++ b/server/tests/lifecycleKnowledgeService.test.js
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import mongoose from "mongoose";
+
+vi.mock("../models/decisionModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "decisions" },
+  },
+}));
+
+vi.mock("../models/actionItemModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "actionitems" },
+  },
+}));
+
+const Decision = (await import("../models/decisionModel.js")).default;
+const ActionItem = (await import("../models/actionItemModel.js")).default;
+const {
+  buildLifecycleMatch,
+  buildLifecyclePipeline,
+  getLifecycleMemoriesPage,
+} = await import("../services/lifecycleKnowledgeService.js");
+
+describe("lifecycleKnowledgeService (#1552)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("buildLifecycleMatch", () => {
+    it("scopes to organization and optional lifecycle state", () => {
+      const orgId = new mongoose.Types.ObjectId();
+      const match = buildLifecycleMatch({
+        organization: orgId,
+        lifecycleState: "dormant",
+      });
+
+      expect(String(match.organization)).toBe(String(orgId));
+      expect(match.lifecycleState).toBe("dormant");
+    });
+
+    it("omits lifecycleState when requesting all states", () => {
+      const match = buildLifecycleMatch({
+        organization: "507f1f77bcf86cd799439011",
+        lifecycleState: "all",
+      });
+      expect(match.lifecycleState).toBeUndefined();
+    });
+
+    it("adds literal text search when provided", () => {
+      const match = buildLifecycleMatch({
+        organization: "507f1f77bcf86cd799439011",
+        search: "  roadmap  ",
+      });
+      expect(match.text).toEqual({ $regex: "roadmap", $options: "i" });
+    });
+  });
+
+  describe("buildLifecyclePipeline", () => {
+    it("unions decisions and action items before skip/limit", () => {
+      const pipeline = buildLifecyclePipeline({
+        type: "all",
+        organization: "507f1f77bcf86cd799439011",
+        skip: 20,
+        limit: 20,
+      });
+
+      expect(pipeline).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            $unionWith: expect.objectContaining({ coll: "actionitems" }),
+          }),
+          expect.objectContaining({ $sort: { createdAt: -1, _id: -1 } }),
+        ]),
+      );
+
+      const facet = pipeline.find((stage) => stage.$facet);
+      expect(facet.$facet.data[0]).toEqual({ $skip: 20 });
+      expect(facet.$facet.data[1]).toEqual({ $limit: 20 });
+      expect(facet.$facet.metadata).toEqual([{ $count: "total" }]);
+    });
+
+    it("does not union for a single memory type", () => {
+      const pipeline = buildLifecyclePipeline({
+        type: "decision",
+        organization: "507f1f77bcf86cd799439011",
+        skip: 0,
+        limit: 20,
+      });
+      expect(pipeline.some((stage) => stage.$unionWith)).toBe(false);
+    });
+  });
+
+  describe("getLifecycleMemoriesPage", () => {
+    it("returns first page with pagination metadata", async () => {
+      Decision.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 45 }],
+          data: [
+            { _id: "d1", type: "decision", text: "Decide A" },
+            { _id: "a1", type: "action-item", text: "Do B" },
+          ],
+        },
+      ]);
+
+      const result = await getLifecycleMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        type: "all",
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.memories).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        total: 45,
+        page: 1,
+        limit: 20,
+        totalPages: 3,
+        hasMore: true,
+      });
+    });
+
+    it("returns subsequent page with correct skip", async () => {
+      Decision.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 45 }],
+          data: [{ _id: "d2", type: "decision" }],
+        },
+      ]);
+
+      await getLifecycleMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        type: "all",
+        page: 2,
+        limit: 20,
+      });
+
+      const pipeline = Decision.aggregate.mock.calls[0][0];
+      const facet = pipeline.find((stage) => stage.$facet);
+      expect(facet.$facet.data[0]).toEqual({ $skip: 20 });
+      expect(facet.$facet.data[1]).toEqual({ $limit: 20 });
+    });
+
+    it("returns last page with hasMore false", async () => {
+      Decision.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 25 }],
+          data: [{ _id: "d3", type: "decision" }],
+        },
+      ]);
+
+      const result = await getLifecycleMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        page: 2,
+        limit: 20,
+      });
+
+      expect(result.pagination).toEqual({
+        total: 25,
+        page: 2,
+        limit: 20,
+        totalPages: 2,
+        hasMore: false,
+      });
+    });
+
+    it("returns empty results with zero totals", async () => {
+      Decision.aggregate.mockResolvedValue([{ metadata: [], data: [] }]);
+
+      const result = await getLifecycleMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        lifecycleState: "expired",
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.memories).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.hasMore).toBe(false);
+    });
+
+    it("queries ActionItem when type is action-item", async () => {
+      ActionItem.aggregate.mockResolvedValue([
+        {
+          metadata: [{ total: 1 }],
+          data: [{ _id: "a1", type: "action-item" }],
+        },
+      ]);
+
+      await getLifecycleMemoriesPage({
+        organization: "507f1f77bcf86cd799439011",
+        type: "action-item",
+        page: 1,
+        limit: 10,
+      });
+
+      expect(ActionItem.aggregate).toHaveBeenCalled();
+      expect(Decision.aggregate).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid type and missing organization", async () => {
+      await expect(
+        getLifecycleMemoriesPage({
+          organization: "507f1f77bcf86cd799439011",
+          type: "notes",
+        }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+
+      await expect(
+        getLifecycleMemoriesPage({ type: "all" }),
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #1552
- Adds `GET /api/knowledge/lifecycle` with unified, server-side pagination for decisions + action items
- Updates Memory Lifecycle UI to consume pagination metadata and navigate pages without loading full datasets
## Test plan
- [ ] `npm run lint:changed --prefix client && npm run format:check:changed --prefix client`
- [ ] `npm run lint:changed --prefix server && npm run format:check:changed --prefix server`
- [ ] `cd server && npx vitest run tests/lifecycleKnowledgeService.test.js`
- [ ] `cd client && npx vitest run src/pages/__tests__/MemoryLifecyclePagination.test.jsx src/pages/__tests__/MemoryLifecycleAccessibility.test.jsx`
- [ ] Open `/knowledge/lifecycle`, confirm page size + Previous/Next work
- [ ] Filter by state/type/search and confirm only one page of results loads
- [ ] Verify empty and error/retry states
