### PR TITLE
fix: restore canonical /api prefix on personal notes routes

### DIFF
--- a/client/src/services/__tests__/personalNoteApi.test.js
+++ b/client/src/services/__tests__/personalNoteApi.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import apiClient from "../apiClient";
+import { personalNoteApi } from "../personalNoteApi";
+
+vi.mock("../apiClient", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("personalNoteApi endpoint prefix (#1534)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({ data: { success: true } });
+    apiClient.post.mockResolvedValue({ data: { success: true } });
+    apiClient.put.mockResolvedValue({ data: { success: true } });
+    apiClient.patch.mockResolvedValue({ data: { success: true } });
+    apiClient.delete.mockResolvedValue({ data: { success: true } });
+  });
+
+  it("targets /api/personal-notes/:meetingId for getNoteByMeetingId and getByMeetingId", async () => {
+    await personalNoteApi.getNoteByMeetingId("m-123");
+    expect(apiClient.get).toHaveBeenCalledWith("/api/personal-notes/m-123");
+
+    await personalNoteApi.getByMeetingId("m-123");
+    expect(apiClient.get).toHaveBeenCalledWith("/api/personal-notes/m-123");
+  });
+
+  it("targets /api/personal-notes/:meetingId for upsertNote", async () => {
+    await personalNoteApi.upsertNote("m-123", { content: "Note text" });
+    expect(apiClient.post).toHaveBeenCalledWith("/api/personal-notes/m-123", {
+      content: "Note text",
+    });
+  });
+
+  it("targets /api/personal-notes/:meetingId/annotations for annotations", async () => {
+    await personalNoteApi.addAnnotation("m-123", { text: "Annotation" });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/personal-notes/m-123/annotations",
+      { text: "Annotation" },
+    );
+
+    await personalNoteApi.removeAnnotation("m-123", "ann-456");
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      "/api/personal-notes/m-123/annotations/ann-456",
+    );
+  });
+
+  it("targets /api/personal-notes/:meetingId/pin for togglePin", async () => {
+    await personalNoteApi.togglePin("m-123", true);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      "/api/personal-notes/m-123/pin",
+      { isPinned: true },
+    );
+  });
+
+  it("targets /api/personal-notes/pinned for getPinnedNotes", async () => {
+    await personalNoteApi.getPinnedNotes();
+    expect(apiClient.get).toHaveBeenCalledWith("/api/personal-notes/pinned");
+  });
+
+  it("targets /api/personal-notes/search for searchNotes", async () => {
+    await personalNoteApi.searchNotes("roadmap");
+    expect(apiClient.get).toHaveBeenCalledWith("/api/personal-notes/search", {
+      params: { q: "roadmap" },
+    });
+  });
+
+  it("targets /api/personal-notes/:meetingId/clear and delete", async () => {
+    await personalNoteApi.clearNoteContent("m-123");
+    expect(apiClient.put).toHaveBeenCalledWith(
+      "/api/personal-notes/m-123/clear",
+    );
+
+    await personalNoteApi.deleteNote("m-123");
+    expect(apiClient.delete).toHaveBeenCalledWith("/api/personal-notes/m-123");
+  });
+
+  it("never produces duplicate /api/api prefixes across all personal note endpoints", async () => {
+    await personalNoteApi.getNoteByMeetingId("m-123");
+    await personalNoteApi.getByMeetingId("m-123");
+    await personalNoteApi.upsertNote("m-123", "test content");
+    await personalNoteApi.addAnnotation("m-123", { text: "ann" });
+    await personalNoteApi.removeAnnotation("m-123", "ann-1");
+    await personalNoteApi.togglePin("m-123", false);
+    await personalNoteApi.getPinnedNotes();
+    await personalNoteApi.searchNotes("query");
+    await personalNoteApi.clearNoteContent("m-123");
+    await personalNoteApi.deleteNote("m-123");
+
+    const calls = [
+      ...apiClient.get.mock.calls,
+      ...apiClient.post.mock.calls,
+      ...apiClient.put.mock.calls,
+      ...apiClient.patch.mock.calls,
+      ...apiClient.delete.mock.calls,
+    ];
+
+    for (const [url] of calls) {
+      expect(url).toMatch(/^\/api\/personal-notes\b/);
+      expect(url).not.toContain("/api/api/");
+    }
+  });
+});

--- a/client/src/services/personalNoteApi.js
+++ b/client/src/services/personalNoteApi.js
@@ -17,20 +17,20 @@ const wrap = async (promise) => {
 
 export const personalNoteApi = {
   getNoteByMeetingId: (meetingId) =>
-    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+    wrap(apiClient.get(`/api/personal-notes/${meetingId}`)),
 
   getByMeetingId: (meetingId) =>
-    wrap(apiClient.get(`/personal-notes/${meetingId}`)),
+    wrap(apiClient.get(`/api/personal-notes/${meetingId}`)),
 
   upsertNote: (meetingId, data) => {
     const payload = typeof data === "string" ? { content: data } : data;
-    return wrap(apiClient.post(`/personal-notes/${meetingId}`, payload));
+    return wrap(apiClient.post(`/api/personal-notes/${meetingId}`, payload));
   },
 
   addAnnotation: (meetingId, annotationData) =>
     wrap(
       apiClient.post(
-        `/personal-notes/${meetingId}/annotations`,
+        `/api/personal-notes/${meetingId}/annotations`,
         annotationData,
       ),
     ),
@@ -38,21 +38,21 @@ export const personalNoteApi = {
   removeAnnotation: (meetingId, annotationId) =>
     wrap(
       apiClient.delete(
-        `/personal-notes/${meetingId}/annotations/${annotationId}`,
+        `/api/personal-notes/${meetingId}/annotations/${annotationId}`,
       ),
     ),
 
   togglePin: (meetingId, isPinned) =>
-    wrap(apiClient.patch(`/personal-notes/${meetingId}/pin`, { isPinned })),
+    wrap(apiClient.patch(`/api/personal-notes/${meetingId}/pin`, { isPinned })),
 
-  getPinnedNotes: () => wrap(apiClient.get(`/personal-notes/pinned`)),
+  getPinnedNotes: () => wrap(apiClient.get(`/api/personal-notes/pinned`)),
 
   searchNotes: (query) =>
-    wrap(apiClient.get(`/personal-notes/search`, { params: { q: query } })),
+    wrap(apiClient.get(`/api/personal-notes/search`, { params: { q: query } })),
 
   clearNoteContent: (meetingId) =>
-    wrap(apiClient.put(`/personal-notes/${meetingId}/clear`)),
+    wrap(apiClient.put(`/api/personal-notes/${meetingId}/clear`)),
 
   deleteNote: (meetingId) =>
-    wrap(apiClient.delete(`/personal-notes/${meetingId}`)),
+    wrap(apiClient.delete(`/api/personal-notes/${meetingId}`)),
 };


### PR DESCRIPTION
## Description
This PR fixes the route prefix in `personalNoteApi.js` so that all personal notes client requests target `/api/personal-notes/*` matching the backend Express route mount, resolving 404 Not Found errors while preserving Clerk authentication headers.

## Related Issue
Closes #1534

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Updated all endpoints in client/src/services/personalNoteApi.js from `/personal-notes/...` to `/api/personal-notes/...` (`getNoteByMeetingId`, `getByMeetingId`, `upsertNote`, `addAnnotation`, `removeAnnotation`, `togglePin`, `getPinnedNotes`, `searchNotes`, `clearNoteContent`, `deleteNote`).
- Created client test suite in client/src/services/__tests__/personalNoteApi.test.js ensuring canonical `/api/personal-notes` prefixes and verifying no duplicate `/api/api` paths are produced.

## How Has This Been Tested?
- Executed `npx vitest run src/services/__tests__/personalNoteApi.test.js` (8/8 tests passed).
- Executed `npm run validate:pr --prefix client` (ESLint, Prettier, and Vite production build passed).
