### PR TITLE
fix: use SPA navigation for meeting empty state

### DIFF
--- a/client/src/components/meetings/EmptyState.jsx
+++ b/client/src/components/meetings/EmptyState.jsx
@@ -1,7 +1,30 @@
 import React from "react";
 import { Calendar, Search, FileText } from "lucide-react";
+import { Link } from "react-router-dom";
 import RoleGate from "../RoleGate.jsx";
 import { useRBAC } from "../../hooks/useRBAC.js";
+
+const ActionLink = ({ href, children, className }) => {
+  if (!href) return null;
+  const isExternal = href.startsWith("http") || href.startsWith("//");
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        className={className}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link to={href} className={className}>
+      {children}
+    </Link>
+  );
+};
 
 const EmptyState = ({ type }) => {
   const { hasPermission } = useRBAC();
@@ -53,20 +76,20 @@ const EmptyState = ({ type }) => {
       {state.actionLink &&
         (state.requiresCreate ? (
           <RoleGate resource="meetings" action="create">
-            <a
+            <ActionLink
               href={state.actionLink}
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
             >
               {state.actionText}
-            </a>
+            </ActionLink>
           </RoleGate>
         ) : (
-          <a
+          <ActionLink
             href={state.actionLink}
             className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
           >
             {state.actionText}
-          </a>
+          </ActionLink>
         ))}
     </div>
   );

--- a/client/src/components/meetings/__tests__/EmptyState.test.jsx
+++ b/client/src/components/meetings/__tests__/EmptyState.test.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import EmptyState from "../EmptyState";
+
+vi.mock("../../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../RoleGate.jsx", () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>,
+}));
+
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+};
+
+describe("EmptyState Component SPA Navigation (#1660)", () => {
+  it("renders internal links as SPA Link elements and navigates without full reload", () => {
+    render(
+      <MemoryRouter initialEntries={["/meetings"]}>
+        <Routes>
+          <Route path="/meetings" element={<EmptyState type="noMeetings" />} />
+          <Route path="/upload-meeting" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", {
+      name: /Upload Your First Meeting/i,
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/upload-meeting");
+    expect(link).not.toHaveAttribute("target", "_blank");
+
+    // Click the link and verify SPA navigation
+    fireEvent.click(link);
+    expect(screen.getByTestId("location-display")).toHaveTextContent(
+      "/upload-meeting",
+    );
+  });
+
+  it("renders another internal state correctly", () => {
+    render(
+      <MemoryRouter initialEntries={["/meetings"]}>
+        <Routes>
+          <Route path="/meetings" element={<EmptyState type="noScheduled" />} />
+          <Route path="/create-meeting" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: /Schedule a Meeting/i });
+    expect(link).toBeInTheDocument();
+
+    // Click the link and verify SPA navigation
+    fireEvent.click(link);
+    expect(screen.getByTestId("location-display")).toHaveTextContent(
+      "/create-meeting",
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Replaced internal Meeting List Empty-State anchor navigation with React Router SPA navigation. This prevents unnecessary full-page reloads while preserving existing destinations, styling, accessibility, and external link behavior.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [x] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

- Closes #1660

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

Verified internal navigation uses the router, destinations remain correct, and navigation does not trigger a full document reload.

## Screenshots

Not applicable.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review