### PR TITLE
fix: make MeetingRoom side panels mutually exclusive

### DIFF
--- a/client/src/components/meetings/MeetingHeader.jsx
+++ b/client/src/components/meetings/MeetingHeader.jsx
@@ -15,14 +15,10 @@ export default function MeetingHeader({
   duration,
   peers,
   copyLink,
-  showNotes,
-  setShowNotes,
-  showParkingLot,
-  setShowParkingLot,
+  activePanel,
+  onTogglePanel,
   transcriptionEnabled,
   toggleTranscription,
-  showTranscript,
-  setShowTranscript,
 }) {
   const formatTime = (seconds) => {
     const hrs = Math.floor(seconds / 3600);
@@ -30,6 +26,10 @@ export default function MeetingHeader({
     const secs = seconds % 60;
     return `${hrs > 0 ? hrs + ":" : ""}${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
   };
+
+  const isNotesOpen = activePanel === "notes";
+  const isParkingLotOpen = activePanel === "parkingLot";
+  const isTranscriptOpen = activePanel === "transcript";
 
   return (
     <header
@@ -52,6 +52,7 @@ export default function MeetingHeader({
       </div>
 
       <button
+        type="button"
         onClick={copyLink}
         className="text-gray-300 hover:text-white flex items-center gap-1.5 text-sm font-semibold bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-xl transition-all cursor-pointer"
       >
@@ -61,40 +62,46 @@ export default function MeetingHeader({
 
       {/* Notes Toggle */}
       <button
-        onClick={() => setShowNotes((v) => !v)}
+        type="button"
+        onClick={() => onTogglePanel("notes")}
+        aria-pressed={isNotesOpen}
         className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-          showNotes
+          isNotesOpen
             ? "bg-indigo-600 text-white hover:bg-indigo-700"
             : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
         }`}
-        title={showNotes ? "Hide notes" : "Open collaborative notes"}
+        title={isNotesOpen ? "Hide notes" : "Open collaborative notes"}
       >
-        {showNotes ? <PanelRightClose size={16} /> : <NotebookPen size={16} />}
+        {isNotesOpen ? (
+          <PanelRightClose size={16} />
+        ) : (
+          <NotebookPen size={16} />
+        )}
         <span className="hidden sm:inline">
-          {showNotes ? "Hide Notes" : "Notes"}
+          {isNotesOpen ? "Hide Notes" : "Notes"}
         </span>
       </button>
 
-      {typeof setShowParkingLot === "function" && (
-        <button
-          type="button"
-          onClick={() => setShowParkingLot((v) => !v)}
-          className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-            showParkingLot
-              ? "bg-indigo-600 text-white hover:bg-indigo-700"
-              : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
-          }`}
-          title={showParkingLot ? "Hide parking lot" : "Open parking lot"}
-        >
-          <Lightbulb size={16} />
-          <span className="hidden sm:inline">
-            {showParkingLot ? "Hide Ideas" : "Parking Lot"}
-          </span>
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => onTogglePanel("parkingLot")}
+        aria-pressed={isParkingLotOpen}
+        className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
+          isParkingLotOpen
+            ? "bg-indigo-600 text-white hover:bg-indigo-700"
+            : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
+        }`}
+        title={isParkingLotOpen ? "Hide parking lot" : "Open parking lot"}
+      >
+        <Lightbulb size={16} />
+        <span className="hidden sm:inline">
+          {isParkingLotOpen ? "Hide Ideas" : "Parking Lot"}
+        </span>
+      </button>
 
       {/* Transcription Toggle */}
       <button
+        type="button"
         onClick={toggleTranscription}
         className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
           transcriptionEnabled
@@ -115,17 +122,19 @@ export default function MeetingHeader({
 
       {/* Transcript Toggle */}
       <button
-        onClick={() => setShowTranscript((v) => !v)}
+        type="button"
+        onClick={() => onTogglePanel("transcript")}
+        aria-pressed={isTranscriptOpen}
         className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
-          showTranscript
+          isTranscriptOpen
             ? "bg-indigo-600 text-white hover:bg-indigo-700"
             : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
         }`}
-        title={showTranscript ? "Hide transcript" : "Show transcript"}
+        title={isTranscriptOpen ? "Hide transcript" : "Show transcript"}
       >
         <FileText size={16} />
         <span className="hidden sm:inline">
-          {showTranscript ? "Hide" : "Transcript"}
+          {isTranscriptOpen ? "Hide" : "Transcript"}
         </span>
       </button>
     </header>

--- a/client/src/components/meetings/TranscriptPanel.jsx
+++ b/client/src/components/meetings/TranscriptPanel.jsx
@@ -3,7 +3,7 @@ import { FileText, X, Captions } from "lucide-react";
 
 export default function TranscriptPanel({
   showTranscript,
-  setShowTranscript,
+  onClose,
   transcriptSegments,
 }) {
   if (!showTranscript) return null;
@@ -15,15 +15,20 @@ export default function TranscriptPanel({
   };
 
   return (
-    <div className="w-full md:w-[420px] lg:w-[480px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col">
+    <div
+      data-testid="meeting-room-transcript-panel"
+      className="w-full md:w-[420px] lg:w-[480px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col transition-all duration-300"
+    >
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-white font-semibold flex items-center gap-2">
           <FileText size={18} />
           Live Transcript
         </h3>
         <button
-          onClick={() => setShowTranscript(false)}
+          type="button"
+          onClick={onClose}
           className="text-gray-400 hover:text-white transition-colors"
+          aria-label="Close transcript panel"
         >
           <X size={20} />
         </button>

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -48,6 +48,13 @@ const buildLocalUserInfo = (userData) => ({
   profilePic: userData?.profilePic || "",
 });
 
+/** Side panel ids for exclusive panel visibility (Issue #1648). */
+const MEETING_ROOM_PANELS = {
+  NOTES: "notes",
+  PARKING_LOT: "parkingLot",
+  TRANSCRIPT: "transcript",
+};
+
 const MeetingRoom = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
@@ -83,12 +90,22 @@ const MeetingRoom = () => {
   });
   const timerStateRef = useRef(timerState);
 
-  const [showNotes, setShowNotes] = useState(false);
-  const [showParkingLot, setShowParkingLot] = useState(false);
+  const [activePanel, setActivePanel] = useState(null);
+
+  const togglePanel = useCallback((panel) => {
+    setActivePanel((current) => (current === panel ? null : panel));
+  }, []);
+
+  const closePanel = useCallback(() => {
+    setActivePanel(null);
+  }, []);
+
+  const showNotes = activePanel === MEETING_ROOM_PANELS.NOTES;
+  const showParkingLot = activePanel === MEETING_ROOM_PANELS.PARKING_LOT;
+  const showTranscript = activePanel === MEETING_ROOM_PANELS.TRANSCRIPT;
 
   // Transcription state
   const [showCaptions] = useState(true);
-  const [showTranscript, setShowTranscript] = useState(false);
   const [captions, setCaptions] = useState([]);
   const [transcriptSegments, setTranscriptSegments] = useState([]);
   const [transcriptionEnabled, setTranscriptionEnabled] = useState(false);
@@ -522,14 +539,10 @@ const MeetingRoom = () => {
             duration={timerState.elapsed}
             peers={peers}
             copyLink={copyLink}
-            showNotes={showNotes}
-            setShowNotes={setShowNotes}
-            showParkingLot={showParkingLot}
-            setShowParkingLot={setShowParkingLot}
+            activePanel={activePanel}
+            onTogglePanel={togglePanel}
             transcriptionEnabled={transcriptionEnabled}
             toggleTranscription={toggleTranscription}
-            showTranscript={showTranscript}
-            setShowTranscript={setShowTranscript}
           />
           <ReactionOverlay reactions={reactions} />
 
@@ -538,7 +551,7 @@ const MeetingRoom = () => {
             {/* Video Grid — responsive by participant count + viewport (#907) */}
             <div
               className={`flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden bg-gray-900 transition-all duration-300 ${
-                showNotes ? "hidden md:block" : "block"
+                activePanel ? "hidden md:block" : "block"
               }`}
             >
               <div
@@ -596,14 +609,20 @@ const MeetingRoom = () => {
 
             {/* Collaborative Notes Panel */}
             {showNotes && (
-              <div className="w-full md:w-[420px] lg:w-[480px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col">
+              <div
+                data-testid="meeting-room-notes-panel"
+                className="w-full md:w-[420px] lg:w-[480px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col transition-all duration-300"
+              >
                 <CollaborativeEditor meetingId={roomId} />
               </div>
             )}
 
             {/* Parking Lot Panel */}
             {showParkingLot && (
-              <div className="w-full md:w-[320px] lg:w-[360px] shrink-0 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col">
+              <div
+                data-testid="meeting-room-parking-lot-panel"
+                className="w-full md:w-[320px] lg:w-[360px] shrink-0 bg-gray-950 border-l border-gray-800 overflow-hidden flex flex-col transition-all duration-300"
+              >
                 <ParkingLotPanel
                   organizationId={
                     userData?.currentOrganization?._id ||
@@ -617,7 +636,7 @@ const MeetingRoom = () => {
             {/* Transcript Panel */}
             <TranscriptPanel
               showTranscript={showTranscript}
-              setShowTranscript={setShowTranscript}
+              onClose={closePanel}
               transcriptSegments={transcriptSegments}
             />
           </div>

--- a/client/src/pages/__tests__/MeetingRoomLayout.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomLayout.test.jsx
@@ -96,7 +96,10 @@ vi.mock("../../components/meetings/ParkingLotPanel.jsx", () => ({
 }));
 
 vi.mock("../../components/meetings/TranscriptPanel.jsx", () => ({
-  default: () => <div data-testid="transcript">Transcript</div>,
+  default: ({ showTranscript }) =>
+    showTranscript ? (
+      <div data-testid="meeting-room-transcript-panel">Transcript Panel</div>
+    ) : null,
 }));
 
 vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({

--- a/client/src/pages/__tests__/MeetingRoomPanelState.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomPanelState.test.jsx
@@ -1,0 +1,245 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MeetingRoom from "../MeetingRoom.jsx";
+import AppContent from "../../context/AppContent.js";
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ roomId: "room-panel-123" }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    isSignedIn: true,
+    isLoaded: true,
+    userId: "user_1",
+  }),
+}));
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    id: "socket_1",
+    auth: {},
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async () => ({
+    auth: { token: "token_1" },
+    transports: ["websocket"],
+  })),
+  getClerkBearerToken: vi.fn(async () => "token_1"),
+}));
+
+vi.mock("../../hooks/useDevicePermission", () => ({
+  default: () => ({
+    selectedCamera: "cam-1",
+    selectedMicrophone: "mic-1",
+    releaseStream: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useWebRTC", () => ({
+  default: () => ({
+    socketRef: { current: { on: vi.fn(), emit: vi.fn(), disconnect: vi.fn() } },
+    userVideoRef: { current: null },
+    streamRef: { current: null },
+  }),
+}));
+
+vi.mock("../../hooks/useLiveTranscription", () => ({
+  default: () => ({
+    toggleTranscription: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useReactions", () => ({
+  default: () => ({
+    reactions: [],
+    sendReaction: vi.fn(),
+    onCooldown: false,
+  }),
+}));
+
+vi.mock("../../utils/mediaStream", () => ({
+  resolveMeetingMediaStream: vi.fn().mockResolvedValue({
+    getTracks: () => [],
+    getAudioTracks: () => [],
+    getVideoTracks: () => [],
+  }),
+  getTrackEnabledState: vi
+    .fn()
+    .mockReturnValue({ micOn: true, cameraOn: true }),
+}));
+
+vi.mock("../../components/meetings/DeviceSetupModal.jsx", () => ({
+  default: ({ onJoin }) => (
+    <div data-testid="device-setup">
+      <button type="button" onClick={() => onJoin(null)}>
+        Mock Join Button
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/meetings/CollaborativeEditor.jsx", () => ({
+  default: () => <div data-testid="editor">Editor</div>,
+}));
+
+vi.mock("../../components/meetings/ParkingLotPanel.jsx", () => ({
+  default: () => <div data-testid="parking-lot-content">Parking Lot Panel</div>,
+}));
+
+vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({
+  default: () => <div data-testid="captions">Captions</div>,
+}));
+
+describe("MeetingRoom exclusive panel state (#1648)", () => {
+  const wrapper = ({ children }) => (
+    <AppContent.Provider
+      value={{
+        userData: { _id: "mongo_user_1", name: "Alice" },
+      }}
+    >
+      {children}
+    </AppContent.Provider>
+  );
+
+  const joinMeeting = async () => {
+    fireEvent.click(screen.getByRole("button", { name: /mock join button/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("banner", { name: /meeting room header/i }),
+      ).toBeInTheDocument();
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens Notes from the initial state", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /^notes$/i }));
+
+    expect(screen.getByTestId("meeting-room-notes-panel")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-parking-lot-panel"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-transcript-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches from Notes to Parking Lot exclusively", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /^notes$/i }));
+    expect(screen.getByTestId("meeting-room-notes-panel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /parking lot/i }));
+
+    expect(
+      screen.getByTestId("meeting-room-parking-lot-panel"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-notes-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches from Parking Lot to Transcript exclusively", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /parking lot/i }));
+    expect(
+      screen.getByTestId("meeting-room-parking-lot-panel"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /transcript/i }));
+
+    expect(
+      screen.getByTestId("meeting-room-transcript-panel"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-parking-lot-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches from Transcript back to Notes exclusively", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /transcript/i }));
+    expect(
+      screen.getByTestId("meeting-room-transcript-panel"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^notes$/i }));
+
+    expect(screen.getByTestId("meeting-room-notes-panel")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-transcript-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes the active panel when its header toggle is clicked again", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    const notesButton = screen.getByRole("button", { name: /^notes$/i });
+    fireEvent.click(notesButton);
+    expect(screen.getByTestId("meeting-room-notes-panel")).toBeInTheDocument();
+
+    fireEvent.click(notesButton);
+    expect(
+      screen.queryByTestId("meeting-room-notes-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes the transcript panel from its close control", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /transcript/i }));
+    expect(
+      screen.getByTestId("meeting-room-transcript-panel"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /close transcript panel/i }),
+    );
+
+    expect(
+      screen.queryByTestId("meeting-room-transcript-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("never renders more than one side panel at a time", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /^notes$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /parking lot/i }));
+    fireEvent.click(screen.getByRole("button", { name: /transcript/i }));
+
+    const visiblePanels = [
+      screen.queryByTestId("meeting-room-notes-panel"),
+      screen.queryByTestId("meeting-room-parking-lot-panel"),
+      screen.queryByTestId("meeting-room-transcript-panel"),
+    ].filter(Boolean);
+
+    expect(visiblePanels).toHaveLength(1);
+    expect(
+      screen.getByTestId("meeting-room-transcript-panel"),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/__tests__/MeetingRoomTimer.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomTimer.test.jsx
@@ -96,12 +96,10 @@ describe("MeetingHeader Timer Formatting (#1658)", () => {
         duration={45} // 45 seconds
         peers={[]}
         copyLink={vi.fn()}
-        showNotes={false}
-        setShowNotes={vi.fn()}
+        activePanel={null}
+        onTogglePanel={vi.fn()}
         transcriptionEnabled={false}
         toggleTranscription={vi.fn()}
-        showTranscript={false}
-        setShowTranscript={vi.fn()}
       />,
     );
     expect(screen.getByText("00:45")).toBeInTheDocument();
@@ -114,12 +112,10 @@ describe("MeetingHeader Timer Formatting (#1658)", () => {
         duration={3665} // 1 hour, 1 minute, 5 seconds
         peers={[]}
         copyLink={vi.fn()}
-        showNotes={false}
-        setShowNotes={vi.fn()}
+        activePanel={null}
+        onTogglePanel={vi.fn()}
         transcriptionEnabled={false}
         toggleTranscription={vi.fn()}
-        showTranscript={false}
-        setShowTranscript={vi.fn()}
       />,
     );
     expect(screen.getByText("1:01:05")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fixes #1648

Prevents Notes, Parking Lot, and Transcript panels from opening simultaneously in MeetingRoom, keeping the video grid usable across screen sizes.

## Problem

MeetingRoom previously managed each side panel with an independent boolean state, allowing multiple panels to remain open at the same time.

This could significantly reduce the available video area, especially on tablet and mobile layouts.

## Changes Made

- Replaced independent panel booleans with a single `activePanel` state.
- Opening one panel automatically closes the previously active panel.
- Clicking the active panel toggle closes it.
- Updated `MeetingHeader` to use the centralized panel state.
- Updated Transcript close behavior to use the shared close handler.
- Video grid now responds consistently when any side panel is active.
- Preserved existing panel animations and meeting controls.

## Panel Behavior

| Action | Result |
|---|---|
| Open Notes | Notes opens |
| Open Parking Lot | Notes closes, Parking Lot opens |
| Open Transcript | Parking Lot closes, Transcript opens |
| Switch back to Notes | Transcript closes, Notes opens |
| Toggle active panel | Active panel closes |
| Close Transcript | Panel closes |

## Responsive Behavior

- Only one side panel can be open at a time at all screen sizes.
- Mobile/tablet layouts hide the video grid while a panel is open.
- Desktop layouts keep the video grid visible alongside the active panel.
- Existing transition behavior is preserved.

## Files Changed

- `client/src/pages/MeetingRoom.jsx`
- `client/src/components/meetings/MeetingHeader.jsx`
- `client/src/components/meetings/TranscriptPanel.jsx`
- `client/src/pages/__tests__/MeetingRoomLayout.test.jsx`
- `client/src/pages/__tests__/MeetingRoomTimer.test.jsx`

### Added

- `client/src/pages/__tests__/MeetingRoomPanelState.test.jsx`

## Tests

Regression coverage includes:

- Notes panel opening
- Notes → Parking Lot switching
- Parking Lot → Transcript switching
- Transcript → Notes switching
- Active panel toggle-to-close
- Transcript close button
- Ensuring multiple panels cannot be open simultaneously

## Expected Behavior

- Exactly one side panel is visible at a time.
- Switching panels automatically closes the previous panel.
- Closing the active panel restores the normal video layout.
- The video grid remains usable on constrained screens.
- Existing meeting controls remain functional.

## Scope

This is a focused MeetingRoom UI/state-management fix.

No backend, Socket.IO, meeting logic, authentication, or panel business logic was changed.

## Manual Verification

- [ ] Open Notes → only Notes is visible.
- [ ] Open Parking Lot → Notes closes and Parking Lot opens.
- [ ] Open Transcript → Parking Lot closes and Transcript opens.
- [ ] Switch back to Notes → Transcript closes.
- [ ] Toggle the active panel → panel closes.
- [ ] Transcript X button closes the panel.
- [ ] Desktop video grid remains usable with one panel open.
- [ ] Mobile/tablet panel layout does not crush the video grid.
- [ ] Mic, camera, screen share, captions, and Leave controls remain functional.