### PR TITLE
feat: implement organization discovery flow

### DIFF
--- a/client/src/components/__tests__/ProtectedRoute.test.jsx
+++ b/client/src/components/__tests__/ProtectedRoute.test.jsx
@@ -100,6 +100,38 @@ describe("ProtectedRoute", () => {
     );
   });
 
+  it("allows onboarding users to access browse-organizations (#293)", () => {
+    vi.spyOn(useRBACHook, "useRBAC").mockReturnValue({
+      hasPermission: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/browse-organizations"]}>
+        <AppContent.Provider
+          value={{
+            loading: false,
+            isLoggedin: true,
+            userData: { hasCompletedOnboarding: false },
+          }}
+        >
+          <Routes>
+            <Route
+              path="/browse-organizations"
+              element={
+                <ProtectedRoute>
+                  <div>Browse Organizations</div>
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/organizations" element={<LocationDisplay />} />
+          </Routes>
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Browse Organizations")).toBeInTheDocument();
+  });
+
   it("redirects to /dashboard if onboarding is completed but user is on an onboarding page", () => {
     vi.spyOn(useRBACHook, "useRBAC").mockReturnValue({
       hasPermission: vi.fn(),

--- a/client/src/components/organization/OrganizationHeader.jsx
+++ b/client/src/components/organization/OrganizationHeader.jsx
@@ -44,7 +44,7 @@ const OrganizationHeader = ({ showActions = true }) => {
           </button>
 
           <button
-            onClick={() => navigate("/join-organization")}
+            onClick={() => navigate("/browse-organizations")}
             className="flex items-center justify-center w-full sm:w-auto gap-2 px-5 py-2.5 bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-xl font-semibold transition-all border border-gray-200 dark:border-gray-700"
           >
             <Search className="w-5 h-5" />

--- a/client/src/components/organization/__tests__/OrganizationHeaderDiscovery.test.jsx
+++ b/client/src/components/organization/__tests__/OrganizationHeaderDiscovery.test.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import OrganizationHeader from "../OrganizationHeader";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("OrganizationHeader discovery navigation (#293)", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("routes browse action to the canonical browse organizations page", () => {
+    render(
+      <MemoryRouter>
+        <OrganizationHeader showActions />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Browse/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/browse-organizations");
+  });
+});

--- a/client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx
+++ b/client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { organizationApi, membershipRequestApi } from "../../services";
 import { toast } from "react-toastify";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import Navbar from "../../components/Navbar.jsx";
 import {
   Search,
@@ -15,7 +15,7 @@ import {
   UserCheck,
   UserPlus,
   Tag,
-  Sparkles,
+  ArrowLeft,
 } from "lucide-react";
 
 const BrowseOrganizations = () => {
@@ -40,51 +40,64 @@ const BrowseOrganizations = () => {
 
   const observerRef = useRef(null);
   const searchTimeoutRef = useRef(null);
+  const fetchSequenceRef = useRef(0);
 
-  // Fetch organizations
-  const fetchOrganizations = async (
-    page = 1,
-    search = searchQuery,
-    sort = sortBy,
-    filt = filter,
-    append = false,
-  ) => {
-    try {
-      if (!append) {
-        setLoading(true);
-      } else {
-        setLoadingMore(true);
-      }
-      setError(null);
+  const fetchOrganizations = useCallback(
+    async (
+      page = 1,
+      search = "",
+      sort = "createdAt",
+      filt = "all",
+      append = false,
+    ) => {
+      const requestId = ++fetchSequenceRef.current;
 
-      const params = {
-        page,
-        limit: pagination.limit,
-        search: search.trim(),
-        sortBy: sort,
-        filter: filt,
-      };
-
-      const { data } = await organizationApi.browsePublicOrganizations(params);
-
-      if (data.success) {
-        if (append) {
-          setOrganizations((prev) => [...prev, ...data.organizations]);
+      try {
+        if (!append) {
+          setLoading(true);
         } else {
-          setOrganizations(data.organizations);
+          setLoadingMore(true);
         }
-        setPagination(data.pagination);
-      } else {
-        setError(data.message || "Failed to fetch organizations");
+        setError(null);
+
+        const params = {
+          page,
+          limit: pagination.limit,
+          search: search.trim(),
+          sortBy: sort,
+          filter: filt,
+        };
+
+        const { data } =
+          await organizationApi.browsePublicOrganizations(params);
+
+        if (requestId !== fetchSequenceRef.current) return;
+
+        if (data.success) {
+          if (append) {
+            setOrganizations((prev) => [...prev, ...data.organizations]);
+          } else {
+            setOrganizations(data.organizations);
+          }
+          setPagination(data.pagination);
+        } else {
+          setError(data.message || "Failed to fetch organizations");
+        }
+      } catch (err) {
+        if (requestId !== fetchSequenceRef.current) return;
+        setError(
+          err.response?.data?.message || "Failed to fetch organizations",
+        );
+        toast.error("Failed to load organizations");
+      } finally {
+        if (requestId === fetchSequenceRef.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
-    } catch (err) {
-      setError(err.response?.data?.message || "Failed to fetch organizations");
-      toast.error("Failed to load organizations");
-    } finally {
-      setLoading(false);
-      setLoadingMore(false);
-    }
-  };
+    },
+    [pagination.limit],
+  );
 
   // Debounced search
   const debouncedSearch = useCallback(
@@ -183,6 +196,10 @@ const BrowseOrganizations = () => {
       );
       return;
     }
+    if (org.joinPolicy === "invite_only") {
+      toast.info("This organization is invite only");
+      return;
+    }
 
     try {
       setActionLoadingId(org._id);
@@ -236,6 +253,14 @@ const BrowseOrganizations = () => {
       <Navbar />
       <div className="flex-grow container mx-auto px-4 pt-28 pb-8">
         <div className="max-w-7xl mx-auto">
+          <Link
+            to="/organizations"
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 mb-6 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Organization Hub
+          </Link>
+
           {/* Header */}
           <div className="text-center mb-8">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 mb-4 shadow-lg">
@@ -539,6 +564,13 @@ const BrowseOrganizations = () => {
                             className="flex items-center justify-center gap-1 px-3 py-2 bg-red-500/10 text-red-500 rounded-xl font-semibold text-sm cursor-not-allowed"
                           >
                             Rejected
+                          </button>
+                        ) : org.joinPolicy === "invite_only" ? (
+                          <button
+                            disabled
+                            className="flex items-center justify-center gap-1 px-3 py-2 bg-gray-500/10 text-gray-500 rounded-xl font-semibold text-sm cursor-not-allowed"
+                          >
+                            Invite Only
                           </button>
                         ) : (
                           <button

--- a/client/src/pages/JoinOrganizationPage.jsx
+++ b/client/src/pages/JoinOrganizationPage.jsx
@@ -1,96 +1,52 @@
 // client/src/pages/JoinOrganizationPage.jsx
 import React, { useContext, useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import AppContent from "../context/AppContent";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
-import { organizationApi, invitationApi } from "../services";
-import {
-  Building2,
-  Search,
-  ArrowRight,
-  Users,
-  Mail,
-  Check,
-  X,
-  AlertTriangle,
-} from "lucide-react";
+import { invitationApi } from "../services";
+import { Building2, Check, AlertTriangle } from "lucide-react";
 
 const JoinOrganizationPage = () => {
   const { getUserData, setUserData } = useContext(AppContent);
-  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
 
-  const [orgList, setOrgList] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(Boolean(token));
   const navigate = useNavigate();
 
-  // Invitation handling state
   const [inviteDetails, setInviteDetails] = useState(null);
   const [inviteError, setInviteError] = useState("");
   const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
-    if (token) {
-      // Handle invitation flow
-      const fetchInvitation = async () => {
-        try {
-          setLoading(true);
-          const { data } = await invitationApi.getInvitationByToken(token);
-          if (data.success) {
-            setInviteDetails(data.invitation);
-          } else {
-            setInviteError(data.message || "Invalid invitation");
-          }
-        } catch (err) {
-          console.error("Error loading invitation:", err);
-          setInviteError(
-            err.response?.data?.message || "Invalid or expired invitation",
-          );
-        } finally {
-          setLoading(false);
+    if (!token) return;
+
+    const fetchInvitation = async () => {
+      try {
+        setLoading(true);
+        const { data } = await invitationApi.getInvitationByToken(token);
+        if (data.success) {
+          setInviteDetails(data.invitation);
+        } else {
+          setInviteError(data.message || "Invalid invitation");
         }
-      };
-      fetchInvitation();
-    } else {
-      // Regular join list flow
-      const fetchOrgs = async () => {
-        try {
-          const { data } = await organizationApi.getAllOrganizations();
-          if (data.success) setOrgList(data.organizations);
-        } catch {
-          toast.error("Failed to load organizations");
-        } finally {
-          setLoading(false);
-        }
-      };
-      fetchOrgs();
-    }
+      } catch (err) {
+        console.error("Error loading invitation:", err);
+        setInviteError(
+          err.response?.data?.message || "Invalid or expired invitation",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInvitation();
   }, [token]);
 
-  const handleJoin = async (orgId) => {
-    try {
-      const { data } = await organizationApi.joinOrganization({
-        organizationId: orgId,
-      });
-
-      if (data.success) {
-        toast.success("Joined organization successfully!");
-        const updatedUser = await getUserData();
-        if (updatedUser) {
-          setUserData(updatedUser);
-          localStorage.setItem("userData", JSON.stringify(updatedUser));
-        }
-        navigate("/organizations");
-      } else {
-        toast.error(data.message);
-      }
-    } catch {
-      toast.error("Failed to join organization");
-    }
-  };
+  if (!token) {
+    return <Navigate to="/browse-organizations" replace />;
+  }
 
   const handleAcceptInvite = async () => {
     if (!token) return;
@@ -104,7 +60,6 @@ const JoinOrganizationPage = () => {
           setUserData(updatedUser);
           localStorage.setItem("userData", JSON.stringify(updatedUser));
         }
-        // Force fully reload or navigate to trigger switcher updates
         window.location.href = "/dashboard";
       } else {
         toast.error(data.message || "Failed to accept invitation");
@@ -143,196 +98,115 @@ const JoinOrganizationPage = () => {
       <Navbar />
       <div className="flex-grow container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto">
-          {token ? (
-            /* Invitation Flow rendering */
-            <div className="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-3xl border border-gray-100 dark:border-gray-700 shadow-xl overflow-hidden mt-12">
-              {loading ? (
-                <div className="p-12 text-center">
-                  <div className="animate-spin rounded-full h-10 w-10 border-4 border-slate-200 dark:border-slate-700 border-t-blue-600 mx-auto mb-4"></div>
-                  <p className="text-gray-500 dark:text-gray-400">
-                    Verifying invitation link...
-                  </p>
-                </div>
-              ) : inviteError ? (
-                <div className="p-8 text-center space-y-4">
-                  <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-50 dark:bg-red-900/20 text-red-500 mb-2">
-                    <AlertTriangle className="w-6 h-6" />
-                  </div>
-                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-                    Invitation Invalid
-                  </h2>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {inviteError}
-                  </p>
-                  <div className="pt-4">
-                    <button
-                      onClick={() => navigate("/organizations")}
-                      className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all shadow-md shadow-blue-600/10 cursor-pointer"
-                    >
-                      Go to Organization Hub
-                    </button>
-                  </div>
-                </div>
-              ) : inviteDetails ? (
-                <div className="p-8 space-y-6">
-                  {/* Organization Logo/Header */}
-                  <div className="text-center">
-                    <div className="w-20 h-20 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-100/50 dark:border-blue-800/30 flex items-center justify-center mx-auto mb-4 overflow-hidden shrink-0">
-                      {inviteDetails.organization?.logo ? (
-                        <img
-                          src={inviteDetails.organization.logo}
-                          alt={inviteDetails.organization.name}
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <Building2 className="w-10 h-10 text-blue-600" />
-                      )}
-                    </div>
-                    <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-                      Invitation to Join
-                    </h2>
-                    <p className="text-lg font-semibold text-blue-600 dark:text-blue-400 mt-1">
-                      {inviteDetails.organization?.name}
-                    </p>
-                  </div>
-
-                  <hr className="border-gray-100 dark:border-gray-700" />
-
-                  {/* Inviter Info */}
-                  <div className="bg-gray-50 dark:bg-gray-800/50 rounded-2xl p-4 space-y-2 border border-gray-100/40 dark:border-gray-700/40">
-                    <p className="text-xs text-gray-400 dark:text-gray-500 uppercase tracking-wider font-bold">
-                      Invited By
-                    </p>
-                    <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                      {inviteDetails.invitedBy?.name} (
-                      {inviteDetails.invitedBy?.email})
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      Role offered:{" "}
-                      <span className="font-bold text-blue-600 dark:text-blue-400 capitalize">
-                        {inviteDetails.role}
-                      </span>
-                    </p>
-                  </div>
-
-                  {/* Message */}
-                  {inviteDetails.message && (
-                    <div className="bg-blue-50/30 dark:bg-blue-950/10 border-l-4 border-blue-500 p-4 rounded-r-xl">
-                      <p className="text-xs font-bold text-blue-600 dark:text-blue-400 mb-1">
-                        Personal Message
-                      </p>
-                      <p className="text-sm text-gray-600 dark:text-gray-400 italic">
-                        "{inviteDetails.message}"
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Actions */}
-                  <div className="flex gap-4 pt-2">
-                    <button
-                      onClick={handleDeclineInvite}
-                      disabled={actionLoading}
-                      className="flex-1 py-3 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-850 text-gray-700 dark:text-gray-300 rounded-xl font-semibold transition-all cursor-pointer text-sm"
-                    >
-                      Decline
-                    </button>
-                    <button
-                      onClick={handleAcceptInvite}
-                      disabled={actionLoading}
-                      className="flex-1 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all shadow-md shadow-blue-600/10 cursor-pointer text-sm flex items-center justify-center gap-1.5"
-                    >
-                      {actionLoading ? (
-                        <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white" />
-                      ) : (
-                        <Check className="w-4 h-4" />
-                      )}
-                      Accept & Join
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          ) : (
-            /* Regular Browse Flow */
-            <>
-              {/* Header */}
-              <div className="text-center mb-8">
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-purple-600 mb-4 shadow-lg">
-                  <Search className="w-8 h-8 text-white" />
-                </div>
-                <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-                  {t("organizations.browse")}
-                </h1>
+          <div className="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-3xl border border-gray-100 dark:border-gray-700 shadow-xl overflow-hidden mt-12">
+            {loading ? (
+              <div className="p-12 text-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-4 border-slate-200 dark:border-slate-700 border-t-blue-600 mx-auto mb-4"></div>
                 <p className="text-gray-500 dark:text-gray-400">
-                  {t("organizations.browseDesc")}
+                  Verifying invitation link...
                 </p>
               </div>
-
-              {/* Organization List */}
-              {loading ? (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {[1, 2, 3, 4, 5, 6].map((i) => (
-                    <div
-                      key={i}
-                      className="bg-white dark:bg-gray-800 rounded-2xl h-40 animate-pulse"
-                    />
-                  ))}
+            ) : inviteError ? (
+              <div className="p-8 text-center space-y-4">
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-50 dark:bg-red-900/20 text-red-500 mb-2">
+                  <AlertTriangle className="w-6 h-6" />
                 </div>
-              ) : orgList.length === 0 ? (
-                <div className="text-center py-16">
-                  <Building2 className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-                  <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
-                    {t("organizations.noOrgsAvailable")}
-                  </h2>
-                  <p className="text-gray-500 dark:text-gray-400 mb-6">
-                    {t("organizations.noOrgsAvailableDesc")}
-                  </p>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+                  Invitation Invalid
+                </h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {inviteError}
+                </p>
+                <div className="pt-4 space-y-2">
                   <button
-                    onClick={() => navigate("/create-organization")}
-                    className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all cursor-pointer"
+                    onClick={() => navigate("/browse-organizations")}
+                    className="w-full py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all shadow-md shadow-blue-600/10 cursor-pointer"
                   >
-                    {t("organizations.create")}
+                    Browse Organizations
+                  </button>
+                  <button
+                    onClick={() => navigate("/organizations")}
+                    className="w-full py-2.5 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-xl font-semibold transition-all cursor-pointer"
+                  >
+                    Go to Organization Hub
                   </button>
                 </div>
-              ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {orgList.map((org) => (
-                    <div
-                      key={org._id}
-                      className="bg-white dark:bg-gray-800 rounded-3xl border border-gray-100 dark:border-gray-700 p-6 flex flex-col justify-between hover:shadow-xl transition-all duration-300"
-                    >
-                      <div>
-                        <div className="w-12 h-12 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-100/50 dark:border-blue-800/30 flex items-center justify-center mb-4 overflow-hidden shrink-0">
-                          {org.logo ? (
-                            <img
-                              src={org.logo}
-                              alt={org.name}
-                              className="w-full h-full object-cover"
-                            />
-                          ) : (
-                            <Building2 className="w-6 h-6 text-blue-600" />
-                          )}
-                        </div>
-                        <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-2 truncate">
-                          {org.name}
-                        </h3>
-                        <p className="text-gray-500 dark:text-gray-400 text-sm line-clamp-2 mb-4">
-                          {org.description || t("organizations.noDescription")}
-                        </p>
-                      </div>
-                      <button
-                        onClick={() => handleJoin(org._id)}
-                        className="w-full py-2.5 bg-blue-50 hover:bg-blue-100 text-blue-600 dark:bg-gray-750 dark:hover:bg-gray-700 dark:text-blue-400 rounded-2xl font-bold transition-all flex items-center justify-center gap-1.5 cursor-pointer"
-                      >
-                        Join Organization
-                        <ArrowRight className="w-4 h-4" />
-                      </button>
-                    </div>
-                  ))}
+              </div>
+            ) : inviteDetails ? (
+              <div className="p-8 space-y-6">
+                <div className="text-center">
+                  <div className="w-20 h-20 rounded-2xl bg-blue-50 dark:bg-blue-900/20 border border-blue-100/50 dark:border-blue-800/30 flex items-center justify-center mx-auto mb-4 overflow-hidden shrink-0">
+                    {inviteDetails.organization?.logo ? (
+                      <img
+                        src={inviteDetails.organization.logo}
+                        alt={inviteDetails.organization.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <Building2 className="w-10 h-10 text-blue-600" />
+                    )}
+                  </div>
+                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                    Invitation to Join
+                  </h2>
+                  <p className="text-lg font-semibold text-blue-600 dark:text-blue-400 mt-1">
+                    {inviteDetails.organization?.name}
+                  </p>
                 </div>
-              )}
-            </>
-          )}
+
+                <hr className="border-gray-100 dark:border-gray-700" />
+
+                <div className="bg-gray-50 dark:bg-gray-800/50 rounded-2xl p-4 space-y-2 border border-gray-100/40 dark:border-gray-700/40">
+                  <p className="text-xs text-gray-400 dark:text-gray-500 uppercase tracking-wider font-bold">
+                    Invited By
+                  </p>
+                  <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                    {inviteDetails.invitedBy?.name} (
+                    {inviteDetails.invitedBy?.email})
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Role offered:{" "}
+                    <span className="font-bold text-blue-600 dark:text-blue-400 capitalize">
+                      {inviteDetails.role}
+                    </span>
+                  </p>
+                </div>
+
+                {inviteDetails.message && (
+                  <div className="bg-blue-50/30 dark:bg-blue-950/10 border-l-4 border-blue-500 p-4 rounded-r-xl">
+                    <p className="text-xs font-bold text-blue-600 dark:text-blue-400 mb-1">
+                      Personal Message
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-400 italic">
+                      "{inviteDetails.message}"
+                    </p>
+                  </div>
+                )}
+
+                <div className="flex gap-4 pt-2">
+                  <button
+                    onClick={handleDeclineInvite}
+                    disabled={actionLoading}
+                    className="flex-1 py-3 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-850 text-gray-700 dark:text-gray-300 rounded-xl font-semibold transition-all cursor-pointer text-sm"
+                  >
+                    Decline
+                  </button>
+                  <button
+                    onClick={handleAcceptInvite}
+                    disabled={actionLoading}
+                    className="flex-1 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-all shadow-md shadow-blue-600/10 cursor-pointer text-sm flex items-center justify-center gap-1.5"
+                  >
+                    {actionLoading ? (
+                      <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white" />
+                    ) : (
+                      <Check className="w-4 h-4" />
+                    )}
+                    Accept & Join
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/pages/PublicOrganizationProfile.jsx
+++ b/client/src/pages/PublicOrganizationProfile.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import React, { useState, useEffect, useContext, useCallback } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { organizationApi, membershipRequestApi } from "../services";
+import AppContent from "../context/AppContent";
 import { toast } from "react-toastify";
 import {
   Building2,
@@ -13,8 +14,10 @@ import {
   Loader2,
   AlertCircle,
   X,
-  Check,
   Clock,
+  ArrowLeft,
+  UserPlus,
+  UserCheck,
 } from "lucide-react";
 import OrganizationBanner from "../components/organization/OrganizationBanner.jsx";
 import OrganizationLogo from "../components/organization/OrganizationLogo.jsx";
@@ -22,13 +25,60 @@ import OrganizationLogo from "../components/organization/OrganizationLogo.jsx";
 const PublicOrganizationProfile = () => {
   const { slug } = useParams();
   const navigate = useNavigate();
+  const { isLoggedin, getUserData, setUserData } = useContext(AppContent);
   const [organization, setOrganization] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [requestStatus, setRequestStatus] = useState(null);
-  const [requestLoading, setRequestLoading] = useState(false);
+  const [membershipStatus, setMembershipStatus] = useState("none");
+  const [actionLoading, setActionLoading] = useState(false);
   const [showRequestModal, setShowRequestModal] = useState(false);
   const [requestMessage, setRequestMessage] = useState("");
+
+  const resolveMembershipStatus = useCallback(
+    async (organizationId) => {
+      if (!isLoggedin) {
+        setMembershipStatus("none");
+        return;
+      }
+
+      try {
+        const [orgsResponse, requestsResponse] = await Promise.all([
+          organizationApi.getUserOrganizations(),
+          membershipRequestApi.getUserRequests(),
+        ]);
+
+        const joined =
+          orgsResponse.data.success &&
+          (orgsResponse.data.organizations || []).some(
+            (org) => org._id === organizationId,
+          );
+
+        if (joined) {
+          setMembershipStatus("member");
+          return;
+        }
+
+        const requests = requestsResponse.data.success
+          ? requestsResponse.data.requests || []
+          : [];
+        const orgRequest = requests.find(
+          (req) => req.organization._id === organizationId,
+        );
+
+        if (orgRequest?.status === "pending") {
+          setMembershipStatus("pending");
+        } else if (orgRequest?.status === "rejected") {
+          setMembershipStatus("rejected");
+        } else {
+          setMembershipStatus("none");
+        }
+      } catch (err) {
+        console.error("Error resolving membership status:", err);
+        setMembershipStatus("none");
+      }
+    },
+    [isLoggedin],
+  );
 
   useEffect(() => {
     const fetchOrganization = async () => {
@@ -40,8 +90,7 @@ const PublicOrganizationProfile = () => {
 
         if (data.success) {
           setOrganization(data.organization);
-          // Check for existing request
-          await checkExistingRequest(data.organization._id);
+          await resolveMembershipStatus(data.organization._id);
         } else {
           setError(data.message || "Failed to load organization");
         }
@@ -62,24 +111,7 @@ const PublicOrganizationProfile = () => {
     if (slug) {
       fetchOrganization();
     }
-  }, [slug]);
-
-  const checkExistingRequest = async (organizationId) => {
-    try {
-      const { data } = await membershipRequestApi.getUserRequests();
-      if (data.success && data.requests) {
-        const existingRequest = data.requests.find(
-          (req) =>
-            req.organization._id === organizationId && req.status === "pending",
-        );
-        if (existingRequest) {
-          setRequestStatus("pending");
-        }
-      }
-    } catch (err) {
-      console.error("Error checking existing request:", err);
-    }
-  };
+  }, [slug, resolveMembershipStatus]);
 
   const formatDate = (dateString) => {
     if (!dateString) return "N/A";
@@ -90,19 +122,66 @@ const PublicOrganizationProfile = () => {
     });
   };
 
+  const handleJoinOrganization = async () => {
+    if (!organization) return;
+
+    try {
+      setActionLoading(true);
+      const { data } = await organizationApi.joinOrganization({
+        organizationId: organization._id,
+      });
+
+      if (data.success) {
+        toast.success("Joined organization successfully!");
+        setMembershipStatus("member");
+        const updatedUser = await getUserData();
+        if (updatedUser) {
+          setUserData(updatedUser);
+          localStorage.setItem("userData", JSON.stringify(updatedUser));
+        }
+      } else {
+        toast.error(data.message || "Failed to join organization");
+      }
+    } catch (err) {
+      toast.error(err.response?.data?.message || "Failed to join organization");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
   const handleRequestAccess = () => {
-    if (requestStatus === "pending") {
+    if (!isLoggedin) {
+      navigate("/login", { state: { from: `/organizations/${slug}` } });
+      return;
+    }
+
+    if (membershipStatus === "pending") {
       toast.info("You already have a pending request for this organization");
       return;
     }
+
     setShowRequestModal(true);
+  };
+
+  const handlePrimaryAction = () => {
+    if (!isLoggedin) {
+      navigate("/login", { state: { from: `/organizations/${slug}` } });
+      return;
+    }
+
+    if (organization?.joinPolicy === "open") {
+      handleJoinOrganization();
+      return;
+    }
+
+    handleRequestAccess();
   };
 
   const handleSubmitRequest = async () => {
     if (!organization) return;
 
     try {
-      setRequestLoading(true);
+      setActionLoading(true);
       const { data } = await membershipRequestApi.createRequest({
         organizationId: organization._id,
         message: requestMessage,
@@ -110,7 +189,7 @@ const PublicOrganizationProfile = () => {
 
       if (data.success) {
         toast.success("Membership request submitted successfully");
-        setRequestStatus("pending");
+        setMembershipStatus("pending");
         setShowRequestModal(false);
         setRequestMessage("");
       } else {
@@ -120,7 +199,7 @@ const PublicOrganizationProfile = () => {
       console.error("Error submitting request:", err);
       toast.error(err.response?.data?.message || "Failed to submit request");
     } finally {
-      setRequestLoading(false);
+      setActionLoading(false);
     }
   };
 
@@ -128,7 +207,7 @@ const PublicOrganizationProfile = () => {
     if (!organization) return;
 
     try {
-      setRequestLoading(true);
+      setActionLoading(true);
       const { data } = await membershipRequestApi.getUserRequests();
       if (data.success && data.requests) {
         const pendingRequest = data.requests.find(
@@ -139,18 +218,103 @@ const PublicOrganizationProfile = () => {
         if (pendingRequest) {
           await membershipRequestApi.cancelRequest(pendingRequest._id);
           toast.success("Request cancelled successfully");
-          setRequestStatus(null);
+          setMembershipStatus("none");
         }
       }
     } catch (err) {
       console.error("Error cancelling request:", err);
       toast.error(err.response?.data?.message || "Failed to cancel request");
     } finally {
-      setRequestLoading(false);
+      setActionLoading(false);
     }
   };
 
-  // Loading Skeleton
+  const renderMembershipAction = (fullWidth = false) => {
+    if (!isLoggedin) {
+      return (
+        <button
+          onClick={() =>
+            navigate("/login", { state: { from: `/organizations/${slug}` } })
+          }
+          className={`${fullWidth ? "w-full" : ""} px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors shadow-lg hover:shadow-xl`}
+        >
+          Sign in to Join
+        </button>
+      );
+    }
+
+    if (membershipStatus === "member") {
+      return (
+        <span
+          className={`inline-flex items-center gap-2 px-4 py-2 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-lg text-sm font-medium ${fullWidth ? "w-full justify-center" : ""}`}
+        >
+          <UserCheck className="w-4 h-4" />
+          Member
+        </span>
+      );
+    }
+
+    if (membershipStatus === "pending") {
+      return (
+        <div className={`flex items-center gap-2 ${fullWidth ? "w-full" : ""}`}>
+          <span className="px-4 py-2 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 rounded-lg text-sm font-medium flex items-center gap-2">
+            <Clock className="w-4 h-4" />
+            Pending
+          </span>
+          <button
+            onClick={handleCancelRequest}
+            disabled={actionLoading}
+            className="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg font-medium transition-colors flex items-center gap-2"
+          >
+            {actionLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <X className="w-4 h-4" />
+            )}
+            Cancel
+          </button>
+        </div>
+      );
+    }
+
+    if (membershipStatus === "rejected") {
+      return (
+        <span className="px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg text-sm font-medium">
+          Request Rejected
+        </span>
+      );
+    }
+
+    if (organization?.joinPolicy === "invite_only") {
+      return (
+        <span className="px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-lg text-sm font-medium">
+          Invite only — contact an admin for access
+        </span>
+      );
+    }
+
+    const isOpenJoin = organization?.joinPolicy === "open";
+    const label = isOpenJoin ? "Join Organization" : "Request Access";
+    const Icon = isOpenJoin ? UserPlus : UserPlus;
+
+    return (
+      <button
+        onClick={handlePrimaryAction}
+        disabled={actionLoading}
+        className={`${fullWidth ? "w-full" : ""} px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors shadow-lg hover:shadow-xl flex items-center justify-center gap-2 disabled:opacity-50`}
+      >
+        {actionLoading ? (
+          <Loader2 className="w-4 h-4 animate-spin" />
+        ) : (
+          <>
+            <Icon className="w-4 h-4" />
+            {label}
+          </>
+        )}
+      </button>
+    );
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
@@ -166,11 +330,6 @@ const PublicOrganizationProfile = () => {
                   <div className="h-4 w-48 bg-gray-200 dark:bg-gray-700 rounded" />
                 </div>
               </div>
-              <div className="space-y-4">
-                <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded" />
-                <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded" />
-                <div className="h-4 w-1/2 bg-gray-200 dark:bg-gray-700 rounded" />
-              </div>
             </div>
           </div>
         </div>
@@ -178,7 +337,6 @@ const PublicOrganizationProfile = () => {
     );
   }
 
-  // Error State
   if (error) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 flex items-center justify-center">
@@ -197,43 +355,30 @@ const PublicOrganizationProfile = () => {
                 ? "The organization you're looking for doesn't exist or may have been removed."
                 : error}
             </p>
-            <button
-              onClick={() => navigate("/")}
-              className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors"
-            >
-              Go to Homepage
-            </button>
+            <div className="flex flex-col gap-2">
+              {isLoggedin && (
+                <button
+                  onClick={() => navigate("/browse-organizations")}
+                  className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors"
+                >
+                  Browse Organizations
+                </button>
+              )}
+              <button
+                onClick={() => navigate("/")}
+                className="px-6 py-3 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded-xl font-semibold transition-colors"
+              >
+                Go to Homepage
+              </button>
+            </div>
           </div>
         </div>
       </div>
     );
   }
 
-  // Empty State
   if (!organization) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 flex items-center justify-center">
-        <div className="max-w-md w-full mx-4">
-          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-8 text-center">
-            <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Building2 className="w-8 h-8 text-gray-400" />
-            </div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-              No Organization Data
-            </h2>
-            <p className="text-gray-600 dark:text-gray-400 mb-6">
-              Unable to load organization information.
-            </p>
-            <button
-              onClick={() => navigate("/")}
-              className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors"
-            >
-              Go to Homepage
-            </button>
-          </div>
-        </div>
-      </div>
-    );
+    return null;
   }
 
   const {
@@ -244,6 +389,7 @@ const PublicOrganizationProfile = () => {
     bannerUrl,
     memberCount,
     visibility,
+    joinPolicy,
     createdAt,
     website,
     socialLinks,
@@ -254,15 +400,22 @@ const PublicOrganizationProfile = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      {/* Hero / Banner */}
       <OrganizationBanner src={bannerUrl || ""} name={name} />
 
       <div className="max-w-6xl mx-auto px-4 -mt-24 pb-12">
+        {isLoggedin && (
+          <Link
+            to="/browse-organizations"
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 mb-4 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Browse Organizations
+          </Link>
+        )}
+
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg overflow-hidden">
-          {/* Organization Header */}
           <div className="p-8 border-b border-gray-200 dark:border-gray-700">
             <div className="flex flex-col md:flex-row items-start gap-6">
-              {/* Logo */}
               <OrganizationLogo
                 src={resolvedLogo}
                 name={name}
@@ -270,7 +423,6 @@ const PublicOrganizationProfile = () => {
                 className="shadow-xl"
               />
 
-              {/* Organization Info */}
               <div className="flex-1">
                 <div className="flex items-center gap-3 mb-2">
                   <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
@@ -295,7 +447,6 @@ const PublicOrganizationProfile = () => {
                   </p>
                 )}
 
-                {/* Metadata */}
                 <div className="flex flex-wrap items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
                   <div className="flex items-center gap-1.5">
                     <Users className="w-4 h-4" />
@@ -320,40 +471,10 @@ const PublicOrganizationProfile = () => {
                 </div>
               </div>
 
-              {/* Request Access Button */}
-              <div className="flex-shrink-0">
-                {requestStatus === "pending" ? (
-                  <div className="flex items-center gap-2">
-                    <span className="px-4 py-2 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 rounded-lg text-sm font-medium flex items-center gap-2">
-                      <Clock className="w-4 h-4" />
-                      Pending
-                    </span>
-                    <button
-                      onClick={handleCancelRequest}
-                      disabled={requestLoading}
-                      className="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg font-medium transition-colors flex items-center gap-2"
-                    >
-                      {requestLoading ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <X className="w-4 h-4" />
-                      )}
-                      Cancel
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={handleRequestAccess}
-                    className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-semibold transition-colors shadow-lg hover:shadow-xl"
-                  >
-                    Request Access
-                  </button>
-                )}
-              </div>
+              <div className="flex-shrink-0">{renderMembershipAction()}</div>
             </div>
           </div>
 
-          {/* Tags Section */}
           {tags && tags.length > 0 && (
             <div className="p-8 border-b border-gray-200 dark:border-gray-700">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
@@ -373,7 +494,6 @@ const PublicOrganizationProfile = () => {
             </div>
           )}
 
-          {/* Social Links Section */}
           {socialLinks && Object.keys(socialLinks).length > 0 && (
             <div className="p-8 border-b border-gray-200 dark:border-gray-700">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
@@ -396,7 +516,6 @@ const PublicOrganizationProfile = () => {
             </div>
           )}
 
-          {/* Additional Info Section */}
           <div className="p-8">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="bg-gray-50 dark:bg-gray-700/50 rounded-xl p-6">
@@ -412,6 +531,12 @@ const PublicOrganizationProfile = () => {
                     <span className="font-medium text-gray-900 dark:text-gray-100">
                       {visibility?.charAt(0)?.toUpperCase() +
                         visibility?.slice(1) || "Private"}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Join Policy:</span>
+                    <span className="font-medium text-gray-900 dark:text-gray-100 capitalize">
+                      {(joinPolicy || "open").replace(/_/g, " ")}
                     </span>
                   </div>
                   <div className="flex justify-between">
@@ -437,43 +562,19 @@ const PublicOrganizationProfile = () => {
                   </h4>
                 </div>
                 <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                  Join this organization to collaborate with team members and
-                  access shared resources.
+                  {joinPolicy === "open"
+                    ? "This organization accepts open join requests from authenticated users."
+                    : joinPolicy === "invite_only"
+                      ? "Membership is limited to invited users."
+                      : "Submit a request and an admin will review your application."}
                 </p>
-                {requestStatus === "pending" ? (
-                  <div className="flex items-center gap-2">
-                    <span className="px-3 py-2 bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 rounded-lg text-sm font-medium flex items-center gap-2">
-                      <Clock className="w-4 h-4" />
-                      Pending
-                    </span>
-                    <button
-                      onClick={handleCancelRequest}
-                      disabled={requestLoading}
-                      className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
-                    >
-                      {requestLoading ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <X className="w-4 h-4" />
-                      )}
-                      Cancel
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    onClick={handleRequestAccess}
-                    className="w-full px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors"
-                  >
-                    Request to Join
-                  </button>
-                )}
+                {renderMembershipAction(true)}
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      {/* Request Access Modal */}
       {showRequestModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-md w-full p-6">
@@ -517,17 +618,17 @@ const PublicOrganizationProfile = () => {
                   setShowRequestModal(false);
                   setRequestMessage("");
                 }}
-                disabled={requestLoading}
+                disabled={actionLoading}
                 className="flex-1 px-4 py-3 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-xl font-medium transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSubmitRequest}
-                disabled={requestLoading}
+                disabled={actionLoading}
                 className="flex-1 px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-colors flex items-center justify-center gap-2"
               >
-                {requestLoading ? (
+                {actionLoading ? (
                   <>
                     <Loader2 className="w-4 h-4 animate-spin" />
                     Submitting...

--- a/client/src/pages/__tests__/BrowseOrganizations.test.jsx
+++ b/client/src/pages/__tests__/BrowseOrganizations.test.jsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import BrowseOrganizations from "../BrowseOrganizations/BrowseOrganizations";
+import { organizationApi, membershipRequestApi } from "../../services";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../services", () => ({
+  organizationApi: {
+    browsePublicOrganizations: vi.fn(),
+    joinOrganization: vi.fn(),
+  },
+  membershipRequestApi: {
+    createRequest: vi.fn(),
+  },
+}));
+
+const mockOrganizations = [
+  {
+    _id: "org-1",
+    name: "Open Community",
+    slug: "open-community",
+    description: "A public org with open join",
+    visibility: "public",
+    joinPolicy: "open",
+    memberCount: 12,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    membershipStatus: "none",
+  },
+  {
+    _id: "org-2",
+    name: "Approval Required Org",
+    slug: "approval-org",
+    description: "Requires admin approval",
+    visibility: "public",
+    joinPolicy: "approval_required",
+    memberCount: 4,
+    createdAt: "2025-02-01T00:00:00.000Z",
+    membershipStatus: "none",
+  },
+];
+
+describe("BrowseOrganizations (#293)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    organizationApi.browsePublicOrganizations.mockResolvedValue({
+      data: {
+        success: true,
+        organizations: mockOrganizations,
+        pagination: {
+          page: 1,
+          limit: 12,
+          total: 2,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPrevPage: false,
+        },
+      },
+    });
+  });
+
+  it("loads and renders public organizations for discovery", async () => {
+    render(
+      <MemoryRouter>
+        <BrowseOrganizations />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByText("Discover Organizations")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Open Community")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Approval Required Org")).toBeInTheDocument();
+    expect(organizationApi.browsePublicOrganizations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: 1,
+        search: "",
+        sortBy: "createdAt",
+        filter: "all",
+      }),
+    );
+  });
+
+  it("shows join vs request labels based on join policy", async () => {
+    render(
+      <MemoryRouter>
+        <BrowseOrganizations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Open Community")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByRole("button", { name: /Join/i })).toHaveLength(2);
+    expect(
+      screen.getByRole("button", { name: /^Request Join$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits a membership request for approval-required organizations", async () => {
+    membershipRequestApi.createRequest.mockResolvedValue({
+      data: { success: true },
+    });
+
+    render(
+      <MemoryRouter>
+        <BrowseOrganizations />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Approval Required Org")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Request Join/i }));
+
+    await waitFor(() => {
+      expect(membershipRequestApi.createRequest).toHaveBeenCalledWith({
+        organizationId: "org-2",
+        message: "Request to join via Browse Organizations",
+      });
+    });
+  });
+
+  it("links back to the organization hub", async () => {
+    render(
+      <MemoryRouter>
+        <BrowseOrganizations />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /Back to Organization Hub/i }),
+    ).toHaveAttribute("href", "/organizations");
+  });
+});

--- a/client/src/pages/__tests__/JoinOrganizationDiscovery.test.jsx
+++ b/client/src/pages/__tests__/JoinOrganizationDiscovery.test.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import JoinOrganizationPage from "../JoinOrganizationPage";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../services", () => ({
+  invitationApi: {
+    getInvitationByToken: vi.fn(),
+    acceptInvitation: vi.fn(),
+    rejectInvitation: vi.fn(),
+  },
+}));
+
+const renderJoinPage = (initialRoute) =>
+  render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <AppContent.Provider
+        value={{
+          getUserData: vi.fn(),
+          setUserData: vi.fn(),
+        }}
+      >
+        <Routes>
+          <Route path="/join-organization" element={<JoinOrganizationPage />} />
+          <Route
+            path="/browse-organizations"
+            element={<div>Browse Organizations Page</div>}
+          />
+        </Routes>
+      </AppContent.Provider>
+    </MemoryRouter>,
+  );
+
+describe("JoinOrganizationPage discovery redirect (#293)", () => {
+  it("redirects non-token visits to the browse organizations flow", () => {
+    renderJoinPage("/join-organization");
+
+    expect(screen.getByText("Browse Organizations Page")).toBeInTheDocument();
+  });
+});

--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -417,7 +417,7 @@ export const getPublicOrganizationBySlug = async (slug) => {
   // Find organization by slug - only select public fields
   const organization = await Organization.findOne(
     { slug, visibility: "public" },
-    "name slug description logo bannerUrl visibility createdAt metadata",
+    "name slug description logo bannerUrl visibility joinPolicy createdAt metadata",
   );
 
   if (!organization) {
@@ -442,6 +442,7 @@ export const getPublicOrganizationBySlug = async (slug) => {
     logoUrl,
     bannerUrl: organization.bannerUrl || "",
     visibility: organization.visibility,
+    joinPolicy: organization.joinPolicy || "open",
     createdAt: organization.createdAt,
     memberCount,
     website: metadata.website || organization.website || null,


### PR DESCRIPTION
## Summary

Fixes #293

Implements the Organization Discovery flow so users can browse, search, and explore public organizations before joining or requesting access.

## Changes Made

### Organization Discovery

- Fixed the **Browse Organizations** navigation to use `/browse-organizations`.
- Added/updated organization discovery UI with loading, empty, and error handling.
- Added stale-request protection for discovery requests.
- Preserved existing search, filtering, and pagination behavior.
- Added support for `invite_only` organizations.

### Organization Profiles

- Public organization profiles now expose the required `joinPolicy`.
- Aligned profile actions with organization join policies:
  - `open` → Join directly
  - `approval_required` → Request access
  - `invite_only` → Invitation required
- Preserved existing member, pending, and rejected states.
- Added appropriate navigation between Browse Organizations and public profiles.

### Invitation Flow

- `/join-organization` now acts as the invitation-token flow.
- Users visiting it without an invitation token are redirected to Browse Organizations.
- Existing invitation-based joining remains supported.

### Onboarding

- New users can access Browse Organizations before becoming organization members.
- Existing onboarding and protected-route behavior remains intact.

## Files Changed

### Modified

- `client/src/components/__tests__/ProtectedRoute.test.jsx`
- `client/src/components/organization/OrganizationHeader.jsx`
- `client/src/pages/BrowseOrganizations/BrowseOrganizations.jsx`
- `client/src/pages/JoinOrganizationPage.jsx`
- `client/src/pages/PublicOrganizationProfile.jsx`
- `server/services/OrganizationService.js`

### Added

- `client/src/components/organization/__tests__/OrganizationHeaderDiscovery.test.jsx`
- `client/src/pages/__tests__/BrowseOrganizations.test.jsx`
- `client/src/pages/__tests__/JoinOrganizationDiscovery.test.jsx`

## Tests Added

Regression coverage includes:

- Browse Organizations navigation
- Public organization rendering
- Organization join-policy behavior
- Join vs Request Access actions
- Invitation-only behavior
- Join Organization redirect behavior
- Protected-route access during onboarding

## Expected Behavior

| Scenario | Result |
|---|---|
| New user opens Browse Organizations | Organizations are displayed |
| Search organizations | Matching organizations are displayed |
| Open organization profile | Public profile is displayed |
| `open` organization | Direct join is available |
| `approval_required` organization | Request Access is available |
| `invite_only` organization | Invitation is required |
| `/join-organization` without token | Redirects to Browse Organizations |
| `/join-organization` with valid token | Existing invitation flow works |

## Security & Access

- Public discovery only exposes organizations intended for public discovery.
- Existing organization membership and authorization behavior is preserved.
- Invitation-only organizations cannot be joined through the public browse flow.
- Existing authenticated and onboarding access rules remain intact.

## Scope

This PR focuses on restoring and completing the Organization Discovery / Browse Organizations flow.

Existing organization membership, invitation, and authorization systems were reused rather than duplicated.

## Manual Verification

- [ ] New user can open Browse Organizations from Organization Hub
- [ ] Public organizations are displayed
- [ ] Search/filter functionality works
- [ ] Loading state displays correctly
- [ ] Empty state displays correctly
- [ ] Organization profile opens correctly
- [ ] Open organizations allow joining
- [ ] Approval-required organizations allow requesting access
- [ ] Invite-only organizations require an invitation
- [ ] `/join-organization` without a token redirects to Browse Organizations
- [ ] Existing invitation-token flow continues working
- [ ] Existing organization functionality remains unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public organization browsing experience with navigation back to the Organization Hub.
  * Open organizations can be joined directly, while restricted organizations support access requests.
  * Invite-only organizations are clearly labeled and cannot be joined directly.
  * Invitation links now provide the dedicated path for joining organizations.
  * Membership status and request progress are displayed on organization profiles.

* **Bug Fixes**
  * Prevented outdated organization results from replacing current data.
  * Preserved the intended destination after signing in.

* **Tests**
  * Added coverage for browsing, navigation, invitations, membership actions, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->