### PR TITLE
fix(search): enforce hybrid search tenant isolation

### DIFF
--- a/server/controllers/hybridSearchController.js
+++ b/server/controllers/hybridSearchController.js
@@ -6,8 +6,12 @@
 // ================================
 
 import { hybridRetrieve } from "../services/hybridRetrievalService.js";
-import { getRedisClient, setSearchCache } from "../services/redisService.js"; // eslint-disable-line no-unused-vars
+import { setSearchCache } from "../services/redisService.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import {
+  assertHybridSearchOrganization,
+  resolveHybridSearchContext,
+} from "../utils/resolveSearchTenant.js";
 
 /**
  * @desc  Hybrid retrieval: semantic vector search fused with knowledge-graph
@@ -38,7 +42,7 @@ export const hybridSearch = async (req, res) => {
       );
     }
 
-    const { query, ...options } = req.body;
+    const { query, organizationId, options } = resolveHybridSearchContext(req);
 
     if (!query || typeof query !== "string" || query.trim().length < 3) {
       return sendError(
@@ -48,15 +52,27 @@ export const hybridSearch = async (req, res) => {
       );
     }
 
-    const organization = req.user?.organization || null;
+    if (!organizationId) {
+      return sendError(
+        res,
+        403,
+        "Forbidden: Organization membership required for hybrid search",
+      );
+    }
 
     console.log(
-      `🔀 Hybrid search for query: "${query}" (org: ${organization})`,
+      `🔀 Hybrid search for query: "${query}" (org: ${organizationId})`,
     );
+
+    try {
+      assertHybridSearchOrganization(organizationId);
+    } catch (error) {
+      return sendError(res, 403, error.message);
+    }
 
     const { results, meta } = await hybridRetrieve(
       query,
-      organization,
+      organizationId,
       options,
     );
 
@@ -81,6 +97,12 @@ export const hybridSearch = async (req, res) => {
 
     if (error.message === "A non-empty query string is required") {
       return sendError(res, 400, error.message);
+    }
+
+    if (
+      error.message === "Organization context is required for hybrid search"
+    ) {
+      return sendError(res, 403, error.message);
     }
 
     sendError(

--- a/server/graph/graphIndex.js
+++ b/server/graph/graphIndex.js
@@ -22,6 +22,7 @@
 // action items for a workspace, not the whole database).
 // ==============================================
 
+import mongoose from "mongoose";
 import Decision from "../models/decisionModel.js";
 import ActionItem from "../models/actionItemModel.js";
 
@@ -49,7 +50,15 @@ export function nodeKey(type, id) {
  * @returns {Promise<{adjacency: Map<string, Array<{key:string, weight:number}>>, nodes: Map<string, object>}>}
  */
 export async function buildGraph(organization) {
-  const orgFilter = { organization: organization || null };
+  if (!organization) {
+    throw new Error("Organization context is required for hybrid search");
+  }
+
+  const orgFilter = {
+    organization: mongoose.isValidObjectId(organization)
+      ? new mongoose.Types.ObjectId(organization)
+      : organization,
+  };
 
   const [decisions, actionItems] = await Promise.all([
     Decision.find(orgFilter).select(

--- a/server/services/hybridRetrievalService.js
+++ b/server/services/hybridRetrievalService.js
@@ -17,10 +17,16 @@
 // ==============================================
 
 import Meeting from "../models/meetingModel.js";
+import mongoose from "mongoose";
 import { embedText, searchVectorStore } from "../utils/embeddingUtils.js";
 import { cosineSimilarity } from "../utils/similarity.js";
 import { buildExplanation } from "../utils/explanationBuilder.js";
 import { recordMemoryAccessBatch } from "./importanceScoringService.js";
+import {
+  assertHybridSearchOrganization,
+  filterHybridResultsByTenant,
+  stripClientTenantFields,
+} from "../utils/resolveSearchTenant.js";
 import {
   buildGraph,
   expandFromSeeds,
@@ -51,18 +57,19 @@ function clamp01(n, fallback) {
  * for request parsing.
  */
 export function resolveOptions(rawOptions = {}) {
+  const sanitized = stripClientTenantFields(rawOptions);
   const topK = Math.max(
     1,
-    Math.min(50, parseInt(rawOptions.topK, 10) || DEFAULT_OPTIONS.topK),
+    Math.min(50, parseInt(sanitized.topK, 10) || DEFAULT_OPTIONS.topK),
   );
   const semanticTopK = Math.max(
     topK,
     Math.min(
       100,
-      parseInt(rawOptions.semanticTopK, 10) || DEFAULT_OPTIONS.semanticTopK,
+      parseInt(sanitized.semanticTopK, 10) || DEFAULT_OPTIONS.semanticTopK,
     ),
   );
-  const parsedMaxHops = parseInt(rawOptions.maxHops, 10);
+  const parsedMaxHops = parseInt(sanitized.maxHops, 10);
   const maxHops = Math.max(
     0,
     Math.min(
@@ -71,23 +78,23 @@ export function resolveOptions(rawOptions = {}) {
     ),
   );
   const decay =
-    clamp01(rawOptions.decay, DEFAULT_OPTIONS.decay) || DEFAULT_OPTIONS.decay;
+    clamp01(sanitized.decay, DEFAULT_OPTIONS.decay) || DEFAULT_OPTIONS.decay;
   const minEdgeWeight = Math.max(
     0,
     Math.min(
       100,
-      Number(rawOptions.minEdgeWeight) || DEFAULT_OPTIONS.minEdgeWeight,
+      Number(sanitized.minEdgeWeight) || DEFAULT_OPTIONS.minEdgeWeight,
     ),
   );
 
   let semanticWeight =
-    typeof rawOptions.semanticWeight === "number" &&
-    rawOptions.semanticWeight >= 0
-      ? rawOptions.semanticWeight
+    typeof sanitized.semanticWeight === "number" &&
+    sanitized.semanticWeight >= 0
+      ? sanitized.semanticWeight
       : DEFAULT_OPTIONS.semanticWeight;
   let graphWeight =
-    typeof rawOptions.graphWeight === "number" && rawOptions.graphWeight >= 0
-      ? rawOptions.graphWeight
+    typeof sanitized.graphWeight === "number" && sanitized.graphWeight >= 0
+      ? sanitized.graphWeight
       : DEFAULT_OPTIONS.graphWeight;
 
   // Normalize so the two weights always sum to 1 - keeps the fused score
@@ -104,8 +111,8 @@ export function resolveOptions(rawOptions = {}) {
   }
 
   const includeTypes =
-    Array.isArray(rawOptions.includeTypes) && rawOptions.includeTypes.length
-      ? rawOptions.includeTypes.filter((t) =>
+    Array.isArray(sanitized.includeTypes) && sanitized.includeTypes.length
+      ? sanitized.includeTypes.filter((t) =>
           DEFAULT_OPTIONS.includeTypes.includes(t),
         )
       : DEFAULT_OPTIONS.includeTypes;
@@ -142,6 +149,13 @@ async function runSemanticSearch(query, organization, graph, options) {
         organization: organization.toString(),
       });
       for (const hit of meetingHits) {
+        if (
+          hit.organization &&
+          hit.organization.toString() !== organization.toString()
+        ) {
+          continue;
+        }
+
         results.push({
           key: nodeKey(NODE_TYPES.MEETING, hit.meetingId),
           type: NODE_TYPES.MEETING,
@@ -149,6 +163,7 @@ async function runSemanticSearch(query, organization, graph, options) {
           title: hit.title,
           summary: hit.summary,
           semanticScore: hit.similarityScore || 0,
+          organization: hit.organization || organization.toString(),
         });
       }
     } catch (err) {
@@ -177,6 +192,12 @@ async function runSemanticSearch(query, organization, graph, options) {
       )
         continue;
       if (!node.embedding?.length) continue;
+      if (
+        node.organization &&
+        node.organization.toString() !== organization.toString()
+      ) {
+        continue;
+      }
 
       const score = cosineSimilarity(queryEmbedding, node.embedding);
       if (score <= 0) continue;
@@ -188,6 +209,7 @@ async function runSemanticSearch(query, organization, graph, options) {
         title: node.text,
         summary: node.text,
         semanticScore: score,
+        organization: node.organization || organization.toString(),
       });
     }
   }
@@ -246,6 +268,7 @@ export function fuseResults(semanticResults, graphExpansions, options) {
         graphScore: hit.graphScore,
         hops: hit.hops,
         connectedVia: hit.path,
+        organization: node.organization || null,
       });
     }
   }
@@ -266,8 +289,9 @@ export function fuseResults(semanticResults, graphExpansions, options) {
  * action-item results so the client doesn't need a second round trip for
  * the common case of "what meeting did this come from".
  */
-async function enrichWithMeetingContext(rankedResults, graph) {
+async function enrichWithMeetingContext(rankedResults, graph, organization) {
   const meetingIds = new Set();
+  const expectedOrg = organization.toString();
 
   for (const result of rankedResults) {
     if (result.type === NODE_TYPES.MEETING) {
@@ -280,38 +304,56 @@ async function enrichWithMeetingContext(rankedResults, graph) {
 
   if (!meetingIds.size) return rankedResults;
 
-  const meetings = await Meeting.find({ _id: { $in: Array.from(meetingIds) } })
-    .select("title createdAt")
+  const validMeetingIds = Array.from(meetingIds).filter((id) =>
+    mongoose.isValidObjectId(id),
+  );
+  if (!validMeetingIds.length) return rankedResults;
+
+  const meetings = await Meeting.find({
+    _id: { $in: validMeetingIds },
+    organization: mongoose.isValidObjectId(expectedOrg)
+      ? new mongoose.Types.ObjectId(expectedOrg)
+      : expectedOrg,
+  })
+    .select("title createdAt organization")
     .lean();
   const meetingById = new Map(meetings.map((m) => [m._id.toString(), m]));
 
-  return rankedResults.map((result) => {
-    if (result.type === NODE_TYPES.MEETING) {
-      const meeting = meetingById.get(result.id);
-      return meeting
-        ? {
+  return rankedResults
+    .map((result) => {
+      if (result.type === NODE_TYPES.MEETING) {
+        const meeting = meetingById.get(result.id);
+        if (meeting) {
+          return {
             ...result,
             title: result.title || meeting.title,
             createdAt: meeting.createdAt,
+            organization: meeting.organization?.toString() || expectedOrg,
+          };
+        }
+        if (result.organization?.toString() === expectedOrg) {
+          return result;
+        }
+        return null;
+      }
+
+      const node = graph.nodes.get(result.key);
+      const meeting = node?.sourceMeetingId
+        ? meetingById.get(node.sourceMeetingId)
+        : null;
+      return meeting
+        ? {
+            ...result,
+            sourceMeeting: {
+              id: meeting._id.toString(),
+              title: meeting.title,
+              createdAt: meeting.createdAt,
+              organization: meeting.organization?.toString() || expectedOrg,
+            },
           }
         : result;
-    }
-
-    const node = graph.nodes.get(result.key);
-    const meeting = node?.sourceMeetingId
-      ? meetingById.get(node.sourceMeetingId)
-      : null;
-    return meeting
-      ? {
-          ...result,
-          sourceMeeting: {
-            id: meeting._id.toString(),
-            title: meeting.title,
-            createdAt: meeting.createdAt,
-          },
-        }
-      : result;
-  });
+    })
+    .filter(Boolean);
 }
 
 /**
@@ -371,15 +413,16 @@ export async function hybridRetrieve(query, organization, rawOptions = {}) {
     throw new Error("A non-empty query string is required");
   }
 
-  const options = resolveOptions(rawOptions);
+  assertHybridSearchOrganization(organization);
 
-  // Build the graph once - also carries decision/action-item embeddings so
-  // semantic search doesn't need a second DB round trip.
-  const graph = await buildGraph(organization);
+  const options = resolveOptions(rawOptions);
+  const tenantOrg = organization.toString();
+
+  const graph = await buildGraph(tenantOrg);
 
   const semanticResults = await runSemanticSearch(
     query,
-    organization,
+    tenantOrg,
     graph,
     options,
   );
@@ -399,13 +442,19 @@ export async function hybridRetrieve(query, organization, rawOptions = {}) {
 
   const fused = fuseResults(semanticResults, graphExpansions, options);
   const topResults = fused.slice(0, options.topK);
-  const enriched = await enrichWithMeetingContext(topResults, graph);
-  const explained = attachExplanations(enriched, graph, organization);
+  const enriched = await enrichWithMeetingContext(topResults, graph, tenantOrg);
+  const explained = attachExplanations(enriched, graph, tenantOrg);
+  const results = filterHybridResultsByTenant(
+    explained,
+    graph.nodes,
+    tenantOrg,
+  );
 
   return {
-    results: explained,
+    results,
     meta: {
       query,
+      organizationId: tenantOrg,
       options,
       semanticHitCount: semanticResults.length,
       graphExpansionCount: graphExpansions.length,

--- a/server/tests/hybridRetrievalService.test.js
+++ b/server/tests/hybridRetrievalService.test.js
@@ -74,24 +74,33 @@ describe("hybridRetrievalService", () => {
 
   describe("hybridRetrieve", () => {
     it("throws on an empty query", async () => {
-      await expect(hybridRetrieve("", null)).rejects.toThrow(
-        "A non-empty query string is required",
+      await expect(
+        hybridRetrieve("", new mongoose.Types.ObjectId().toString()),
+      ).rejects.toThrow("A non-empty query string is required");
+    });
+
+    it("throws when organization context is missing", async () => {
+      await expect(hybridRetrieve("valid query", null)).rejects.toThrow(
+        "Organization context is required for hybrid search",
       );
     });
 
     it("finds a semantically-matched decision and expands to its graph neighbor", async () => {
-      const meeting = await makeMeeting();
+      const orgA = new mongoose.Types.ObjectId();
+      const meeting = await makeMeeting({ organization: orgA });
 
       // Two related decisions: only "chessDecision" will match the query
       // semantically; "openaiDecision" is reachable only through the graph.
       const chessDecision = await Decision.create({
         text: "Alice likes chess",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [1, 0, 0],
       });
       const openaiDecision = await Decision.create({
         text: "Alice works at OpenAI",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [0, 1, 0], // deliberately dissimilar to the query embedding
         relatesTo: [{ target: chessDecision._id, confidence: 95 }],
       });
@@ -101,7 +110,7 @@ describe("hybridRetrievalService", () => {
 
       const { results, meta } = await hybridRetrieve(
         "Where does the person who likes chess work?",
-        null,
+        orgA.toString(),
         { maxHops: 2, includeTypes: ["decision"] },
       );
 
@@ -127,7 +136,7 @@ describe("hybridRetrievalService", () => {
     it("respects organization scoping", async () => {
       const orgA = new mongoose.Types.ObjectId();
       const orgB = new mongoose.Types.ObjectId();
-      const meeting = await makeMeeting();
+      const meeting = await makeMeeting({ organization: orgA });
 
       await Decision.create({
         text: "Org A only decision",
@@ -144,7 +153,7 @@ describe("hybridRetrievalService", () => {
 
       mockEmbedText.mockResolvedValue([1, 0, 0]);
 
-      const { results } = await hybridRetrieve("decision", orgA, {
+      const { results } = await hybridRetrieve("decision", orgA.toString(), {
         includeTypes: ["decision"],
       });
 
@@ -160,14 +169,16 @@ describe("hybridRetrievalService", () => {
       );
       mockEmbedText.mockResolvedValue([1, 0, 0]);
 
-      const meeting = await makeMeeting();
+      const orgA = new mongoose.Types.ObjectId();
+      const meeting = await makeMeeting({ organization: orgA });
       await Decision.create({
         text: "Still findable via decision embeddings",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [1, 0, 0],
       });
 
-      const { results } = await hybridRetrieve("query", null, {
+      const { results } = await hybridRetrieve("query", orgA.toString(), {
         includeTypes: ["meeting", "decision"],
       });
 
@@ -179,33 +190,41 @@ describe("hybridRetrievalService", () => {
     });
 
     it("higher graphWeight favors graph-connected results over weakly-matching semantic ones", async () => {
-      const meeting = await makeMeeting();
+      const orgA = new mongoose.Types.ObjectId();
+      const meeting = await makeMeeting({ organization: orgA });
 
       const seed = await Decision.create({
         text: "Seed decision",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [1, 0, 0],
       });
       const strongGraphNeighbor = await Decision.create({
         text: "Strongly linked neighbor",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [0, 1, 0],
         relatesTo: [{ target: seed._id, confidence: 100 }],
       });
       const weakSemanticOnly = await Decision.create({
         text: "Weak semantic-only match",
         sourceMeetingId: meeting._id,
+        organization: orgA,
         embedding: [0.15, 0.98, 0],
       });
 
       mockEmbedText.mockResolvedValue([1, 0, 0]);
 
-      const { results } = await hybridRetrieve("seed decision", null, {
-        includeTypes: ["decision"],
-        semanticWeight: 0.1,
-        graphWeight: 0.9,
-        maxHops: 1,
-      });
+      const { results } = await hybridRetrieve(
+        "seed decision",
+        orgA.toString(),
+        {
+          includeTypes: ["decision"],
+          semanticWeight: 0.1,
+          graphWeight: 0.9,
+          maxHops: 1,
+        },
+      );
 
       const neighborKey = nodeKey(NODE_TYPES.DECISION, strongGraphNeighbor._id);
       const weakKey = nodeKey(NODE_TYPES.DECISION, weakSemanticOnly._id);

--- a/server/tests/hybridSearchControllerTenant.test.js
+++ b/server/tests/hybridSearchControllerTenant.test.js
@@ -1,0 +1,67 @@
+/**
+ * Issue #1539 — Hybrid search controller tenant boundary.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+const mockHybridRetrieve = jest.fn();
+
+jest.unstable_mockModule("../services/hybridRetrievalService.js", () => ({
+  hybridRetrieve: (...args) => mockHybridRetrieve(...args),
+}));
+
+const { hybridSearch } =
+  await import("../controllers/hybridSearchController.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+describe("hybridSearch controller tenant isolation (#1539)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHybridRetrieve.mockResolvedValue({ results: [], meta: {} });
+  });
+
+  it("returns 403 when the authenticated user has no organization", async () => {
+    const req = {
+      body: { query: "attendance policy" },
+      user: { _id: new mongoose.Types.ObjectId() },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await hybridSearch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockHybridRetrieve).not.toHaveBeenCalled();
+  });
+
+  it("ignores client organizationId and scopes to the authenticated org", async () => {
+    const req = {
+      body: {
+        query: "attendance policy",
+        organizationId: ORG_B.toString(),
+        topK: 4,
+      },
+      user: {
+        _id: new mongoose.Types.ObjectId(),
+        organization: ORG_A.toString(),
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    await hybridSearch(req, res);
+
+    expect(mockHybridRetrieve).toHaveBeenCalledWith(
+      "attendance policy",
+      ORG_A.toString(),
+      { topK: 4 },
+    );
+  });
+});

--- a/server/tests/hybridSearchTenantIsolation.test.js
+++ b/server/tests/hybridSearchTenantIsolation.test.js
@@ -1,0 +1,241 @@
+/**
+ * Issue #1539 — Hybrid Search tenant isolation.
+ */
+
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+import {
+  stripClientTenantFields,
+  resolveHybridSearchContext,
+  filterHybridResultsByTenant,
+} from "../utils/resolveSearchTenant.js";
+
+const mockEmbedText = jest.fn();
+const mockSearchVectorStore = jest.fn();
+
+jest.unstable_mockModule("../utils/embeddingUtils.js", () => ({
+  embedText: mockEmbedText,
+  searchVectorStore: mockSearchVectorStore,
+}));
+
+const Decision = (await import("../models/decisionModel.js")).default;
+const Meeting = (await import("../models/meetingModel.js")).default;
+const User = (await import("../models/userModel.js")).default;
+const { nodeKey, NODE_TYPES } = await import("../graph/graphIndex.js");
+const hybridRetrievalService =
+  await import("../services/hybridRetrievalService.js");
+const { hybridRetrieve, resolveOptions } = hybridRetrievalService;
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+async function makeMeeting(organization = ORG_A, overrides = {}) {
+  const owner = await User.create({
+    name: "Owner",
+    email: `owner-${new mongoose.Types.ObjectId()}@example.com`,
+    password: "hashedpw123",
+  });
+
+  return Meeting.create({
+    title: "Team Sync",
+    transcript: "Discussed roadmap and priorities.",
+    uploadedBy: owner._id,
+    organization,
+    date: new Date(),
+    ...overrides,
+  });
+}
+
+describe("Hybrid search tenant isolation (#1539)", () => {
+  beforeAll(async () => {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchVectorStore.mockResolvedValue([]);
+    mockEmbedText.mockResolvedValue([1, 0, 0]);
+  });
+
+  describe("resolveSearchTenant utilities", () => {
+    it("strips client-controlled tenant fields from options", () => {
+      expect(
+        stripClientTenantFields({
+          topK: 5,
+          organizationId: ORG_B.toString(),
+          organization: ORG_B.toString(),
+          tenantId: "evil",
+          orgId: "evil",
+        }),
+      ).toEqual({ topK: 5 });
+    });
+
+    it("resolveHybridSearchContext uses req.user.organization only", () => {
+      const ctx = resolveHybridSearchContext({
+        body: {
+          query: "policy update",
+          organizationId: ORG_B.toString(),
+          topK: 8,
+        },
+        user: { _id: "user-a", organization: ORG_A.toString() },
+      });
+
+      expect(ctx.organizationId).toBe(ORG_A.toString());
+      expect(ctx.options).toEqual({ topK: 8 });
+      expect(ctx.options.organizationId).toBeUndefined();
+    });
+
+    it("filterHybridResultsByTenant removes foreign-organization rows", () => {
+      const graphNodes = new Map([
+        [
+          nodeKey(NODE_TYPES.DECISION, "d-foreign"),
+          { organization: ORG_B.toString() },
+        ],
+      ]);
+
+      const filtered = filterHybridResultsByTenant(
+        [
+          {
+            key: nodeKey(NODE_TYPES.DECISION, "d-local"),
+            organization: ORG_A.toString(),
+          },
+          {
+            key: nodeKey(NODE_TYPES.DECISION, "d-foreign"),
+            organization: ORG_B.toString(),
+          },
+        ],
+        graphNodes,
+        ORG_A.toString(),
+      );
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].key).toBe(nodeKey(NODE_TYPES.DECISION, "d-local"));
+    });
+  });
+
+  describe("hybridRetrieve service", () => {
+    it("throws when organization context is missing", async () => {
+      await expect(hybridRetrieve("valid query", null)).rejects.toThrow(
+        "Organization context is required for hybrid search",
+      );
+    });
+
+    it("resolveOptions strips spoofed organization identifiers", () => {
+      const opts = resolveOptions({
+        organizationId: ORG_B.toString(),
+        topK: 7,
+      });
+      expect(opts.topK).toBe(7);
+    });
+
+    it("returns only Organization A decisions when scoped to Organization A", async () => {
+      const meeting = await makeMeeting(ORG_A);
+
+      await Decision.create({
+        text: "Org A only decision",
+        sourceMeetingId: meeting._id,
+        organization: ORG_A,
+        embedding: [1, 0, 0],
+      });
+      await Decision.create({
+        text: "Org B only decision",
+        sourceMeetingId: meeting._id,
+        organization: ORG_B,
+        embedding: [1, 0, 0],
+      });
+
+      const { results } = await hybridRetrieve("decision", ORG_A.toString(), {
+        includeTypes: ["decision"],
+      });
+
+      expect(results.some((r) => r.title === "Org B only decision")).toBe(
+        false,
+      );
+      expect(results.some((r) => r.title === "Org A only decision")).toBe(true);
+    });
+
+    it("passes authenticated organization to Pinecone vector search", async () => {
+      mockSearchVectorStore.mockResolvedValue([
+        {
+          meetingId: new mongoose.Types.ObjectId().toString(),
+          title: "Org A Meeting",
+          summary: "summary",
+          similarityScore: 0.9,
+          organization: ORG_A.toString(),
+        },
+      ]);
+
+      await hybridRetrieve("meeting notes", ORG_A.toString(), {
+        includeTypes: ["meeting"],
+      });
+
+      expect(mockSearchVectorStore).toHaveBeenCalledWith("meeting notes", {
+        limit: expect.any(Number),
+        organization: ORG_A.toString(),
+      });
+    });
+
+    it("drops foreign-organization vector hits before returning results", async () => {
+      const localMeeting = await makeMeeting(ORG_A, { title: "Local Meeting" });
+
+      mockSearchVectorStore.mockResolvedValue([
+        {
+          meetingId: localMeeting._id.toString(),
+          title: "Local Meeting",
+          summary: "local",
+          similarityScore: 0.95,
+          organization: ORG_A.toString(),
+        },
+        {
+          meetingId: new mongoose.Types.ObjectId().toString(),
+          title: "Foreign Meeting",
+          summary: "foreign",
+          similarityScore: 0.99,
+          organization: ORG_B.toString(),
+        },
+      ]);
+
+      const { results } = await hybridRetrieve("meeting", ORG_A.toString(), {
+        includeTypes: ["meeting"],
+        maxHops: 0,
+      });
+
+      expect(results.some((r) => r.title === "Foreign Meeting")).toBe(false);
+      expect(results.some((r) => r.title === "Local Meeting")).toBe(true);
+    });
+
+    it("does not enrich meetings from another organization during lookup", async () => {
+      const meetingA = await makeMeeting(ORG_A, { title: "Org A Meeting" });
+      const meetingB = await makeMeeting(ORG_B, { title: "Org B Meeting" });
+
+      await Decision.create({
+        text: "Decision tied to foreign meeting id",
+        sourceMeetingId: meetingB._id,
+        organization: ORG_A,
+        embedding: [1, 0, 0],
+      });
+
+      mockSearchVectorStore.mockResolvedValue([
+        {
+          meetingId: meetingA._id.toString(),
+          title: "Org A Meeting",
+          summary: "summary",
+          similarityScore: 0.9,
+          organization: ORG_A.toString(),
+        },
+      ]);
+
+      const { results } = await hybridRetrieve("meeting", ORG_A.toString(), {
+        includeTypes: ["meeting", "decision"],
+        maxHops: 1,
+      });
+
+      for (const result of results) {
+        expect(result.sourceMeeting?.title).not.toBe("Org B Meeting");
+        if (result.organization) {
+          expect(result.organization.toString()).toBe(ORG_A.toString());
+        }
+      }
+    });
+  });
+});

--- a/server/utils/resolveSearchTenant.js
+++ b/server/utils/resolveSearchTenant.js
@@ -1,0 +1,110 @@
+/**
+ * Authoritative tenant context for search routes (Issue #1539).
+ *
+ * Search tenant identity comes from the authenticated session (`req.user`) only.
+ * Client-supplied organization identifiers must never widen or override scope.
+ */
+
+import { getOrganizationIdFromReq } from "../middleware/cacheMiddleware.js";
+
+/** Body/query fields that must not influence tenant scope. */
+export const CLIENT_TENANT_FIELD_NAMES = Object.freeze([
+  "organizationId",
+  "organization",
+  "tenantId",
+  "orgId",
+]);
+
+/**
+ * Removes client-controlled tenant identifiers from search option bags.
+ *
+ * @param {object} options
+ * @returns {object}
+ */
+export function stripClientTenantFields(options = {}) {
+  if (!options || typeof options !== "object") return {};
+
+  const sanitized = { ...options };
+  for (const key of CLIENT_TENANT_FIELD_NAMES) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}
+
+/**
+ * Resolves the authenticated user's organization for search scoping.
+ *
+ * @param {object} user - `req.user`
+ * @returns {string|null}
+ */
+export function resolveAuthenticatedSearchOrganization(user) {
+  if (!user) return null;
+  return getOrganizationIdFromReq({ user });
+}
+
+/**
+ * @param {object} req
+ * @returns {{ organizationId: string|null, options: object }}
+ */
+export function resolveHybridSearchContext(req) {
+  const { query, ...rawOptions } = req.body || {};
+  return {
+    query,
+    organizationId: resolveAuthenticatedSearchOrganization(req.user),
+    options: stripClientTenantFields(rawOptions),
+  };
+}
+
+/**
+ * @param {string} organizationId
+ * @throws {Error}
+ */
+export function assertHybridSearchOrganization(organizationId) {
+  if (!organizationId) {
+    throw new Error("Organization context is required for hybrid search");
+  }
+}
+
+/**
+ * Defense-in-depth: drop any result whose organization metadata does not match
+ * the authenticated tenant. Returns a new array.
+ *
+ * @param {Array<object>} results
+ * @param {Map<string, object>} graphNodes
+ * @param {string} organizationId
+ */
+export function filterHybridResultsByTenant(
+  results,
+  graphNodes,
+  organizationId,
+) {
+  if (!organizationId) return [];
+
+  const expectedOrg = organizationId.toString();
+
+  return results.filter((result) => {
+    if (result.organization && result.organization.toString() !== expectedOrg) {
+      return false;
+    }
+
+    if (result.sourceMeeting?.organization) {
+      return result.sourceMeeting.organization.toString() === expectedOrg;
+    }
+
+    const node = graphNodes?.get?.(result.key);
+    if (node?.organization && node.organization.toString() !== expectedOrg) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export default {
+  CLIENT_TENANT_FIELD_NAMES,
+  stripClientTenantFields,
+  resolveAuthenticatedSearchOrganization,
+  resolveHybridSearchContext,
+  assertHybridSearchOrganization,
+  filterHybridResultsByTenant,
+};


### PR DESCRIPTION
## Summary

Fixes #1539

Enforces organization-level tenant isolation across the Hybrid Search pipeline using the authenticated user's organization as the authoritative tenant scope.

## Changes

- Removed trust in client-supplied `organizationId`, `organization`, `tenantId`, and `orgId`.
- Required a valid authenticated organization before Hybrid Search.
- Added organization filtering to database and graph queries.
- Enforced organization metadata filtering for vector/Pinecone search.
- Added organization filtering to meeting enrichment queries.
- Added final defense-in-depth filtering for merged search results.
- Added shared tenant-resolution logic through `resolveSearchTenant`.

## Security

```text
Authenticated User
        ↓
Resolve Organization
        ↓
Organization-Scoped Search
        ↓
Database + Vector + Enrichment
        ↓
Final Tenant Validation
        ↓
Response
```
Cross-organization documents, meetings, decisions, action items, and vector results are rejected before reaching the client.

Client-supplied organization IDs cannot override the authenticated user's organization.

## Tests

Added regression coverage for:

- Same-organization search
- Cross-organization database isolation
- Cross-organization vector isolation
- Client organization spoofing
- Organization-scoped meeting enrichment
- Final merged-result filtering
- Users without an organization

## Files Changed

### Modified

- `server/controllers/hybridSearchController.js`
- `server/graph/graphIndex.js`
- `server/services/hybridRetrievalService.js`
- `server/tests/hybridRetrievalService.test.js`

### Added

- `server/utils/resolveSearchTenant.js`
- `server/tests/hybridSearchControllerTenant.test.js`
- `server/tests/hybridSearchTenantIsolation.test.js`

## Expected Behavior

| Scenario | Result |
|---|---|
| Same-organization search | Allowed |
| No organization | `403 Forbidden` |
| Unauthenticated request | `401 Unauthorized` |
| Client-supplied foreign organization ID | Ignored |
| Cross-organization database result | Excluded |
| Cross-organization vector result | Excluded |
| Foreign meeting enrichment | Excluded |

## Scope

Only Hybrid Search was changed. Standard semantic search and federated search remain outside the scope of #1539.

## Manual Verification

- [ ] Same-organization Hybrid Search works
- [ ] Foreign `organizationId` cannot change search scope
- [ ] Cross-organization results are excluded
- [ ] Unauthenticated requests return `401`
- [ ] Users without an organization return `403`
- [ ] Existing search relevance and functionality remain unchanged