### PR TITLE
fix: enforce meeting feedback authorization

### DIFF
--- a/server/controllers/meetingFeedbackController.js
+++ b/server/controllers/meetingFeedbackController.js
@@ -1,7 +1,10 @@
 import { z } from "zod";
 import mongoose from "mongoose";
 import MeetingFeedback from "../models/meetingFeedbackModel.js";
-import Meeting from "../models/meetingModel.js";
+import {
+  resolveMeetingFeedbackAccess,
+  resolveOwnedFeedbackForMutation,
+} from "../utils/meetingFeedbackAccess.js";
 
 const feedbackSchema = z.object({
   meetingId: z.string().min(1, "Meeting ID is required"),
@@ -12,6 +15,9 @@ const feedbackSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+const sendAccessError = (res, error) =>
+  res.status(error.status).json({ success: false, message: error.message });
+
 // @desc    Submit or update feedback for a meeting
 // @route   POST /api/feedback
 // @access  Private
@@ -20,46 +26,16 @@ export const submitFeedback = async (req, res, next) => {
     const validatedData = feedbackSchema.parse(req.body);
     const userId = req.user._id;
 
-    if (!mongoose.isValidObjectId(validatedData.meetingId)) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Invalid meeting ID" });
-    }
-
-    // Verify meeting exists and user is a participant or organizer
-    const meeting = await Meeting.findById(validatedData.meetingId);
-    if (!meeting) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Meeting not found" });
-    }
-
-    // Organization Isolation Check
-    if (
-      meeting.organization &&
-      (!req.user.organization ||
-        meeting.organization.toString() !== req.user.organization.toString())
-    ) {
-      return res.status(403).json({
-        success: false,
-        message: "Forbidden: Meeting belongs to another organization",
-      });
-    }
-
-    // Check if user is participant or the owner
-    const isOwner = meeting.uploadedBy.toString() === userId.toString();
-    const isParticipant = meeting.participants?.some(
-      (p) => p.user?.toString() === userId.toString(),
+    const access = await resolveMeetingFeedbackAccess(
+      validatedData.meetingId,
+      req.user,
     );
-
-    if (!isOwner && !isParticipant) {
-      return res.status(403).json({
-        success: false,
-        message: "Not authorized to submit feedback for this meeting",
-      });
+    if (access.error) {
+      return sendAccessError(res, access.error);
     }
 
-    // Upsert feedback
+    const { meeting } = access;
+
     const feedbackData = {
       ...validatedData,
       userId,
@@ -95,46 +71,10 @@ export const submitFeedback = async (req, res, next) => {
 export const getFeedbackForMeeting = async (req, res) => {
   try {
     const { meetingId } = req.params;
-    const userId = req.user._id;
 
-    if (!mongoose.isValidObjectId(meetingId)) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Invalid meeting ID" });
-    }
-
-    // Authorize: only the meeting owner or a participant may read its feedback,
-    // matching submitFeedback in this file. Without this, any authenticated user
-    // could read another org's feedback and submitter PII (IDOR).
-    const meeting = await Meeting.findById(meetingId);
-    if (!meeting) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Meeting not found" });
-    }
-
-    // Organization Isolation Check
-    if (
-      meeting.organization &&
-      (!req.user.organization ||
-        meeting.organization.toString() !== req.user.organization.toString())
-    ) {
-      return res.status(403).json({
-        success: false,
-        message: "Forbidden: Meeting belongs to another organization",
-      });
-    }
-
-    const isOwner = meeting.uploadedBy.toString() === userId.toString();
-    const isParticipant = meeting.participants?.some(
-      (p) => p.user?.toString() === userId.toString(),
-    );
-
-    if (!isOwner && !isParticipant) {
-      return res.status(403).json({
-        success: false,
-        message: "Not authorized to view feedback for this meeting",
-      });
+    const access = await resolveMeetingFeedbackAccess(meetingId, req.user);
+    if (access.error) {
+      return sendAccessError(res, access.error);
     }
 
     const feedback = await MeetingFeedback.find({ meetingId }).populate(
@@ -159,42 +99,9 @@ export const getUserFeedbackForMeeting = async (req, res) => {
     const { meetingId } = req.params;
     const userId = req.user._id;
 
-    if (!mongoose.isValidObjectId(meetingId)) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Invalid meeting ID" });
-    }
-
-    const meeting = await Meeting.findById(meetingId);
-    if (!meeting) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Meeting not found" });
-    }
-
-    // Organization Isolation Check
-    if (
-      meeting.organization &&
-      (!req.user.organization ||
-        meeting.organization.toString() !== req.user.organization.toString())
-    ) {
-      return res.status(403).json({
-        success: false,
-        message: "Forbidden: Meeting belongs to another organization",
-      });
-    }
-
-    // User Access Check
-    const isOwner = meeting.uploadedBy.toString() === userId.toString();
-    const isParticipant = meeting.participants?.some(
-      (p) => p.user?.toString() === userId.toString(),
-    );
-
-    if (!isOwner && !isParticipant) {
-      return res.status(403).json({
-        success: false,
-        message: "Not authorized to view feedback for this meeting",
-      });
+    const access = await resolveMeetingFeedbackAccess(meetingId, req.user);
+    if (access.error) {
+      return sendAccessError(res, access.error);
     }
 
     const feedback = await MeetingFeedback.findOne({ meetingId, userId });
@@ -221,7 +128,6 @@ export const getAggregateFeedback = async (req, res) => {
         .json({ success: false, message: "Invalid organization ID" });
     }
 
-    // Ensure the user belongs to the org
     if (req.user.organization?.toString() !== orgId) {
       return res.status(403).json({
         success: false,
@@ -276,43 +182,12 @@ export const deleteFeedback = async (req, res) => {
   try {
     const { id } = req.params;
 
-    if (!mongoose.isValidObjectId(id)) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Invalid feedback ID" });
+    const access = await resolveOwnedFeedbackForMutation(id, req.user);
+    if (access.error) {
+      return sendAccessError(res, access.error);
     }
 
-    const feedback = await MeetingFeedback.findById(id);
-
-    if (!feedback) {
-      return res
-        .status(404)
-        .json({ success: false, message: "Feedback not found" });
-    }
-
-    // Check meeting organization isolation if meeting exists
-    const meeting = await Meeting.findById(feedback.meetingId);
-    if (meeting) {
-      if (
-        meeting.organization &&
-        (!req.user.organization ||
-          meeting.organization.toString() !== req.user.organization.toString())
-      ) {
-        return res.status(403).json({
-          success: false,
-          message: "Forbidden: Meeting belongs to another organization",
-        });
-      }
-    }
-
-    if (feedback.userId.toString() !== req.user._id.toString()) {
-      return res.status(403).json({
-        success: false,
-        message: "Not authorized to delete this feedback",
-      });
-    }
-
-    await feedback.deleteOne();
+    await access.feedback.deleteOne();
 
     res
       .status(200)

--- a/server/tests/meetingFeedback.test.js
+++ b/server/tests/meetingFeedback.test.js
@@ -88,7 +88,10 @@ describe("Meeting Feedback Controller", () => {
 
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ success: false }),
+        expect.objectContaining({
+          success: false,
+          message: "Not authorized to access feedback for this meeting",
+        }),
       );
     });
 
@@ -190,7 +193,10 @@ describe("Meeting Feedback Controller", () => {
 
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ success: false }),
+        expect.objectContaining({
+          success: false,
+          message: "Not authorized to access feedback for this meeting",
+        }),
       );
       // Must not query/leak feedback for an unauthorized user.
       expect(findSpy).not.toHaveBeenCalled();
@@ -348,12 +354,43 @@ describe("Meeting Feedback Controller", () => {
       jest.spyOn(Meeting, "findById").mockResolvedValue({
         _id: meetingId,
         organization: req.user.organization,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        participants: [{ user: req.user._id }],
       });
 
       await deleteFeedback(req, res);
 
       expect(mockDeleteOne).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("should fail to delete if user is not the feedback owner", async () => {
+      const feedbackId = new mongoose.Types.ObjectId().toString();
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.id = feedbackId;
+
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: feedbackId,
+        meetingId,
+        userId: new mongoose.Types.ObjectId().toString(),
+      });
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue({
+        _id: meetingId,
+        uploadedBy: new mongoose.Types.ObjectId().toString(),
+        organization: req.user.organization,
+        participants: [{ user: req.user._id }],
+      });
+
+      await deleteFeedback(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Not authorized to modify this feedback",
+        }),
+      );
     });
 
     it("should fail to delete if the associated meeting belongs to a different organization", async () => {
@@ -370,6 +407,7 @@ describe("Meeting Feedback Controller", () => {
       jest.spyOn(Meeting, "findById").mockResolvedValue({
         _id: meetingId,
         organization: new mongoose.Types.ObjectId().toString(),
+        participants: [{ user: req.user._id }],
       });
 
       await deleteFeedback(req, res);
@@ -379,6 +417,30 @@ describe("Meeting Feedback Controller", () => {
         expect.objectContaining({
           success: false,
           message: "Forbidden: Meeting belongs to another organization",
+        }),
+      );
+    });
+
+    it("should fail to delete if the associated meeting no longer exists", async () => {
+      const feedbackId = new mongoose.Types.ObjectId().toString();
+      const meetingId = new mongoose.Types.ObjectId().toString();
+      req.params.id = feedbackId;
+
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: feedbackId,
+        meetingId,
+        userId: req.user._id,
+      });
+
+      jest.spyOn(Meeting, "findById").mockResolvedValue(null);
+
+      await deleteFeedback(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Meeting not found",
         }),
       );
     });

--- a/server/tests/meetingFeedbackAuthorization.test.js
+++ b/server/tests/meetingFeedbackAuthorization.test.js
@@ -1,0 +1,222 @@
+/**
+ * Issue #1538 — Meeting Feedback participant authorization.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import {
+  isMeetingFeedbackParticipant,
+  resolveMeetingFeedbackAccess,
+  resolveOwnedFeedbackForMutation,
+} from "../utils/meetingFeedbackAccess.js";
+import Meeting from "../models/meetingModel.js";
+import MeetingFeedback from "../models/meetingFeedbackModel.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const MEETING_ID = new mongoose.Types.ObjectId();
+const OWNER_ID = new mongoose.Types.ObjectId();
+const PARTICIPANT_ID = new mongoose.Types.ObjectId();
+const OUTSIDER_ID = new mongoose.Types.ObjectId();
+const FEEDBACK_ID = new mongoose.Types.ObjectId();
+
+const owner = {
+  _id: OWNER_ID,
+  organization: ORG_A,
+  email: "owner@example.com",
+};
+
+const participant = {
+  _id: PARTICIPANT_ID,
+  organization: ORG_A,
+  email: "participant@example.com",
+};
+
+const orgMemberOutsider = {
+  _id: OUTSIDER_ID,
+  organization: ORG_A,
+  email: "outsider@example.com",
+};
+
+const meetingDoc = (overrides = {}) => ({
+  _id: MEETING_ID,
+  uploadedBy: OWNER_ID,
+  organization: ORG_A,
+  participants: [{ user: PARTICIPANT_ID, email: "participant@example.com" }],
+  ...overrides,
+});
+
+describe("meetingFeedbackAccess (#1538)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("isMeetingFeedbackParticipant", () => {
+    it("allows the meeting uploader", () => {
+      expect(isMeetingFeedbackParticipant(meetingDoc(), owner)).toBe(true);
+    });
+
+    it("allows a listed participant by user id", () => {
+      expect(isMeetingFeedbackParticipant(meetingDoc(), participant)).toBe(
+        true,
+      );
+    });
+
+    it("allows a listed participant matched by email when user id differs", () => {
+      const invitee = {
+        _id: new mongoose.Types.ObjectId(),
+        email: "participant@example.com",
+      };
+      expect(isMeetingFeedbackParticipant(meetingDoc(), invitee)).toBe(true);
+    });
+
+    it("denies org members who are not participants", () => {
+      expect(
+        isMeetingFeedbackParticipant(meetingDoc(), orgMemberOutsider),
+      ).toBe(false);
+    });
+  });
+
+  describe("resolveMeetingFeedbackAccess", () => {
+    it("returns 400 for invalid meeting ids", async () => {
+      const result = await resolveMeetingFeedbackAccess("bad-id", participant);
+      expect(result.error).toEqual({
+        status: 400,
+        message: "Invalid meeting ID",
+      });
+    });
+
+    it("returns 404 when the meeting does not exist", async () => {
+      jest.spyOn(Meeting, "findById").mockResolvedValue(null);
+
+      const result = await resolveMeetingFeedbackAccess(
+        MEETING_ID.toString(),
+        participant,
+      );
+
+      expect(result.error).toEqual({
+        status: 404,
+        message: "Meeting not found",
+      });
+    });
+
+    it("returns 403 for cross-organization meetings", async () => {
+      jest
+        .spyOn(Meeting, "findById")
+        .mockResolvedValue(meetingDoc({ organization: ORG_B }));
+
+      const result = await resolveMeetingFeedbackAccess(
+        MEETING_ID.toString(),
+        participant,
+      );
+
+      expect(result.error?.status).toBe(403);
+      expect(result.error?.message).toContain("another organization");
+    });
+
+    it("returns 403 for org members who are not participants", async () => {
+      jest.spyOn(Meeting, "findById").mockResolvedValue(meetingDoc());
+
+      const result = await resolveMeetingFeedbackAccess(
+        MEETING_ID.toString(),
+        orgMemberOutsider,
+      );
+
+      expect(result.error).toEqual({
+        status: 403,
+        message: "Not authorized to access feedback for this meeting",
+      });
+    });
+
+    it("returns the meeting for authorized participants", async () => {
+      const meeting = meetingDoc();
+      jest.spyOn(Meeting, "findById").mockResolvedValue(meeting);
+
+      const result = await resolveMeetingFeedbackAccess(
+        MEETING_ID.toString(),
+        participant,
+      );
+
+      expect(result.meeting).toBe(meeting);
+    });
+  });
+
+  describe("resolveOwnedFeedbackForMutation", () => {
+    it("denies delete when the caller is not the feedback owner", async () => {
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: FEEDBACK_ID,
+        meetingId: MEETING_ID,
+        userId: OWNER_ID,
+      });
+      jest.spyOn(Meeting, "findById").mockResolvedValue(meetingDoc());
+
+      const result = await resolveOwnedFeedbackForMutation(
+        FEEDBACK_ID.toString(),
+        participant,
+      );
+
+      expect(result.error).toEqual({
+        status: 403,
+        message: "Not authorized to modify this feedback",
+      });
+    });
+
+    it("denies delete when the caller owns feedback but lost meeting access", async () => {
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: FEEDBACK_ID,
+        meetingId: MEETING_ID,
+        userId: OUTSIDER_ID,
+      });
+      jest.spyOn(Meeting, "findById").mockResolvedValue(meetingDoc());
+
+      const result = await resolveOwnedFeedbackForMutation(
+        FEEDBACK_ID.toString(),
+        orgMemberOutsider,
+      );
+
+      expect(result.error?.status).toBe(403);
+      expect(result.error?.message).toBe(
+        "Not authorized to access feedback for this meeting",
+      );
+    });
+
+    it("denies delete when the associated meeting no longer exists", async () => {
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue({
+        _id: FEEDBACK_ID,
+        meetingId: MEETING_ID,
+        userId: PARTICIPANT_ID,
+      });
+      jest.spyOn(Meeting, "findById").mockResolvedValue(null);
+
+      const result = await resolveOwnedFeedbackForMutation(
+        FEEDBACK_ID.toString(),
+        participant,
+      );
+
+      expect(result.error).toEqual({
+        status: 404,
+        message: "Meeting not found",
+      });
+    });
+
+    it("returns feedback when the owner still has meeting access", async () => {
+      const feedback = {
+        _id: FEEDBACK_ID,
+        meetingId: MEETING_ID,
+        userId: PARTICIPANT_ID,
+      };
+      const meeting = meetingDoc();
+
+      jest.spyOn(MeetingFeedback, "findById").mockResolvedValue(feedback);
+      jest.spyOn(Meeting, "findById").mockResolvedValue(meeting);
+
+      const result = await resolveOwnedFeedbackForMutation(
+        FEEDBACK_ID.toString(),
+        participant,
+      );
+
+      expect(result.feedback).toBe(feedback);
+      expect(result.meeting).toBe(meeting);
+    });
+  });
+});

--- a/server/utils/meetingFeedbackAccess.js
+++ b/server/utils/meetingFeedbackAccess.js
@@ -1,0 +1,152 @@
+/**
+ * Meeting Feedback authorization (Issue #1538).
+ *
+ * Every feedback operation resolves the associated meeting before trusting a
+ * feedback record or client-supplied meeting id. Feedback is limited to the
+ * meeting uploader or listed participants — org membership alone is not enough.
+ */
+
+import mongoose from "mongoose";
+import Meeting from "../models/meetingModel.js";
+import MeetingFeedback from "../models/meetingFeedbackModel.js";
+
+/**
+ * @param {{ uploadedBy?: unknown, participants?: Array<{ user?: unknown, email?: string }> }} meeting
+ * @param {{ _id?: unknown, email?: string }} user
+ */
+export const isMeetingFeedbackParticipant = (meeting, user) => {
+  if (!meeting || !user?._id) return false;
+
+  const userId = user._id.toString();
+  if (meeting.uploadedBy?.toString() === userId) return true;
+
+  const email = user.email?.toLowerCase?.() || "";
+  return (meeting.participants || []).some((participant) => {
+    if (participant.user?.toString() === userId) return true;
+    if (
+      email &&
+      participant.email &&
+      participant.email.toLowerCase() === email
+    ) {
+      return true;
+    }
+    return false;
+  });
+};
+
+/**
+ * @param {{ organization?: unknown }} meeting
+ * @param {{ organization?: unknown }} user
+ * @returns {{ status: number, message: string } | null}
+ */
+export const getMeetingOrganizationViolation = (meeting, user) => {
+  if (
+    meeting.organization &&
+    (!user.organization ||
+      meeting.organization.toString() !== user.organization.toString())
+  ) {
+    return {
+      status: 403,
+      message: "Forbidden: Meeting belongs to another organization",
+    };
+  }
+  return null;
+};
+
+/**
+ * Resolve a meeting and verify the caller may access its feedback.
+ *
+ * @param {string} meetingId
+ * @param {object} user
+ * @returns {Promise<{ meeting: object } | { error: { status: number, message: string } }>}
+ */
+export const resolveMeetingFeedbackAccess = async (meetingId, user) => {
+  if (!mongoose.isValidObjectId(meetingId)) {
+    return {
+      error: {
+        status: 400,
+        message: "Invalid meeting ID",
+      },
+    };
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    return {
+      error: {
+        status: 404,
+        message: "Meeting not found",
+      },
+    };
+  }
+
+  const orgViolation = getMeetingOrganizationViolation(meeting, user);
+  if (orgViolation) {
+    return { error: orgViolation };
+  }
+
+  if (!isMeetingFeedbackParticipant(meeting, user)) {
+    return {
+      error: {
+        status: 403,
+        message: "Not authorized to access feedback for this meeting",
+      },
+    };
+  }
+
+  return { meeting };
+};
+
+/**
+ * Resolve feedback by id, then re-check meeting participant access before mutation.
+ *
+ * @param {string} feedbackId
+ * @param {object} user
+ * @returns {Promise<{ feedback: object, meeting: object } | { error: { status: number, message: string } }>}
+ */
+export const resolveOwnedFeedbackForMutation = async (feedbackId, user) => {
+  if (!mongoose.isValidObjectId(feedbackId)) {
+    return {
+      error: {
+        status: 400,
+        message: "Invalid feedback ID",
+      },
+    };
+  }
+
+  const feedback = await MeetingFeedback.findById(feedbackId);
+  if (!feedback) {
+    return {
+      error: {
+        status: 404,
+        message: "Feedback not found",
+      },
+    };
+  }
+
+  const access = await resolveMeetingFeedbackAccess(
+    feedback.meetingId.toString(),
+    user,
+  );
+  if (access.error) {
+    return { error: access.error };
+  }
+
+  if (feedback.userId.toString() !== user._id.toString()) {
+    return {
+      error: {
+        status: 403,
+        message: "Not authorized to modify this feedback",
+      },
+    };
+  }
+
+  return { feedback, meeting: access.meeting };
+};
+
+export default {
+  isMeetingFeedbackParticipant,
+  getMeetingOrganizationViolation,
+  resolveMeetingFeedbackAccess,
+  resolveOwnedFeedbackForMutation,
+};


### PR DESCRIPTION
## Summary

Fixes #1538

Enforces participant-level authorization for Meeting Feedback operations and prevents unauthorized users from accessing or manipulating feedback through meeting IDs or feedback IDs.

## Problem

Meeting Feedback contains participant-specific information, but some operations relied primarily on the feedback record or authenticated identity without consistently validating access to the associated meeting.

The main security gap was the feedback deletion flow, where authorization could be bypassed when the associated meeting was missing or could not be resolved.

Participant authorization also did not consistently account for email-based meeting participants.

## Root Cause

Feedback authorization was implemented through duplicated controller-level checks rather than a centralized meeting feedback authorization flow.

The `DELETE /:id` operation could authorize based on the feedback owner without first resolving and validating the associated meeting.

This created a potential IDOR-style authorization gap where manipulating a feedback ID could target another participant's feedback.

## Changes Made

### Centralized Feedback Authorization

Added:

`server/utils/meetingFeedbackAccess.js`

The helper provides a shared authorization flow:

```text
Authenticated User
        ↓
Resolve Meeting
        ↓
Verify Organization
        ↓
Verify Participant / Uploader
        ↓
Verify Feedback Ownership
        ↓
Allow Operation