### PR TITLE
feat: optimize AI meeting summary caching

### DIFF
--- a/server/services/batchedMeetingSummaryService.js
+++ b/server/services/batchedMeetingSummaryService.js
@@ -1,0 +1,44 @@
+import { generateCachedMeetingSummary } from "./meetingSummaryCache.js";
+
+/**
+ * Generate summaries for multiple meetings while preserving input order.
+ *
+ * The cache layer deduplicates identical work, so repeated requests for the
+ * same meeting/transcript do not trigger another Gemini call. A concurrency
+ * limit prevents a large request from flooding the AI provider.
+ */
+export const generateMeetingSummariesBatch = async (
+  meetings,
+  generateSummary,
+  { concurrency = 4 } = {},
+) => {
+  if (!Array.isArray(meetings) || meetings.length === 0) {
+    return [];
+  }
+
+  const limit = Math.max(1, Number(concurrency) || 1);
+  const results = new Array(meetings.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < meetings.length) {
+      const index = cursor++;
+      const meeting = meetings[index];
+
+      results[index] = await generateCachedMeetingSummary({
+        meetingId: meeting.id ?? meeting._id ?? null,
+        transcript: meeting.transcript ?? "",
+        date: meeting.date ?? null,
+        title: meeting.title ?? null,
+        customInstructions: meeting.customInstructions ?? null,
+        generator: () => generateSummary(meeting),
+      });
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, meetings.length) }, worker),
+  );
+
+  return results;
+};

--- a/server/services/meetingSummaryCache.js
+++ b/server/services/meetingSummaryCache.js
@@ -1,0 +1,211 @@
+import crypto from "node:crypto";
+import { getRedisClient } from "./redisService.js";
+
+const CACHE_VERSION = process.env.MEETING_SUMMARY_CACHE_VERSION || "v1";
+const HARD_TTL_SECONDS = Number.parseInt(
+  process.env.MEETING_SUMMARY_CACHE_TTL_SECONDS || "3600",
+  10,
+);
+const STALE_TTL_SECONDS = Number.parseInt(
+  process.env.MEETING_SUMMARY_CACHE_STALE_SECONDS || "300",
+  10,
+);
+
+const localCache = new Map();
+const refreshes = new Map();
+
+const now = () => Date.now();
+
+const getTtl = (value, fallback) =>
+  Number.isFinite(value) && value > 0 ? value : fallback;
+
+const stableHash = (value) =>
+  crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+
+export const buildMeetingSummaryCacheKey = ({
+  meetingId = null,
+  transcript = "",
+  date = null,
+  title = null,
+  customInstructions = null,
+}) =>
+  `meeting-summary:${CACHE_VERSION}:${stableHash({
+    meetingId,
+    transcript,
+    date,
+    title,
+    customInstructions,
+  })}`;
+
+const readLocal = (key) => {
+  const entry = localCache.get(key);
+  if (!entry) return null;
+  if (entry.hardExpiresAt <= now()) {
+    localCache.delete(key);
+    return null;
+  }
+  return entry;
+};
+
+const writeLocal = (key, payload) => {
+  const hardTtlMs = getTtl(HARD_TTL_SECONDS, 3600) * 1000;
+  localCache.set(key, {
+    payload,
+    cachedAt: now(),
+    staleAt: now() + getTtl(STALE_TTL_SECONDS, 300) * 1000,
+    hardExpiresAt: now() + hardTtlMs,
+    version: CACHE_VERSION,
+  });
+};
+
+const readRedis = async (key) => {
+  const client = getRedisClient();
+  if (!client || !client.isReady) return null;
+
+  try {
+    const raw = await client.get(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed ||
+      parsed.version !== CACHE_VERSION ||
+      typeof parsed.cachedAt !== "number"
+    ) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.warn("Meeting summary cache read failed:", error.message);
+    return null;
+  }
+};
+
+const writeRedis = async (key, payload) => {
+  const client = getRedisClient();
+  if (!client || !client.isReady) return false;
+
+  try {
+    const hardTtl = getTtl(HARD_TTL_SECONDS, 3600);
+    await client.setEx(
+      key,
+      hardTtl,
+      JSON.stringify({
+        payload,
+        cachedAt: now(),
+        staleAt: now() + getTtl(STALE_TTL_SECONDS, 300) * 1000,
+        version: CACHE_VERSION,
+      }),
+    );
+    return true;
+  } catch (error) {
+    console.warn("Meeting summary cache write failed:", error.message);
+    return false;
+  }
+};
+
+const refresh = async (key, generator) => {
+  if (refreshes.has(key)) return refreshes.get(key);
+
+  const task = Promise.resolve()
+    .then(generator)
+    .then(async (payload) => {
+      writeLocal(key, payload);
+      await writeRedis(key, payload);
+      return payload;
+    })
+    .finally(() => {
+      refreshes.delete(key);
+    });
+
+  refreshes.set(key, task);
+  return task;
+};
+
+export const getCachedMeetingSummary = async ({ cacheKey, generator }) => {
+  if (!cacheKey) {
+    return generator();
+  }
+
+  const local = readLocal(cacheKey);
+  if (local) {
+    if (local.staleAt <= now()) {
+      void refresh(cacheKey, generator).catch((error) => {
+        console.warn("Meeting summary stale refresh failed:", error.message);
+      });
+    }
+    return local.payload;
+  }
+
+  const remote = await readRedis(cacheKey);
+  if (remote) {
+    writeLocal(cacheKey, remote.payload);
+
+    if (remote.staleAt <= now()) {
+      void refresh(cacheKey, generator).catch((error) => {
+        console.warn("Meeting summary stale refresh failed:", error.message);
+      });
+    }
+
+    return remote.payload;
+  }
+
+  return refresh(cacheKey, generator);
+};
+
+export const generateCachedMeetingSummary = async ({
+  meetingId,
+  transcript,
+  date,
+  title,
+  customInstructions = null,
+  generator,
+}) => {
+  const cacheKey = buildMeetingSummaryCacheKey({
+    meetingId,
+    transcript,
+    date,
+    title,
+    customInstructions,
+  });
+
+  return getCachedMeetingSummary({
+    cacheKey,
+    generator,
+  });
+};
+
+export const clearMeetingSummaryCache = async ({
+  meetingId,
+  transcript,
+  date,
+  title,
+  customInstructions = null,
+}) => {
+  const key = buildMeetingSummaryCacheKey({
+    meetingId,
+    transcript,
+    date,
+    title,
+    customInstructions,
+  });
+
+  localCache.delete(key);
+
+  const client = getRedisClient();
+  if (!client || !client.isReady) return false;
+
+  try {
+    await client.del(key);
+    return true;
+  } catch (error) {
+    console.warn("Meeting summary cache clear failed:", error.message);
+    return false;
+  }
+};
+
+export const clearMeetingSummaryLocalCacheForTests = () => {
+  localCache.clear();
+  refreshes.clear();
+};

--- a/server/tests/meetingSummaryCache.test.js
+++ b/server/tests/meetingSummaryCache.test.js
@@ -1,0 +1,153 @@
+import {
+  buildMeetingSummaryCacheKey,
+  clearMeetingSummaryCache,
+  clearMeetingSummaryLocalCacheForTests,
+  generateCachedMeetingSummary,
+} from "../services/meetingSummaryCache.js";
+import { overrideRedisClientForTesting } from "../services/redisService.js";
+
+describe("meeting summary cache", () => {
+  afterEach(() => {
+    clearMeetingSummaryLocalCacheForTests();
+    overrideRedisClientForTesting(null);
+  });
+
+  test("uses the same versioned key for equivalent inputs", () => {
+    const first = buildMeetingSummaryCacheKey({
+      meetingId: "meeting-1",
+      transcript: "hello",
+      date: "2026-08-17",
+      title: "Weekly sync",
+    });
+
+    const second = buildMeetingSummaryCacheKey({
+      meetingId: "meeting-1",
+      transcript: "hello",
+      date: "2026-08-17",
+      title: "Weekly sync",
+    });
+
+    expect(first).toBe(second);
+    expect(first).toContain("meeting-summary:");
+  });
+
+  test("does not call the generator twice for a fresh cached result", async () => {
+    const generator = jest.fn().mockResolvedValue({
+      summary: "cached summary",
+    });
+
+    const input = {
+      meetingId: "meeting-1",
+      transcript: "same transcript",
+      date: "2026-08-17",
+      title: "Weekly sync",
+      generator,
+    };
+
+    await expect(generateCachedMeetingSummary(input)).resolves.toEqual({
+      summary: "cached summary",
+    });
+
+    await expect(generateCachedMeetingSummary(input)).resolves.toEqual({
+      summary: "cached summary",
+    });
+
+    expect(generator).toHaveBeenCalledTimes(1);
+  });
+
+  test("deduplicates concurrent generation", async () => {
+    let resolveGeneration;
+    const generator = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+
+    const input = {
+      meetingId: "meeting-2",
+      transcript: "concurrent transcript",
+      date: "2026-08-17",
+      title: "Planning",
+      generator,
+    };
+
+    const first = generateCachedMeetingSummary(input);
+    const second = generateCachedMeetingSummary(input);
+
+    expect(generator).toHaveBeenCalledTimes(1);
+
+    resolveGeneration({ summary: "generated once" });
+
+    await expect(first).resolves.toEqual({ summary: "generated once" });
+    await expect(second).resolves.toEqual({ summary: "generated once" });
+  });
+
+  test("stores and reads through the Redis adapter when available", async () => {
+    const store = new Map();
+    const client = {
+      isReady: true,
+      get: jest.fn(async (key) => store.get(key) ?? null),
+      setEx: jest.fn(async (key, _ttl, value) => {
+        store.set(key, value);
+        return "OK";
+      }),
+      del: jest.fn(async (key) => {
+        store.delete(key);
+        return 1;
+      }),
+    };
+
+    overrideRedisClientForTesting(client);
+
+    const generator = jest.fn().mockResolvedValue({
+      summary: "redis summary",
+    });
+
+    await generateCachedMeetingSummary({
+      meetingId: "meeting-3",
+      transcript: "redis transcript",
+      date: "2026-08-17",
+      title: "Redis",
+      generator,
+    });
+
+    clearMeetingSummaryLocalCacheForTests();
+
+    await expect(
+      generateCachedMeetingSummary({
+        meetingId: "meeting-3",
+        transcript: "redis transcript",
+        date: "2026-08-17",
+        title: "Redis",
+        generator,
+      }),
+    ).resolves.toEqual({
+      summary: "redis summary",
+    });
+
+    expect(generator).toHaveBeenCalledTimes(1);
+    expect(client.setEx).toHaveBeenCalledTimes(1);
+  });
+
+  test("clear removes a cached summary", async () => {
+    const generator = jest.fn().mockResolvedValue({
+      summary: "to be cleared",
+    });
+
+    const input = {
+      meetingId: "meeting-4",
+      transcript: "clear me",
+      date: "2026-08-17",
+      title: "Clear",
+      generator,
+    };
+
+    await generateCachedMeetingSummary(input);
+    await clearMeetingSummaryCache(input);
+
+    await generateCachedMeetingSummary(input);
+
+    expect(generator).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1479

Optimizes AI meeting summary generation by adding cache-backed reuse,
stale-while-revalidate refreshes, request coalescing, and bounded batch
processing.

## What changed

- Added versioned meeting-summary cache keys.
- Added Redis-backed summary caching.
- Added configurable hard TTL.
- Added configurable stale TTL.
- Added stale-while-revalidate behavior.
- Added concurrent request deduplication.
- Added graceful fallback when Redis is unavailable.
- Added explicit summary cache invalidation.
- Added bounded-concurrency batch summary generation.
- Added regression tests for cache hits, concurrent generation, Redis
  persistence, and invalidation.

## Architecture

The existing `redisService.js` abstraction is reused rather than introducing
another Redis client.

The existing Gemini resilience pipeline remains responsible for provider
timeouts, retries, circuit breaking, and local fallback.

The cache layer sits around summary generation so cached requests avoid
unnecessary Gemini calls.

## Configuration

Defaults:

- `MEETING_SUMMARY_CACHE_VERSION=v1`
- `MEETING_SUMMARY_CACHE_TTL_SECONDS=3600`
- `MEETING_SUMMARY_CACHE_STALE_SECONDS=300`
- Batch concurrency: `4`

## Testing

- ESLint
- Prettier
- Meeting summary cache unit tests
- Server PR validation
- `git diff --check`

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
