### PR TITLE
fix(validation): validate deliveryId parameter format and schedule schema limits in recapScheduleController

### DIFF
--- a/server/controllers/__tests__/recapScheduleValidation.test.js
+++ b/server/controllers/__tests__/recapScheduleValidation.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { retryDelivery, upsertSchedule } from "../recapScheduleController.js";
+import RecapDelivery from "../../models/recapDeliveryModel.js";
+import RecapSchedule from "../../models/recapScheduleModel.js";
+
+vi.mock("../../models/recapDeliveryModel.js");
+vi.mock("../../models/recapScheduleModel.js");
+vi.mock("../../services/queueService.js", () => ({
+  recapDeliveryQueue: { isActive: false, add: vi.fn() },
+}));
+
+describe("Recap Schedule Controller Validation (#1609)", () => {
+  let req, res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      params: {},
+      body: {},
+      user: { _id: "507f1f77bcf86cd799439011", organization: "org123" },
+      authorizedOrganizationId: "org123",
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  describe("retryDelivery", () => {
+    it("returns 400 Bad Request when deliveryId is invalid ObjectId format", async () => {
+      req.params.deliveryId = "invalid-delivery-id";
+
+      await retryDelivery(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "Invalid delivery ID format" }),
+      );
+    });
+
+    it("retries delivery successfully for valid deliveryId", async () => {
+      req.params.deliveryId = "507f1f77bcf86cd799439011";
+      RecapDelivery.findOne.mockReturnValue({
+        populate: vi.fn().mockResolvedValue({
+          _id: "507f1f77bcf86cd799439011",
+          userId: "507f1f77bcf86cd799439011",
+          meetingId: { organization: "org123", title: "Team Sync" },
+        }),
+      });
+
+      await retryDelivery(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Delivery retry enqueued successfully",
+        }),
+      );
+    });
+  });
+
+  describe("upsertSchedule", () => {
+    it("returns 400 Bad Request when timezone exceeds maximum characters", async () => {
+      req.body = {
+        scheduleType: "daily",
+        timezone: "a".repeat(51),
+      };
+
+      await upsertSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("upserts valid schedule payload successfully", async () => {
+      req.body = {
+        scheduleType: "daily",
+        timezone: "America/New_York",
+        preferredTime: "09:00",
+      };
+      RecapSchedule.findOneAndUpdate.mockResolvedValue({
+        scheduleType: "daily",
+        timezone: "America/New_York",
+      });
+
+      await upsertSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/server/controllers/recapScheduleController.js
+++ b/server/controllers/recapScheduleController.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import RecapSchedule from "../models/recapScheduleModel.js";
 import RecapDelivery from "../models/recapDeliveryModel.js";
 import { recapDeliveryQueue } from "../services/queueService.js";
@@ -6,8 +7,14 @@ import { z } from "zod";
 const scheduleSchema = z.object({
   scheduleType: z.enum(["immediate", "daily", "weekly"]),
   deliveryChannel: z.enum(["email", "webhook", "in_app"]).optional(),
-  preferredTime: z.string().optional(),
-  timezone: z.string().optional(),
+  preferredTime: z
+    .string()
+    .max(10, "Preferred time cannot exceed 10 characters")
+    .optional(),
+  timezone: z
+    .string()
+    .max(50, "Timezone cannot exceed 50 characters")
+    .optional(),
 });
 
 /**
@@ -110,6 +117,10 @@ export const retryDelivery = async (req, res) => {
     const { deliveryId } = req.params;
     const userId = req.user._id;
     const organizationId = resolveAuthorizedOrganizationId(req);
+
+    if (!mongoose.Types.ObjectId.isValid(deliveryId)) {
+      return res.status(400).json({ error: "Invalid delivery ID format" });
+    }
 
     if (!organizationId) {
       return res.status(403).json({


### PR DESCRIPTION
Fixes #1609

## Description
This PR validates the deliveryId parameter format in etryDelivery and enforces string length limits in scheduleSchema within ecapScheduleController.js.

## Proposed Changes
- **ObjectId Validation**: Checked mongoose.Types.ObjectId.isValid(deliveryId) in etryDelivery, returning 400 Bad Request if malformed.
- **Zod Schema String Length Boundaries**: Added character length boundaries (	imezone max 50, preferredTime max 10) in scheduleSchema.
- **Unit Test Coverage**: Added Vitest test suite (ecapScheduleValidation.test.js) verifying deliveryId validation and schedule payload boundaries.

## Checklist
- [x] Related Issue is linked (Fixes #1609).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.