### PR TITLE
Implement pagination in getTerms function

### DIFF
--- a/server/controllers/glossaryController.js
+++ b/server/controllers/glossaryController.js
@@ -114,6 +114,9 @@ const sendAppError = (res, error) => {
 /**
  * Get all glossary terms for an organization
  */
+/**
+ * Get all glossary terms for an organization
+ */
 export const getTerms = async (req, res) => {
   try {
     const orgId = resolveOrgId(req);
@@ -121,7 +124,7 @@ export const getTerms = async (req, res) => {
       return res.status(400).json({ message: "Organization ID is missing" });
     }
 
-    const { status, search } = req.query;
+    const { status, search, page: pageQuery, limit: limitQuery } = req.query;
 
     const query = { organization: orgId };
 
@@ -143,14 +146,40 @@ export const getTerms = async (req, res) => {
       query.$text = { $search: search };
     }
 
-    const terms = await GlossaryTerm.find(query).sort({ term: 1 });
-    res.status(200).json(terms);
+    // --- Pagination Logic ---
+    let page = parseInt(pageQuery, 10);
+    let limit = parseInt(limitQuery, 10);
+
+    // Apply safe defaults for missing or invalid parameters
+    if (isNaN(page) || page < 1) page = 1;
+    if (isNaN(limit) || limit < 1) limit = 20;
+
+    // Enforce a strict upper bound to prevent heavy DB hits
+    const MAX_LIMIT = 100;
+    if (limit > MAX_LIMIT) limit = MAX_LIMIT;
+
+    const skip = (page - 1) * limit;
+
+    // Fetch records and count concurrently
+    const [terms, total] = await Promise.all([
+      GlossaryTerm.find(query).sort({ term: 1 }).skip(skip).limit(limit).exec(),
+      GlossaryTerm.countDocuments(query).exec()
+    ]);
+
+    res.status(200).json({
+      data: terms,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit)
+      }
+    });
   } catch (error) {
     console.error("Error fetching glossary terms:", error);
     res.status(500).json({ message: "Server error fetching glossary terms" });
   }
 };
-
 /**
  * Create a new glossary term
  */

--- a/server/tests/controllers/glossaryController.test.js
+++ b/server/tests/controllers/glossaryController.test.js
@@ -1,0 +1,77 @@
+import { getTerms } from '../../controllers/glossaryController.js';
+import GlossaryTerm from '../../models/glossaryTermModel.js';
+
+// Mock the Mongoose model
+jest.mock('../../models/glossaryTermModel.js');
+
+describe('glossaryController.getTerms (Pagination)', () => {
+  let req, res;
+  
+  // Create a mock chain for Mongoose queries: find().sort().skip().limit().exec()
+  const mockExec = jest.fn();
+  const mockLimit = jest.fn().mockReturnValue({ exec: mockExec });
+  const mockSkip = jest.fn().mockReturnValue({ limit: mockLimit });
+  const mockSort = jest.fn().mockReturnValue({ skip: mockSkip });
+
+  beforeEach(() => {
+    req = {
+      user: { organization: 'org123' },
+      query: {}
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    jest.clearAllMocks();
+
+    GlossaryTerm.find.mockReturnValue({ sort: mockSort });
+    GlossaryTerm.countDocuments.mockReturnValue({ exec: jest.fn().mockResolvedValue(45) });
+    mockExec.mockResolvedValue([{ term: 'Test' }]);
+  });
+
+  it('should apply default pagination when no parameters are provided', async () => {
+    await getTerms(req, res);
+
+    expect(GlossaryTerm.find).toHaveBeenCalledWith({ organization: 'org123' });
+    expect(mockSkip).toHaveBeenCalledWith(0); // (page 1 - 1) * 20
+    expect(mockLimit).toHaveBeenCalledWith(20); // default limit
+    
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      meta: { total: 45, page: 1, limit: 20, totalPages: 3 }
+    }));
+  });
+
+  it('should respect custom valid page and limit parameters', async () => {
+    req.query = { page: '2', limit: '10' };
+    await getTerms(req, res);
+
+    expect(mockSkip).toHaveBeenCalledWith(10); // (page 2 - 1) * 10
+    expect(mockLimit).toHaveBeenCalledWith(10);
+  });
+
+  it('should clamp excessively large limits to the maximum allowed limit', async () => {
+    req.query = { limit: '500' };
+    await getTerms(req, res);
+
+    expect(mockLimit).toHaveBeenCalledWith(100); // Clamped to MAX_LIMIT
+  });
+
+  it('should fallback to safe defaults for invalid/negative pagination parameters', async () => {
+    req.query = { page: 'invalid', limit: '-5' };
+    await getTerms(req, res);
+
+    expect(mockSkip).toHaveBeenCalledWith(0);
+    expect(mockLimit).toHaveBeenCalledWith(20);
+  });
+
+  it('should preserve existing search filters alongside pagination', async () => {
+    req.query = { search: 'API', page: '1', limit: '5' };
+    await getTerms(req, res);
+
+    expect(GlossaryTerm.find).toHaveBeenCalledWith({
+      organization: 'org123',
+      $text: { $search: 'API' }
+    });
+    expect(mockLimit).toHaveBeenCalledWith(5);
+  });
+});


### PR DESCRIPTION
## Description
Added server-side pagination to the Glossary list endpoint (`getTerms`) to prevent excessive database load and large payload responses, resolving Issue #1679.

---

## Related Issue
Closes #1679

---

## Changes Made
- Updated `server/controllers/glossaryController.js` to extract `page` and `limit` from request queries.
- Added strict integer parsing, falling back to safe defaults (`page=1`, `limit=20`) if missing or invalid.
- Enforced a hard ceiling of `limit=100` to prevent malicious or accidental abuse of large payload requests.
- Converted `GlossaryTerm.find()` to use `.skip()` and `.limit()`.
- Implemented `Promise.all` to fetch the paginated data and the total document count concurrently for optimal performance.
- Returned standard pagination metadata (`total`, `page`, `limit`, `totalPages`) alongside the dataset.
- Preserved existing organization scoping and regex search filtering.
- Created `server/tests/controllers/glossaryController.test.js` to verify pagination logic, defaults, and boundary constraints.

---

## Testing
- [x] Default pagination test (fallback to page 1, limit 20).
- [x] Custom page and limit test.
- [x] Maximum-limit test (clamped to 100).
- [x] Invalid pagination parameter test (safely falls back).
- [x] Search/filtering alongside pagination test.

