### PR TITLE
refactor: prevent rsvp status upserts for unauthorized meetings (#1673)

### DIFF
--- a/server/controllers/meetingRsvpController.js
+++ b/server/controllers/meetingRsvpController.js
@@ -4,7 +4,8 @@ import {
   getPendingRsvpsForUser,
   getMeetingRsvpSummary,
 } from "../services/meetingRsvpService.js";
-import Meeting from "../models/meetingModel.js";
+import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
+import MeetingRsvp from "../models/meetingRsvpModel.js";
 
 /**
  * Send RSVP requests to participants
@@ -13,7 +14,7 @@ export const sendRsvpRequests = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const { userIds } = req.body;
-    const userId = req.user.id;
+    const userId = req.user.id || req.user._id;
 
     if (!Array.isArray(userIds) || userIds.length === 0) {
       return res.status(400).json({
@@ -22,15 +23,22 @@ export const sendRsvpRequests = async (req, res) => {
       });
     }
 
-    const meeting = await Meeting.findById(meetingId);
-    if (!meeting) {
-      return res
-        .status(404)
-        .json({ success: false, message: "meeting_not_found" });
+    // Verify meeting access and retrieve meeting document
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res.status(access.error.status).json({
+        success: false,
+        message: access.error.message,
+      });
     }
 
-    // Only organizer can send RSVPs (assuming uploadedBy is the organizer)
-    if (meeting.uploadedBy.toString() !== userId) {
+    const meeting = access.meeting;
+
+    // Only organizer or admin can send RSVPs
+    const isOrganizer = meeting.uploadedBy?.toString() === userId.toString();
+    const isAdmin = req.user.role === "admin" || req.user.role === "owner";
+
+    if (!isOrganizer && !isAdmin) {
       return res.status(403).json({
         success: false,
         message: "only_organizer_can_send_rsvps",
@@ -55,7 +63,7 @@ export const sendRsvpRequests = async (req, res) => {
 export const respondToRsvp = async (req, res) => {
   try {
     const { meetingId } = req.params;
-    const userId = req.user.id;
+    const userId = req.user.id || req.user._id;
     const { status, declineReason, availabilityNote } = req.body;
 
     if (!status) {
@@ -65,6 +73,39 @@ export const respondToRsvp = async (req, res) => {
       });
     }
 
+    // 1. Verify meeting access and retrieve meeting document
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res.status(access.error.status).json({
+        success: false,
+        message: access.error.message,
+      });
+    }
+
+    const meeting = access.meeting;
+
+    // 2. Verify authorization to RSVP (must be owner, admin, listed participant, or have an existing RSVP)
+    const isOwner = meeting.uploadedBy?.toString() === userId.toString();
+    const isAdmin = req.user.role === "admin" || req.user.role === "owner";
+    const isParticipant = meeting.participants?.some(
+      (p) =>
+        p.user?.toString() === userId.toString() ||
+        (p.email &&
+          req.user.email &&
+          p.email.toLowerCase() === req.user.email.toLowerCase()),
+    );
+
+    const hasExistingRsvp = await MeetingRsvp.findOne({ meetingId, userId });
+
+    if (!isOwner && !isAdmin && !isParticipant && !hasExistingRsvp) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: You are not invited or authorized to RSVP for this meeting",
+      });
+    }
+
+    // 3. Perform upsert
     const updatedRsvp = await updateRsvpStatus(meetingId, userId, {
       status,
       declineReason,
@@ -88,7 +129,7 @@ export const respondToRsvp = async (req, res) => {
  */
 export const getPendingRsvps = async (req, res) => {
   try {
-    const userId = req.user.id;
+    const userId = req.user.id || req.user._id;
     const rsvps = await getPendingRsvpsForUser(userId);
 
     res.status(200).json({
@@ -107,6 +148,15 @@ export const getPendingRsvps = async (req, res) => {
 export const getMeetingSummary = async (req, res) => {
   try {
     const { meetingId } = req.params;
+
+    // Verify meeting access before returning summary
+    const access = await resolveAccessibleMeeting(meetingId, req.user);
+    if (access.error) {
+      return res.status(access.error.status).json({
+        success: false,
+        message: access.error.message,
+      });
+    }
 
     const summary = await getMeetingRsvpSummary(meetingId);
 

--- a/server/tests/meetingRsvpAuthorization.test.js
+++ b/server/tests/meetingRsvpAuthorization.test.js
@@ -1,0 +1,202 @@
+import { jest } from "@jest/globals";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: meetingRsvpRoutes } =
+  await import("../routes/meetingRsvpRoutes.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: MeetingRsvp } = await import("../models/meetingRsvpModel.js");
+const { default: express } = await import("express");
+
+const app = express();
+app.use(express.json());
+app.use("/api/rsvps", meetingRsvpRoutes);
+
+describe("Meeting RSVP Authorization & IDOR Tests (#1673)", () => {
+  const ORG_A = new mongoose.Types.ObjectId();
+  const ORG_B = new mongoose.Types.ObjectId();
+
+  const ALICE_ORG_A = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: ORG_A,
+    role: "member",
+    email: "alice@orga.com",
+  };
+
+  const BOB_ORG_A = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: ORG_A,
+    role: "member",
+    email: "bob@orga.com",
+  };
+
+  const CHARLIE_ORG_A = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: ORG_A,
+    role: "member",
+    email: "charlie@orga.com",
+  };
+
+  const MALLORY_ORG_B = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: ORG_B,
+    role: "member",
+    email: "mallory@orgb.com",
+  };
+
+  let meetingA;
+
+  beforeEach(async () => {
+    await Meeting.deleteMany({});
+    await MeetingRsvp.deleteMany({});
+
+    meetingA = await Meeting.create({
+      title: "Architecture Sync",
+      uploadedBy: ALICE_ORG_A._id,
+      organization: ORG_A,
+      date: new Date(),
+      status: "uploaded",
+      participants: [
+        {
+          user: ALICE_ORG_A._id,
+          name: "Alice Owner",
+          email: ALICE_ORG_A.email,
+        },
+        {
+          user: BOB_ORG_A._id,
+          name: "Bob Participant",
+          email: BOB_ORG_A.email,
+        },
+      ],
+    });
+  });
+
+  describe("RSVP Creation and Updates", () => {
+    it("allows invited user (in participants list) to create/update RSVP", async () => {
+      currentUser = BOB_ORG_A;
+
+      const res = await request(app)
+        .put(`/api/rsvps/${meetingA._id}/respond`)
+        .send({ status: "accepted" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.status).toBe("accepted");
+
+      const rsvp = await MeetingRsvp.findOne({
+        meetingId: meetingA._id,
+        userId: BOB_ORG_A._id,
+      });
+      expect(rsvp).toBeDefined();
+      expect(rsvp.status).toBe("accepted");
+    });
+
+    it("allows user with an existing RSVP record to update RSVP status", async () => {
+      // Pre-seed an RSVP record for Bob
+      await MeetingRsvp.create({
+        meetingId: meetingA._id,
+        userId: BOB_ORG_A._id,
+        status: "pending",
+      });
+
+      currentUser = BOB_ORG_A;
+
+      const res = await request(app)
+        .put(`/api/rsvps/${meetingA._id}/respond`)
+        .send({ status: "declined", declineReason: "Busy" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.status).toBe("declined");
+      expect(res.body.data.declineReason).toBe("Busy");
+    });
+
+    it("denies RSVP creation for non-invited user from the same organization (403)", async () => {
+      currentUser = CHARLIE_ORG_A;
+
+      const res = await request(app)
+        .put(`/api/rsvps/${meetingA._id}/respond`)
+        .send({ status: "accepted" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toMatch(/not invited or authorized/i);
+
+      // Verify no RSVP database record was created
+      const count = await MeetingRsvp.countDocuments({
+        meetingId: meetingA._id,
+        userId: CHARLIE_ORG_A._id,
+      });
+      expect(count).toBe(0);
+    });
+
+    it("denies RSVP creation for user from a different organization (403 IDOR check)", async () => {
+      currentUser = MALLORY_ORG_B;
+
+      const res = await request(app)
+        .put(`/api/rsvps/${meetingA._id}/respond`)
+        .send({ status: "accepted" });
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+
+      const count = await MeetingRsvp.countDocuments({
+        meetingId: meetingA._id,
+        userId: MALLORY_ORG_B._id,
+      });
+      expect(count).toBe(0);
+    });
+
+    it("returns 400 for invalid meeting ID formatting", async () => {
+      currentUser = BOB_ORG_A;
+
+      const res = await request(app)
+        .put("/api/rsvps/invalid-meeting-id/respond")
+        .send({ status: "accepted" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for nonexistent meeting ID", async () => {
+      currentUser = BOB_ORG_A;
+      const fakeId = new mongoose.Types.ObjectId();
+
+      const res = await request(app)
+        .put(`/api/rsvps/${fakeId}/respond`)
+        .send({ status: "accepted" });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("RSVP Summary Retrieval", () => {
+    it("allows access to RSVP summary for member of the organization", async () => {
+      currentUser = BOB_ORG_A;
+
+      const res = await request(app).get(`/api/rsvps/meeting/${meetingA._id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.participants).toBeDefined();
+    });
+
+    it("denies access to RSVP summary for cross-organization user", async () => {
+      currentUser = MALLORY_ORG_B;
+
+      const res = await request(app).get(`/api/rsvps/meeting/${meetingA._id}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR enforces meeting access check and participation rules on RSVP endpoints to prevent unauthorized users from creating or updating RSVPs for meetings they aren't invited to. It secures template rendering, RSVP status update flow, and summary retrieval.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1673

---

## ✨ Changes Made
- **Meeting Access Validation**:
  - Enforced `resolveAccessibleMeeting` across RSVP response, dispatch, and summary routes.
- **Strict Participant Authorization Checks**:
  - Restricted RSVP respond updates to owners, admins, participants list users, or existing RSVP owners.
- **Added Integration Tests**:
  - Created `server/tests/meetingRsvpAuthorization.test.js` validating authentication, same-organization/cross-organization access controls, invalid IDs, and database insertion verification.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Jest tests:
```bash
cd server
npm run test tests/meetingRsvpAuthorization.test.js
