### PR TITLE
fix: maintain accurate tag usage counts

### DIFF
--- a/server/tests/tagUsage.test.js
+++ b/server/tests/tagUsage.test.js
@@ -1,0 +1,92 @@
+import mongoose from "mongoose";
+import Tag from "../models/tagModel.js";
+import Meeting from "../models/meetingModel.js";
+import {
+  updateTagUsageForAssociationChange,
+  reconcileTagUsageCounts,
+  normalizeTagNames,
+} from "../utils/tagUsage.js";
+
+describe("tag usage counts (Issue #1554)", () => {
+  const organization = new mongoose.Types.ObjectId();
+
+  afterEach(async () => {
+    await Tag.deleteMany({ organization });
+    await Meeting.deleteMany({ organization });
+  });
+
+  test("normalizes duplicate associations before calculating a delta", async () => {
+    expect(
+      normalizeTagNames([" finance ", "finance", "Finance", "", null]),
+    ).toEqual(["finance", "Finance"]);
+  });
+
+  test("increments only newly-created associations", async () => {
+    await Tag.create([
+      { name: "finance", organization, createdBy: organization, usageCount: 0 },
+      { name: "policy", organization, createdBy: organization, usageCount: 2 },
+    ]);
+
+    await updateTagUsageForAssociationChange({
+      organization,
+      previousTags: ["finance", "policy"],
+      currentTags: ["finance", "policy", "policy"],
+    });
+
+    const tags = await Tag.find({ organization }).sort({ name: 1 }).lean();
+    expect(tags.map((tag) => tag.usageCount)).toEqual([0, 2]);
+  });
+
+  test("increments additions and decrements removals", async () => {
+    await Tag.create([
+      { name: "finance", organization, createdBy: organization, usageCount: 1 },
+      { name: "policy", organization, createdBy: organization, usageCount: 3 },
+    ]);
+
+    await updateTagUsageForAssociationChange({
+      organization,
+      previousTags: ["finance", "policy"],
+      currentTags: ["finance"],
+    });
+
+    const policy = await Tag.findOne({ organization, name: "policy" });
+    expect(policy.usageCount).toBe(2);
+  });
+
+  test("reconciles counts from actual meeting associations", async () => {
+    await Tag.create([
+      {
+        name: "finance",
+        organization,
+        createdBy: organization,
+        usageCount: 99,
+      },
+      { name: "policy", organization, createdBy: organization, usageCount: 99 },
+      { name: "unused", organization, createdBy: organization, usageCount: 99 },
+    ]);
+
+    await Meeting.create([
+      {
+        uploadedBy: organization,
+        organization,
+        title: "A",
+        date: new Date(),
+        tags: ["finance", "finance", "policy"],
+      },
+      {
+        uploadedBy: organization,
+        organization,
+        title: "B",
+        date: new Date(),
+        tags: ["finance"],
+      },
+    ]);
+
+    const result = await reconcileTagUsageCounts(organization);
+    const byName = Object.fromEntries(
+      result.map((item) => [item.name, item.usageCount]),
+    );
+
+    expect(byName).toEqual({ finance: 2, policy: 1, unused: 0 });
+  });
+});

--- a/server/utils/tagUsage.js
+++ b/server/utils/tagUsage.js
@@ -1,0 +1,121 @@
+import Tag from "../models/tagModel.js";
+
+const uniqueTagNames = (tags = []) => [
+  ...new Set(
+    tags
+      .filter((tag) => typeof tag === "string")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+  ),
+];
+
+/**
+ * Apply only the association delta between two versions of a resource.
+ *
+ * This keeps usageCount tied to real associations rather than to the number
+ * of times an update endpoint was called. Duplicate tag names in a resource
+ * are collapsed before calculating the delta.
+ */
+export const updateTagUsageForAssociationChange = async ({
+  organization,
+  previousTags = [],
+  currentTags = [],
+}) => {
+  if (!organization) return;
+
+  const previous = new Set(
+    uniqueTagNames(previousTags).map((tag) => tag.toLocaleLowerCase()),
+  );
+  const current = new Set(
+    uniqueTagNames(currentTags).map((tag) => tag.toLocaleLowerCase()),
+  );
+
+  const added = [...current].filter((tag) => !previous.has(tag));
+  const removed = [...previous].filter((tag) => !current.has(tag));
+
+  const updateByNames = async (names, increment) => {
+    if (!names.length) return;
+
+    const tags = await Tag.find({ organization, name: { $in: names } })
+      .collation({ locale: "en", strength: 2 })
+      .select("_id")
+      .lean();
+
+    if (!tags.length) return;
+
+    await Tag.updateMany(
+      { organization, _id: { $in: tags.map((tag) => tag._id) } },
+      { $inc: { usageCount: increment } },
+    );
+  };
+
+  await updateByNames(added, 1);
+  await updateByNames(removed, -1);
+
+  if (removed.length) {
+    await Tag.updateMany(
+      { organization, usageCount: { $lt: 0 } },
+      { $set: { usageCount: 0 } },
+    );
+  }
+};
+
+export const reconcileTagUsageCounts = async (organization) => {
+  if (!organization) return [];
+
+  // Dynamic import avoids a Meeting -> helper -> Meeting module cycle.
+  const { default: Meeting } = await import("../models/meetingModel.js");
+
+  const counts = await Meeting.aggregate([
+    { $match: { organization } },
+    { $project: { tags: { $ifNull: ["$tags", []] } } },
+    { $unwind: "$tags" },
+    {
+      $group: {
+        _id: {
+          $toLower: { $trim: { input: "$tags" } },
+        },
+        resourceIds: { $addToSet: "$_id" },
+      },
+    },
+    {
+      $project: {
+        _id: 1,
+        usageCount: { $size: "$resourceIds" },
+      },
+    },
+  ]);
+
+  const countByName = new Map(
+    counts.map((entry) => [
+      String(entry._id).trim().toLocaleLowerCase(),
+      entry.usageCount,
+    ]),
+  );
+
+  const tags = await Tag.find({ organization }).select("_id name").lean();
+  const operations = tags.map((tag) => ({
+    updateOne: {
+      filter: { _id: tag._id, organization },
+      update: {
+        $set: {
+          usageCount:
+            countByName.get(String(tag.name).trim().toLocaleLowerCase()) || 0,
+        },
+      },
+    },
+  }));
+
+  if (operations.length) {
+    await Tag.bulkWrite(operations);
+  }
+
+  return tags.map((tag) => ({
+    tagId: tag._id,
+    name: tag.name,
+    usageCount:
+      countByName.get(String(tag.name).trim().toLocaleLowerCase()) || 0,
+  }));
+};
+
+export const normalizeTagNames = uniqueTagNames;


### PR DESCRIPTION
# Pull Request

## Summary

Fixes inaccurate tag usage counts by keeping the stored `usageCount`
synchronized with actual meeting-to-tag associations.

## Related Issue

Closes #1554

## What changed?

- Added centralized tag association delta handling.
- Increment tag usage only when a new association is created.
- Decrement usage when an association is removed.
- Prevent duplicate tag associations from inflating counts.
- Update tag usage when meetings are permanently deleted.
- Handle organization changes safely.
- Handle case-insensitive tag names consistently.
- Added organization-scoped tag usage reconciliation.
- Added an admin/owner-only reconciliation endpoint.
- Added regression tests for duplicate, increment, decrement, and reconciliation scenarios.

## Reconciliation

Added:

`POST /api/tags/reconcile`

The endpoint is organization-scoped and protected by the existing
admin/owner authorization middleware.

It recalculates usage counts from the actual meeting associations,
allowing stale legacy counters to be safely repaired.

## Testing

- Tag association increment/decrement tests
- Duplicate association regression test
- Existing-count reconciliation test
- Organization-scoped queries
- Prettier validation
- ESLint validation
- Server PR validation

## Regression Safety

Tag usage is treated as derived metadata. A failure while updating a
counter does not roll back a successful meeting write. The reconciliation
operation can repair stale counters from the source-of-truth meeting
associations.

## Type

- [x] Bug fix
- [x] Regression tests
- [ ] New feature
- [ ] Breaking change