### PR TITLE
fix: enforce meeting authorization on comparisons

### DIFF
--- a/server/controllers/comparisonController.js
+++ b/server/controllers/comparisonController.js
@@ -1,5 +1,17 @@
 import Meeting from "../models/meetingModel.js";
 import ComparisonService from "../services/ComparisonService.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
+
+/**
+ * Reject the whole comparison when any meeting fails authorization (#1403).
+ * Never continue into ComparisonService / AI with a partial authorized set.
+ */
+const rejectIfUnauthorized = (res, access) => {
+  if (!access.error) return false;
+  res.status(access.error.status).json({ message: access.error.message });
+  return true;
+};
 
 // @desc    Compare two meetings (summary, decisions, action items)
 // @route   POST /api/comparison/compare
@@ -20,36 +32,18 @@ export const compareMeetings = async (req, res) => {
       });
     }
 
-    // Fetch both meetings
-    const meetingA =
-      await Meeting.findById(meetingIdA).populate("organization");
-    const meetingB =
-      await Meeting.findById(meetingIdB).populate("organization");
+    // Ignore any client-supplied organization fields — membership comes from req.user.
+    // Authorize EVERY meeting independently before comparison / AI work (#1403).
+    const accessA = await resolveAccessibleMeeting(meetingIdA, req.user);
+    if (rejectIfUnauthorized(res, accessA)) return;
 
-    if (!meetingA || !meetingB) {
-      return res
-        .status(404)
-        .json({ message: "One or both meetings not found" });
-    }
+    const accessB = await resolveAccessibleMeeting(meetingIdB, req.user);
+    if (rejectIfUnauthorized(res, accessB)) return;
 
-    // Check RBAC/Ownership
-    const userId = req.user._id.toString();
-    const canAccessA =
-      meetingA.uploadedBy.toString() === userId ||
-      (meetingA.organization &&
-        req.user.organizations?.includes(meetingA.organization._id.toString()));
-    const canAccessB =
-      meetingB.uploadedBy.toString() === userId ||
-      (meetingB.organization &&
-        req.user.organizations?.includes(meetingB.organization._id.toString()));
+    const meetingA = accessA.meeting;
+    const meetingB = accessB.meeting;
 
-    if (!canAccessA || !canAccessB) {
-      return res
-        .status(403)
-        .json({ message: "Not authorized to access these meetings" });
-    }
-
-    // Compute Diffs
+    // Compute Diffs — only authorized documents reach ComparisonService
     const actionItemsA = meetingA.structuredMoM?.action_items || [];
     const actionItemsB = meetingB.structuredMoM?.action_items || [];
     const actionItemsDiff = ComparisonService.computeItemDiff(
@@ -102,22 +96,13 @@ export const getComparableMeetings = async (req, res) => {
   try {
     const { meetingId } = req.params;
 
-    const baseMeeting = await Meeting.findById(meetingId);
-    if (!baseMeeting) {
-      return res.status(404).json({ message: "Meeting not found" });
-    }
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (rejectIfUnauthorized(res, access)) return;
 
-    // Check access
-    const userId = req.user._id.toString();
-    const canAccess =
-      baseMeeting.uploadedBy.toString() === userId ||
-      (baseMeeting.organization &&
-        req.user.organizations?.includes(baseMeeting.organization.toString()));
-    if (!canAccess) {
-      return res.status(403).json({ message: "Not authorized" });
-    }
+    const baseMeeting = access.meeting;
 
-    // Find comparable meetings (same organization or user, and ideally same series or tags)
+    // Candidate pool is scoped to the authorized meeting's org (or owner-only).
+    // Never accept a client organization override.
     const query = {
       _id: { $ne: baseMeeting._id },
     };
@@ -128,14 +113,26 @@ export const getComparableMeetings = async (req, res) => {
       query.uploadedBy = req.user._id;
     }
 
-    // We can prioritize same series if available, otherwise just fetch recent meetings
-    // For now, let's just fetch the 10 most recent meetings the user has access to in this context
     const comparableMeetings = await Meeting.find(query)
       .sort({ date: -1 })
       .limit(10)
-      .select("title date summary series tags");
+      .select("title date summary series tags organization uploadedBy");
 
-    res.json(comparableMeetings);
+    // Defense in depth: only return meetings the caller can independently access.
+    const authorized = comparableMeetings.filter((m) =>
+      canAccessMeetingDoc(m, req.user),
+    );
+
+    res.json(
+      authorized.map((m) => ({
+        _id: m._id,
+        title: m.title,
+        date: m.date,
+        summary: m.summary,
+        series: m.series,
+        tags: m.tags,
+      })),
+    );
   } catch (error) {
     console.error("Error in getComparableMeetings:", error);
     res

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -1,9 +1,11 @@
-import mongoose from "mongoose";
 import { z } from "zod";
 import PersonalNote from "../models/personalNoteModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
-import { canAccessMeetingDoc } from "../middleware/rbac.js";
+import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
+
+// Re-export for existing personal-note tests and callers (Issue #1389).
+export { resolveAccessibleMeeting };
 
 /**
  * Maximum character limits for note fields
@@ -58,50 +60,6 @@ const annotationSchema = z.object({
     .regex(/^#[0-9A-Fa-f]{6}$/, "Color must be a valid hex color")
     .default("#ffeb3b"),
 });
-
-/**
- * Resolve and validate meeting access for a user.
- * Uses the shared `canAccessMeetingDoc` predicate (same rule as requireOrgAccess)
- * so personal-note reads/writes stay aligned with meeting-scoped authorization
- * (Issue #1389).
- *
- * @param {string} meetingId - Meeting ID to check
- * @param {Object} user - User object from request
- * @returns {Promise<Object>} Access result with meeting or error
- */
-export const resolveAccessibleMeeting = async (meetingId, user) => {
-  // Validate meeting ID format
-  if (!mongoose.isValidObjectId(meetingId)) {
-    return {
-      error: {
-        status: 400,
-        message: "Invalid meeting ID format",
-      },
-    };
-  }
-
-  // Fetch meeting from database — never trust the client id alone
-  const meeting = await Meeting.findById(meetingId);
-  if (!meeting) {
-    return {
-      error: {
-        status: 404,
-        message: "Meeting not found",
-      },
-    };
-  }
-
-  if (!canAccessMeetingDoc(meeting, user)) {
-    return {
-      error: {
-        status: 403,
-        message: "Forbidden: You don't have access to this meeting",
-      },
-    };
-  }
-
-  return { meeting };
-};
 
 /**
  * Helper to fetch all meeting IDs that a user is authorized to access.

--- a/server/routes/comparisonRoutes.js
+++ b/server/routes/comparisonRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
+import { requirePermission } from "../middleware/rbac.js";
 import {
   compareMeetings,
   getComparableMeetings,
@@ -7,7 +8,18 @@ import {
 
 const router = express.Router();
 
-router.post("/compare", userAuth, compareMeetings);
-router.get("/comparable/:meetingId", userAuth, getComparableMeetings);
+// Issue #1403: Clerk auth + meetings:view, then per-meeting authorization in controllers.
+router.post(
+  "/compare",
+  userAuth,
+  requirePermission("meetings", "view"),
+  compareMeetings,
+);
+router.get(
+  "/comparable/:meetingId",
+  userAuth,
+  requirePermission("meetings", "view"),
+  getComparableMeetings,
+);
 
 export default router;

--- a/server/tests/meetingComparisonAuthorization.test.js
+++ b/server/tests/meetingComparisonAuthorization.test.js
@@ -1,0 +1,384 @@
+/**
+ * Issue #1403 — Meeting comparison must authorize EVERY meeting independently
+ * via resolveAccessibleMeeting / canAccessMeetingDoc before ComparisonService runs.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const findByIdSpy = jest.fn();
+const findSpy = jest.fn();
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: {
+    findById: (...args) => findByIdSpy(...args),
+    find: (...args) => findSpy(...args),
+  },
+}));
+
+const computeItemDiffSpy = jest.fn(() => ({
+  resolved: [],
+  added: [],
+  carriedOver: [],
+}));
+const generateAiDiffSummarySpy = jest.fn(async () => "ai summary");
+
+jest.unstable_mockModule("../services/ComparisonService.js", () => ({
+  default: {
+    computeItemDiff: (...args) => computeItemDiffSpy(...args),
+    generateAiDiffSummary: (...args) => generateAiDiffSummarySpy(...args),
+  },
+}));
+
+const { default: comparisonRoutes } =
+  await import("../routes/comparisonRoutes.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const MEETING_A = new mongoose.Types.ObjectId();
+const MEETING_B = new mongoose.Types.ObjectId();
+const MEETING_C = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+const OWNER_ID = new mongoose.Types.ObjectId();
+
+const alice = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: "member",
+};
+
+const mallory = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const noRoleUser = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: undefined,
+};
+
+const meetingDoc = (overrides = {}) => ({
+  _id: MEETING_A,
+  title: "Meeting A",
+  date: new Date("2026-01-01"),
+  summary: "Summary A",
+  uploadedBy: OWNER_ID,
+  organization: ORG_A,
+  structuredMoM: {
+    action_items: [{ task: "Do A", owner: "Alice" }],
+    decisions: ["Decide A"],
+  },
+  ...overrides,
+});
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use("/api/comparison", comparisonRoutes);
+});
+
+beforeEach(() => {
+  currentUser = alice;
+  findByIdSpy.mockReset();
+  findSpy.mockReset();
+  computeItemDiffSpy.mockClear();
+  generateAiDiffSummarySpy.mockClear();
+});
+
+describe("POST /api/comparison/compare authorization (#1403)", () => {
+  it("compares two meetings the user can access (same org)", async () => {
+    findByIdSpy
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_A,
+          title: "Alpha",
+          summary: "Sum A",
+        }),
+      )
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_B,
+          title: "Beta",
+          summary: "Sum B",
+          structuredMoM: {
+            action_items: [{ task: "Do B", owner: "Bob" }],
+            decisions: ["Decide B"],
+          },
+        }),
+      );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.meetingA.title).toBe("Alpha");
+    expect(res.body.meetingB.title).toBe("Beta");
+    expect(computeItemDiffSpy).toHaveBeenCalledTimes(2);
+    expect(generateAiDiffSummarySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the meeting owner even across organizations", async () => {
+    currentUser = { _id: OWNER_ID, organization: ORG_B, role: "member" };
+    findByIdSpy
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_A,
+          uploadedBy: OWNER_ID,
+          organization: ORG_A,
+        }),
+      )
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_B,
+          uploadedBy: OWNER_ID,
+          organization: ORG_A,
+          title: "Second",
+        }),
+      );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(generateAiDiffSummarySpy).toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated requests before comparison", async () => {
+    currentUser = null;
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(401);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects callers without meetings:view permission", async () => {
+    currentUser = noRoleUser;
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(403);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing meeting ids", async () => {
+    const res = await request(app).post("/api/comparison/compare").send({});
+
+    expect(res.status).toBe(400);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid meeting id format", async () => {
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: "not-an-id",
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects when either meeting is missing", async () => {
+    findByIdSpy.mockResolvedValueOnce(null);
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(404);
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("denies an inaccessible meeting and never runs comparison", async () => {
+    findByIdSpy.mockResolvedValueOnce(
+      meetingDoc({
+        _id: MEETING_A,
+        organization: ORG_B,
+        uploadedBy: OWNER_ID,
+        title: "Secret Foreign Meeting",
+        summary: "should not leak",
+      }),
+    );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/access/i);
+    expect(res.body).not.toHaveProperty("meetingA");
+    expect(JSON.stringify(res.body)).not.toContain("Secret Foreign Meeting");
+    expect(JSON.stringify(res.body)).not.toContain("should not leak");
+    expect(computeItemDiffSpy).not.toHaveBeenCalled();
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed authorized + unauthorized meetings as a whole", async () => {
+    findByIdSpy
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_A,
+          organization: ORG_A,
+          title: "Allowed",
+        }),
+      )
+      .mockResolvedValueOnce(
+        meetingDoc({
+          _id: MEETING_B,
+          organization: ORG_B,
+          uploadedBy: OWNER_ID,
+          title: "Forbidden Org B",
+          summary: "cross-org secret",
+        }),
+      );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+    });
+
+    expect(res.status).toBe(403);
+    expect(computeItemDiffSpy).not.toHaveBeenCalled();
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+    expect(JSON.stringify(res.body)).not.toContain("Forbidden Org B");
+    expect(JSON.stringify(res.body)).not.toContain("cross-org secret");
+  });
+
+  it("denies Organization B admin comparing Organization A meetings", async () => {
+    currentUser = mallory;
+    findByIdSpy.mockResolvedValueOnce(
+      meetingDoc({
+        _id: MEETING_A,
+        organization: ORG_A,
+        uploadedBy: OWNER_ID,
+      }),
+    );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+      organizationId: ORG_A.toString(), // client spoof must not bypass
+    });
+
+    expect(res.status).toBe(403);
+    expect(generateAiDiffSummarySpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores client-supplied organization identifiers", async () => {
+    findByIdSpy
+      .mockResolvedValueOnce(
+        meetingDoc({ _id: MEETING_A, organization: ORG_A }),
+      )
+      .mockResolvedValueOnce(
+        meetingDoc({ _id: MEETING_B, organization: ORG_A, title: "B" }),
+      );
+
+    const res = await request(app).post("/api/comparison/compare").send({
+      meetingIdA: MEETING_A.toString(),
+      meetingIdB: MEETING_B.toString(),
+      organizationId: ORG_B.toString(),
+      organization: ORG_B.toString(),
+    });
+
+    expect(res.status).toBe(200);
+    // Still authorized via membership org A, not the spoofed org B.
+    expect(generateAiDiffSummarySpy).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/comparison/comparable/:meetingId authorization (#1403)", () => {
+  it("returns comparable meetings only after base meeting is authorized", async () => {
+    findByIdSpy.mockResolvedValue(
+      meetingDoc({ _id: MEETING_A, organization: ORG_A }),
+    );
+    findSpy.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          select: jest.fn().mockResolvedValue([
+            meetingDoc({
+              _id: MEETING_B,
+              title: "Peer",
+              organization: ORG_A,
+              uploadedBy: OWNER_ID,
+            }),
+            meetingDoc({
+              _id: MEETING_C,
+              title: "Should filter",
+              organization: ORG_B,
+              uploadedBy: OWNER_ID,
+            }),
+          ]),
+        }),
+      }),
+    });
+
+    const res = await request(app).get(
+      `/api/comparison/comparable/${MEETING_A}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].title).toBe("Peer");
+    expect(res.body.find((m) => m.title === "Should filter")).toBeUndefined();
+  });
+
+  it("denies comparable list for an unauthorized base meeting", async () => {
+    findByIdSpy.mockResolvedValue(
+      meetingDoc({
+        _id: MEETING_A,
+        organization: ORG_B,
+        uploadedBy: OWNER_ID,
+      }),
+    );
+
+    const res = await request(app).get(
+      `/api/comparison/comparable/${MEETING_A}`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated comparable requests", async () => {
+    currentUser = null;
+
+    const res = await request(app).get(
+      `/api/comparison/comparable/${MEETING_A}`,
+    );
+
+    expect(res.status).toBe(401);
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/utils/resolveAccessibleMeeting.js
+++ b/server/utils/resolveAccessibleMeeting.js
@@ -1,0 +1,50 @@
+/**
+ * Shared meeting access resolver (Issues #1389 / #1403).
+ *
+ * Loads a meeting by id and applies the same `canAccessMeetingDoc` rule used by
+ * `requireOrgAccess` — owner or same organization. Never trust the client id
+ * alone; never treat access to one meeting as access to another.
+ */
+
+import mongoose from "mongoose";
+import Meeting from "../models/meetingModel.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+
+/**
+ * @param {string} meetingId
+ * @param {object} user - Authenticated MongoDB user (`req.user`)
+ * @returns {Promise<{ meeting: object } | { error: { status: number, message: string } }>}
+ */
+export const resolveAccessibleMeeting = async (meetingId, user) => {
+  if (!mongoose.isValidObjectId(meetingId)) {
+    return {
+      error: {
+        status: 400,
+        message: "Invalid meeting ID format",
+      },
+    };
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    return {
+      error: {
+        status: 404,
+        message: "Meeting not found",
+      },
+    };
+  }
+
+  if (!canAccessMeetingDoc(meeting, user)) {
+    return {
+      error: {
+        status: 403,
+        message: "Forbidden: You don't have access to this meeting",
+      },
+    };
+  }
+
+  return { meeting };
+};
+
+export default resolveAccessibleMeeting;


### PR DESCRIPTION
## Summary

Fixes #1403

Enforces server-side authorization for all Meeting Comparison operations to prevent unauthorized and cross-organization meeting data from being accessed through comparison endpoints.

## Problem

Meeting comparison endpoints accepted meeting IDs without consistently verifying that the authenticated user was authorized to access every requested meeting.

A malicious user could potentially provide unauthorized meeting IDs and retrieve sensitive comparison data.

## Changes Made

- Added per-meeting authorization before comparison.
- Reused the existing meeting access model through `resolveAccessibleMeeting`.
- Enforced `meetings:view` permission at the route level.
- Rejects the entire comparison when any requested meeting is unauthorized.
- Prevents client-supplied organization values from bypassing authorization.
- Added authorization filtering for comparable meetings.
- Ensured unauthorized meetings never reach comparison/AI processing.

## Authorization Flow

```text
Clerk Authentication
        ↓
meetings:view Permission
        ↓
Resolve Each Meeting
        ↓
Verify Meeting Access
        ↓
Authorize Every Meeting
        ↓
Run Comparison
        ↓
Return Result
```

## Security Improvements

- Blocks unauthorized meeting comparisons.
- Prevents cross-organization data access.
- Prevents mixed authorized/unauthorized comparisons.
- Prevents organization ID spoofing.
- Prevents unauthorized meeting data from reaching comparison/AI services.
- Avoids leaking sensitive meeting metadata on authorization failures.

## Files Changed

- `server/controllers/comparisonController.js`
- `server/controllers/personalNoteController.js`
- `server/routes/comparisonRoutes.js`
- `server/utils/resolveAccessibleMeeting.js`
- `server/tests/meetingComparisonAuthorization.test.js`

## Tests Added

Regression coverage includes:

- Authorized same-organization comparison
- Meeting owner access
- Unauthorized meeting rejection
- Cross-organization comparison rejection
- Mixed authorized/unauthorized meeting rejection
- Organization ID spoofing protection
- Missing/invalid meeting IDs
- Comparable meeting filtering
- Ensuring comparison/AI logic is not called for unauthorized requests

## Expected Behavior

| Scenario | Result |
|---|---|
| Authorized user compares accessible meetings | `200 OK` |
| User compares unauthorized meeting | `403 Forbidden` |
| Cross-organization meeting comparison | `403 Forbidden` |
| Mixed authorized + unauthorized meetings | `403 Forbidden` |
| Invalid meeting ID | `400 Bad Request` |
| Missing authentication | `401 Unauthorized` |
| Insufficient permission | `403 Forbidden` |

## Security Impact

This change closes the Meeting Comparison authorization gap by requiring every requested meeting to pass server-side access validation before any comparison or AI processing occurs.

Existing authorized comparison functionality remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization for meeting comparisons and comparable-meeting searches.
  * Prevented unauthorized users from accessing meeting data or triggering comparison processing.
  * Improved handling of invalid, missing, and inaccessible meetings.
  * Added organization and ownership checks to prevent cross-organization data exposure.

* **Tests**
  * Added comprehensive coverage for authentication, permissions, ownership, organization filtering, validation, and data-leakage prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->