### PR TITLE
feat(meetings): add recycle bin recovery CTA after soft-deleting meetings

### DIFF
--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -218,7 +218,18 @@ const MeetingRepository = () => {
       const response = await meetingApi.deleteMeeting(meetingId);
 
       if (response.data?.success) {
-        toast.success("Meeting deleted successfully");
+        toast.success(
+          <div className="flex items-center justify-between gap-3">
+            <span>Meeting moved to recycle bin</span>
+            <button
+              type="button"
+              onClick={() => navigate("/meetings/recycle-bin")}
+              className="text-xs font-semibold text-blue-600 hover:text-blue-700 underline shrink-0"
+            >
+              View Recycle Bin
+            </button>
+          </div>,
+        );
         fetchMeetings();
       } else {
         toast.error(response.data?.message || "Failed to delete meeting");

--- a/client/src/components/meetings/__tests__/MeetingDeleteRecycleBinCta.test.jsx
+++ b/client/src/components/meetings/__tests__/MeetingDeleteRecycleBinCta.test.jsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import MeetingRepository from "../MeetingRepository";
+import { toast } from "react-toastify";
+import { meetingApi } from "../../../services";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services", () => ({
+  meetingApi: {
+    getAllMeetings: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+  savedFilterApi: {
+    getFilters: vi
+      .fn()
+      .mockResolvedValue({ data: { success: true, filters: [] } }),
+    getSavedFilters: vi.fn().mockResolvedValue({ data: [] }),
+    createSavedFilter: vi.fn(),
+    deleteSavedFilter: vi.fn(),
+  },
+}));
+
+vi.mock("../MeetingCard.jsx", () => ({
+  default: ({ meeting, onDelete }) => (
+    <div>
+      <span>{meeting.title}</span>
+      <button onClick={() => onDelete(meeting._id)}>Delete Meeting</button>
+    </div>
+  ),
+}));
+
+vi.mock("../MeetingSearch.jsx", () => ({
+  default: () => <div data-testid="meeting-search" />,
+}));
+
+vi.mock("../MeetingFilters.jsx", () => ({
+  default: () => <div data-testid="meeting-filters" />,
+}));
+
+vi.mock("../Pagination.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../EmptyState.jsx", () => ({
+  default: () => <div>Empty</div>,
+}));
+
+describe("Meeting Soft Delete Recycle Bin CTA (#1685)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("shows toast with 'View Recycle Bin' CTA when meeting is soft deleted and navigates on click", async () => {
+    meetingApi.getAllMeetings.mockResolvedValue({
+      data: {
+        success: true,
+        meetings: [
+          {
+            _id: "m-123",
+            title: "Sprint Planning",
+            createdAt: "2026-08-01T10:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    meetingApi.deleteMeeting.mockResolvedValue({
+      data: {
+        success: true,
+        message: "Meeting deleted successfully",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingRepository />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sprint Planning")).toBeInTheDocument();
+    });
+
+    const deleteBtn = screen.getByRole("button", { name: /delete meeting/i });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(meetingApi.deleteMeeting).toHaveBeenCalledWith("m-123");
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    // Extract JSX passed to toast.success and render it to test interaction
+    const toastCallArg = toast.success.mock.calls[0][0];
+    const { getByRole, getByText } = render(toastCallArg);
+
+    expect(getByText(/meeting moved to recycle bin/i)).toBeInTheDocument();
+    const ctaButton = getByRole("button", { name: /view recycle bin/i });
+    expect(ctaButton).toBeInTheDocument();
+
+    fireEvent.click(ctaButton);
+    expect(mockNavigate).toHaveBeenCalledWith("/meetings/recycle-bin");
+  });
+});

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -81,8 +81,19 @@ const MeetingDetails = () => {
     try {
       const { data } = await meetingApi.deleteMeeting(meetingId);
       if (data.success) {
-        toast.success("Meeting deleted successfully");
-        navigate("/summaries");
+        toast.success(
+          <div className="flex items-center justify-between gap-3">
+            <span>Meeting moved to recycle bin</span>
+            <button
+              type="button"
+              onClick={() => navigate("/meetings/recycle-bin")}
+              className="text-xs font-semibold text-blue-600 hover:text-blue-700 underline shrink-0"
+            >
+              View Recycle Bin
+            </button>
+          </div>,
+        );
+        navigate("/meetings");
       } else {
         toast.error(data.message || "Failed to delete meeting");
       }


### PR DESCRIPTION
# Description
Adds a direct "View Recycle Bin" recovery CTA to toast notifications after soft-deleting a meeting. Previously, users received a text confirmation when a meeting was moved to trash without an immediate action to view the recycle bin or restore the item.

Closes #1685

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Changes Made
- Updated `handleDelete` in [MeetingRepository.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/components/meetings/MeetingRepository.jsx) to trigger an interactive toast containing a "View Recycle Bin" button navigating to `/meetings/recycle-bin`.
- Updated `handleDelete` in [MeetingDetails.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/pages/MeetingDetails.jsx) to offer the same interactive "View Recycle Bin" CTA toast before redirecting to `/meetings`.
- Added unit test in [MeetingDeleteRecycleBinCta.test.jsx](file:///c:/Users/babin/Desktop/ECSoC_2026/MeetOnMemory/client/src/components/meetings/__tests__/MeetingDeleteRecycleBinCta.test.jsx) and verified existing meeting repository tests pass.

## Visual Changes
Toast on soft deletion now renders:
> Meeting moved to Recycle Bin.  [View Recycle Bin]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting deletion now displays a notification confirming the meeting was moved to the recycle bin.
  * Added a “View Recycle Bin” link for quick access to deleted meetings.

* **Bug Fixes**
  * Improved deletion feedback across meeting lists and meeting details pages.

* **Tests**
  * Added coverage for deletion notifications and recycle bin navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->