### PR TITLE
fix(security): remove hardcoded fallback secret from shared link JWT authentication

### DIFF
--- a/server/controllers/__tests__/sharedLinkJwtSecret.test.js
+++ b/server/controllers/__tests__/sharedLinkJwtSecret.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getSharedLinkJwtSecret } from "../sharedLinkController.js";
+
+describe("Shared Link JWT Secret Configuration (#1675)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.SHARED_LINK_JWT_SECRET;
+    delete process.env.SHARED_LINK_SECRET;
+    delete process.env.JWT_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("throws error when no JWT secret is configured", () => {
+    expect(() => getSharedLinkJwtSecret()).toThrowError(
+      "SHARED_LINK_JWT_SECRET is not configured",
+    );
+  });
+
+  it("returns SHARED_LINK_JWT_SECRET when configured", () => {
+    process.env.SHARED_LINK_JWT_SECRET = "custom_shared_link_secret_123";
+    expect(getSharedLinkJwtSecret()).toBe("custom_shared_link_secret_123");
+  });
+
+  it("falls back to SHARED_LINK_SECRET when SHARED_LINK_JWT_SECRET is absent", () => {
+    process.env.SHARED_LINK_SECRET = "fallback_shared_secret";
+    expect(getSharedLinkJwtSecret()).toBe("fallback_shared_secret");
+  });
+
+  it("falls back to JWT_SECRET when other secrets are absent", () => {
+    process.env.JWT_SECRET = "general_jwt_secret";
+    expect(getSharedLinkJwtSecret()).toBe("general_jwt_secret");
+  });
+});

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -15,11 +15,16 @@ import {
   isPasscodeLocked,
 } from "../utils/sharedLinkSecurity.js";
 
-const getSharedLinkJwtSecret = () =>
-  process.env.SHARED_LINK_JWT_SECRET ||
-  process.env.SHARED_LINK_SECRET ||
-  process.env.JWT_SECRET ||
-  "default_shared_link_secret";
+export const getSharedLinkJwtSecret = () => {
+  const secret =
+    process.env.SHARED_LINK_JWT_SECRET ||
+    process.env.SHARED_LINK_SECRET ||
+    process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("SHARED_LINK_JWT_SECRET is not configured");
+  }
+  return secret;
+};
 
 /**
  * Maps shareable resource types to their Mongoose models.


### PR DESCRIPTION
Fixes #1675

## Description
This PR removes the hardcoded "default_shared_link_secret" fallback from sharedLinkController.js, requiring dedicated environment configuration (SHARED_LINK_JWT_SECRET) and failing safely when missing.

## Proposed Changes
- **Removed Hardcoded Fallback**: Removed "default_shared_link_secret" fallback in getSharedLinkJwtSecret.
- **Fail-Safe Secret Validation**: Enforced requirement of SHARED_LINK_JWT_SECRET / SHARED_LINK_SECRET / JWT_SECRET, throwing an explicit Error if unconfigured without leaking secrets in responses.
- **Unit Test Coverage**: Added Vitest test suite (sharedLinkJwtSecret.test.js) verifying secret retrieval, fallback chain, and missing secret error handling.

## Checklist
- [x] Related Issue is linked (Fixes #1675).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.