### PR TITLE
fix: enforce saved filter authorization

### DIFF
--- a/server/controllers/savedFilterController.js
+++ b/server/controllers/savedFilterController.js
@@ -1,5 +1,38 @@
 import SavedFilter from "../models/savedFilterModel.js";
 import savedFilterService from "../services/savedFilterService.js";
+import { isSameOrganization } from "../utils/organizationScope.js";
+import { hasPermission } from "../utils/rbacPermissions.js";
+
+const getUserId = (req) =>
+  req.user?._id?.toString?.() || String(req.user?._id || "");
+
+const isOwner = (filter, req) =>
+  filter?.user && filter.user.toString() === getUserId(req);
+
+const canManageSharing = (req) =>
+  hasPermission(req.user?.role, "organizations", "edit");
+
+const findAccessibleFilter = async (id, req, { requireShared = true } = {}) => {
+  const filter = await SavedFilter.findById(id);
+  if (!filter) return { filter: null, forbidden: false };
+
+  const sameOrg = isSameOrganization(
+    filter.organization,
+    req.user?.organization,
+  );
+  const owner = isOwner(filter, req);
+  const shared = filter.isShared === true;
+
+  if (!sameOrg) return { filter: null, forbidden: true };
+  if (owner) return { filter, forbidden: false };
+  if (requireShared && !shared) return { filter: null, forbidden: true };
+  if (!shared) return { filter: null, forbidden: true };
+
+  return { filter, forbidden: false };
+};
+
+const unauthorized = (res, message = "Not authorized to access this filter") =>
+  res.status(403).json({ success: false, message });
 
 export const createFilter = async (req, res) => {
   try {
@@ -12,11 +45,23 @@ export const createFilter = async (req, res) => {
         .json({ success: false, message: "Name and filters are required" });
     }
 
+    if (!req.user?.organization) {
+      return res.status(403).json({
+        success: false,
+        message: "An organization is required to create saved filters",
+      });
+    }
+
+    if (isShared && !canManageSharing(req)) {
+      return unauthorized(res, "Not authorized to create a shared filter");
+    }
+
+    const organization = req.user.organization;
     const savedFilter = new SavedFilter({
       name,
       description,
       user: req.user._id,
-      organization: req.user.organization,
+      organization,
       filters,
       isPinned: !!isPinned,
       isShared: !!isShared,
@@ -26,21 +71,19 @@ export const createFilter = async (req, res) => {
 
     await savedFilter.save();
 
-    // Compute initial count if pinned
     if (savedFilter.isPinned) {
-      await savedFilterService.refreshMatchCounts(
-        req.user._id,
-        req.user.organization,
-      );
-      // Refetch to get updated count
-      const updated = await SavedFilter.findById(savedFilter._id);
+      await savedFilterService.refreshMatchCounts(req.user._id, organization);
+      const updated = await SavedFilter.findOne({
+        _id: savedFilter._id,
+        organization,
+      });
       return res.status(201).json({ success: true, filter: updated });
     }
 
-    res.status(201).json({ success: true, filter: savedFilter });
+    return res.status(201).json({ success: true, filter: savedFilter });
   } catch (error) {
     console.error("Error creating saved filter:", error);
-    res
+    return res
       .status(500)
       .json({ success: false, message: "Failed to create saved filter" });
   }
@@ -51,24 +94,26 @@ export const getFilters = async (req, res) => {
     const orgId = req.user.organization;
     const userId = req.user._id;
 
-    // Refresh match counts for pinned filters before returning
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "An organization is required to access saved filters",
+      });
+    }
+
     await savedFilterService.refreshMatchCounts(userId, orgId);
 
-    const query = {
+    const filters = await SavedFilter.find({
       $or: [
-        { user: userId },
-        ...(orgId ? [{ organization: orgId, isShared: true }] : []),
+        { user: userId, organization: orgId },
+        { organization: orgId, isShared: true },
       ],
-    };
+    }).sort({ isPinned: -1, createdAt: -1 });
 
-    const filters = await SavedFilter.find(query).sort({
-      isPinned: -1,
-      createdAt: -1,
-    });
-    res.status(200).json({ success: true, filters });
+    return res.status(200).json({ success: true, filters });
   } catch (error) {
     console.error("Error fetching saved filters:", error);
-    res
+    return res
       .status(500)
       .json({ success: false, message: "Failed to fetch saved filters" });
   }
@@ -77,29 +122,36 @@ export const getFilters = async (req, res) => {
 export const updateFilter = async (req, res) => {
   try {
     const { id } = req.params;
-    const updates = req.body;
+    const updates = { ...req.body };
+    const { filter, forbidden } = await findAccessibleFilter(id, req, {
+      requireShared: false,
+    });
 
-    const filter = await SavedFilter.findById(id);
     if (!filter) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Filter not found" });
-    }
-
-    // Ensure user owns the filter OR it's shared in their org and they have org access (though typically only owners should update)
-    // For now, let's restrict updates to the owner
-    if (filter.user.toString() !== req.user._id.toString()) {
-      return res.status(403).json({
+      return res.status(forbidden ? 403 : 404).json({
         success: false,
-        message: "Not authorized to update this filter",
+        message: forbidden
+          ? "Not authorized to update this filter"
+          : "Filter not found",
       });
     }
 
-    Object.keys(updates).forEach((key) => {
-      // Prevent updating read-only fields
-      if (key !== "user" && key !== "organization" && key !== "matchCount") {
-        filter[key] = updates[key];
+    if (!isOwner(filter, req)) {
+      return unauthorized(res, "Not authorized to update this filter");
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, "isShared")) {
+      if (!canManageSharing(req)) {
+        return unauthorized(res, "Not authorized to change filter sharing");
       }
+    }
+
+    delete updates.user;
+    delete updates.organization;
+    delete updates.matchCount;
+
+    Object.keys(updates).forEach((key) => {
+      filter[key] = updates[key];
     });
 
     await filter.save();
@@ -111,12 +163,14 @@ export const updateFilter = async (req, res) => {
       );
     }
 
-    const updatedFilter = await SavedFilter.findById(id);
-
-    res.status(200).json({ success: true, filter: updatedFilter });
+    const updatedFilter = await SavedFilter.findOne({
+      _id: id,
+      organization: req.user.organization,
+    });
+    return res.status(200).json({ success: true, filter: updatedFilter });
   } catch (error) {
     console.error("Error updating saved filter:", error);
-    res
+    return res
       .status(500)
       .json({ success: false, message: "Failed to update saved filter" });
   }
@@ -125,28 +179,35 @@ export const updateFilter = async (req, res) => {
 export const deleteFilter = async (req, res) => {
   try {
     const { id } = req.params;
+    const { filter, forbidden } = await findAccessibleFilter(id, req, {
+      requireShared: false,
+    });
 
-    const filter = await SavedFilter.findById(id);
     if (!filter) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Filter not found" });
-    }
-
-    if (filter.user.toString() !== req.user._id.toString()) {
-      return res.status(403).json({
+      return res.status(forbidden ? 403 : 404).json({
         success: false,
-        message: "Not authorized to delete this filter",
+        message: forbidden
+          ? "Not authorized to delete this filter"
+          : "Filter not found",
       });
     }
 
-    await SavedFilter.findByIdAndDelete(id);
-    res
+    if (!isOwner(filter, req)) {
+      return unauthorized(res, "Not authorized to delete this filter");
+    }
+
+    await SavedFilter.deleteOne({
+      _id: id,
+      organization: req.user.organization,
+      user: req.user._id,
+    });
+
+    return res
       .status(200)
       .json({ success: true, message: "Filter deleted successfully" });
   } catch (error) {
     console.error("Error deleting saved filter:", error);
-    res
+    return res
       .status(500)
       .json({ success: false, message: "Failed to delete saved filter" });
   }
@@ -156,36 +217,24 @@ export const togglePin = async (req, res) => {
   try {
     const { id } = req.params;
     const { isPinned } = req.body;
+    const { filter, forbidden } = await findAccessibleFilter(id, req);
 
-    const filter = await SavedFilter.findById(id);
     if (!filter) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Filter not found" });
-    }
-
-    // Allow toggling pin if owner OR if it's shared in same org
-    const isOwner = filter.user.toString() === req.user._id.toString();
-    const isSharedInOrg =
-      filter.isShared &&
-      filter.organization?.toString() === req.user.organization?.toString();
-
-    if (!isOwner && !isSharedInOrg) {
-      return res.status(403).json({
+      return res.status(forbidden ? 403 : 404).json({
         success: false,
-        message: "Not authorized to access this filter",
+        message: forbidden
+          ? "Not authorized to pin this filter"
+          : "Filter not found",
       });
     }
 
-    // Technically, `isPinned` state should be user-specific if shared filters can be pinned by different users.
-    // But based on the current schema, `isPinned` is a global property of the filter. Let's keep it simple as defined in the schema.
-    // A better approach for the future would be a `pinnedBy: [{type: ObjectId, ref: 'User'}]` array.
-    if (filter.user.toString() !== req.user._id.toString() && isSharedInOrg) {
-      // For now, if we allow shared filters to be pinned globally, anyone can pin/unpin it.
-      // We'll proceed with updating it.
+    // `isPinned` is currently a filter-level field, not user-specific. Only the
+    // owner may change it so a shared filter cannot be modified by another member.
+    if (!isOwner(filter, req)) {
+      return unauthorized(res, "Not authorized to pin this filter");
     }
 
-    filter.isPinned = isPinned;
+    filter.isPinned = !!isPinned;
     await filter.save();
 
     if (filter.isPinned) {
@@ -195,11 +244,14 @@ export const togglePin = async (req, res) => {
       );
     }
 
-    const updatedFilter = await SavedFilter.findById(id);
-    res.status(200).json({ success: true, filter: updatedFilter });
+    const updatedFilter = await SavedFilter.findOne({
+      _id: id,
+      organization: req.user.organization,
+    });
+    return res.status(200).json({ success: true, filter: updatedFilter });
   } catch (error) {
     console.error("Error toggling pin status:", error);
-    res
+    return res
       .status(500)
       .json({ success: false, message: "Failed to toggle pin status" });
   }

--- a/server/routes/savedFilterRoutes.js
+++ b/server/routes/savedFilterRoutes.js
@@ -10,12 +10,11 @@ import {
 
 const router = express.Router();
 
-router.use(protect); // Ensure all routes are protected
+// Every saved-filter operation requires an authenticated Clerk-backed user.
+router.use(protect);
 
 router.route("/").post(createFilter).get(getFilters);
-
 router.route("/:id").put(updateFilter).delete(deleteFilter);
-
 router.put("/:id/pin", togglePin);
 
 export default router;

--- a/server/tests/savedFilterAuthorization.test.js
+++ b/server/tests/savedFilterAuthorization.test.js
@@ -1,0 +1,181 @@
+import { jest } from "@jest/globals";
+
+const SavedFilter = {
+  findById: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  deleteOne: jest.fn(),
+};
+
+const savedFilterService = {
+  refreshMatchCounts: jest.fn(),
+};
+
+jest.unstable_mockModule("../models/savedFilterModel.js", () => ({
+  default: SavedFilter,
+}));
+jest.unstable_mockModule("../services/savedFilterService.js", () => ({
+  default: savedFilterService,
+}));
+
+const { updateFilter, deleteFilter, togglePin, getFilters } =
+  await import("../controllers/savedFilterController.js");
+
+const makeResponse = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+});
+
+const makeFilter = ({
+  id = "filter-1",
+  user = "owner-1",
+  organization = "org-1",
+  isShared = true,
+} = {}) => ({
+  _id: id,
+  user: { toString: () => user },
+  organization: { toString: () => organization },
+  isShared,
+  isPinned: false,
+  save: jest.fn(),
+});
+
+describe("Saved Filter authorization (Issue #1541)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    SavedFilter.findOne.mockResolvedValue(null);
+    savedFilterService.refreshMatchCounts.mockResolvedValue([]);
+  });
+
+  test("rejects a cross-organization filter ID", async () => {
+    const filter = makeFilter({ organization: "org-other" });
+    SavedFilter.findById.mockResolvedValue(filter);
+    const res = makeResponse();
+
+    await updateFilter(
+      {
+        params: { id: "filter-1" },
+        body: { name: "attacker update" },
+        user: { _id: "member-1", organization: "org-1", role: "member" },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(filter.save).not.toHaveBeenCalled();
+  });
+
+  test("allows an owner to update a filter in the same organization", async () => {
+    const filter = makeFilter({
+      user: "owner-1",
+      organization: "org-1",
+      isShared: false,
+    });
+    SavedFilter.findById.mockResolvedValue(filter);
+    SavedFilter.findOne.mockResolvedValue(filter);
+    const res = makeResponse();
+
+    await updateFilter(
+      {
+        params: { id: "filter-1" },
+        body: { name: "updated" },
+        user: { _id: "owner-1", organization: "org-1", role: "owner" },
+      },
+      res,
+    );
+
+    expect(filter.name).toBe("updated");
+    expect(filter.save).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test("prevents a non-owner shared member from modifying a filter", async () => {
+    const filter = makeFilter({
+      user: "owner-1",
+      organization: "org-1",
+      isShared: true,
+    });
+    SavedFilter.findById.mockResolvedValue(filter);
+    const res = makeResponse();
+
+    await updateFilter(
+      {
+        params: { id: "filter-1" },
+        body: { name: "member update" },
+        user: { _id: "member-1", organization: "org-1", role: "member" },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(filter.save).not.toHaveBeenCalled();
+  });
+
+  test("prevents a shared member from changing global pin state", async () => {
+    const filter = makeFilter({
+      user: "owner-1",
+      organization: "org-1",
+      isShared: true,
+    });
+    SavedFilter.findById.mockResolvedValue(filter);
+    const res = makeResponse();
+
+    await togglePin(
+      {
+        params: { id: "filter-1" },
+        body: { isPinned: true },
+        user: { _id: "member-1", organization: "org-1", role: "member" },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(filter.save).not.toHaveBeenCalled();
+  });
+
+  test("allows an authorized organization member to read shared filters only from their organization", async () => {
+    const query = {
+      sort: jest
+        .fn()
+        .mockResolvedValue([
+          { _id: "filter-1", organization: "org-1", isShared: true },
+        ]),
+    };
+    SavedFilter.find.mockReturnValue(query);
+    const res = makeResponse();
+
+    await getFilters(
+      { user: { _id: "member-1", organization: "org-1", role: "member" } },
+      res,
+    );
+
+    expect(SavedFilter.find).toHaveBeenCalledWith({
+      $or: [
+        { user: "member-1", organization: "org-1" },
+        { organization: "org-1", isShared: true },
+      ],
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  test("prevents deleting another owner's filter", async () => {
+    const filter = makeFilter({
+      user: "owner-1",
+      organization: "org-1",
+      isShared: true,
+    });
+    SavedFilter.findById.mockResolvedValue(filter);
+    const res = makeResponse();
+
+    await deleteFilter(
+      {
+        params: { id: "filter-1" },
+        user: { _id: "member-1", organization: "org-1", role: "admin" },
+      },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(SavedFilter.deleteOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1541

Enforces authorization and organization isolation for Saved Filter operations.

## What changed

- Require authentication for all Saved Filter operations.
- Bind newly created filters to the authenticated user's organization.
- Restrict shared-filter visibility to authorized organization members.
- Prevent cross-organization access through manipulated filter IDs.
- Restrict filter updates and deletion to the filter owner.
- Protect sharing-state changes with organization-management permissions.
- Prevent non-owners from modifying the global pin state of shared filters.
- Prevent clients from overwriting owner, organization, or match-count fields.
- Keep saved-filter match-count queries organization-scoped.
- Add regression tests covering ownership, sharing, and cross-organization access.

## Security

Saved Filter authorization is now performed using the persisted filter owner and organization rather than trusting request parameters.

A user cannot access another organization's filter by manipulating its ID.

Shared filters remain readable only by members of the owning organization, while modifying the filter or changing its sharing state requires the appropriate authorization.

## Tests

- [x] Owner can manage an authorized filter
- [x] Authorized organization member can read shared filters
- [x] Non-owner cannot modify a shared filter
- [x] Non-owner cannot change shared filter pin state
- [x] Cross-organization filter IDs are rejected
- [x] Non-owner cannot delete a filter
- [x] Saved-filter queries remain organization-scoped
- [ ] Full server test suite
- [ ] Full server lint/format validation