### PR TITLE
fix(validation): validate ObjectId format and query boundaries in speakingTimeController

### DIFF
--- a/server/controllers/__tests__/speakingTimeValidation.test.js
+++ b/server/controllers/__tests__/speakingTimeValidation.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getSpeakingTimeBreakdown,
+  getSpeakingTimeTrends,
+} from "../speakingTimeController.js";
+import Meeting from "../../models/meetingModel.js";
+import * as speakingTimeService from "../../services/speakingTimeService.js";
+
+vi.mock("../../models/meetingModel.js");
+vi.mock("../../services/speakingTimeService.js");
+
+describe("Speaking Time Controller Validation (#1608)", () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      params: {},
+      query: {},
+      user: { _id: "507f1f77bcf86cd799439011", organization: "org123" },
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  describe("getSpeakingTimeBreakdown", () => {
+    it("returns 400 Bad Request when meetingId is invalid ObjectId format", async () => {
+      req.params.meetingId = "invalid-id";
+
+      await getSpeakingTimeBreakdown(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Invalid meeting ID format",
+        }),
+      );
+    });
+
+    it("fetches breakdown successfully for valid meetingId", async () => {
+      req.params.meetingId = "507f1f77bcf86cd799439011";
+      Meeting.findById.mockResolvedValue({
+        uploadedBy: "507f1f77bcf86cd799439011",
+        participants: [],
+      });
+      speakingTimeService.getBreakdownForMeeting.mockResolvedValue({
+        meetingId: "507f1f77bcf86cd799439011",
+        breakdown: [],
+      });
+
+      await getSpeakingTimeBreakdown(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.any(Object),
+        }),
+      );
+    });
+  });
+
+  describe("getSpeakingTimeTrends", () => {
+    it("defaults limit to 10 when negative limit query is passed", async () => {
+      req.query.limit = "-5";
+      speakingTimeService.getTrendsForUser.mockResolvedValue([]);
+
+      await getSpeakingTimeTrends(req, res);
+
+      expect(speakingTimeService.getTrendsForUser).toHaveBeenCalledWith(
+        "507f1f77bcf86cd799439011",
+        10,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("clamps limit to 50 when query exceeds max limit", async () => {
+      req.query.limit = "100";
+      speakingTimeService.getTrendsForUser.mockResolvedValue([]);
+
+      await getSpeakingTimeTrends(req, res);
+
+      expect(speakingTimeService.getTrendsForUser).toHaveBeenCalledWith(
+        "507f1f77bcf86cd799439011",
+        50,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/server/controllers/speakingTimeController.js
+++ b/server/controllers/speakingTimeController.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import {
   getBreakdownForMeeting,
   getTrendsForUser,
@@ -11,6 +12,12 @@ export const getSpeakingTimeBreakdown = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const userId = req.user._id;
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid meeting ID format" });
+    }
 
     // Verify meeting exists and user has access
     const meeting = await Meeting.findById(meetingId);
@@ -51,8 +58,12 @@ export const getSpeakingTimeBreakdown = async (req, res) => {
 export const getSpeakingTimeTrends = async (req, res) => {
   try {
     const userId = req.user._id;
-    let limit = parseInt(req.query.limit, 10) || 10;
-    if (limit > 50) limit = 50;
+    let limit = parseInt(req.query.limit, 10);
+    if (isNaN(limit) || limit < 1) {
+      limit = 10;
+    } else if (limit > 50) {
+      limit = 50;
+    }
 
     const trends = await getTrendsForUser(userId, limit);
     return res.status(200).json({ success: true, data: trends });


### PR DESCRIPTION
Fixes #1608

## Description
This PR adds ObjectId validation for meetingId and sanitizes the limit query parameter in speakingTimeController.js.

## Proposed Changes
- **ObjectId Validation**: Checked mongoose.Types.ObjectId.isValid(meetingId) in getSpeakingTimeBreakdown, returning a 400 Bad Request error if invalid.
- **Query Boundary Clamping**: Sanitized limit query in getSpeakingTimeTrends strictly between 1 and 50 (defaulting to 10 for negative/NaN values).
- **Unit Test Coverage**: Added Vitest test suite (speakingTimeValidation.test.js) verifying parameter validation and boundary limits.

## Checklist
- [x] Related Issue is linked (Fixes #1608).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid meeting IDs now return a clear HTTP 400 response.
  * Speaking-trend limits are normalized: invalid or low values default to 10, while values above 50 are capped.

* **Tests**
  * Added coverage for meeting ID validation, successful breakdown requests, and trend limit boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->