### PR TITLE
refactor: enforce an upper bound on activity feed pagination limits (#1668)

### DIFF
--- a/server/controllers/activityController.js
+++ b/server/controllers/activityController.js
@@ -1,4 +1,5 @@
 import * as activityService from "../services/activityService.js";
+import { parsePagination } from "../utils/pagination.js";
 
 /**
  * Get activities for the user's current organization
@@ -12,11 +13,17 @@ export const getActivities = async (req, res) => {
       return res.status(400).json({ error: "No organization selected." });
     }
 
-    const { page, limit, action, actor } = req.query;
+    const { action, actor } = req.query;
+
+    // Use shared pagination helper to enforce hard limit upper bound (Issue #1668)
+    const { page, limit } = parsePagination(req.query, {
+      defaultLimit: 20,
+      maxLimit: 100,
+    });
 
     const result = await activityService.getOrgActivities(orgId, {
-      page: parseInt(page, 10) || 1,
-      limit: parseInt(limit, 10) || 20,
+      page,
+      limit,
       action,
       actor,
     });

--- a/server/services/activityService.js
+++ b/server/services/activityService.js
@@ -58,7 +58,11 @@ export const logActivity = async (
  */
 export const getOrgActivities = async (orgId, filters = {}) => {
   const { page = 1, limit = 20, action, actor } = filters;
-  const skip = (page - 1) * limit;
+
+  // Defensively clamp page and limit for database queries (Issue #1668)
+  const parsedLimit = Math.min(Math.max(1, parseInt(limit, 10) || 20), 100);
+  const parsedPage = Math.max(1, parseInt(page, 10) || 1);
+  const skip = (parsedPage - 1) * parsedLimit;
 
   const query = { organization: orgId };
   if (typeof action === "string") query.action = action;
@@ -68,7 +72,7 @@ export const getOrgActivities = async (orgId, filters = {}) => {
     Activity.find(query)
       .sort({ createdAt: -1 })
       .skip(skip)
-      .limit(parseInt(limit))
+      .limit(parsedLimit)
       .populate("actor", "name avatarUrl email")
       .lean(),
     Activity.countDocuments(query),
@@ -76,8 +80,8 @@ export const getOrgActivities = async (orgId, filters = {}) => {
 
   return {
     activities,
-    totalPages: Math.ceil(total / limit),
-    currentPage: parseInt(page),
+    totalPages: Math.ceil(total / parsedLimit),
+    currentPage: parsedPage,
     totalActivities: total,
   };
 };

--- a/server/tests/activityFeedPagination.test.js
+++ b/server/tests/activityFeedPagination.test.js
@@ -1,0 +1,118 @@
+import { jest } from "@jest/globals";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+jest.unstable_mockModule("../middleware/rbac.js", () => ({
+  requireOrgMembership: (req, res, next) => {
+    if (!req.user || !req.user.organization) {
+      return res.status(400).json({ error: "No organization selected." });
+    }
+    next();
+  },
+}));
+
+const { default: activityRoutes } = await import("../routes/activityRoutes.js");
+const { default: Activity } = await import("../models/activityModel.js");
+const { default: express } = await import("express");
+
+const app = express();
+app.use(express.json());
+app.use("/api/activities", activityRoutes);
+
+describe("Activity Feed Pagination Boundaries (#1668)", () => {
+  const ORG_ID = new mongoose.Types.ObjectId();
+
+  beforeEach(async () => {
+    await Activity.deleteMany({});
+
+    currentUser = {
+      _id: new mongoose.Types.ObjectId(),
+      organization: ORG_ID,
+      role: "member",
+    };
+
+    // Create 150 dummy activity records for testing limits up to 100
+    const activitiesToCreate = [];
+    for (let i = 1; i <= 150; i++) {
+      activitiesToCreate.push({
+        organization: ORG_ID,
+        actor: currentUser._id,
+        action: "meeting.created",
+        targetType: "Meeting",
+        targetTitle: `Meeting ${i}`,
+      });
+    }
+    await Activity.insertMany(activitiesToCreate);
+  });
+
+  it("uses default limit of 20 when limit parameter is omitted", async () => {
+    const res = await request(app).get("/api/activities");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(20);
+    expect(res.body.totalActivities).toBe(150);
+  });
+
+  it("respects valid limit within maximum (limit=35)", async () => {
+    const res = await request(app).get("/api/activities?limit=35");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(35);
+  });
+
+  it("respects limit exactly equal to maximum (limit=100)", async () => {
+    const res = await request(app).get("/api/activities?limit=100");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(100);
+  });
+
+  it("clamps limit above maximum (limit=150) to configured max (100)", async () => {
+    const res = await request(app).get("/api/activities?limit=150");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(100);
+  });
+
+  it("handles zero (limit=0) safely by falling back to default limit (20)", async () => {
+    const res = await request(app).get("/api/activities?limit=0");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(20);
+  });
+
+  it("handles negative values (limit=-5, page=-2) safely without throwing or breaking MongoDB skip", async () => {
+    const res = await request(app).get("/api/activities?limit=-5&page=-2");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(20);
+    expect(res.body.currentPage).toBe(1);
+  });
+
+  it("handles non-numeric values (limit=abc) safely by falling back to default limit (20)", async () => {
+    const res = await request(app).get("/api/activities?limit=abc&page=xyz");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(20);
+    expect(res.body.currentPage).toBe(1);
+  });
+
+  it("clamps very large values (limit=10000000) to configured maximum (100)", async () => {
+    const res = await request(app).get("/api/activities?limit=10000000");
+
+    expect(res.status).toBe(200);
+    expect(res.body.activities).toHaveLength(100);
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR enforces a hard upper bound ceiling (max 100) on Activity Feed pagination limits to prevent memory spikes and denial-of-service risks from excessively large client-provided limit parameters.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1668

---

## ✨ Changes Made
- **Shared Pagination Utility**:
  - Refactored `server/controllers/activityController.js` to utilize `parsePagination` with `defaultLimit: 20` and `maxLimit: 100`.
- **Bounded Database Queries**:
  - Clamped pagination parameters inside `server/services/activityService.js` to ensure Mongoose queries remain bounded.
- **Added Comprehensive Tests**:
  - Created `server/tests/activityFeedPagination.test.js` validating default, within-max, exact-max, oversized, zero, negative, non-numeric, and extremely large limit parameters.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Jest tests:
```bash
cd server
npm run test tests/activityFeedPagination.test.js
