### PR TITLE
fix: make notification actions touch accessible

### DIFF
--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -497,14 +497,15 @@ const Notifications = () => {
                       </div>
 
                       {/* Actions */}
-                      <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="flex-shrink-0 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
                         {!notification.isRead && (
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
                               handleMarkAsRead(notification._id);
                             }}
-                            className="p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                            aria-label={`Mark "${notification.title}" as read`}
+                            className="p-3 sm:p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                             title="Mark as read"
                           >
                             <Check className="w-4 h-4" />
@@ -515,7 +516,8 @@ const Notifications = () => {
                             e.stopPropagation();
                             handleDelete(notification._id);
                           }}
-                          className="p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                          aria-label={`Delete notification "${notification.title}"`}
+                          className="p-3 sm:p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
                           title="Delete"
                         >
                           <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
# Pull Request

## Description

Updated notification row actions so mark-read and delete controls are accessible without hover on touch devices, while preserving the existing desktop hover behavior.

- Fixes #1649

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

Notification actions are now reachable on mobile/touch devices without requiring hover, while desktop hover behavior remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to notification action buttons for improved screen reader support.

* **UI Improvements**
  * Notification actions remain visible on small screens and appear on hover or focus on larger screens.
  * Increased button touch targets for easier interaction on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->