### PR TITLE
fix(rbac): align UploadMeeting gate with RBAC meetings.create permission

### DIFF
--- a/client/src/pages/UploadMeeting.jsx
+++ b/client/src/pages/UploadMeeting.jsx
@@ -28,19 +28,14 @@ import MeetingRecorder from "../components/meetings/MeetingRecorder.jsx";
 import TagAutocomplete from "../components/meetings/TagAutocomplete.jsx";
 import { createClerkSocketOptions } from "../services/apiClient.js";
 
+import { hasPermission } from "../utils/rbacPermissions.js";
+
 const UploadMeeting = () => {
   const { userData, backendUrl } = useContext(AppContent);
   const navigate = useNavigate();
 
-  const isAdmin = userData?.role === "admin" || userData?.role === "owner";
-
-  // Redirect members to dashboard
-  useEffect(() => {
-    if (!isAdmin) {
-      toast.error("Only admins can upload or record meetings");
-      navigate("/dashboard");
-    }
-  }, [isAdmin, navigate]);
+  const userRole = userData?.role || "member";
+  const canCreateMeeting = hasPermission(userRole, "meetings", "create");
 
   const {
     file,
@@ -233,6 +228,34 @@ const UploadMeeting = () => {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  if (userData && !canCreateMeeting) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col font-sans">
+        <Navbar />
+        <div className="flex-grow pt-28 pb-16 px-4 sm:px-6 lg:px-8 flex items-center justify-center">
+          <div className="max-w-md w-full text-center bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700">
+            <div className="w-16 h-16 bg-red-50 dark:bg-red-900/30 rounded-2xl flex items-center justify-center mx-auto mb-4 text-red-500">
+              <AlertCircle className="w-8 h-8" />
+            </div>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+              Access Denied
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 mb-6 text-sm">
+              You do not have permission to upload or record meetings. Please
+              contact your organization administrator if you need access.
+            </p>
+            <button
+              onClick={() => navigate("/dashboard")}
+              className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl text-sm transition-colors cursor-pointer"
+            >
+              Back to Dashboard
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 via-slate-50 to-blue-50/50 dark:from-gray-900 dark:via-slate-900 dark:to-blue-900/20 flex flex-col font-sans">

--- a/client/src/pages/__tests__/UploadMeetingRbac.test.jsx
+++ b/client/src/pages/__tests__/UploadMeetingRbac.test.jsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import UploadMeeting from "../UploadMeeting.jsx";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="navbar">Navbar</nav>,
+}));
+
+vi.mock("../../hooks/useMeetingUpload", () => ({
+  default: () => ({
+    file: null,
+    setFile: vi.fn(),
+    uploadProgress: 0,
+    isUploading: false,
+    isDragging: false,
+    transcript: "",
+    meetingId: null,
+    setMeetingId: vi.fn(),
+    fileInputRef: { current: null },
+    handleDragOver: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleDrop: vi.fn(),
+    handleFileChange: vi.fn(),
+    resetUpload: vi.fn(),
+    handleUpload: vi.fn(),
+    formatFileSize: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useExport.js", () => ({
+  default: () => ({ exportMeeting: vi.fn(), isExporting: false }),
+}));
+
+vi.mock("../../components/meetings/Dropzone.jsx", () => ({
+  default: () => <div data-testid="dropzone">Dropzone</div>,
+}));
+
+vi.mock("../../components/meetings/MeetingRecorder.jsx", () => ({
+  default: () => <div data-testid="recorder">Recorder</div>,
+}));
+
+vi.mock("../../components/meetings/TagAutocomplete.jsx", () => ({
+  default: () => <div data-testid="tags">Tags</div>,
+}));
+
+describe("UploadMeeting RBAC Permission Gate (#1638)", () => {
+  it("allows access for users with meetings.create permission (e.g. member)", () => {
+    render(
+      <AppContent.Provider
+        value={{
+          userData: { role: "member", organization: "org_1" },
+          backendUrl: "http://localhost:4000",
+        }}
+      >
+        <BrowserRouter>
+          <UploadMeeting />
+        </BrowserRouter>
+      </AppContent.Provider>,
+    );
+
+    expect(screen.getByText(/upload or record meeting/i)).toBeInTheDocument();
+    expect(screen.queryByText(/access denied/i)).not.toBeInTheDocument();
+  });
+
+  it("allows access for admin and owner roles", () => {
+    render(
+      <AppContent.Provider
+        value={{
+          userData: { role: "admin", organization: "org_1" },
+          backendUrl: "http://localhost:4000",
+        }}
+      >
+        <BrowserRouter>
+          <UploadMeeting />
+        </BrowserRouter>
+      </AppContent.Provider>,
+    );
+
+    expect(screen.getByText(/upload or record meeting/i)).toBeInTheDocument();
+  });
+
+  it("renders Access Denied for roles without meetings.create permission (e.g. guest, viewer)", () => {
+    render(
+      <AppContent.Provider
+        value={{
+          userData: { role: "guest", organization: "org_1" },
+          backendUrl: "http://localhost:4000",
+        }}
+      >
+        <BrowserRouter>
+          <UploadMeeting />
+        </BrowserRouter>
+      </AppContent.Provider>,
+    );
+
+    expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /you do not have permission to upload or record meetings/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1638

## Description
This PR aligns the UploadMeeting.jsx access gate with the application's permission system (hasPermission(userRole, "meetings", "create")), avoiding misleading error toasts and redirect loops for authorized roles (like members/moderators/custom roles) while gracefully showing an Access Denied view for unauthorized roles.

## Proposed Changes
- **Permission Gate Alignment**: Replaced hardcoded isAdmin check with hasPermission(userRole, "meetings", "create").
- **Graceful Access Denied State**: Rendered an accessible Access Denied screen for unauthorized users without disruptive error toasts or redirect loops.
- **Unit Test Coverage**: Added Vitest test suite (UploadMeetingRbac.test.jsx) verifying access for create-capable roles and access denial for unauthorized roles.

## Checklist
- [x] Related Issue is linked (Fixes #1638).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.