### PR TITLE
feat: add favorite meetings

### DIFF
--- a/client/src/components/meetings/MeetingCard.jsx
+++ b/client/src/components/meetings/MeetingCard.jsx
@@ -10,11 +10,12 @@ import {
   Eye,
   MoreVertical,
   Check,
+  Star,
 } from "lucide-react";
 
 import useExport from "../../hooks/useExport.js";
 import ConfirmModal from "../ConfirmModal.jsx";
-
+import { favoriteApi } from "../../services";
 const MeetingCard = ({
   meeting,
   onDelete,
@@ -30,6 +31,8 @@ const MeetingCard = ({
   const [isRenaming, setIsRenaming] = useState(false);
   const [newTitle, setNewTitle] = useState(meeting.title);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isFavorite, setIsFavorite] = useState(false);
+  const [isFavoriteLoading, setIsFavoriteLoading] = useState(false);
   const menuRef = useRef(null);
 
   useEffect(() => {
@@ -48,6 +51,28 @@ const MeetingCard = ({
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [showMenu]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadFavoriteStatus = async () => {
+      try {
+        const response = await favoriteApi.getFavoriteStatus(meeting._id);
+
+        if (!cancelled && response.data?.favorited !== undefined) {
+         setIsFavorite(response.data.favorited);
+        }
+      } catch (error) {
+        console.error("Failed to load favorite status:", error);
+      }
+    };
+
+    loadFavoriteStatus();
+
+    return () => {
+    cancelled = true;
+    };
+  }, [meeting._id]);
 
   const handleRenameSubmit = (e) => {
     e.preventDefault();
@@ -77,6 +102,28 @@ const MeetingCard = ({
         return "bg-red-100 text-red-700 dark:bg-red-950/70 dark:text-red-300 border border-red-200 dark:border-red-800";
       default:
         return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 border border-gray-200 dark:border-gray-700";
+    }
+  };
+
+  const handleFavoriteToggle = async (event) => {
+    event.stopPropagation();
+
+    if (isFavoriteLoading) {
+      return;
+    }
+
+    setIsFavoriteLoading(true);
+
+    try {
+      const response = await favoriteApi.toggleFavorite(meeting._id);
+
+      if (response.data?.favorited !== undefined) {
+        setIsFavorite(response.data.favorited);
+      }
+    } catch (error) {
+      console.error("Failed to toggle favorite:", error);
+    } finally {
+      setIsFavoriteLoading(false);
     }
   };
 
@@ -133,6 +180,26 @@ const MeetingCard = ({
               {meeting.title || "Untitled Meeting"}
             </h3>
           )}
+
+          <button
+            type="button"
+            onClick={handleFavoriteToggle}
+            disabled={isFavoriteLoading}
+            aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
+            aria-pressed={isFavorite}
+            data-testid="favorite-button"
+            className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50"
+          >
+          <Star
+            size={18}
+            className={
+              isFavorite
+              ? "fill-yellow-400 text-yellow-400"
+              : "text-gray-400 dark:text-gray-500"
+            }
+          />
+          </button>
+
           <div className="relative" ref={menuRef}>
             <button
               onClick={() => {

--- a/client/src/services/favoriteApi.js
+++ b/client/src/services/favoriteApi.js
@@ -1,0 +1,11 @@
+import apiClient from "./apiClient";
+
+export const favoriteApi = {
+  toggleFavorite: (meetingId) =>
+    apiClient.post("/api/favorites/toggle", { meetingId }),
+
+  getFavorites: () => apiClient.get("/api/favorites"),
+
+  getFavoriteStatus: (meetingId) =>
+    apiClient.get(`/api/favorites/status/${meetingId}`),
+};

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -28,3 +28,4 @@ export * from "./parkingLotApi";
 export { default as sentimentTimelineApi } from "./sentimentTimelineApi";
 export { default as carryForwardApi } from "./carryForwardApi";
 export { default as bulkMeetingApi } from "./bulkMeetingApi";
+export { favoriteApi } from "./favoriteApi";

--- a/server/controllers/favoriteController.js
+++ b/server/controllers/favoriteController.js
@@ -1,0 +1,119 @@
+import mongoose from "mongoose";
+import Favorite from "../models/favoriteModel.js";
+import Meeting from "../models/meetingModel.js";
+import { isSameOrganization } from "../utils/authUtils.js";
+
+// Toggle favorite status for the current user.
+export const toggleFavorite = async (req, res) => {
+  try {
+    const { meetingId } = req.body;
+    const userId = req.user._id;
+
+    if (!meetingId) {
+      return res.status(400).json({ message: "meetingId is required" });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meetingId" });
+    }
+
+    const meeting = await Meeting.findById(meetingId).select(
+      "organization _id",
+    );
+
+    if (!meeting) {
+      return res.status(404).json({ message: "Meeting not found" });
+    }
+
+    if (!isSameOrganization(req.user, meeting)) {
+      return res.status(403).json({
+        message: "Meeting does not belong to your organization",
+      });
+    }
+
+    const existingFavorite = await Favorite.findOne({
+      user: userId,
+      meeting: meetingId,
+    });
+
+    if (existingFavorite) {
+      await Favorite.deleteOne({ _id: existingFavorite._id });
+
+      return res.status(200).json({
+        message: "Favorite removed",
+        favorited: false,
+      });
+    }
+
+    const favorite = await Favorite.create({
+      user: userId,
+      meeting: meetingId,
+    });
+
+    return res.status(201).json({
+      message: "Favorite added",
+      favorited: true,
+      data: favorite,
+    });
+  } catch (error) {
+    console.error("Error in toggleFavorite:", error);
+
+    // Protect against a race condition with the unique index.
+    if (error?.code === 11000) {
+      return res.status(409).json({
+        message: "Meeting is already favorited",
+      });
+    }
+
+    return res.status(500).json({
+      message: "Server error toggling favorite",
+    });
+  }
+};
+
+// Get all favorite meeting IDs for the current user.
+export const getFavorites = async (req, res) => {
+  try {
+    const favorites = await Favorite.find({
+      user: req.user._id,
+    })
+      .select("meeting")
+      .sort({ createdAt: -1 });
+
+    return res.status(200).json({
+      favorites: favorites.map((favorite) => favorite.meeting),
+    });
+  } catch (error) {
+    console.error("Error fetching favorites:", error);
+
+    return res.status(500).json({
+      message: "Server error fetching favorites",
+    });
+  }
+};
+
+// Get favorite status for one meeting.
+export const getFavoriteStatus = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meetingId" });
+    }
+
+    const favorite = await Favorite.findOne({
+      user: req.user._id,
+      meeting: meetingId,
+    });
+
+    return res.status(200).json({
+      favorited: !!favorite,
+    });
+  } catch (error) {
+    console.error("Error checking favorite status:", error);
+
+    return res.status(500).json({
+      message: "Server error checking favorite status",
+    });
+  }
+};

--- a/server/models/favoriteModel.js
+++ b/server/models/favoriteModel.js
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+
+const favoriteSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    meeting: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Meeting",
+      required: true,
+    },
+  },
+  { timestamps: true },
+);
+
+// A user can favorite a meeting only once.
+favoriteSchema.index({ user: 1, meeting: 1 }, { unique: true });
+
+const Favorite = mongoose.model("Favorite", favoriteSchema);
+
+export default Favorite;

--- a/server/routes/favoriteRoutes.js
+++ b/server/routes/favoriteRoutes.js
@@ -1,0 +1,17 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import {
+  toggleFavorite,
+  getFavorites,
+  getFavoriteStatus,
+} from "../controllers/favoriteController.js";
+
+const router = express.Router();
+
+router.use(userAuth);
+
+router.post("/toggle", toggleFavorite);
+router.get("/", getFavorites);
+router.get("/status/:meetingId", getFavoriteStatus);
+
+export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -64,6 +64,7 @@ import bulkMeetingRoutes from "./bulkMeetingRoutes.js";
 import parkingLotRoutes from "./parkingLotRoutes.js";
 import sentimentTimelineRoutes from "./sentimentTimelineRoutes.js";
 import meetingRsvpRoutes from "./meetingRsvpRoutes.js";
+import favoriteRoutes from "./favoriteRoutes.js";
 import testimonialRoutes, {
   adminTestimonialRouter,
 } from "./testimonialRoutes.js";
@@ -103,6 +104,7 @@ router.use("/api/policies", policyRoutes);
 router.use("/api/analytics", analyticsRoutes);
 router.use("/api/gemini", geminiRoutes);
 router.use("/api/notes", notesRoutes);
+router.use("/api/favorites", favoriteRoutes);
 router.use(["/api/user", "/api/users"], userRoutes);
 router.use(["/api/notification", "/api/notifications"], notificationRoutes);
 router.use("/api/knowledge", knowledgeRoutes);


### PR DESCRIPTION
# Pull Request

## Description

Adds a per-user favorite meetings feature for quick access to frequently referenced meetings.

Users can:
- Mark a meeting as a favorite using a star icon.
- Remove a meeting from favorites.
- See the favorite state visually on the meeting card.
- Store favorites independently per user.

The implementation adds a Favorite model, controller, routes, and frontend API integration.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #1571 

## Testing

Describe the testing performed.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors


## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to favorite and unfavorite meetings.
  * Meeting cards now display the current favorite status with an accessible star control.
  * Added loading states to prevent duplicate favorite actions.
  * Favorite status persists and can be viewed across meetings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->