### PR TITLE
fix(security): enforce organization ownership for automation webhook actions

### DIFF
--- a/server/services/__tests__/automationWebhookOrgOwnership.test.js
+++ b/server/services/__tests__/automationWebhookOrgOwnership.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { evaluateRules } from "../automationRuleService.js";
+import AutomationRule from "../../models/automationRuleModel.js";
+import Organization from "../../models/organizationModel.js";
+import Webhook from "../../models/Webhook.js";
+import { webhookQueue } from "../webhookDispatcherService.js";
+
+vi.mock("../../models/automationRuleModel.js");
+vi.mock("../../models/organizationModel.js");
+vi.mock("../../models/Webhook.js");
+vi.mock("../webhookDispatcherService.js", () => ({
+  webhookQueue: {
+    isActive: true,
+    add: vi.fn(),
+  },
+}));
+
+describe("Automation Webhook Organization Ownership (#1674)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches webhook action when webhook belongs to the same organization", async () => {
+    const mockRule = {
+      _id: "rule1",
+      name: "Send Webhook on MoM",
+      organization: "org123",
+      enabled: true,
+      trigger: { event: "mom.generated", filters: {} },
+      actions: [
+        {
+          type: "webhook",
+          config: { webhookId: "wh_same_org" },
+        },
+      ],
+      executionCount: 0,
+      save: vi.fn().mockResolvedValue(true),
+    };
+
+    AutomationRule.find.mockResolvedValue([mockRule]);
+    Organization.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({}),
+    });
+    Webhook.findById.mockResolvedValue({
+      _id: "wh_same_org",
+      organizationId: "org123",
+    });
+
+    await evaluateRules("mom.generated", {
+      organization: "org123",
+      meetingId: "m1",
+    });
+
+    expect(Webhook.findById).toHaveBeenCalledWith("wh_same_org");
+    expect(webhookQueue.add).toHaveBeenCalledWith("dispatch-webhook", {
+      webhookId: "wh_same_org",
+      payload: expect.objectContaining({
+        event: "mom.generated",
+        ruleName: "Send Webhook on MoM",
+      }),
+    });
+  });
+
+  it("rejects and skips webhook dispatch when webhook belongs to a foreign organization", async () => {
+    const mockRule = {
+      _id: "rule2",
+      name: "Malicious Webhook Trigger",
+      organization: "org123",
+      enabled: true,
+      trigger: { event: "mom.generated", filters: {} },
+      actions: [
+        {
+          type: "webhook",
+          config: { webhookId: "wh_foreign_org" },
+        },
+      ],
+      executionCount: 0,
+      save: vi.fn().mockResolvedValue(true),
+    };
+
+    AutomationRule.find.mockResolvedValue([mockRule]);
+    Organization.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({}),
+    });
+    Webhook.findById.mockResolvedValue({
+      _id: "wh_foreign_org",
+      organizationId: "org_FOREIGN_456",
+    });
+
+    await evaluateRules("mom.generated", {
+      organization: "org123",
+      meetingId: "m1",
+    });
+
+    expect(Webhook.findById).toHaveBeenCalledWith("wh_foreign_org");
+    expect(webhookQueue.add).not.toHaveBeenCalled();
+  });
+
+  it("handles non-existent webhook gracefully without throwing", async () => {
+    const mockRule = {
+      _id: "rule3",
+      name: "Missing Webhook Rule",
+      organization: "org123",
+      enabled: true,
+      trigger: { event: "mom.generated", filters: {} },
+      actions: [
+        {
+          type: "webhook",
+          config: { webhookId: "wh_non_existent" },
+        },
+      ],
+      executionCount: 0,
+      save: vi.fn().mockResolvedValue(true),
+    };
+
+    AutomationRule.find.mockResolvedValue([mockRule]);
+    Organization.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({}),
+    });
+    Webhook.findById.mockResolvedValue(null);
+
+    await evaluateRules("mom.generated", {
+      organization: "org123",
+      meetingId: "m1",
+    });
+
+    expect(Webhook.findById).toHaveBeenCalledWith("wh_non_existent");
+    expect(webhookQueue.add).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/automationRuleService.js
+++ b/server/services/automationRuleService.js
@@ -1,6 +1,7 @@
 import eventBus from "./eventBus.js";
 import AutomationRule from "../models/automationRuleModel.js";
 import Organization from "../models/organizationModel.js";
+import Webhook from "../models/Webhook.js";
 import {
   postBlockMessage,
   buildMeetingCreatedBlocks,
@@ -122,6 +123,25 @@ const executeActions = async (rule, payload, meetingData) => {
         }
       } else if (action.type === "webhook") {
         if (action.config.webhookId) {
+          // Verify webhook exists and belongs to the same organization as the rule (#1674)
+          const webhook = await Webhook.findById(action.config.webhookId);
+          if (!webhook) {
+            console.warn(
+              `[AutomationRule] Webhook ${action.config.webhookId} not found for rule ${rule._id}. Skipping dispatch.`,
+            );
+            continue;
+          }
+
+          const webhookOrg = webhook.organizationId?.toString();
+          const ruleOrg = rule.organization?.toString();
+
+          if (webhookOrg !== ruleOrg) {
+            console.warn(
+              `[AutomationRule] Webhook ${action.config.webhookId} belongs to org ${webhookOrg}, but rule belongs to org ${ruleOrg}. Rejecting foreign webhook dispatch.`,
+            );
+            continue;
+          }
+
           if (webhookQueue.isActive) {
             await webhookQueue.add("dispatch-webhook", {
               webhookId: action.config.webhookId,


### PR DESCRIPTION
Fixes #1674

## Description
This PR verifies organization ownership of referenced webhooks prior to dispatching automation webhook actions in utomationRuleService.js, preventing cross-tenant webhook hijacking and data exfiltration.

## Proposed Changes
- **Organization Ownership Verification**: Loaded the target Webhook by webhookId and verified webhook.organizationId matches ule.organization.
- **Foreign & Missing Webhook Rejection**: Safely skipped/logged non-existent or foreign webhooks without dispatching external requests.
- **Unit Test Coverage**: Added Vitest test suite (utomationWebhookOrgOwnership.test.js) verifying same-organization dispatch, foreign webhook rejection, and missing webhook handling.

## Checklist
- [x] Related Issue is linked (Fixes #1674).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook automation safety by ensuring actions only dispatch valid webhooks belonging to the same organization as the automation rule.
  * Missing or unauthorized webhook references are now skipped without triggering dispatches.
* **Tests**
  * Added coverage for valid, missing, and cross-organization webhook scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->