### PR TITLE
fix(security): revalidate transcript socket room membership before broadcasting

### DIFF
--- a/server/socket/__tests__/transcriptSocketSecurity.test.js
+++ b/server/socket/__tests__/transcriptSocketSecurity.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import transcriptSocketHandler from "../transcriptSocket.js";
+
+describe("Transcript Socket Room Membership Security (#1676)", () => {
+  let ioMock;
+  let socketMock;
+  let eventHandlers;
+
+  beforeEach(() => {
+    eventHandlers = {};
+    socketMock = {
+      id: "socket_123",
+      userId: "user_123",
+      userRole: "member",
+      userOrganization: "org_123",
+      rooms: new Set(["socket_123"]),
+      on: vi.fn((event, handler) => {
+        eventHandlers[event] = handler;
+      }),
+      emit: vi.fn(),
+      to: vi.fn().mockReturnThis(),
+      join: vi.fn((room) => socketMock.rooms.add(room)),
+      leave: vi.fn((room) => socketMock.rooms.delete(room)),
+    };
+
+    ioMock = {
+      on: vi.fn((event, handler) => {
+        if (event === "connection") {
+          handler(socketMock);
+        }
+      }),
+      to: vi.fn().mockReturnThis(),
+      emit: vi.fn(),
+    };
+
+    transcriptSocketHandler(ioMock);
+  });
+
+  it("rejects transcript-segment if socket has not joined the meeting transcript room", () => {
+    eventHandlers["transcript-segment"]({
+      meetingId: "meeting_target",
+      segment: { text: "unauthorized injection" },
+    });
+
+    expect(socketMock.emit).toHaveBeenCalledWith("transcript-error", {
+      message: "Forbidden: You have not joined this transcript room",
+    });
+    expect(socketMock.to).not.toHaveBeenCalled();
+  });
+
+  it("allows transcript-segment if socket has joined the meeting transcript room", () => {
+    const roomId = "meeting:meeting_target:transcript";
+    socketMock.rooms.add(roomId);
+
+    eventHandlers["transcript-segment"]({
+      meetingId: "meeting_target",
+      segment: { text: "authorized segment" },
+    });
+
+    expect(socketMock.to).toHaveBeenCalledWith(roomId);
+    expect(socketMock.emit).not.toHaveBeenCalledWith(
+      "transcript-error",
+      expect.anything(),
+    );
+  });
+
+  it("rejects transcript-final if socket has not joined the meeting transcript room", () => {
+    eventHandlers["transcript-final"]({
+      meetingId: "meeting_target",
+      transcript: { fullText: "forged final transcript" },
+    });
+
+    expect(socketMock.emit).toHaveBeenCalledWith("transcript-error", {
+      message: "Forbidden: You have not joined this transcript room",
+    });
+    expect(ioMock.to).not.toHaveBeenCalled();
+  });
+
+  it("allows transcript-final if socket has joined the meeting transcript room", () => {
+    const roomId = "meeting:meeting_target:transcript";
+    socketMock.rooms.add(roomId);
+
+    eventHandlers["transcript-final"]({
+      meetingId: "meeting_target",
+      transcript: { fullText: "valid final transcript" },
+    });
+
+    expect(ioMock.to).toHaveBeenCalledWith(roomId);
+  });
+});

--- a/server/socket/transcriptSocket.js
+++ b/server/socket/transcriptSocket.js
@@ -28,7 +28,7 @@ export default (io) => {
         }
 
         const isOwner =
-          meeting.uploadedBy?.toString() === socket.userId.toString();
+          meeting.uploadedBy?.toString() === socket.userId?.toString();
         const isInSameOrg =
           meeting.organization &&
           socket.userOrganization &&
@@ -73,13 +73,33 @@ export default (io) => {
 
     // Broadcast partial transcript segment (real-time)
     socket.on("transcript-segment", ({ meetingId, segment }) => {
+      if (!meetingId) {
+        socket.emit("transcript-error", { message: "Meeting ID required" });
+        return;
+      }
       const roomId = `meeting:${meetingId}:transcript`;
+      if (!socket.rooms || !socket.rooms.has(roomId)) {
+        socket.emit("transcript-error", {
+          message: "Forbidden: You have not joined this transcript room",
+        });
+        return;
+      }
       socket.to(roomId).emit("transcript-segment", segment);
     });
 
     // Broadcast final transcript
     socket.on("transcript-final", ({ meetingId, transcript }) => {
+      if (!meetingId) {
+        socket.emit("transcript-error", { message: "Meeting ID required" });
+        return;
+      }
       const roomId = `meeting:${meetingId}:transcript`;
+      if (!socket.rooms || !socket.rooms.has(roomId)) {
+        socket.emit("transcript-error", {
+          message: "Forbidden: You have not joined this transcript room",
+        });
+        return;
+      }
       io.to(roomId).emit("transcript-final", transcript);
     });
 


### PR DESCRIPTION
Fixes #1676

## Description
This PR verifies socket room membership before broadcasting 	ranscript-segment and 	ranscript-final events in 	ranscriptSocket.js, preventing unjoined sockets or unauthorized clients from injecting transcript data into meetings.

## Proposed Changes
- **Room Membership Revalidation**: Added explicit socket.rooms.has(roomId) validation before emitting 	ranscript-segment or 	ranscript-final events.
- **Unauthorized Broadcast Denial**: Dispatched 	ranscript-error and blocked broadcast if the socket has not legitimately joined the meeting transcript room.
- **Unit Test Coverage**: Added Vitest test suite (	ranscriptSocketSecurity.test.js) verifying rejection of non-joined sockets and authorization for joined sockets.

## Checklist
- [x] Related Issue is linked (Fixes #1676).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.