### PR TITLE
fix(ui): add responsive horizontal overflow container for calendar month/week grid on mobile

### DIFF
--- a/client/src/components/calendar/CalendarGrid.jsx
+++ b/client/src/components/calendar/CalendarGrid.jsx
@@ -16,7 +16,10 @@ const CalendarGrid = ({
   setSelectedMeeting,
 }) => {
   return (
-    <div className="flex-1 bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl shadow-xs overflow-hidden">
+    <div
+      data-testid="calendar-grid-container"
+      className="flex-1 bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl shadow-xs overflow-x-auto max-w-full"
+    >
       {/* MONTH VIEW */}
       {view === "month" && (
         <div className="flex flex-col h-full min-w-[700px]">

--- a/client/src/components/calendar/__tests__/CalendarMobileResponsive.test.jsx
+++ b/client/src/components/calendar/__tests__/CalendarMobileResponsive.test.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import CalendarGrid from "../CalendarGrid.jsx";
+
+describe("CalendarGrid Mobile Responsiveness (#1639)", () => {
+  const dummyMeetings = [
+    {
+      _id: "m_1",
+      title: "Sprint Planning",
+      date: new Date().toISOString(),
+      time: "10:00 AM",
+      status: "completed",
+    },
+  ];
+
+  it("renders with horizontal overflow container for month view", () => {
+    render(
+      <CalendarGrid
+        view="month"
+        currentDate={new Date()}
+        filteredMeetings={dummyMeetings}
+        setSelectedMeeting={vi.fn()}
+      />,
+    );
+
+    const container = screen.getByTestId("calendar-grid-container");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass("overflow-x-auto");
+    expect(container).toHaveClass("max-w-full");
+    expect(screen.getByText("Sprint Planning")).toBeInTheDocument();
+  });
+
+  it("renders with horizontal overflow container for week view", () => {
+    render(
+      <CalendarGrid
+        view="week"
+        currentDate={new Date()}
+        filteredMeetings={dummyMeetings}
+        setSelectedMeeting={vi.fn()}
+      />,
+    );
+
+    const container = screen.getByTestId("calendar-grid-container");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass("overflow-x-auto");
+    expect(container).toHaveClass("max-w-full");
+  });
+
+  it("renders day view appropriately", () => {
+    render(
+      <CalendarGrid
+        view="day"
+        currentDate={new Date()}
+        filteredMeetings={dummyMeetings}
+        setSelectedMeeting={vi.fn()}
+      />,
+    );
+
+    const container = screen.getByTestId("calendar-grid-container");
+    expect(container).toBeInTheDocument();
+    expect(screen.getByText("Timeline")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1639

## Description
This PR resolves document-level horizontal overflow on mobile viewports for the Calendar month and week views by encapsulating the calendar grid within a responsive horizontal scroll container (overflow-x-auto max-w-full).

## Proposed Changes
- **Horizontal Scroll Container**: Configured CalendarGrid.jsx main container with overflow-x-auto max-w-full so wide grids (e.g. min-w-[700px], min-w-[800px]) can be scrolled horizontally within their card without overflowing the mobile viewport (e.g. 375px).
- **Unit Test Coverage**: Added Vitest test suite (CalendarMobileResponsive.test.jsx) verifying responsive horizontal overflow container classes on month, week, and day views.

## Checklist
- [x] Related Issue is linked (Fixes #1639).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.