### PR TITLE
fix(accessibility): add WAI-ARIA region landmarks, chart labels, and accessible progress bars in MeetingHealthDashboard

### DIFF
--- a/client/src/pages/MeetingHealthDashboard.jsx
+++ b/client/src/pages/MeetingHealthDashboard.jsx
@@ -71,6 +71,7 @@ const MeetingHealthDashboard = () => {
         height={height}
         viewBox={`0 0 ${width} ${height}`}
         className="w-full"
+        aria-label="Meeting health composite score chart"
       >
         {/* Y Axis */}
         <line
@@ -177,7 +178,11 @@ const MeetingHealthDashboard = () => {
         </div>
 
         {/* Trend Chart */}
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+        <div
+          role="region"
+          aria-label="Composite score trend chart"
+          className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
+        >
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
             Composite Score Trend
           </h2>
@@ -216,7 +221,14 @@ const MeetingHealthDashboard = () => {
                       {factor.value}%
                     </span>
                   </div>
-                  <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                  <div
+                    role="progressbar"
+                    aria-valuenow={factor.value}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${factor.label} percentage`}
+                    className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2"
+                  >
                     <div
                       className={`h-2 rounded-full ${factor.value >= 80 ? "bg-green-500" : factor.value >= 60 ? "bg-yellow-500" : "bg-red-500"}`}
                       style={{ width: `${factor.value}%` }}

--- a/client/src/pages/__tests__/MeetingHealthDashboardAccessibility.test.jsx
+++ b/client/src/pages/__tests__/MeetingHealthDashboardAccessibility.test.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MeetingHealthDashboard from "../MeetingHealthDashboard.jsx";
+import { meetingHealthApi } from "../../services/meetingHealthApi";
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    user: { organization: "org-123" },
+  }),
+}));
+
+vi.mock("../../services/meetingHealthApi", () => ({
+  meetingHealthApi: {
+    getOrganizationHealthTrends: vi.fn(),
+  },
+}));
+
+describe("MeetingHealthDashboard Accessibility (#1611)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders chart region and factor benchmark progressbars with ARIA attributes", async () => {
+    meetingHealthApi.getOrganizationHealthTrends.mockResolvedValue({
+      success: true,
+      data: {
+        trends: [
+          {
+            _id: "t1",
+            compositeScore: 85,
+            meetingId: { title: "Executive Review" },
+          },
+        ],
+        benchmarks: {
+          averageComposite: 85,
+          averageEngagement: 88,
+          averageAgendaCoverage: 90,
+          averageTimeAdherence: 82,
+          averageActionItemClarity: 78,
+          averageSentiment: 80,
+        },
+      },
+    });
+
+    render(<MeetingHealthDashboard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("region", { name: /composite score trend chart/i }),
+      ).toBeInTheDocument();
+    });
+
+    const progressbars = screen.getAllByRole("progressbar");
+    expect(progressbars.length).toBe(5);
+
+    const agendaProgress = screen.getByRole("progressbar", {
+      name: /agenda coverage percentage/i,
+    });
+    expect(agendaProgress).toHaveAttribute("aria-valuenow", "90");
+    expect(agendaProgress).toHaveAttribute("aria-valuemin", "0");
+    expect(agendaProgress).toHaveAttribute("aria-valuemax", "100");
+  });
+});


### PR DESCRIPTION
Fixes #1611

## Description
This PR adds WAI-ARIA region landmarks and accessible progress bar attributes to MeetingHealthDashboard.jsx.

## Proposed Changes
- **WAI-ARIA Region Landmarks**: Added ole="region" and ria-label="Composite score trend chart" to trend chart container.
- **WAI-ARIA Progressbar Attributes**: Added ole="progressbar", ria-valuenow, ria-valuemin="0", ria-valuemax="100", and ria-label to factor benchmark progress bars.
- **Unit Test Coverage**: Added Vitest test suite (MeetingHealthDashboardAccessibility.test.jsx) verifying ARIA region landmarks and progressbar properties.

## Checklist
- [x] Related Issue is linked (Fixes #1611).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.