### PR TITLE
fix: handle multiple tag occurrences during rename

### DIFF
--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -5,6 +5,7 @@ import { sendSuccess } from "../utils/responseHandler.js";
 import { ValidationError, NotFoundError } from "../utils/errors.js";
 import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 import { caseInsensitiveEquals, escapeRegExp } from "../utils/regexUtils.js";
+import mongoose from "mongoose";
 
 // Validation schemas
 const createTagSchema = z.object({
@@ -86,8 +87,10 @@ export const updateTag = async (req, res, next) => {
     }
 
     const oldName = tag.name;
+    const isRename = Boolean(updates.name && updates.name !== oldName);
 
-    // If name is changing, check uniqueness
+    // If name is changing, check uniqueness using the same case-insensitive
+    // equality semantics used by tag creation.
     if (updates.name && updates.name.toLowerCase() !== tag.name.toLowerCase()) {
       const existingTag = await findTagByName(orgId, updates.name);
       if (existingTag) {
@@ -97,18 +100,126 @@ export const updateTag = async (req, res, next) => {
       }
     }
 
-    Object.assign(tag, updates);
-    await tag.save();
-
-    // Cascade rename in meetings if name changed
-    if (updates.name && updates.name !== oldName) {
-      await Meeting.updateMany(
-        { organization: orgId, tags: oldName },
-        { $set: { "tags.$": updates.name } },
-      );
+    if (!isRename) {
+      Object.assign(tag, updates);
+      await tag.save();
+      return sendSuccess(res, tag, "Tag updated successfully");
     }
 
-    return sendSuccess(res, tag, "Tag updated successfully");
+    const newName = updates.name;
+
+    // Replace every matching array element, not just the first one. The
+    // previous positional `$` update could leave stale occurrences when a
+    // meeting contained the same tag more than once.
+    const renameMeetings = (filter, options = {}) =>
+      Meeting.updateMany(
+        { organization: orgId, tags: oldName, ...filter },
+        [
+          {
+            $set: {
+              tags: {
+                $map: {
+                  input: "$tags",
+                  as: "tag",
+                  in: {
+                    $cond: [{ $eq: ["$$tag", oldName] }, newName, "$$tag"],
+                  },
+                },
+              },
+            },
+          },
+        ],
+        options,
+      );
+
+    // MongoDB transactions make the tag document and all meeting references
+    // commit/rollback together when the deployment supports transactions.
+    // The project's test MongoDB is standalone, so use a compensating rollback
+    // there to avoid leaving a partial rename behind if the second write fails.
+    const supportsTransactions = async () => {
+      try {
+        const hello = await mongoose.connection.db.admin().command({
+          hello: 1,
+        });
+        return Boolean(hello.setName || hello.msg === "isdbgrid");
+      } catch {
+        return false;
+      }
+    };
+
+    if (await supportsTransactions()) {
+      const session = await mongoose.startSession();
+      try {
+        let updatedTag;
+        await session.withTransaction(async () => {
+          const transactionalTag = await Tag.findOne({
+            _id: id,
+            organization: orgId,
+          }).session(session);
+
+          if (!transactionalTag) {
+            throw new NotFoundError("Tag not found");
+          }
+
+          // Re-check uniqueness inside the transaction to reduce the race
+          // window between the initial read and the rename commit.
+          const duplicate = await findTagByName(orgId, newName).session(
+            session,
+          );
+          if (duplicate && !duplicate._id.equals(transactionalTag._id)) {
+            throw new ValidationError(
+              "Tag with this name already exists in your organization.",
+            );
+          }
+
+          Object.assign(transactionalTag, updates);
+          await transactionalTag.save({ session });
+          await renameMeetings({}, { session });
+          updatedTag = transactionalTag;
+        });
+
+        return sendSuccess(res, updatedTag, "Tag updated successfully");
+      } finally {
+        await session.endSession();
+      }
+    }
+
+    // Standalone MongoDB fallback (including the repository's test server).
+    // Capture the exact affected documents so rollback cannot touch an
+    // unrelated meeting that already uses the new name.
+    const affectedMeetings = await Meeting.find({
+      organization: orgId,
+      tags: oldName,
+    })
+      .select("_id tags")
+      .lean();
+
+    let meetingsRenamed = false;
+    try {
+      await renameMeetings();
+      meetingsRenamed = true;
+
+      Object.assign(tag, updates);
+      await tag.save();
+
+      return sendSuccess(res, tag, "Tag updated successfully");
+    } catch (err) {
+      if (meetingsRenamed) {
+        try {
+          await Meeting.bulkWrite(
+            affectedMeetings.map(({ _id: meetingId, tags }) => ({
+              updateOne: {
+                filter: { _id: meetingId },
+                update: { $set: { tags } },
+              },
+            })),
+          );
+        } catch (rollbackError) {
+          err.rollbackError = rollbackError;
+        }
+      }
+      throw err;
+    }
   } catch (err) {
     next(err);
   }

--- a/server/tests/tagRename.test.js
+++ b/server/tests/tagRename.test.js
@@ -1,0 +1,165 @@
+import mongoose from "mongoose";
+import Tag from "../models/tagModel.js";
+import Meeting from "../models/meetingModel.js";
+import { updateTag } from "../controllers/tagController.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: undefined };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+};
+
+const invoke = async (req) => {
+  const res = mockRes();
+  let error;
+  await updateTag(req, res, (err) => {
+    error = err;
+  });
+  return { res, error };
+};
+
+const user = { _id: USER_A, organization: ORG_A };
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+describe("Tag rename cascade (Issue #1553)", () => {
+  it("renames every occurrence of a tag in every meeting", async () => {
+    const tag = await Tag.create({
+      name: "old-tag",
+      organization: ORG_A,
+      createdBy: USER_A,
+    });
+
+    await Meeting.create([
+      {
+        title: "Meeting with repeated tag",
+        organization: ORG_A,
+        uploadedBy: USER_A,
+        date: new Date(),
+        tags: ["old-tag", "other", "old-tag"],
+      },
+      {
+        title: "Second meeting",
+        organization: ORG_A,
+        uploadedBy: USER_A,
+        date: new Date(),
+        tags: ["old-tag"],
+      },
+      {
+        title: "Other organization",
+        organization: ORG_B,
+        uploadedBy: USER_A,
+        date: new Date(),
+        tags: ["old-tag"],
+      },
+    ]);
+
+    const { res, error } = await invoke({
+      params: { id: tag._id.toString() },
+      body: { name: "new-tag" },
+      user,
+    });
+
+    expect(error).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+
+    const orgMeetings = await Meeting.find({ organization: ORG_A }).lean();
+    expect(orgMeetings).toHaveLength(2);
+    expect(orgMeetings[0].tags).toEqual(
+      expect.not.arrayContaining(["old-tag"]),
+    );
+    expect(orgMeetings[1].tags).toEqual(["new-tag"]);
+
+    const repeated = orgMeetings.find((meeting) =>
+      meeting.title.startsWith("Meeting"),
+    );
+    expect(repeated.tags).toEqual(["new-tag", "other", "new-tag"]);
+
+    const otherOrg = await Meeting.findOne({ organization: ORG_B }).lean();
+    expect(otherOrg.tags).toEqual(["old-tag"]);
+
+    const renamedTag = await Tag.findById(tag._id).lean();
+    expect(renamedTag.name).toBe("new-tag");
+  });
+
+  it("does not create a duplicate tag during rename", async () => {
+    const tag = await Tag.create({
+      name: "old-name",
+      organization: ORG_A,
+      createdBy: USER_A,
+    });
+    await Tag.create({
+      name: "existing-name",
+      organization: ORG_A,
+      createdBy: USER_A,
+    });
+
+    const { res, error } = await invoke({
+      params: { id: tag._id.toString() },
+      body: { name: "existing-name" },
+      user,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(error).toBeDefined();
+    expect(await Tag.countDocuments({ organization: ORG_A })).toBe(2);
+    expect((await Tag.findById(tag._id)).name).toBe("old-name");
+  });
+
+  it("keeps the rename scoped to the tag's organization", async () => {
+    const tag = await Tag.create({
+      name: "scoped-old",
+      organization: ORG_A,
+      createdBy: USER_A,
+    });
+
+    await Meeting.create([
+      {
+        title: "same org",
+        organization: ORG_A,
+        uploadedBy: USER_A,
+        date: new Date(),
+        tags: ["scoped-old", "scoped-old"],
+      },
+      {
+        title: "different org",
+        organization: ORG_B,
+        uploadedBy: USER_A,
+        date: new Date(),
+        tags: ["scoped-old", "scoped-old"],
+      },
+    ]);
+
+    const { error } = await invoke({
+      params: { id: tag._id.toString() },
+      body: { name: "scoped-new" },
+      user,
+    });
+
+    expect(error).toBeUndefined();
+
+    expect((await Meeting.findOne({ title: "same org" })).tags).toEqual([
+      "scoped-new",
+      "scoped-new",
+    ]);
+    expect((await Meeting.findOne({ title: "different org" })).tags).toEqual([
+      "scoped-old",
+      "scoped-old",
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

Fixes tag renaming so every occurrence of the renamed tag is updated consistently across all affected meetings.

## Related Issue

Closes #1553

## What changed?

- Replaced the positional tag update with an array-wide replacement.
- Updated every matching tag occurrence within affected meetings.
- Kept the rename scoped to the tag's organization.
- Added duplicate-name protection during rename.
- Added MongoDB transaction support where transactions are available.
- Added a compensating rollback path for standalone MongoDB deployments.
- Preserved the exact original meeting tags during rollback.
- Added regression coverage for single and multiple tag occurrences.
- Verified that meetings in other organizations are not modified.

## Regression coverage

The new tests verify:

- A tag appearing multiple times in one meeting is fully renamed.
- The tag is renamed across multiple meetings.
- Single-occurrence tags continue to work.
- Other organizations are not affected.
- Existing duplicate tags are not created during rename.

## Validation

- ESLint
- Tag rename regression tests
- Related tag/regex regression tests
- Server PR validation
- Client PR validation

## Type

- [x] Bug fix
- [x] Regression tests
- [x] No unrelated feature changes