### PR TITLE
fix: enforce organization authorization for parking lot data

### DIFF
--- a/server/controllers/parkingLotController.js
+++ b/server/controllers/parkingLotController.js
@@ -1,4 +1,8 @@
+import mongoose from "mongoose";
 import * as parkingLotService from "../services/parkingLotService.js";
+import ParkingLotItem from "../models/parkingLotItemModel.js";
+import Meeting from "../models/meetingModel.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
 
 /**
  * Add a topic to the parking lot
@@ -7,17 +11,56 @@ import * as parkingLotService from "../services/parkingLotService.js";
 export const addTopic = async (req, res, next) => {
   try {
     const { organizationId, sourceMeetingId, topic } = req.body;
-    const userId = req.user._id; // Assuming authMiddleware sets req.user
+    const userId = req.user._id || req.user.id;
+    const userOrgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
 
-    if (!organizationId || !sourceMeetingId || !topic) {
+    if (!userOrgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    if (!sourceMeetingId || !topic) {
       return res.status(400).json({
         success: false,
         message: "Organization ID, Meeting ID, and Topic are required.",
       });
     }
 
+    if (organizationId && organizationId.toString() !== userOrgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Cross-organization access denied",
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(sourceMeetingId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid meeting ID format",
+      });
+    }
+
+    const meeting = await Meeting.findById(sourceMeetingId);
+    if (!meeting) {
+      return res.status(404).json({
+        success: false,
+        message: "Meeting not found",
+      });
+    }
+
+    if (!canAccessMeetingDoc(meeting, req.user)) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You don't have access to this meeting",
+      });
+    }
+
     const item = await parkingLotService.addTopicToParkingLot(
-      organizationId,
+      userOrgId,
       sourceMeetingId,
       userId,
       topic,
@@ -41,6 +84,9 @@ export const getOrganizationParkingLot = async (req, res, next) => {
   try {
     const { orgId } = req.params;
     const { status, page, limit } = req.query;
+    const userOrgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
 
     if (!orgId) {
       return res.status(400).json({
@@ -49,11 +95,21 @@ export const getOrganizationParkingLot = async (req, res, next) => {
       });
     }
 
-    const result = await parkingLotService.getParkingLotForOrganization(orgId, {
-      status,
-      page,
-      limit,
-    });
+    if (!userOrgId || orgId.toString() !== userOrgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Cross-organization access denied",
+      });
+    }
+
+    const result = await parkingLotService.getParkingLotForOrganization(
+      userOrgId,
+      {
+        status,
+        page,
+        limit,
+      },
+    );
 
     res.status(200).json({
       success: true,
@@ -72,6 +128,16 @@ export const updateTopicStatus = async (req, res, next) => {
   try {
     const { id } = req.params;
     const { status, scheduledForMeetingId } = req.body;
+    const userOrgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid topic ID format",
+      });
+    }
 
     if (!status) {
       return res.status(400).json({
@@ -80,18 +146,48 @@ export const updateTopicStatus = async (req, res, next) => {
       });
     }
 
-    const updatedItem = await parkingLotService.updateTopicStatus(
-      id,
-      status,
-      scheduledForMeetingId,
-    );
-
-    if (!updatedItem) {
+    const item = await ParkingLotItem.findById(id);
+    if (!item) {
       return res.status(404).json({
         success: false,
         message: "Parking lot item not found.",
       });
     }
+
+    if (!userOrgId || item.organization?.toString() !== userOrgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Cross-organization access denied",
+      });
+    }
+
+    if (scheduledForMeetingId) {
+      if (!mongoose.Types.ObjectId.isValid(scheduledForMeetingId)) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid meeting ID format",
+        });
+      }
+      const meeting = await Meeting.findById(scheduledForMeetingId);
+      if (!meeting) {
+        return res.status(404).json({
+          success: false,
+          message: "Scheduled meeting not found",
+        });
+      }
+      if (!canAccessMeetingDoc(meeting, req.user)) {
+        return res.status(403).json({
+          success: false,
+          message: "Forbidden: You don't have access to this meeting",
+        });
+      }
+    }
+
+    const updatedItem = await parkingLotService.updateTopicStatus(
+      id,
+      status,
+      scheduledForMeetingId,
+    );
 
     res.status(200).json({
       success: true,
@@ -110,6 +206,9 @@ export const updateTopicStatus = async (req, res, next) => {
 export const assignTopics = async (req, res, next) => {
   try {
     const { topicIds, meetingId } = req.body;
+    const userOrgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
 
     if (!topicIds || !Array.isArray(topicIds) || !meetingId) {
       return res.status(400).json({
@@ -118,8 +217,53 @@ export const assignTopics = async (req, res, next) => {
       });
     }
 
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid meeting ID format",
+      });
+    }
+
+    const meeting = await Meeting.findById(meetingId);
+    if (!meeting) {
+      return res.status(404).json({
+        success: false,
+        message: "Meeting not found",
+      });
+    }
+
+    if (!canAccessMeetingDoc(meeting, req.user)) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: You don't have access to this meeting",
+      });
+    }
+
+    const validTopicIds = topicIds.filter((tid) =>
+      mongoose.Types.ObjectId.isValid(tid),
+    );
+    if (validTopicIds.length !== topicIds.length) {
+      return res.status(400).json({
+        success: false,
+        message: "One or more topic IDs are invalid format",
+      });
+    }
+
+    const matchingItems = await ParkingLotItem.find({
+      _id: { $in: validTopicIds },
+      organization: userOrgId,
+    });
+
+    if (matchingItems.length !== topicIds.length) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: One or more topics do not belong to your organization",
+      });
+    }
+
     const items = await parkingLotService.assignTopicsToMeeting(
-      topicIds,
+      validTopicIds,
       meetingId,
     );
 

--- a/server/routes/parkingLotRoutes.js
+++ b/server/routes/parkingLotRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
 import {
   addTopic,
   getOrganizationParkingLot,
@@ -9,19 +10,28 @@ import {
 
 const router = express.Router();
 
-// Require authentication for all routes
+// Require authentication and org membership for all routes
 router.use(userAuth);
+router.use(requireOrgMembership);
 
 // POST /api/v1/parking-lot - Add a new topic
-router.post("/", addTopic);
+router.post("/", requirePermission("meetings", "edit"), addTopic);
 
 // POST /api/v1/parking-lot/assign - Assign multiple topics
-router.post("/assign", assignTopics);
+router.post("/assign", requirePermission("meetings", "edit"), assignTopics);
 
 // GET /api/v1/parking-lot/organization/:orgId - Get parking lot for org
-router.get("/organization/:orgId", getOrganizationParkingLot);
+router.get(
+  "/organization/:orgId",
+  requirePermission("meetings", "view"),
+  getOrganizationParkingLot,
+);
 
 // PATCH /api/v1/parking-lot/:id/status - Update topic status
-router.patch("/:id/status", updateTopicStatus);
+router.patch(
+  "/:id/status",
+  requirePermission("meetings", "edit"),
+  updateTopicStatus,
+);
 
 export default router;

--- a/server/tests/parkingLotAuthorization.test.js
+++ b/server/tests/parkingLotAuthorization.test.js
@@ -1,0 +1,300 @@
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: parkingLotRoutes } =
+  await import("../routes/parkingLotRoutes.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: ParkingLotItem } =
+  await import("../models/parkingLotItemModel.js");
+const { default: User } = await import("../models/userModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const aliceMember = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const aliceViewer = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "viewer",
+};
+
+const malloryOtherOrg = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noOrgUser = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "member",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/v1/parking-lot", parkingLotRoutes);
+});
+
+beforeEach(async () => {
+  currentUser = aliceMember;
+  await User.deleteMany({});
+  await seedUser({
+    _id: aliceMember._id,
+    organization: ORG_A,
+    role: "member",
+  });
+  await seedUser({
+    _id: aliceViewer._id,
+    organization: ORG_A,
+    role: "guest",
+  });
+  await seedUser({
+    _id: malloryOtherOrg._id,
+    organization: ORG_B,
+    role: "admin",
+  });
+});
+
+afterEach(async () => {
+  await Meeting.deleteMany({});
+  await ParkingLotItem.deleteMany({});
+  await User.deleteMany({});
+});
+
+const seedUser = async ({
+  _id = new mongoose.Types.ObjectId(),
+  name = "Alice",
+  email = `alice-${Date.now()}-${Math.random()}@example.com`,
+  organization = ORG_A,
+  role = "member",
+} = {}) => {
+  return User.create({
+    _id,
+    name,
+    email,
+    password: "password123",
+    organization,
+    role,
+  });
+};
+
+const seedMeeting = async ({
+  organization = ORG_A,
+  uploadedBy = aliceMember._id,
+  title = "Parking Lot Meeting",
+} = {}) => {
+  return Meeting.create({
+    uploadedBy,
+    organization,
+    title,
+    date: new Date(),
+  });
+};
+
+const seedTopic = async ({
+  organization = ORG_A,
+  meeting,
+  submittedBy = aliceMember._id,
+  topic = "Future roadmap discussion",
+} = {}) => {
+  return ParkingLotItem.create({
+    organization,
+    sourceMeetingId: meeting._id,
+    submittedBy,
+    topic,
+    status: "pending",
+  });
+};
+
+describe("Parking lot authorization (#1536)", () => {
+  describe("Authentication & Org Membership Guards", () => {
+    it("returns 401 when request is unauthenticated", async () => {
+      currentUser = null;
+      const res = await request(app).get(
+        `/api/v1/parking-lot/organization/${ORG_A}`,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when user has no organization membership", async () => {
+      currentUser = noOrgUser;
+      const res = await request(app).get(
+        `/api/v1/parking-lot/organization/${ORG_A}`,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /api/v1/parking-lot (addTopic)", () => {
+    it("allows authorized member with edit permissions to add topic", async () => {
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const res = await request(app).post("/api/v1/parking-lot").send({
+        organizationId: ORG_A.toString(),
+        sourceMeetingId: meeting._id.toString(),
+        topic: "Security Review",
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.item.topic).toBe("Security Review");
+    });
+
+    it("rejects topic addition when viewer lacks edit permission", async () => {
+      currentUser = aliceViewer;
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const res = await request(app).post("/api/v1/parking-lot").send({
+        sourceMeetingId: meeting._id.toString(),
+        topic: "Security Review",
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects cross-organization topic addition", async () => {
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const res = await request(app).post("/api/v1/parking-lot").send({
+        organizationId: ORG_B.toString(),
+        sourceMeetingId: meeting._id.toString(),
+        topic: "Security Review",
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects topic addition for a meeting belonging to another organization", async () => {
+      const foreignMeeting = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: malloryOtherOrg._id,
+      });
+
+      const res = await request(app).post("/api/v1/parking-lot").send({
+        sourceMeetingId: foreignMeeting._id.toString(),
+        topic: "Security Review",
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /api/v1/parking-lot/organization/:orgId", () => {
+    it("allows authorized viewer to fetch parking lot for their organization", async () => {
+      currentUser = aliceViewer;
+      const meeting = await seedMeeting({ organization: ORG_A });
+      await seedTopic({ organization: ORG_A, meeting });
+
+      const res = await request(app).get(
+        `/api/v1/parking-lot/organization/${ORG_A}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.items).toHaveLength(1);
+    });
+
+    it("rejects cross-organization attempt to read parking lot data", async () => {
+      currentUser = malloryOtherOrg;
+      const res = await request(app).get(
+        `/api/v1/parking-lot/organization/${ORG_A}`,
+      );
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("PATCH /api/v1/parking-lot/:id/status", () => {
+    it("allows same-org member to update topic status", async () => {
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const topicItem = await seedTopic({ organization: ORG_A, meeting });
+
+      const res = await request(app)
+        .patch(`/api/v1/parking-lot/${topicItem._id}/status`)
+        .send({ status: "discarded" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.item.status).toBe("discarded");
+    });
+
+    it("rejects cross-organization attempt to update topic status", async () => {
+      currentUser = malloryOtherOrg;
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const topicItem = await seedTopic({ organization: ORG_A, meeting });
+
+      const res = await request(app)
+        .patch(`/api/v1/parking-lot/${topicItem._id}/status`)
+        .send({ status: "discarded" });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /api/v1/parking-lot/assign", () => {
+    it("allows assigning topics within the same organization", async () => {
+      const meeting = await seedMeeting({ organization: ORG_A });
+      const topicItem = await seedTopic({ organization: ORG_A, meeting });
+
+      const res = await request(app)
+        .post("/api/v1/parking-lot/assign")
+        .send({
+          topicIds: [topicItem._id.toString()],
+          meetingId: meeting._id.toString(),
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].status).toBe("scheduled");
+    });
+
+    it("rejects assignment if any topic belongs to another organization", async () => {
+      const meetingA = await seedMeeting({ organization: ORG_A });
+      const meetingB = await seedMeeting({
+        organization: ORG_B,
+        uploadedBy: malloryOtherOrg._id,
+      });
+
+      const topicA = await seedTopic({
+        organization: ORG_A,
+        meeting: meetingA,
+      });
+      const topicB = await seedTopic({
+        organization: ORG_B,
+        meeting: meetingB,
+        submittedBy: malloryOtherOrg._id,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/parking-lot/assign")
+        .send({
+          topicIds: [topicA._id.toString(), topicB._id.toString()],
+          meetingId: meetingA._id.toString(),
+        });
+
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## Description
This PR secures all parking lot endpoints against tenant escape and IDOR vulnerabilities by enforcing organization membership, RBAC permissions, and strict entity-to-organization boundary validations.

## Related Issue
Closes #1536

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security improvement

## Changes Made
- Mounted `requireOrgMembership` on server/routes/parkingLotRoutes.js.
- Added `requirePermission("meetings", "edit")` on `addTopic`, `updateTopicStatus`, and `assignTopics`.
- Added `requirePermission("meetings", "view")` on `getOrganizationParkingLot`.
- Updated server/controllers/parkingLotController.js to:
  - Disallow cross-tenant `organizationId` parameter spoofing.
  - Validate source and scheduled meetings via `canAccessMeetingDoc(meeting, req.user)`.
  - Validate parking lot item tenant ownership prior to updating status.
  - Enforce that all topic IDs in bulk assignment (`POST /assign`) belong exclusively to the authenticated user's organization.
- Created test suite server/tests/parkingLotAuthorization.test.js covering authentication, permission gates, and cross-organization attack scenarios.

## How Has This Been Tested?
- Executed `npm test -- tests/parkingLotAuthorization.test.js` (all 12 tests passed).
- Executed `npm run validate:pr --prefix server` (ESLint and Prettier passed).
