### PR TITLE
fix(footer): localize footer navigation labels using i18n

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -72,7 +72,7 @@ const Footer = () => {
                 {t("footer.security", "Security")}
               </Link>
               <Link to="/cookie-policy" className={footerLinkClass}>
-                Cookies
+                {t("footer.cookies", "Cookies")}
               </Link>
               <Link to="/help-center" className={footerLinkClass}>
                 {t("footer.helpCenter", "Help Center")}
@@ -84,7 +84,7 @@ const Footer = () => {
                 to="/docs"
                 className={`${footerLinkClass} font-semibold text-blue-600 dark:text-blue-400`}
               >
-                Developer Docs
+                {t("footer.developerDocs", "Developer Docs")}
               </Link>
               <span className="text-gray-300 dark:text-gray-700">|</span>
               <Link to="/contact" className={footerLinkClass}>
@@ -100,7 +100,7 @@ const Footer = () => {
                 className={`${footerLinkClass} flex items-center gap-1`}
               >
                 <Github className="h-3.5 w-3.5" aria-hidden="true" />
-                GitHub
+                {t("footer.github", "GitHub")}
               </a>
             </div>
           </div>
@@ -193,7 +193,7 @@ const Footer = () => {
             <ul className="flex flex-col gap-2.5">
               <li>
                 <Link to="/" className={footerLinkClass}>
-                  Home
+                  {t("footer.home", t("navbar.home", "Home"))}
                 </Link>
               </li>
               <li>
@@ -258,7 +258,7 @@ const Footer = () => {
               </li>
               <li>
                 <Link to="/contact" className={footerLinkClass}>
-                  Contact Support
+                  {t("footer.contactSupport", "Contact Support")}
                 </Link>
               </li>
               <li>
@@ -271,7 +271,7 @@ const Footer = () => {
                   to="/docs"
                   className={`${footerLinkClass} font-semibold text-blue-600 dark:text-blue-400`}
                 >
-                  Developer Docs
+                  {t("footer.developerDocs", "Developer Docs")}
                 </Link>
               </li>
               <li>
@@ -282,7 +282,7 @@ const Footer = () => {
                   aria-label="MeetOnMemory GitHub repository (opens in new tab)"
                   className={footerLinkClass}
                 >
-                  GitHub Repository
+                  {t("footer.githubRepo", "GitHub Repository")}
                 </a>
               </li>
               <li>
@@ -293,7 +293,7 @@ const Footer = () => {
                   aria-label="Report issues on GitHub (opens in new tab)"
                   className={footerLinkClass}
                 >
-                  Report Issues
+                  {t("footer.reportIssues", "Report Issues")}
                 </a>
               </li>
               <li>
@@ -304,7 +304,7 @@ const Footer = () => {
                   aria-label="Contributing guide (opens in new tab)"
                   className={footerLinkClass}
                 >
-                  Contributing
+                  {t("footer.contributing", "Contributing")}
                 </a>
               </li>
               <li>
@@ -315,7 +315,7 @@ const Footer = () => {
                   aria-label="Code of Conduct (opens in new tab)"
                   className={footerLinkClass}
                 >
-                  Code of Conduct
+                  {t("footer.codeOfConduct", "Code of Conduct")}
                 </a>
               </li>
             </ul>
@@ -371,7 +371,7 @@ const Footer = () => {
             </ul>
 
             <p className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-              Built with
+              {t("footer.builtWith", "Built with")}
             </p>
             <ul className="flex flex-col gap-2">
               {[
@@ -418,7 +418,7 @@ const Footer = () => {
               </Link>
               <span aria-hidden="true">•</span>
               <Link to="/cookie-policy" className={footerLinkClass}>
-                Cookies
+                {t("footer.cookies", "Cookies")}
               </Link>
               <span aria-hidden="true">•</span>
               <Link to="/help-center" className={footerLinkClass}>

--- a/client/src/components/__tests__/FooterLocalization.test.jsx
+++ b/client/src/components/__tests__/FooterLocalization.test.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import i18n from "../../i18n";
+import Footer from "../Footer";
+
+describe("Footer Localization (#1662)", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
+  });
+
+  it("renders english footer navigation labels correctly", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Footer />
+      </MemoryRouter>,
+    );
+
+    // Verify key localized strings in English
+    expect(screen.getAllByText("Cookies").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Developer Docs").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Contact Support").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GitHub Repository").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Report Issues").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Contributing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Code of Conduct").length).toBeGreaterThan(0);
+    expect(screen.getByText("Built with")).toBeInTheDocument();
+  });
+
+  it("renders hindi footer navigation labels when language switched to hi", async () => {
+    await i18n.changeLanguage("hi");
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Footer />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("कुकीज़").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("डेवलपर दस्तावेज़").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("सहायता से संपर्क करें").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText("GitHub रिपॉजिटरी").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("समस्याओं की रिपोर्ट करें").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("योगदान").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("आचार संहिता").length).toBeGreaterThan(0);
+    expect(screen.getByText("इसके साथ निर्मित")).toBeInTheDocument();
+  });
+});

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -188,7 +188,20 @@
     "meetOnMemoryTeam": "the MeetOnMemory Team",
     "starRepo": "Star the repo if you like",
     "status": "System Status",
-    "security": "Security"
+    "security": "Security",
+    "cookies": "Cookies",
+    "home": "Home",
+    "developerDocs": "Developer Docs",
+    "contactSupport": "Contact Support",
+    "githubRepo": "GitHub Repository",
+    "reportIssues": "Report Issues",
+    "contributing": "Contributing",
+    "codeOfConduct": "Code of Conduct",
+    "builtWith": "Built with",
+    "helpCenter": "Help Center",
+    "careers": "Careers",
+    "contact": "Contact",
+    "github": "GitHub"
   },
   "dashboard": {
     "welcomeBack": "Welcome back,",

--- a/client/src/locales/hi.json
+++ b/client/src/locales/hi.json
@@ -188,7 +188,20 @@
     "meetOnMemoryTeam": "MeetOnMemory टीम",
     "starRepo": "पसंद आए तो रिपॉजिटरी को स्टार करें",
     "status": "सिस्टम स्थिति",
-    "security": "सुरक्षा"
+    "security": "सुरक्षा",
+    "cookies": "कुकीज़",
+    "home": "होम",
+    "developerDocs": "डेवलपर दस्तावेज़",
+    "contactSupport": "सहायता से संपर्क करें",
+    "githubRepo": "GitHub रिपॉजिटरी",
+    "reportIssues": "समस्याओं की रिपोर्ट करें",
+    "contributing": "योगदान",
+    "codeOfConduct": "आचार संहिता",
+    "builtWith": "इसके साथ निर्मित",
+    "helpCenter": "सहायता केंद्र",
+    "careers": "करियर",
+    "contact": "संपर्क",
+    "github": "GitHub"
   },
   "dashboard": {
     "welcomeBack": "वापसी पर स्वागत है,",


### PR DESCRIPTION
# Description
Replaces all hardcoded navigation labels and footer text in `Footer.jsx` with `react-i18next` translation keys. Translation strings and nested structures have been added to English (`en.json`) and Hindi (`hi.json`) locale dictionaries to ensure consistent multi-language footer navigation.

Closes #1662

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Changes Made
- Updated [Footer.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/components/Footer.jsx) to replace hardcoded strings ("Cookies", "Developer Docs", "Contact Support", "GitHub Repository", "Report Issues", "Contributing", "Code of Conduct", "Built with", etc.) with `t("footer.*")`.
- Added corresponding translation keys and values to [en.json](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/locales/en.json) and [hi.json](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/locales/hi.json).
- Added comprehensive unit tests in [FooterLocalization.test.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/components/__tests__/FooterLocalization.test.jsx) verifying footer rendering across language switches.

## Visual Changes
All links, legal headers, resource items, and copyright attribution lines update dynamically when language is toggled.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
