### PR TITLE
fix: improve poll voting keyboard accessibility and replace alert popups

### DIFF
--- a/client/src/components/meeting-details/MeetingActions.jsx
+++ b/client/src/components/meeting-details/MeetingActions.jsx
@@ -36,7 +36,7 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
 
   const handleDownloadTranscript = () => {
     if (!meeting.transcript) {
-      alert("No transcript available to download.");
+      toast.error("No transcript available to download.");
       return;
     }
 

--- a/client/src/components/meeting-details/MeetingTranscript.jsx
+++ b/client/src/components/meeting-details/MeetingTranscript.jsx
@@ -44,7 +44,7 @@ const MeetingTranscript = ({ meeting }) => {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(transcript);
-      alert("Transcript copied to clipboard!");
+      toast.success("Transcript copied to clipboard!");
     } catch (err) {
       console.error("Failed to copy:", err);
     }

--- a/client/src/components/meeting-details/PollSection.jsx
+++ b/client/src/components/meeting-details/PollSection.jsx
@@ -139,9 +139,6 @@ const PollSection = ({ meetingId }) => {
       const selectedOptionIds = [optionId];
       await castVote(pollId, selectedOptionIds);
       toast.success("Vote submitted successfully!");
-    } catch (err) {
-      console.error(err);
-      toast.error(err.response?.data?.message || "Error casting vote");
     }
   };
 

--- a/client/src/components/meeting-details/PollSection.jsx
+++ b/client/src/components/meeting-details/PollSection.jsx
@@ -139,6 +139,9 @@ const PollSection = ({ meetingId }) => {
       const selectedOptionIds = [optionId];
       await castVote(pollId, selectedOptionIds);
       toast.success("Vote submitted successfully!");
+    } catch (err) {
+      console.error(err);
+      toast.error(err.response?.data?.message || "Error casting vote");
     }
   };
 

--- a/client/src/components/meeting-details/PollSection.jsx
+++ b/client/src/components/meeting-details/PollSection.jsx
@@ -316,6 +316,9 @@ const PollSection = ({ meetingId }) => {
                   return (
                     <div
                       key={opt._id}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Vote for ${opt.text}`}
                       className={`relative overflow-hidden rounded-md border p-3 cursor-pointer transition-colors ${
                         !poll.isAnonymous &&
                         opt.votes.some(
@@ -332,6 +335,17 @@ const PollSection = ({ meetingId }) => {
                           poll.options,
                         )
                       }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleVote(
+                            poll._id,
+                            poll.pollType,
+                            opt._id,
+                            poll.options,
+                          );
+                        }
+                      }}
                     >
                       <div
                         className="absolute top-0 left-0 h-full bg-blue-100 dark:bg-blue-900/30 opacity-50 z-0 transition-all duration-500"

--- a/client/src/pages/AiSearch.jsx
+++ b/client/src/pages/AiSearch.jsx
@@ -11,6 +11,7 @@ import SearchSkeleton from "../components/ai-search/SearchSkeleton.jsx";
 import SearchEmptyState from "../components/ai-search/SearchEmptyState.jsx";
 import { apiClient } from "../services";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
+import { toast } from "react-toastify";
 
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -270,7 +271,7 @@ const AiSearch = () => {
     if (textToCopy) {
       try {
         await navigator.clipboard.writeText(textToCopy);
-        alert(t("aiSearch.copiedToClipboard"));
+        toast.success(t("aiSearch.copiedToClipboard"));
       } catch (err) {
         console.error("Failed to copy:", err);
       }


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves issue #987 by implementing keyboard accessibility for poll voting and replacing synchronous `alert()` calls with accessible `toast` notifications.

Specifically, it:
1. Adds keyboard interaction support (`Enter` and `Space` keys) on poll options within [PollSection.jsx](file:///client/src/components/meeting-details/PollSection.jsx) to enable keyboard-only users to cast votes.
2. Implements standard accessibility attributes (`role="button"`, `tabIndex={0}`, and `aria-label`) on the clickable poll option cards.
3. Replaces non-blocking but inaccessible browser `alert()` popups with toast notifications using `react-toastify` in [MeetingActions.jsx](file:///client/src/components/meeting-details/MeetingActions.jsx), [MeetingTranscript.jsx](file:///client/src/components/meeting-details/MeetingTranscript.jsx), [PollSection.jsx](file:///client/src/components/meeting-details/PollSection.jsx), and [AiSearch.jsx](file:///client/src/pages/AiSearch.jsx).

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [x] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #987

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Poll options can now be selected using Enter or Space, in addition to clicking.
  * Improved keyboard focus and accessible labels for single-choice poll options.

* **User Experience**
  * Replaced browser alerts with consistent toast notifications for transcript download errors and successful copy actions.
  * Added success toast feedback when copying AI search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->