### PR TITLE
fix(ui): add dedicated error and retry state for Summaries API failure

### DIFF
--- a/client/src/pages/Summaries.jsx
+++ b/client/src/pages/Summaries.jsx
@@ -18,6 +18,8 @@ import {
   Mic,
   MicOff,
   Download,
+  AlertCircle,
+  RefreshCw,
 } from "lucide-react";
 
 /**
@@ -33,6 +35,7 @@ const Summaries = () => {
   const { t } = useTranslation();
   const [summaries, setSummaries] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
@@ -141,6 +144,7 @@ const Summaries = () => {
         const cached = pageCacheRef.current.get(cacheKey);
         setSummaries(cached.meetings);
         setPagination(cached.pagination);
+        setError(null);
         setLoading(false);
         return;
       }
@@ -160,6 +164,7 @@ const Summaries = () => {
         if (requestId !== requestIdRef.current) return;
 
         if (res.data?.success) {
+          setError(null);
           const meetings = res.data.meetings || [];
           const nextPagination = res.data.pagination || {
             total: meetings.length,
@@ -174,11 +179,20 @@ const Summaries = () => {
           setSummaries(meetings);
           setPagination(nextPagination);
         } else {
+          setError(
+            res.data?.message ||
+              t("summaries.loadFailed") ||
+              "Failed to load summaries",
+          );
           toast.error(res.data?.message || t("summaries.loadFailed"));
         }
       } catch (error) {
         if (requestId !== requestIdRef.current) return;
         console.error("Error fetching summaries:", error);
+        setError(
+          t("summaries.loadFailed") ||
+            "Failed to load summaries. Please check your connection and try again.",
+        );
         toast.error(t("summaries.loadFailed"));
       } finally {
         if (requestId === requestIdRef.current) {
@@ -334,6 +348,31 @@ const Summaries = () => {
             <div className="flex justify-center items-center py-10 text-gray-500">
               <Loader2 className="animate-spin w-6 h-6 mr-2" />{" "}
               {t("summaries.loading")}
+            </div>
+          ) : error ? (
+            <div
+              data-testid="summaries-error-state"
+              className="bg-white dark:bg-gray-800 p-10 rounded-2xl shadow-md border border-red-200 dark:border-red-800 max-w-md mx-auto text-center"
+            >
+              <div className="w-12 h-12 bg-red-50 dark:bg-red-900/30 rounded-2xl flex items-center justify-center mx-auto mb-4 text-red-500">
+                <AlertCircle className="w-6 h-6" />
+              </div>
+              <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-2">
+                Failed to Load Summaries
+              </h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6 leading-relaxed">
+                {error}
+              </p>
+              <button
+                data-testid="retry-button"
+                onClick={() =>
+                  fetchSummaries(currentPage, debouncedSearch, { force: true })
+                }
+                className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl text-sm transition-colors cursor-pointer inline-flex items-center gap-2"
+              >
+                <RefreshCw className="w-4 h-4" />
+                Retry
+              </button>
             </div>
           ) : sortedSummaries.length > 0 ? (
             <>
@@ -508,7 +547,10 @@ const Summaries = () => {
               />
             </>
           ) : (
-            <div className="bg-white dark:bg-gray-800 p-10 rounded-2xl shadow-md border border-gray-100 dark:border-gray-700">
+            <div
+              data-testid="summaries-empty-state"
+              className="bg-white dark:bg-gray-800 p-10 rounded-2xl shadow-md border border-gray-100 dark:border-gray-700"
+            >
               <p className="text-gray-500 dark:text-gray-400">{emptyMessage}</p>
             </div>
           )}

--- a/client/src/pages/__tests__/SummariesErrorState.test.jsx
+++ b/client/src/pages/__tests__/SummariesErrorState.test.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import Summaries from "../Summaries.jsx";
+import { meetingApi } from "../../services";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="navbar">Navbar</nav>,
+}));
+
+vi.mock("../../hooks/useExport.js", () => ({
+  default: () => ({ exportMeeting: vi.fn(), isExporting: false }),
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getAllMeetings: vi.fn(),
+    deleteMeeting: vi.fn(),
+  },
+}));
+
+describe("Summaries API Error and Retry State (#1641)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays dedicated error state on API failure (not empty state) and allows retry", async () => {
+    // First call rejects with 500 error
+    meetingApi.getAllMeetings.mockRejectedValueOnce(
+      new Error("Internal Server Error"),
+    );
+
+    render(
+      <BrowserRouter>
+        <Summaries />
+      </BrowserRouter>,
+    );
+
+    // Should display error state with Retry button
+    await waitFor(() => {
+      expect(screen.getByTestId("summaries-error-state")).toBeInTheDocument();
+      expect(screen.getByText("Failed to Load Summaries")).toBeInTheDocument();
+      expect(screen.getByTestId("retry-button")).toBeInTheDocument();
+    });
+
+    // Should NOT display the normal empty state
+    expect(
+      screen.queryByTestId("summaries-empty-state"),
+    ).not.toBeInTheDocument();
+
+    // Setup second call to succeed on retry
+    meetingApi.getAllMeetings.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [
+          {
+            _id: "m_1",
+            title: "Sprint Review",
+            createdAt: new Date().toISOString(),
+            summary: "Sprint 42 completed on schedule",
+          },
+        ],
+        pagination: { total: 1, page: 1, limit: 9, totalPages: 1 },
+      },
+    });
+
+    // Click Retry
+    fireEvent.click(screen.getByTestId("retry-button"));
+
+    // Should now render the summary card and clear error state
+    await waitFor(() => {
+      expect(screen.getByText("Sprint Review")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("summaries-error-state"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("displays legitimate empty state when API succeeds with no summaries", async () => {
+    meetingApi.getAllMeetings.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [],
+        pagination: { total: 0, page: 1, limit: 9, totalPages: 0 },
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <Summaries />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("summaries-empty-state")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("summaries-error-state"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1641

## Description
This PR adds a dedicated error and retry state to the Summaries.jsx page when the meeting summaries API request fails, preventing API failures from misleadingly appearing as an empty library.

## Proposed Changes
- **Dedicated Error State**: Added explicit error tracking (error state) in Summaries.jsx displayed when meetingApi.getAllMeetings fails.
- **Retry Action**: Provided an interactive Retry button that triggers a forced refetch of summaries without requiring a full browser refresh.
- **Legitimate Empty State Preservation**: Kept the empty summaries message strictly for successful responses that return no meetings.
- **Unit Test Coverage**: Added Vitest test suite (SummariesErrorState.test.jsx) verifying error UI presentation on 500 failure, retry functionality, and distinct empty state presentation on successful empty list.

## Checklist
- [x] Related Issue is linked (Fixes #1641).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.