### PR TITLE
fix(meeting-details): return to meetings on back action and error states

### DIFF
--- a/client/src/components/meeting-details/MeetingActions.jsx
+++ b/client/src/components/meeting-details/MeetingActions.jsx
@@ -98,7 +98,15 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
   };
 
   const handleBack = () => {
-    navigate("/summaries");
+    if (
+      window.history.state &&
+      typeof window.history.state.idx === "number" &&
+      window.history.state.idx > 0
+    ) {
+      navigate(-1);
+    } else {
+      navigate("/meetings");
+    }
   };
 
   // Recording handlers

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -77,12 +77,24 @@ const MeetingDetails = () => {
     fetchMeetingDetails();
   }, [id]);
 
+  const handleBack = () => {
+    if (
+      window.history.state &&
+      typeof window.history.state.idx === "number" &&
+      window.history.state.idx > 0
+    ) {
+      navigate(-1);
+    } else {
+      navigate("/meetings");
+    }
+  };
+
   const handleDelete = async (meetingId) => {
     try {
       const { data } = await meetingApi.deleteMeeting(meetingId);
       if (data.success) {
         toast.success("Meeting deleted successfully");
-        navigate("/summaries");
+        navigate("/meetings");
       } else {
         toast.error(data.message || "Failed to delete meeting");
       }
@@ -148,7 +160,7 @@ const MeetingDetails = () => {
               </h2>
               <p className="text-gray-600 dark:text-gray-400 mb-6">{error}</p>
               <button
-                onClick={() => navigate("/summaries")}
+                onClick={handleBack}
                 className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
               >
                 Back to Meetings
@@ -173,7 +185,7 @@ const MeetingDetails = () => {
                 The meeting you're looking for doesn't exist.
               </p>
               <button
-                onClick={() => navigate("/summaries")}
+                onClick={handleBack}
                 className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
               >
                 Back to Meetings

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MeetingDetails from "../MeetingDetails.jsx";
+import MeetingActions from "../../components/meeting-details/MeetingActions.jsx";
+import { meetingApi } from "../../services";
+import { getBriefing } from "../../services/briefingApi";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: "meeting-123" }),
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useUser: () => ({
+    user: {
+      id: "user_test",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+    },
+    isSignedIn: true,
+  }),
+  useAuth: () => ({ userId: "user_test", getToken: vi.fn() }),
+  useClerk: () => ({ signOut: vi.fn() }),
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar" />,
+}));
+
+vi.mock("../../components/summaries/RecapStoryViewer.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getMeetingById: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/briefingApi", () => ({
+  getBriefing: vi.fn().mockResolvedValue({ data: {} }),
+}));
+
+describe("Meeting Details Back / Error Navigation (#1655)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBriefing.mockResolvedValue({ data: {} });
+    // Default history state with no previous SPA entry
+    window.history.replaceState({ idx: 0 }, "");
+  });
+
+  it("navigates to /meetings when Back CTA clicked on error state with direct URL", async () => {
+    meetingApi.getMeetingById.mockRejectedValueOnce({
+      response: { data: { message: "Meeting load failure" } },
+    });
+
+    render(<MeetingDetails />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Error Loading Meeting")).toBeInTheDocument();
+    });
+
+    const backButton = screen.getByRole("button", {
+      name: /back to meetings/i,
+    });
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/meetings");
+    expect(mockNavigate).not.toHaveBeenCalledWith("/summaries");
+  });
+
+  it("navigates back (-1) on error state when browser history exists", async () => {
+    window.history.replaceState({ idx: 2 }, "");
+    meetingApi.getMeetingById.mockRejectedValueOnce({
+      response: { data: { message: "Meeting load failure" } },
+    });
+
+    render(<MeetingDetails />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Error Loading Meeting")).toBeInTheDocument();
+    });
+
+    const backButton = screen.getByRole("button", {
+      name: /back to meetings/i,
+    });
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(mockNavigate).not.toHaveBeenCalledWith("/summaries");
+  });
+
+  it("navigates to /meetings when meeting not found on direct URL", async () => {
+    meetingApi.getMeetingById.mockResolvedValueOnce({
+      data: { success: true, meeting: null },
+    });
+
+    render(<MeetingDetails />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Meeting Not Found")).toBeInTheDocument();
+    });
+
+    const backButton = screen.getByRole("button", {
+      name: /back to meetings/i,
+    });
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/meetings");
+    expect(mockNavigate).not.toHaveBeenCalledWith("/summaries");
+  });
+
+  it("MeetingActions back button navigates back (-1) when history exists and /meetings as fallback", () => {
+    // 1. Direct URL (idx 0)
+    window.history.replaceState({ idx: 0 }, "");
+    const { unmount } = render(
+      <MeetingActions
+        meeting={{ _id: "123", title: "Test" }}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+      />,
+    );
+
+    const backButton = screen.getByRole("button", {
+      name: /back to meeting repository/i,
+    });
+    fireEvent.click(backButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/meetings");
+    expect(mockNavigate).not.toHaveBeenCalledWith("/summaries");
+
+    unmount();
+    mockNavigate.mockClear();
+
+    // 2. Navigated in app (idx > 0)
+    window.history.replaceState({ idx: 3 }, "");
+    render(
+      <MeetingActions
+        meeting={{ _id: "123", title: "Test" }}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+      />,
+    );
+
+    const backButton2 = screen.getByRole("button", {
+      name: /back to meeting repository/i,
+    });
+    fireEvent.click(backButton2);
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(mockNavigate).not.toHaveBeenCalledWith("/summaries");
+  });
+});


### PR DESCRIPTION
# Description
Fixes the back navigation and error-state CTA behavior on the Meeting Details page. Previously, the "Back" action and error/not-found fallback buttons navigated users to the `/summaries` route instead of returning them to the meeting repository or previous browser history. This change introduces SPA history traversal fallback (`window.history.state?.idx > 0 ? navigate(-1) : navigate('/meetings')`) across `MeetingActions.jsx` and `MeetingDetails.jsx`.

Closes #1655

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Changes Made
- Updated [MeetingActions.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/components/meeting-details/MeetingActions.jsx) so clicking the Back button checks SPA history depth (`window.history.state?.idx > 0 ? navigate(-1) : navigate('/meetings')`).
- Updated [MeetingDetails.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/pages/MeetingDetails.jsx) "Back to Meetings" CTAs for 404 / error states to consistently route to `/meetings`.
- Added unit tests in [MeetingDetailsNavigation.test.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx) covering back button clicks with and without history state, as well as error state recovery clicks.

## Visual Changes
Back button now smoothly navigates back in SPA history or lands on `/meetings`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Back navigation from meeting details now returns to the previous page when available.
  * Direct visits and unavailable meeting pages now fall back to the Meetings page.
  * Deleting a meeting now returns to the Meetings page instead of the Summaries page.

* **Tests**
  * Added coverage for back navigation, loading errors, missing meetings, and direct URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->