### PR TITLE
refactor: enforce organization context on meeting goals (#1545)

### DIFF
--- a/server/config/mongodb.js
+++ b/server/config/mongodb.js
@@ -41,6 +41,38 @@ const connectDB = async () => {
       const resolvedDbName = connectionUri.split("/").pop();
       console.log("Mongo URI:", sanitizedUri);
       console.log("Database:", resolvedDbName);
+
+      // Asynchronously migrate existing MeetingGoal records missing organization context
+      (async () => {
+        try {
+          const { default: MeetingGoal } =
+            await import("../models/meetingGoalModel.js");
+          const { default: Meeting } =
+            await import("../models/meetingModel.js");
+          const unmigrated = await MeetingGoal.find({
+            $or: [{ organization: { $exists: false } }, { organization: null }],
+          });
+          if (unmigrated.length > 0) {
+            console.log(
+              `🧹 Found ${unmigrated.length} MeetingGoal records to migrate...`,
+            );
+            for (const goal of unmigrated) {
+              const meeting = await Meeting.findById(goal.meetingId).select(
+                "organization",
+              );
+              if (meeting && meeting.organization) {
+                goal.organization = meeting.organization;
+                await goal.save();
+              }
+            }
+            console.log(
+              "✅ MeetingGoal organization context migration completed successfully.",
+            );
+          }
+        } catch (migErr) {
+          console.error("⚠️ MeetingGoal migration error:", migErr.message);
+        }
+      })();
     } catch (err) {
       if (
         err.message.includes("ECONNREFUSED") &&

--- a/server/controllers/meetingGoalController.js
+++ b/server/controllers/meetingGoalController.js
@@ -24,11 +24,18 @@ export const setGoals = async (req, res, next) => {
     const { meetingId } = req.params;
     const { goals } = setGoalsSchema.parse(req.body);
     const userId = req.user._id;
+    const userOrg = req.user.organization || req.user.activeOrganization;
+
+    if (!userOrg) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization required" });
+    }
 
     // Verify meeting exists and belongs to the user's organization
     const meeting = await Meeting.findOne({
       _id: meetingId,
-      organization: req.user.activeOrganization,
+      organization: userOrg,
       deletedAt: null,
     });
 
@@ -46,15 +53,19 @@ export const setGoals = async (req, res, next) => {
       });
     }
 
-    let meetingGoal = await MeetingGoal.findOne({ meetingId });
+    let meetingGoal = await MeetingGoal.findOne({
+      meetingId,
+      organization: userOrg,
+    });
 
     if (meetingGoal) {
       meetingGoal.goals = goals.map((g) => ({ ...g, status: "pending" }));
+      meetingGoal.organization = meeting.organization; // Force context from the authorized meeting
       await meetingGoal.save();
     } else {
       meetingGoal = await MeetingGoal.create({
         meetingId,
-        organization: meeting.organization,
+        organization: meeting.organization, // Derived from authorized meeting context
         createdBy: userId,
         goals: goals.map((g) => ({ ...g, status: "pending" })),
       });
@@ -74,10 +85,31 @@ export const setGoals = async (req, res, next) => {
 export const getGoals = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
+    const userOrg = req.user.organization || req.user.activeOrganization;
+
+    if (!userOrg) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization required" });
+    }
+
+    // Ensure the meeting itself belongs to the authorized organization (multi-tenant boundary)
+    const meeting = await Meeting.findOne({
+      _id: meetingId,
+      organization: userOrg,
+      deletedAt: null,
+    });
+
+    if (!meeting) {
+      return res.status(403).json({
+        success: false,
+        message: "Access denied: different organization or meeting not found",
+      });
+    }
 
     const meetingGoal = await MeetingGoal.findOne({
       meetingId,
-      organization: req.user.activeOrganization,
+      organization: userOrg,
     });
 
     if (!meetingGoal) {
@@ -95,10 +127,17 @@ export const updateGoalStatus = async (req, res, next) => {
     const { meetingId, goalId } = req.params;
     const { status, outcomeNote } = updateGoalStatusSchema.parse(req.body);
     const userId = req.user._id;
+    const userOrg = req.user.organization || req.user.activeOrganization;
+
+    if (!userOrg) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization required" });
+    }
 
     const meeting = await Meeting.findOne({
       _id: meetingId,
-      organization: req.user.activeOrganization,
+      organization: userOrg,
       deletedAt: null,
     });
 
@@ -116,7 +155,10 @@ export const updateGoalStatus = async (req, res, next) => {
       });
     }
 
-    const meetingGoal = await MeetingGoal.findOne({ meetingId });
+    const meetingGoal = await MeetingGoal.findOne({
+      meetingId,
+      organization: userOrg,
+    });
     if (!meetingGoal) {
       return res
         .status(404)
@@ -153,9 +195,10 @@ export const updateGoalStatus = async (req, res, next) => {
 export const getOrgGoalStats = async (req, res, next) => {
   try {
     const { orgId } = req.params;
+    const userOrg = req.user.organization || req.user.activeOrganization;
 
     // Check if user is part of the org
-    if (req.user.activeOrganization.toString() !== orgId) {
+    if (!userOrg || userOrg.toString() !== orgId) {
       return res.status(403).json({
         success: false,
         message: "Unauthorized for this organization",
@@ -165,9 +208,7 @@ export const getOrgGoalStats = async (req, res, next) => {
     const pipeline = [
       {
         $match: {
-          organization: new mongoose.Types.ObjectId(
-            req.user.activeOrganization,
-          ),
+          organization: new mongoose.Types.ObjectId(userOrg),
         },
       },
       { $unwind: "$goals" },

--- a/server/tests/meetingGoal.test.js
+++ b/server/tests/meetingGoal.test.js
@@ -212,4 +212,92 @@ describe("Meeting Goal API", () => {
     // G1 (1) + G2 (0.5) / 3 = 1.5/3 = 50%
     expect(res.body.stats[0].achievementRate).toBe(50);
   });
+
+  describe("Multi-tenant Organization Isolation", () => {
+    let otherOrgId;
+    let otherOrgToken;
+    let otherOrgMeeting;
+
+    beforeEach(async () => {
+      otherOrgId = new mongoose.Types.ObjectId();
+      await Organization.create({
+        _id: otherOrgId,
+        name: "Other Org",
+        slug: "other-org-" + Date.now(),
+        owner: new mongoose.Types.ObjectId(),
+      });
+
+      otherOrgToken = jwt.sign(
+        {
+          id: new mongoose.Types.ObjectId(),
+          role: "user",
+          organization: otherOrgId,
+        },
+        process.env.JWT_SECRET,
+      );
+
+      otherOrgMeeting = await Meeting.create({
+        title: "Other Org Meeting",
+        uploadedBy: new mongoose.Types.ObjectId(),
+        organization: otherOrgId,
+        date: new Date(Date.now() + 86400000).toISOString(),
+      });
+    });
+
+    it("should prevent setting goals for a meeting in another organization", async () => {
+      const res = await request(app)
+        .post(`/api/meeting-goals/meeting/${otherOrgMeeting._id}`)
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          goals: [{ text: "Cross-org goal setting" }],
+        });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should prevent retrieving goals for a meeting in another organization", async () => {
+      await MeetingGoal.create({
+        meetingId: otherOrgMeeting._id,
+        organization: otherOrgId,
+        createdBy: new mongoose.Types.ObjectId(),
+        goals: [{ text: "Secret goal", status: "pending" }],
+      });
+
+      const res = await request(app)
+        .get(`/api/meeting-goals/meeting/${otherOrgMeeting._id}`)
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it("should prevent updating goal status for a meeting in another organization", async () => {
+      otherOrgMeeting.date = new Date(Date.now() - 86400000).toISOString();
+      await otherOrgMeeting.save();
+
+      const otherOrgGoal = await MeetingGoal.create({
+        meetingId: otherOrgMeeting._id,
+        organization: otherOrgId,
+        createdBy: new mongoose.Types.ObjectId(),
+        goals: [{ text: "Secret goal", status: "pending" }],
+      });
+      const goalId = otherOrgGoal.goals[0]._id;
+
+      const res = await request(app)
+        .patch(
+          `/api/meeting-goals/meeting/${otherOrgMeeting._id}/goal/${goalId}`,
+        )
+        .set("Authorization", `Bearer ${token}`)
+        .send({ status: "achieved" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should prevent fetching statistics of another organization", async () => {
+      const res = await request(app)
+        .get(`/api/meeting-goals/org/${otherOrgId}/stats`)
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
 });


### PR DESCRIPTION
## 📝 Summary
This PR enforces correct organization context alignment and strict multi-tenant data boundaries on Meeting Goals. It derives the organization context from the authorized meeting resource, scopes all operations to the authenticated user's organization, performs an automatic startup migration on unmigrated records, and adds regression tests covering cross-organization boundaries.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1545

---

## ✨ Changes Made
- **Secured Controllers & Queries**:
  - Scoped meeting checks for creating, retrieving, and updating goal status to the authenticated organization.
  - Ignored client-supplied organization properties in favor of the meeting's verified organization context.
  - Linked stats aggregate matches to `userOrg`.
- **Database Startup Migration**:
  - Added an asynchronous self-migrator in `server/config/mongodb.js` to automatically backfill missing organization fields on historical goal records.
- **Added Isolation Tests**:
  - Expanded `server/tests/meetingGoal.test.js` to confirm cross-organization settings, reads, status updates, and stats aggregates fail with appropriate `403` or `404` barriers.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Jest tests:
```bash
cd server
npm run test tests/meetingGoal.test.js
