### PR TITLE
fix: enforce meeting checklist authorization

### DIFF
--- a/server/controllers/meetingChecklistController.js
+++ b/server/controllers/meetingChecklistController.js
@@ -1,6 +1,11 @@
+import mongoose from "mongoose";
+import { z } from "zod";
+
 import MeetingChecklist from "../models/meetingChecklistModel.js";
 import Meeting from "../models/meetingModel.js";
-import { z } from "zod";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+import { hasPermission } from "../utils/rbacPermissions.js";
+import { isSameOrganization } from "../utils/organizationScope.js";
 import {
   ValidationError,
   UnauthorizedError,
@@ -8,57 +13,94 @@ import {
 } from "../utils/errors.js";
 import { sendSuccess } from "../utils/responseHandler.js";
 
-const checklistItemSchema = z.object({
-  text: z.string().min(1, "Item text is required"),
-  description: z.string().optional(),
-  required: z.boolean().optional(),
-});
-
 const createChecklistSchema = z.object({
-  items: z.array(checklistItemSchema).min(1, "At least one item is required"),
+  items: z
+    .array(
+      z.object({
+        text: z.string().min(1, "Item text is required"),
+        description: z.string().optional(),
+        required: z.boolean().optional(),
+      }),
+    )
+    .min(1, "At least one item is required"),
 });
 
 const toggleItemSchema = z.object({
   itemIndex: z.number().int().min(0),
 });
 
-const canManageChecklist = (meeting, req) =>
-  meeting.uploadedBy.toString() === req.user.id || req.user.role === "admin";
+/**
+ * Resolve a meeting from a client-supplied meeting id and enforce the
+ * meeting's organization boundary before a checklist is read or changed.
+ */
+const resolveAuthorizedMeeting = async (req, action) => {
+  const { meetingId } = req.params;
 
-const requireMeetingOwner = (meeting, req, message) => {
-  if (!canManageChecklist(meeting, req)) {
-    throw new UnauthorizedError(message);
+  if (!mongoose.isValidObjectId(meetingId)) {
+    throw new ValidationError("Invalid meeting ID");
   }
-};
 
-const findMeetingOrThrow = async (meetingId) => {
+  const user = req.user;
+  if (!user?._id && !user?.id) {
+    throw new UnauthorizedError("Authentication required");
+  }
+
+  const userId = String(user._id || user.id);
   const meeting = await Meeting.findById(meetingId);
+
   if (!meeting) {
     throw new NotFoundError("Meeting not found");
   }
-  return meeting;
+
+  const organization = user.activeOrganization || user.organization;
+  if (!isSameOrganization(meeting.organization, organization)) {
+    throw new UnauthorizedError(
+      "You don't have access to this meeting's organization",
+    );
+  }
+
+  if (!hasPermission(user.role, "meetings", action)) {
+    throw new UnauthorizedError(
+      `You don't have permission to ${action} this meeting`,
+    );
+  }
+
+  if (!canAccessMeetingDoc(meeting, { ...user, _id: user._id || user.id })) {
+    throw new UnauthorizedError("You don't have access to this meeting");
+  }
+
+  return { meeting, userId };
+};
+
+const requireChecklistManager = (user, meeting) => {
+  const userId = String(user._id || user.id);
+  const isOwner = String(meeting.uploadedBy) === userId;
+  const isAdminOrOwner = user.role === "admin" || user.role === "owner";
+
+  if (!isOwner && !isAdminOrOwner) {
+    throw new UnauthorizedError(
+      "Only the meeting owner or an organization administrator can manage the checklist",
+    );
+  }
 };
 
 export const createChecklist = async (req, res, next) => {
   try {
-    const { meetingId } = req.params;
     const { items } = createChecklistSchema.parse(req.body);
-    const userId = req.user.id;
+    const { meeting, userId } = await resolveAuthorizedMeeting(req, "create");
 
-    const meeting = await findMeetingOrThrow(meetingId);
-    requireMeetingOwner(
-      meeting,
-      req,
-      "Only the meeting owner can create a checklist",
-    );
+    requireChecklistManager(req.user, meeting);
 
-    const existingChecklist = await MeetingChecklist.findOne({ meetingId });
+    const existingChecklist = await MeetingChecklist.findOne({
+      meetingId: meeting._id,
+    });
+
     if (existingChecklist) {
       throw new ValidationError("Checklist already exists for this meeting");
     }
 
     const checklist = await MeetingChecklist.create({
-      meetingId,
+      meetingId: meeting._id,
       organization: meeting.organization,
       createdBy: userId,
       items,
@@ -73,8 +115,12 @@ export const createChecklist = async (req, res, next) => {
 
 export const getChecklist = async (req, res, next) => {
   try {
-    const { meetingId } = req.params;
-    const checklist = await MeetingChecklist.findOne({ meetingId });
+    const { meeting } = await resolveAuthorizedMeeting(req, "view");
+
+    const checklist = await MeetingChecklist.findOne({
+      meetingId: meeting._id,
+      organization: meeting.organization,
+    });
 
     if (!checklist) {
       return sendSuccess(res, { checklist: null }, "No checklist found");
@@ -86,64 +132,16 @@ export const getChecklist = async (req, res, next) => {
   }
 };
 
-export const updateChecklist = async (req, res, next) => {
-  try {
-    const { meetingId } = req.params;
-    const { items } = createChecklistSchema.parse(req.body);
-
-    const meeting = await findMeetingOrThrow(meetingId);
-    requireMeetingOwner(
-      meeting,
-      req,
-      "Only the meeting owner can update a checklist",
-    );
-
-    const checklist = await MeetingChecklist.findOne({ meetingId });
-    if (!checklist) {
-      throw new NotFoundError("Checklist not found");
-    }
-
-    checklist.items = items;
-    // Item indexes can change when the checklist is edited, so completions
-    // cannot safely be carried over to the new item ordering.
-    checklist.completions = [];
-    await checklist.save();
-
-    sendSuccess(res, { checklist }, "Checklist updated successfully");
-  } catch (error) {
-    next(error);
-  }
-};
-
-export const deleteChecklist = async (req, res, next) => {
-  try {
-    const { meetingId } = req.params;
-
-    const meeting = await findMeetingOrThrow(meetingId);
-    requireMeetingOwner(
-      meeting,
-      req,
-      "Only the meeting owner can delete a checklist",
-    );
-
-    const checklist = await MeetingChecklist.findOneAndDelete({ meetingId });
-    if (!checklist) {
-      throw new NotFoundError("Checklist not found");
-    }
-
-    sendSuccess(res, { checklist }, "Checklist deleted successfully");
-  } catch (error) {
-    next(error);
-  }
-};
-
 export const toggleItem = async (req, res, next) => {
   try {
-    const { meetingId } = req.params;
     const { itemIndex } = toggleItemSchema.parse(req.body);
-    const userId = req.user.id;
+    const { meeting, userId } = await resolveAuthorizedMeeting(req, "edit");
 
-    const checklist = await MeetingChecklist.findOne({ meetingId });
+    const checklist = await MeetingChecklist.findOne({
+      meetingId: meeting._id,
+      organization: meeting.organization,
+    });
+
     if (!checklist) {
       throw new NotFoundError("Checklist not found");
     }
@@ -153,22 +151,27 @@ export const toggleItem = async (req, res, next) => {
     }
 
     const completionIndex = checklist.completions.findIndex(
-      (c) => c.itemIndex === itemIndex && c.userId.toString() === userId,
+      (completion) =>
+        completion.itemIndex === itemIndex &&
+        completion.userId.toString() === userId,
     );
 
-    let updatedChecklist;
-    if (completionIndex > -1) {
-      updatedChecklist = await MeetingChecklist.findOneAndUpdate(
-        { meetingId },
-        { $pull: { completions: { itemIndex, userId } } },
-        { new: true },
-      );
-    } else {
-      updatedChecklist = await MeetingChecklist.findOneAndUpdate(
-        { meetingId },
-        { $push: { completions: { itemIndex, userId } } },
-        { new: true },
-      );
+    const update =
+      completionIndex > -1
+        ? { $pull: { completions: { itemIndex, userId } } }
+        : { $push: { completions: { itemIndex, userId } } };
+
+    const updatedChecklist = await MeetingChecklist.findOneAndUpdate(
+      {
+        meetingId: meeting._id,
+        organization: meeting.organization,
+      },
+      update,
+      { new: true },
+    );
+
+    if (!updatedChecklist) {
+      throw new NotFoundError("Checklist not found");
     }
 
     sendSuccess(
@@ -181,42 +184,65 @@ export const toggleItem = async (req, res, next) => {
   }
 };
 
+export const deleteChecklist = async (req, res, next) => {
+  try {
+    const { meeting } = await resolveAuthorizedMeeting(req, "delete");
+    requireChecklistManager(req.user, meeting);
+
+    const deletedChecklist = await MeetingChecklist.findOneAndDelete({
+      meetingId: meeting._id,
+      organization: meeting.organization,
+    });
+
+    if (!deletedChecklist) {
+      throw new NotFoundError("Checklist not found");
+    }
+
+    sendSuccess(
+      res,
+      { checklist: deletedChecklist },
+      "Checklist deleted successfully",
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const getReadiness = async (req, res, next) => {
   try {
-    const { meetingId } = req.params;
-    const userId = req.user.id;
+    const { meeting } = await resolveAuthorizedMeeting(req, "view");
 
-    const meeting = await findMeetingOrThrow(meetingId);
-    requireMeetingOwner(
-      meeting,
-      req,
-      "Only the meeting owner can view readiness",
-    );
+    const checklist = await MeetingChecklist.findOne({
+      meetingId: meeting._id,
+      organization: meeting.organization,
+    });
 
-    const checklist = await MeetingChecklist.findOne({ meetingId });
     if (!checklist) {
       return sendSuccess(res, { readiness: [] }, "No checklist found");
     }
 
     const totalItems = checklist.items.length;
-    const userCompletions = checklist.completions.reduce((acc, comp) => {
-      const uid = comp.userId.toString();
-      if (!acc[uid]) acc[uid] = 0;
-      acc[uid]++;
+    const userCompletions = checklist.completions.reduce((acc, completion) => {
+      const uid = completion.userId.toString();
+      acc[uid] = (acc[uid] || 0) + 1;
       return acc;
     }, {});
 
-    const readiness = meeting.participants.map((p) => {
+    const readiness = meeting.participants.map((participant) => {
       const uid =
-        p.user?.toString() ||
-        p.userId?.toString() ||
-        p._id?.toString() ||
-        p.id?.toString();
+        participant.user?.toString() ||
+        participant.userId?.toString() ||
+        participant._id?.toString() ||
+        participant.id?.toString();
       const completedCount = uid ? userCompletions[uid] || 0 : 0;
 
       return {
-        userId: p.user || p.userId || p._id || p.id,
-        name: p.name || p.email || "Unknown",
+        userId:
+          participant.user ||
+          participant.userId ||
+          participant._id ||
+          participant.id,
+        name: participant.name || participant.email || "Unknown",
         percentage:
           totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0,
         completedCount,

--- a/server/routes/meetingChecklistRoutes.js
+++ b/server/routes/meetingChecklistRoutes.js
@@ -1,17 +1,18 @@
 import express from "express";
+
 import * as meetingChecklistController from "../controllers/meetingChecklistController.js";
 import userAuth from "../middleware/userAuth.js";
 
 const router = express.Router({ mergeParams: true });
 
-// All routes require user authentication
+// Every checklist endpoint is authenticated. Controllers additionally resolve
+// the meeting and enforce organization + meeting/RBAC permissions.
 router.use(userAuth);
 
 router.post("/", meetingChecklistController.createChecklist);
 router.get("/", meetingChecklistController.getChecklist);
-router.put("/", meetingChecklistController.updateChecklist);
-router.delete("/", meetingChecklistController.deleteChecklist);
 router.patch("/toggle", meetingChecklistController.toggleItem);
+router.delete("/", meetingChecklistController.deleteChecklist);
 router.get("/readiness", meetingChecklistController.getReadiness);
 
 export default router;

--- a/server/tests/meetingChecklistAuthorization.test.js
+++ b/server/tests/meetingChecklistAuthorization.test.js
@@ -1,0 +1,242 @@
+import mongoose from "mongoose";
+
+const meetingFindById = jest.fn();
+const checklistFindOne = jest.fn();
+const checklistCreate = jest.fn();
+const checklistFindOneAndUpdate = jest.fn();
+const checklistFindOneAndDelete = jest.fn();
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: { findById: meetingFindById },
+}));
+
+jest.unstable_mockModule("../models/meetingChecklistModel.js", () => ({
+  default: {
+    findOne: checklistFindOne,
+    create: checklistCreate,
+    findOneAndUpdate: checklistFindOneAndUpdate,
+    findOneAndDelete: checklistFindOneAndDelete,
+  },
+}));
+
+const {
+  createChecklist,
+  getChecklist,
+  toggleItem,
+  deleteChecklist,
+  getReadiness,
+} = await import("../controllers/meetingChecklistController.js");
+
+const makeResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res;
+};
+
+const makeNext = () => jest.fn();
+
+const meetingId = new mongoose.Types.ObjectId();
+const organizationId = new mongoose.Types.ObjectId();
+const ownerId = new mongoose.Types.ObjectId();
+const memberId = new mongoose.Types.ObjectId();
+const otherOrganizationId = new mongoose.Types.ObjectId();
+
+const makeMeeting = (overrides = {}) => ({
+  _id: meetingId,
+  organization: organizationId,
+  uploadedBy: ownerId,
+  participants: [{ user: memberId, name: "Member" }],
+  ...overrides,
+});
+
+const makeUser = (overrides = {}) => ({
+  _id: ownerId,
+  id: ownerId.toString(),
+  organization: organizationId,
+  activeOrganization: organizationId,
+  role: "owner",
+  ...overrides,
+});
+
+describe("Meeting Checklist authorization (Issue #1537)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("rejects cross-organization checklist reads", async () => {
+    meetingFindById.mockResolvedValue(
+      makeMeeting({ organization: otherOrganizationId }),
+    );
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser(),
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await getChecklist(req, res, next);
+
+    expect(checklistFindOne).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "You don't have access to this meeting's organization",
+      }),
+    );
+  });
+
+  test("rejects checklist reads for a user without meeting access", async () => {
+    const outsiderId = new mongoose.Types.ObjectId();
+    meetingFindById.mockResolvedValue(
+      makeMeeting({ uploadedBy: ownerId, participants: [] }),
+    );
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser({ _id: outsiderId, id: outsiderId.toString() }),
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await getChecklist(req, res, next);
+
+    expect(checklistFindOne).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "You don't have access to this meeting",
+      }),
+    );
+  });
+
+  test("allows an authorized organization member to read a checklist", async () => {
+    const checklist = { meetingId, organization: organizationId, items: [] };
+    meetingFindById.mockResolvedValue(makeMeeting());
+    checklistFindOne.mockResolvedValue(checklist);
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser({
+        role: "member",
+        _id: memberId,
+        id: memberId.toString(),
+      }),
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await getChecklist(req, res, next);
+
+    expect(checklistFindOne).toHaveBeenCalledWith({
+      meetingId,
+      organization: organizationId,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("prevents a viewer from modifying a checklist", async () => {
+    meetingFindById.mockResolvedValue(makeMeeting());
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser({ role: "viewer" }),
+      body: { itemIndex: 0 },
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await toggleItem(req, res, next);
+
+    expect(checklistFindOne).not.toHaveBeenCalled();
+    expect(checklistFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "You don't have permission to edit this meeting",
+      }),
+    );
+  });
+
+  test("prevents a non-owner member from creating a checklist", async () => {
+    meetingFindById.mockResolvedValue(makeMeeting());
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser({
+        role: "member",
+        _id: memberId,
+        id: memberId.toString(),
+      }),
+      body: { items: [{ text: "Prepare agenda" }] },
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await createChecklist(req, res, next);
+
+    expect(checklistCreate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Only the meeting owner or an organization administrator can manage the checklist",
+      }),
+    );
+  });
+
+  test("scopes toggle and delete operations to the resolved meeting organization", async () => {
+    const checklist = {
+      meetingId,
+      organization: organizationId,
+      items: [{ text: "Prepare agenda" }],
+      completions: [],
+    };
+    meetingFindById.mockResolvedValue(makeMeeting());
+    checklistFindOne.mockResolvedValue(checklist);
+    checklistFindOneAndUpdate.mockResolvedValue(checklist);
+    checklistFindOneAndDelete.mockResolvedValue(checklist);
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser(),
+      body: { itemIndex: 0 },
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await toggleItem(req, res, next);
+    await deleteChecklist({ ...req, body: undefined }, res, next);
+
+    expect(checklistFindOneAndUpdate).toHaveBeenCalledWith(
+      { meetingId, organization: organizationId },
+      expect.any(Object),
+      { new: true },
+    );
+    expect(checklistFindOneAndDelete).toHaveBeenCalledWith({
+      meetingId,
+      organization: organizationId,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("does not expose readiness for a cross-organization meeting", async () => {
+    meetingFindById.mockResolvedValue(
+      makeMeeting({ organization: otherOrganizationId }),
+    );
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: makeUser(),
+    };
+    const res = makeResponse();
+    const next = makeNext();
+
+    await getReadiness(req, res, next);
+
+    expect(checklistFindOne).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "You don't have access to this meeting's organization",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1537

Enforces authorization and organization isolation across Meeting Checklist operations.

## What changed

- Require authentication for every Meeting Checklist endpoint.
- Resolve and validate the associated meeting before checklist access.
- Enforce the authenticated user's organization boundary.
- Apply existing meeting RBAC permissions to checklist operations.
- Preserve owner/admin restrictions for checklist management.
- Scope checklist reads, updates, and deletes by both meeting and organization.
- Prevent manipulated meeting IDs from crossing organization boundaries.
- Protect meeting readiness data with the same authorization checks.
- Add regression tests for cross-organization and unauthorized access.

## Security

Checklist records can no longer be accessed or modified solely by supplying another meeting ID.

Authorization is performed against the server-resolved meeting and authenticated user rather than trusting client-supplied checklist or organization identifiers.

## Tests

- [x] Cross-organization checklist read rejected
- [x] Unauthorized meeting access rejected
- [x] Authorized organization member can read checklist
- [x] Viewer cannot modify checklist
- [x] Unauthorized member cannot create checklist
- [x] Toggle/delete operations remain organization-scoped
- [x] Cross-organization readiness access rejected
- [ ] Full test suite
- [ ] Full lint/format validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened meeting checklist access controls with authentication, organization scope, meeting access, and role-based permissions.
  * Restricted checklist changes to meeting owners and organization administrators.

* **Improvements**
  * Checklist creation, viewing, toggling, deletion, and readiness reporting now use consistent authorization checks.
  * Simplified checklist updates through a single toggle action.
  * Replaced the checklist update route with the toggle route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->