### PR TITLE
feat(ui): add confirmation modal prior to retrying recap deliveries in RecapScheduleDashboard

### DIFF
--- a/client/src/pages/RecapScheduleDashboard.jsx
+++ b/client/src/pages/RecapScheduleDashboard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from "react";
 import { format } from "date-fns";
 import AppContent from "../context/AppContent";
 import Navbar from "../components/Navbar.jsx";
+import ConfirmModal from "../components/ConfirmModal.jsx";
 import { recapScheduleApi } from "../services/recapScheduleApi";
 import {
   Clock,
@@ -30,6 +31,8 @@ const RecapScheduleDashboard = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [retryingDeliveryId, setRetryingDeliveryId] = useState(null);
+  const [retryTarget, setRetryTarget] = useState(null);
+  const [retryLoading, setRetryLoading] = useState(false);
   const [saveMessage, setSaveMessage] = useState({ type: "", text: "" });
   const [retryMessage, setRetryMessage] = useState({ type: "", text: "" });
 
@@ -112,11 +115,15 @@ const RecapScheduleDashboard = () => {
     }
   };
 
-  const handleRetry = async (deliveryId) => {
+  const handleRetryConfirm = async () => {
+    if (!retryTarget) return;
+    const deliveryId = retryTarget._id;
     setRetryingDeliveryId(deliveryId);
+    setRetryLoading(true);
     setRetryMessage({ type: "", text: "" });
     try {
       await recapScheduleApi.retryDelivery(deliveryId);
+      setRetryTarget(null);
       setRetryMessage({
         type: "success",
         text: "Retry enqueued successfully.",
@@ -133,6 +140,7 @@ const RecapScheduleDashboard = () => {
       });
     } finally {
       setRetryingDeliveryId(null);
+      setRetryLoading(false);
     }
   };
 
@@ -339,7 +347,14 @@ const RecapScheduleDashboard = () => {
                             <td className="px-6 py-4 text-right">
                               <button
                                 type="button"
-                                onClick={() => handleRetry(delivery._id)}
+                                onClick={() =>
+                                  setRetryTarget({
+                                    _id: delivery._id,
+                                    meetingTitle:
+                                      delivery.meetingId?.title ||
+                                      "Unknown Meeting",
+                                  })
+                                }
                                 disabled={retryingDeliveryId === delivery._id}
                                 aria-label={`Retry delivery for ${delivery.meetingId?.title || "Unknown Meeting"}`}
                                 className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 font-medium cursor-pointer disabled:opacity-60 disabled:cursor-wait"
@@ -377,6 +392,18 @@ const RecapScheduleDashboard = () => {
           </div>
         )}
       </div>
+
+      {/* Confirmation Modal prior to retrying recap delivery (#1612) */}
+      <ConfirmModal
+        isOpen={Boolean(retryTarget)}
+        onClose={() => setRetryTarget(null)}
+        onConfirm={handleRetryConfirm}
+        title="Retry Recap Delivery"
+        message={`Are you sure you want to retry the recap delivery for "${retryTarget?.meetingTitle || "this meeting"}"?`}
+        confirmText="Retry Delivery"
+        variant="primary"
+        isLoading={retryLoading}
+      />
     </div>
   );
 };

--- a/client/src/pages/__tests__/RecapScheduleConfirmModal.test.jsx
+++ b/client/src/pages/__tests__/RecapScheduleConfirmModal.test.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RecapScheduleDashboard from "../RecapScheduleDashboard.jsx";
+import { recapScheduleApi } from "../../services/recapScheduleApi";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="navbar">Navbar</nav>,
+}));
+
+vi.mock("../../services/recapScheduleApi", () => ({
+  recapScheduleApi: {
+    getSchedule: vi.fn(),
+    getDeliveryHistory: vi.fn(),
+    upsertSchedule: vi.fn(),
+    retryDelivery: vi.fn(),
+  },
+}));
+
+describe("RecapSchedule Confirm Modal (#1612)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens ConfirmModal when retry button is clicked and executes retry on confirm", async () => {
+    recapScheduleApi.getSchedule.mockResolvedValue({
+      data: { scheduleType: "daily" },
+    });
+    recapScheduleApi.getDeliveryHistory.mockResolvedValue({
+      data: [
+        {
+          _id: "del-123",
+          meetingId: { title: "Q3 Planning Sync" },
+          deliveredAt: "2026-08-10T12:00:00.000Z",
+          status: "delivered",
+        },
+      ],
+    });
+    recapScheduleApi.retryDelivery.mockResolvedValue({ success: true });
+
+    render(
+      <AppContent.Provider value={{ userData: { organization: "org-1" } }}>
+        <RecapScheduleDashboard />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Q3 Planning Sync")).toBeInTheDocument();
+    });
+
+    const retryButton = screen.getByRole("button", {
+      name: /retry delivery for q3 planning sync/i,
+    });
+    fireEvent.click(retryButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/retry recap delivery/i)).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", {
+      name: /retry delivery/i,
+    });
+    const confirmButton = confirmButtons[confirmButtons.length - 1];
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(recapScheduleApi.retryDelivery).toHaveBeenCalledWith("del-123");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1612

## Description
This PR integrates ConfirmModal.jsx into RecapScheduleDashboard.jsx to prompt the user before triggering recap delivery retries.

## Proposed Changes
- **Confirmation Modal Integration**: Replaced direct execution with ConfirmModal.jsx to confirm delivery retries before enqueuing requests.
- **State Management**: Added etryTarget and etryLoading state to manage modal visibility and prevent duplicate submissions.
- **Unit Test Coverage**: Added Vitest test suite (RecapScheduleConfirmModal.test.jsx) verifying confirmation modal opening and retry dispatch.

## Checklist
- [x] Related Issue is linked (Fixes #1612).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.