### PR TITLE
fix: remove duplicate MeetingRoom header and footer

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,7 +22,7 @@ const App = () => {
   const location = useLocation();
   const { isLoggedin } = useContext(AppContent);
 
-  const hideFooterRoutes = ["/login", "/signup"];
+  const hideFooterRoutes = ["/login", "/signup", "/meeting-room"];
   const shouldShowFooter = !hideFooterRoutes.some(
     (route) =>
       location.pathname === route || location.pathname.startsWith(`${route}/`),

--- a/client/src/__tests__/App.test.jsx
+++ b/client/src/__tests__/App.test.jsx
@@ -83,6 +83,9 @@ vi.mock("../pages/SignUp.jsx", () => ({
 vi.mock("../pages/Dashboard.jsx", () => ({
   default: () => <div data-testid="dashboard-page" />,
 }));
+vi.mock("../pages/MeetingRoom.jsx", () => ({
+  default: () => <div data-testid="meeting-room-page" />,
+}));
 
 describe("App Routing", () => {
   it("renders Home on the root path (PublicRoute)", () => {
@@ -137,6 +140,20 @@ describe("App Routing", () => {
     );
     expect(screen.getByTestId("protected-route")).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  it("hides Footer on the live MeetingRoom route (#1647)", () => {
+    render(
+      <MemoryRouter initialEntries={["/meeting-room/room-123"]}>
+        <AppContent.Provider value={{ isLoggedin: true }}>
+          <App />
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("meeting-room-page")).toBeInTheDocument();
+    expect(screen.queryByTestId("footer")).not.toBeInTheDocument();
   });
 
   it("renders NotFound page as fallback on unknown paths", () => {

--- a/client/src/components/meetings/MeetingHeader.jsx
+++ b/client/src/components/meetings/MeetingHeader.jsx
@@ -7,6 +7,7 @@ import {
   NotebookPen,
   Captions,
   FileText,
+  Lightbulb,
 } from "lucide-react";
 
 export default function MeetingHeader({
@@ -16,6 +17,8 @@ export default function MeetingHeader({
   copyLink,
   showNotes,
   setShowNotes,
+  showParkingLot,
+  setShowParkingLot,
   transcriptionEnabled,
   toggleTranscription,
   showTranscript,
@@ -29,7 +32,11 @@ export default function MeetingHeader({
   };
 
   return (
-    <div className="h-16 bg-gray-900 border-b border-gray-800 flex items-center justify-between px-6 z-20 shrink-0">
+    <header
+      role="banner"
+      aria-label="Meeting room header"
+      className="h-16 bg-gray-900 border-b border-gray-800 flex items-center justify-between px-6 z-20 shrink-0"
+    >
       <div className="flex items-center gap-4">
         <h2 className="text-lg font-bold text-white truncate max-w-xs md:max-w-md">
           Room: {roomId}
@@ -68,6 +75,24 @@ export default function MeetingHeader({
         </span>
       </button>
 
+      {typeof setShowParkingLot === "function" && (
+        <button
+          type="button"
+          onClick={() => setShowParkingLot((v) => !v)}
+          className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
+            showParkingLot
+              ? "bg-indigo-600 text-white hover:bg-indigo-700"
+              : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
+          }`}
+          title={showParkingLot ? "Hide parking lot" : "Open parking lot"}
+        >
+          <Lightbulb size={16} />
+          <span className="hidden sm:inline">
+            {showParkingLot ? "Hide Ideas" : "Parking Lot"}
+          </span>
+        </button>
+      )}
+
       {/* Transcription Toggle */}
       <button
         onClick={toggleTranscription}
@@ -103,6 +128,6 @@ export default function MeetingHeader({
           {showTranscript ? "Hide" : "Transcript"}
         </span>
       </button>
-    </div>
+    </header>
   );
 }

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -11,18 +11,7 @@ import { io } from "socket.io-client";
 import { useAuth } from "@clerk/clerk-react";
 import Peer from "simple-peer";
 import { toast } from "react-toastify";
-import {
-  Loader2,
-  CheckCircle2,
-  Clock,
-  Users,
-  Copy,
-  PanelRightClose,
-  NotebookPen,
-  Captions,
-  FileText,
-  Lightbulb,
-} from "lucide-react";
+import { Loader2, CheckCircle2 } from "lucide-react";
 import CollaborativeEditor from "../components/meetings/CollaborativeEditor.jsx";
 import ParkingLotPanel from "../components/meetings/ParkingLotPanel.jsx";
 import PeerVideo from "../components/meetings/PeerVideo.jsx";
@@ -72,13 +61,6 @@ const MeetingRoom = () => {
   const screenTrackRef = useRef();
   const peersRef = useRef([]);
   const backendUrl = import.meta.env.VITE_BACKEND_URL;
-
-  const formatTime = (seconds) => {
-    const hrs = Math.floor(seconds / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-    return `${hrs > 0 ? hrs + ":" : ""}${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  };
 
   const [joined, setJoined] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -535,104 +517,6 @@ const MeetingRoom = () => {
       {/* ---------- ACTIVE MEETING SCREEN ---------- */}
       {joined && !meetingEnded && (
         <div className="flex-1 flex flex-col min-h-0 bg-gray-900 relative">
-          {/* Header */}
-          <div className="h-16 bg-gray-900 border-b border-gray-800 flex items-center justify-between px-6 z-20 shrink-0">
-            <div className="flex items-center gap-4">
-              <h2 className="text-lg font-bold text-white truncate max-w-xs md:max-w-md">
-                Room: {roomId}
-              </h2>
-              <div className="flex items-center gap-2 text-gray-300 bg-gray-800 px-3 py-1 rounded-full text-sm font-mono">
-                <Clock size={14} />
-                <span>{formatTime(timerState.elapsed)}</span>
-              </div>
-              <div className="flex items-center gap-2 text-gray-300 bg-gray-800 px-3 py-1 rounded-full text-sm">
-                <Users size={16} />
-                <span>{peers.length + 1}</span>
-              </div>
-            </div>
-
-            <button
-              onClick={copyLink}
-              className="text-gray-300 hover:text-white flex items-center gap-1.5 text-sm font-semibold bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-xl transition-all cursor-pointer"
-            >
-              <Copy size={16} />
-              <span className="hidden sm:inline">Copy Link</span>
-            </button>
-
-            {/* Notes Toggle */}
-            <button
-              onClick={() => setShowNotes((v) => !v)}
-              className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-                showNotes
-                  ? "bg-indigo-600 text-white hover:bg-indigo-700"
-                  : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
-              }`}
-              title={showNotes ? "Hide notes" : "Open collaborative notes"}
-            >
-              {showNotes ? (
-                <PanelRightClose size={16} />
-              ) : (
-                <NotebookPen size={16} />
-              )}
-              <span className="hidden sm:inline">
-                {showNotes ? "Hide Notes" : "Notes"}
-              </span>
-            </button>
-
-            {/* Parking Lot Toggle */}
-            <button
-              onClick={() => setShowParkingLot((v) => !v)}
-              className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-                showParkingLot
-                  ? "bg-indigo-600 text-white hover:bg-indigo-700"
-                  : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
-              }`}
-              title={showParkingLot ? "Hide parking lot" : "Open parking lot"}
-            >
-              <Lightbulb size={16} />
-              <span className="hidden sm:inline">
-                {showParkingLot ? "Hide Ideas" : "Parking Lot"}
-              </span>
-            </button>
-
-            {/* Transcription Toggle */}
-            <button
-              onClick={toggleTranscription}
-              className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-                transcriptionEnabled
-                  ? "bg-green-600 text-white hover:bg-green-700"
-                  : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
-              }`}
-              title={
-                transcriptionEnabled
-                  ? "Stop transcription"
-                  : "Start live transcription"
-              }
-            >
-              <Captions size={16} />
-              <span className="hidden sm:inline">
-                {transcriptionEnabled ? "Stop" : "Captions"}
-              </span>
-            </button>
-
-            {/* Transcript Toggle */}
-            <button
-              onClick={() => setShowTranscript((v) => !v)}
-              className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-                showTranscript
-                  ? "bg-indigo-600 text-white hover:bg-indigo-700"
-                  : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
-              }`}
-              title={showTranscript ? "Hide transcript" : "Show transcript"}
-            >
-              <FileText size={16} />
-              <span className="hidden sm:inline">
-                {showTranscript ? "Hide" : "Transcript"}
-              </span>
-            </button>
-          </div>
-          <ReactionOverlay reactions={reactions} />
-
           <MeetingHeader
             roomId={roomId}
             duration={timerState.elapsed}
@@ -640,11 +524,14 @@ const MeetingRoom = () => {
             copyLink={copyLink}
             showNotes={showNotes}
             setShowNotes={setShowNotes}
+            showParkingLot={showParkingLot}
+            setShowParkingLot={setShowParkingLot}
             transcriptionEnabled={transcriptionEnabled}
             toggleTranscription={toggleTranscription}
             showTranscript={showTranscript}
             setShowTranscript={setShowTranscript}
           />
+          <ReactionOverlay reactions={reactions} />
 
           {/* Main content area: video grid + notes panel */}
           <div className="flex-1 flex min-h-0 overflow-hidden">

--- a/client/src/pages/__tests__/MeetingRoomLayout.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomLayout.test.jsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MeetingRoom from "../MeetingRoom.jsx";
+import AppContent from "../../context/AppContent.js";
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ roomId: "room-layout-123" }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    isSignedIn: true,
+    isLoaded: true,
+    userId: "user_1",
+  }),
+}));
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    id: "socket_1",
+    auth: {},
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async () => ({
+    auth: { token: "token_1" },
+    transports: ["websocket"],
+  })),
+  getClerkBearerToken: vi.fn(async () => "token_1"),
+}));
+
+vi.mock("../../hooks/useDevicePermission", () => ({
+  default: () => ({
+    selectedCamera: "cam-1",
+    selectedMicrophone: "mic-1",
+    releaseStream: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useWebRTC", () => ({
+  default: () => ({
+    socketRef: { current: { on: vi.fn(), emit: vi.fn(), disconnect: vi.fn() } },
+    userVideoRef: { current: null },
+    streamRef: { current: null },
+  }),
+}));
+
+vi.mock("../../hooks/useLiveTranscription", () => ({
+  default: () => ({
+    toggleTranscription: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useReactions", () => ({
+  default: () => ({
+    reactions: [],
+    sendReaction: vi.fn(),
+    onCooldown: false,
+  }),
+}));
+
+vi.mock("../../utils/mediaStream", () => ({
+  resolveMeetingMediaStream: vi.fn().mockResolvedValue({
+    getTracks: () => [],
+    getAudioTracks: () => [],
+    getVideoTracks: () => [],
+  }),
+  getTrackEnabledState: vi
+    .fn()
+    .mockReturnValue({ micOn: true, cameraOn: true }),
+}));
+
+vi.mock("../../components/meetings/DeviceSetupModal.jsx", () => ({
+  default: ({ onJoin }) => (
+    <div data-testid="device-setup">
+      <button type="button" onClick={() => onJoin(null)}>
+        Mock Join Button
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/meetings/CollaborativeEditor.jsx", () => ({
+  default: () => <div data-testid="editor">Editor</div>,
+}));
+
+vi.mock("../../components/meetings/ParkingLotPanel.jsx", () => ({
+  default: () => <div data-testid="parking-lot">Parking Lot Panel</div>,
+}));
+
+vi.mock("../../components/meetings/TranscriptPanel.jsx", () => ({
+  default: () => <div data-testid="transcript">Transcript</div>,
+}));
+
+vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({
+  default: () => <div data-testid="captions">Captions</div>,
+}));
+
+describe("MeetingRoom layout (#1647)", () => {
+  const wrapper = ({ children }) => (
+    <AppContent.Provider
+      value={{
+        userData: { _id: "mongo_user_1", name: "Alice" },
+      }}
+    >
+      {children}
+    </AppContent.Provider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the device setup screen before joining", () => {
+    render(<MeetingRoom />, { wrapper });
+
+    expect(screen.getByTestId("device-setup")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("banner", { name: /meeting room header/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a single live meeting header after joining", async () => {
+    render(<MeetingRoom />, { wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /mock join button/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("banner", { name: /meeting room header/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getAllByRole("banner", { name: /meeting room header/i }),
+    ).toHaveLength(1);
+    expect(screen.getAllByText(/Room: room-layout-123/i)).toHaveLength(1);
+  });
+
+  it("keeps live meeting controls available after joining", async () => {
+    render(<MeetingRoom />, { wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /mock join button/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /copy link/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /^notes$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /parking lot/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /captions/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /transcript/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /leave/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /mute microphone/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the marketing footer inside MeetingRoom", async () => {
+    render(<MeetingRoom />, { wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /mock join button/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("banner", { name: /meeting room header/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("contentinfo")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1647

Fixes the live MeetingRoom layout by removing the duplicate header and hiding the marketing Footer during active meetings.

## Problem

The MeetingRoom page rendered two header implementations and also displayed the global marketing Footer.

This created duplicated navigation, wasted screen space, and made the live meeting experience less focused.

## Changes Made

### MeetingRoom Header

- Removed the duplicate inline header from `MeetingRoom.jsx`.
- Kept the shared live-room `MeetingHeader.jsx`.
- Moved the Parking Lot toggle into the shared header so no functionality was lost.
- Preserved existing room information, timer, participant count, Copy Link, Notes, Captions, and Transcript controls.
- Meeting controls such as microphone, camera, screen sharing, and Leave remain unchanged.

### Marketing Footer

- Added `/meeting-room` to the existing Footer exclusion logic in `App.jsx`.
- Both `/meeting-room` and `/meeting-room/:roomId` now hide the marketing Footer.
- Existing Footer behavior for other application pages remains unchanged.

## Tests Added

Regression coverage verifies:

- Only one MeetingRoom header is rendered.
- Duplicate room header content is removed.
- Meeting controls remain available.
- Parking Lot functionality remains available.
- Marketing Footer is not rendered inside MeetingRoom.
- MeetingRoom route hides the Footer.
- Dashboard continues to display the Footer.
- Login and signup Footer behavior remains unchanged.

## Files Changed

### Modified

- `client/src/pages/MeetingRoom.jsx`
- `client/src/components/meetings/MeetingHeader.jsx`
- `client/src/App.jsx`
- `client/src/__tests__/App.test.jsx`

### Added

- `client/src/pages/__tests__/MeetingRoomLayout.test.jsx`

## Expected Behavior

| Scenario | Result |
|---|---|
| Open MeetingRoom | One meeting header |
| Duplicate header | Removed |
| Parking Lot | Remains available |
| Notes / Captions / Transcript | Remain available |
| Mic / Camera / Screen Share | Remain functional |
| Leave meeting | Remains available |
| Marketing Footer in MeetingRoom | Hidden |
| Dashboard Footer | Still visible |
| Login/Signup Footer | Still hidden |

## Scope

This is a focused frontend layout fix.

No backend APIs, meeting logic, authentication, Socket.IO behavior, or core meeting functionality were changed.

## Manual Verification

- [ ] Join `/meeting-room/:roomId`.
- [ ] Verify exactly one header is visible.
- [ ] Verify room ID, timer, and participant count are displayed.
- [ ] Verify Copy Link, Notes, Parking Lot, Captions, and Transcript remain available.
- [ ] Verify microphone, camera, screen share, and Leave controls remain functional.
- [ ] Verify the marketing Footer is not displayed.
- [ ] Verify Dashboard still displays the Footer.
- [ ] Verify Login/Signup still hide the Footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Parking Lot toggle to meeting-room controls.
  - Improved meeting-room header accessibility with semantic labeling.
  - Consolidated meeting controls into a consistent header.

- **Bug Fixes**
  - Hidden the marketing footer from meeting rooms and nested meeting-room pages.
  - Ensured meeting-room layouts display the correct controls and room information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->