### PR TITLE
fix: connect careers applications to backend

### DIFF
--- a/client/src/pages/Careers.jsx
+++ b/client/src/pages/Careers.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
+import { submitCareerApplication } from "../services/careersApi.js";
 import {
   Briefcase,
   MapPin,
@@ -272,10 +273,26 @@ const Careers = () => {
     name: "",
     email: "",
     portfolio: "",
-    resume: "",
     coverLetter: "",
   });
+  const [resumeFile, setResumeFile] = useState(null);
+  const [submitError, setSubmitError] = useState("");
+  const resumeInputRef = useRef(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetApplicationForm = () => {
+    setFormData({
+      name: "",
+      email: "",
+      portfolio: "",
+      coverLetter: "",
+    });
+    setResumeFile(null);
+    setSubmitError("");
+    if (resumeInputRef.current) {
+      resumeInputRef.current.value = "";
+    }
+  };
 
   // Accessibility Enhancement: Close modal on Escape key press
   useEffect(() => {
@@ -285,13 +302,7 @@ const Careers = () => {
       if (e.key === "Escape") {
         setIsModalOpen(false);
         setActiveJobForModal(null);
-        setFormData({
-          name: "",
-          email: "",
-          portfolio: "",
-          resume: "",
-          coverLetter: "",
-        });
+        resetApplicationForm();
       }
     };
 
@@ -349,36 +360,78 @@ const Careers = () => {
   const closeModal = () => {
     setIsModalOpen(false);
     setActiveJobForModal(null);
-    setFormData({
-      name: "",
-      email: "",
-      portfolio: "",
-      resume: "",
-      coverLetter: "",
-    });
+    resetApplicationForm();
   };
 
   // Handle Form Change
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
+    if (submitError) setSubmitError("");
   };
 
-  // Submit application
-  const handleSubmit = (e) => {
+  const handleResumeChange = (e) => {
+    const file = e.target.files?.[0] || null;
+    setResumeFile(file);
+    if (submitError) setSubmitError("");
+  };
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!formData.name || !formData.email || !formData.resume) {
+    if (isSubmitting) return;
+
+    if (!formData.name.trim() || !formData.email.trim() || !resumeFile) {
       toast.error("Please fill in all required fields (Name, Email, Resume).");
       return;
     }
+
+    if (!activeJobForModal?.id) {
+      toast.error("Please select a valid job opening.");
+      return;
+    }
+
+    const allowedExtensions = [".pdf", ".docx"];
+    const resumeExt = resumeFile.name
+      .slice(resumeFile.name.lastIndexOf("."))
+      .toLowerCase();
+    if (!allowedExtensions.includes(resumeExt)) {
+      const message = "Resume must be a PDF or DOCX file.";
+      setSubmitError(message);
+      toast.error(message);
+      return;
+    }
+
     setIsSubmitting(true);
-    setTimeout(() => {
-      setIsSubmitting(false);
+    setSubmitError("");
+
+    try {
+      const response = await submitCareerApplication({
+        name: formData.name,
+        email: formData.email,
+        jobId: activeJobForModal.id,
+        portfolio: formData.portfolio,
+        coverLetter: formData.coverLetter,
+        resumeFile,
+      });
+
+      if (response.status !== 200 && response.status !== 201) {
+        throw new Error("Application submission failed.");
+      }
+
       toast.success(
         "✨ Application submitted successfully! We will contact you soon.",
       );
       closeModal();
-    }, 1200);
+    } catch (error) {
+      const message =
+        error?.response?.data?.message ||
+        error?.message ||
+        "Unable to submit your application. Please try again.";
+      setSubmitError(message);
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -837,7 +890,7 @@ const Careers = () => {
             </div>
 
             {/* Application Form */}
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} noValidate className="space-y-4">
               {/* Full Name */}
               <div>
                 <label className="block text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1.5">
@@ -885,21 +938,29 @@ const Careers = () => {
                 />
               </div>
 
-              {/* Resume Link */}
+              {/* Resume Upload */}
               <div>
-                <label className="block text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1.5">
-                  Resume Link (PDF/Drive){" "}
-                  <span className="text-red-500">*</span>
+                <label
+                  htmlFor="careers-resume"
+                  className="block text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-1.5"
+                >
+                  Resume (PDF or DOCX) <span className="text-red-500">*</span>
                 </label>
                 <input
-                  type="url"
+                  id="careers-resume"
+                  ref={resumeInputRef}
+                  type="file"
                   name="resume"
                   required
-                  value={formData.resume}
-                  onChange={handleChange}
-                  placeholder="https://drive.google.com/..."
-                  className="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-950/60 text-slate-900 dark:text-white border border-slate-200 dark:border-slate-800/80 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all text-sm"
+                  accept=".pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                  onChange={handleResumeChange}
+                  className="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-950/60 text-slate-900 dark:text-white border border-slate-200 dark:border-slate-800/80 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all text-sm file:mr-3 file:py-1 file:px-3 file:rounded-lg file:border-0 file:text-xs file:font-semibold file:bg-blue-50 file:text-blue-700 dark:file:bg-blue-900/30 dark:file:text-blue-300"
                 />
+                {resumeFile ? (
+                  <p className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">
+                    Selected: {resumeFile.name}
+                  </p>
+                ) : null}
               </div>
 
               {/* Cover Letter */}
@@ -917,12 +978,22 @@ const Careers = () => {
                 />
               </div>
 
+              {submitError ? (
+                <p
+                  role="alert"
+                  className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/30 border border-red-100 dark:border-red-900/40 rounded-xl px-4 py-3"
+                >
+                  {submitError}
+                </p>
+              ) : null}
+
               {/* Action Buttons */}
               <div className="pt-2 flex items-center justify-end gap-3">
                 <button
                   type="button"
                   onClick={closeModal}
-                  className="px-4 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-300 rounded-xl text-sm font-semibold transition-colors cursor-pointer"
+                  disabled={isSubmitting}
+                  className="px-4 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-300 rounded-xl text-sm font-semibold transition-colors cursor-pointer disabled:opacity-50"
                 >
                   Cancel
                 </button>

--- a/client/src/pages/__tests__/Careers.test.jsx
+++ b/client/src/pages/__tests__/Careers.test.jsx
@@ -1,0 +1,243 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Careers from "../Careers.jsx";
+import { submitCareerApplication } from "../../services/careersApi.js";
+import { toast } from "react-toastify";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav>Navbar</nav>,
+}));
+
+vi.mock("../../services/careersApi.js", () => ({
+  submitCareerApplication: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <span />;
+  return new Proxy(
+    {},
+    {
+      get: () => Icon,
+    },
+  );
+});
+
+const createResumeFile = (name = "resume.pdf") =>
+  new File(["%PDF-1.4"], name, { type: "application/pdf" });
+
+const openFirstJobApplication = async () => {
+  fireEvent.click(screen.getByText("Senior Frontend Engineer"));
+  fireEvent.click(
+    screen.getByRole("button", { name: "Apply for this Position" }),
+  );
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", {
+        name: /Apply for Senior Frontend Engineer/i,
+      }),
+    ).toBeInTheDocument();
+  });
+};
+
+describe("Careers application submission (#1790)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits the application and resume after a successful backend response", async () => {
+    submitCareerApplication.mockResolvedValueOnce({ status: 201, data: {} });
+
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.change(screen.getByPlaceholderText("John Doe"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("john@example.com"), {
+      target: { value: "jane@example.com" },
+    });
+
+    const resumeInput = screen.getByLabelText(/Resume \(PDF or DOCX\)/i);
+    fireEvent.change(resumeInput, {
+      target: { files: [createResumeFile()] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    await waitFor(() => {
+      expect(submitCareerApplication).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Jane Doe",
+          email: "jane@example.com",
+          jobId: "sr-frontend",
+          resumeFile: expect.any(File),
+        }),
+      );
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(
+      "✨ Application submitted successfully! We will contact you soon.",
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("heading", {
+        name: /Apply for Senior Frontend Engineer/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an error state when the backend rejects the submission", async () => {
+    submitCareerApplication.mockRejectedValueOnce({
+      response: { data: { message: "Server unavailable." }, status: 503 },
+      message: "Server unavailable.",
+    });
+
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.change(screen.getByPlaceholderText("John Doe"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("john@example.com"), {
+      target: { value: "jane@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Resume \(PDF or DOCX\)/i), {
+      target: { files: [createResumeFile()] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Server unavailable.",
+      );
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Server unavailable.");
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", {
+        name: /Apply for Senior Frontend Engineer/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("blocks invalid resume file types before calling the API", async () => {
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.change(screen.getByPlaceholderText("John Doe"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("john@example.com"), {
+      target: { value: "jane@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Resume \(PDF or DOCX\)/i), {
+      target: { files: [createResumeFile("resume.exe")] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    expect(submitCareerApplication).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Resume must be a PDF or DOCX file.",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Resume must be a PDF or DOCX file.",
+    );
+  });
+
+  it("requires name, email, and resume before submitting", async () => {
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    expect(submitCareerApplication).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Please fill in all required fields (Name, Email, Resume).",
+    );
+  });
+
+  it("prevents duplicate submissions while a request is pending", async () => {
+    let resolveSubmit;
+    submitCareerApplication.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.change(screen.getByPlaceholderText("John Doe"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("john@example.com"), {
+      target: { value: "jane@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Resume \(PDF or DOCX\)/i), {
+      target: { files: [createResumeFile()] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    const submittingButton = screen.getByRole("button", {
+      name: "Submitting...",
+    });
+    expect(submittingButton).toBeDisabled();
+
+    fireEvent.click(submittingButton);
+    expect(submitCareerApplication).toHaveBeenCalledTimes(1);
+
+    resolveSubmit({ status: 201, data: {} });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+  });
+
+  it("does not show success toast unless the backend returns 200 or 201", async () => {
+    submitCareerApplication.mockResolvedValueOnce({ status: 202, data: {} });
+
+    render(<Careers />);
+    await openFirstJobApplication();
+
+    fireEvent.change(screen.getByPlaceholderText("John Doe"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("john@example.com"), {
+      target: { value: "jane@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Resume \(PDF or DOCX\)/i), {
+      target: { files: [createResumeFile()] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Application" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Application submission failed.",
+      );
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("heading", {
+        name: /Apply for Senior Frontend Engineer/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/services/careersApi.js
+++ b/client/src/services/careersApi.js
@@ -1,0 +1,44 @@
+import apiClient from "./apiClient";
+
+/**
+ * Submit a public careers application with resume upload (Issue #1790).
+ *
+ * @param {object} payload
+ * @param {string} payload.name
+ * @param {string} payload.email
+ * @param {string} payload.jobId
+ * @param {string} [payload.portfolio]
+ * @param {string} [payload.coverLetter]
+ * @param {File} payload.resumeFile
+ */
+export async function submitCareerApplication({
+  name,
+  email,
+  jobId,
+  portfolio,
+  coverLetter,
+  resumeFile,
+}) {
+  const formData = new FormData();
+  formData.append("name", name.trim());
+  formData.append("email", email.trim());
+  formData.append("jobId", jobId);
+
+  if (portfolio?.trim()) {
+    formData.append("portfolio", portfolio.trim());
+  }
+  if (coverLetter?.trim()) {
+    formData.append("coverLetter", coverLetter.trim());
+  }
+
+  formData.append("resume", resumeFile);
+
+  return apiClient.post("/api/careers/applications", formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+    timeout: 60000,
+  });
+}
+
+export default submitCareerApplication;

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -15,6 +15,7 @@ import slackRoutes from "../routes/slackRoutes.js";
 import { slackWebhookParser } from "../middleware/slackWebhookParser.js";
 import publicSharedRoutes from "../routes/publicSharedRoutes.js";
 import { createStatusRoutes } from "../routes/statusRoutes.js";
+import { createCareerRoutes } from "../routes/careerRoutes.js";
 
 export function configureExpress(app) {
   app.set("trust proxy", 1);
@@ -42,6 +43,7 @@ export function configureExpress(app) {
   // or CSRF middleware.
   configureHealthEndpoints(app);
   app.use("/api/status", createStatusRoutes());
+  app.use("/api/careers", createCareerRoutes());
 
   // External/public routes use their own authentication mechanisms.
   app.use("/api/webhooks", webhookRoutes);

--- a/server/constants/careerJobs.js
+++ b/server/constants/careerJobs.js
@@ -1,0 +1,20 @@
+/**
+ * Canonical public job identifiers for careers applications.
+ * Must stay aligned with client/src/pages/Careers.jsx listings.
+ */
+export const CAREER_JOBS = {
+  "sr-frontend": { title: "Senior Frontend Engineer" },
+  "ai-engineer": { title: "AI / NLP Research Engineer" },
+  "product-designer": { title: "Product Designer (UI/UX)" },
+  "marketing-manager": { title: "Product Marketing Manager" },
+  "intern-gemini": { title: "Software Engineer Intern (Gemini Integrations)" },
+  "grad-pm": { title: "Graduate Product Manager" },
+  general: { title: "General Application" },
+};
+
+export const CAREER_JOB_IDS = Object.keys(CAREER_JOBS);
+
+export const isValidCareerJobId = (jobId) =>
+  typeof jobId === "string" && CAREER_JOB_IDS.includes(jobId.trim());
+
+export default CAREER_JOBS;

--- a/server/controllers/careerApplicationController.js
+++ b/server/controllers/careerApplicationController.js
@@ -1,0 +1,30 @@
+import { submitCareerApplication } from "../services/careerApplicationService.js";
+import { sendSuccess } from "../utils/responseHandler.js";
+
+export const createSubmitCareerApplicationHandler = () => {
+  return async (req, res, next) => {
+    try {
+      const result = await submitCareerApplication({
+        name: req.body.name,
+        email: req.body.email,
+        jobId: req.body.jobId,
+        portfolio: req.body.portfolio,
+        coverLetter: req.body.coverLetter,
+        resumeFile: req.file,
+      });
+
+      return sendSuccess(
+        res,
+        { applicationId: result.id },
+        "Application submitted successfully.",
+        201,
+      );
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
+export const submitApplication = createSubmitCareerApplicationHandler();
+
+export default submitApplication;

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -289,3 +289,24 @@ export const createTestimonialSubmitLimiter = (overrides = {}) =>
   });
 
 export const testimonialSubmitLimiter = createTestimonialSubmitLimiter();
+
+/**
+ * Public careers application submissions (Issue #1790).
+ * Limits abuse by client IP while allowing legitimate retries.
+ */
+export const createCareersApplicationLimiter = (overrides = {}) =>
+  rateLimit({
+    ...baseOptions,
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    keyGenerator: (req) => `ip:${getClientIp(req)}`,
+    message: {
+      success: false,
+      message:
+        "Too many career applications from this address. Please try again later.",
+    },
+    store: createStore("rl:careers_application:"),
+    ...overrides,
+  });
+
+export const careersApplicationLimiter = createCareersApplicationLimiter();

--- a/server/models/careerApplicationModel.js
+++ b/server/models/careerApplicationModel.js
@@ -1,0 +1,63 @@
+import mongoose from "mongoose";
+
+const COVER_LETTER_MAX_LENGTH = 2000;
+
+const careerApplicationSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 120,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+      maxlength: 254,
+    },
+    jobId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    jobTitle: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 160,
+    },
+    portfolio: {
+      type: String,
+      trim: true,
+      maxlength: 500,
+      default: "",
+    },
+    coverLetter: {
+      type: String,
+      trim: true,
+      maxlength: COVER_LETTER_MAX_LENGTH,
+      default: "",
+    },
+    resume: {
+      originalName: { type: String, required: true },
+      storedName: { type: String, required: true },
+      mimeType: { type: String, required: true },
+      size: { type: Number, required: true },
+    },
+    status: {
+      type: String,
+      enum: ["received"],
+      default: "received",
+    },
+  },
+  { timestamps: true },
+);
+
+careerApplicationSchema.index({ email: 1, jobId: 1 }, { unique: true });
+
+export const CAREER_COVER_LETTER_MAX_LENGTH = COVER_LETTER_MAX_LENGTH;
+
+export default mongoose.model("CareerApplication", careerApplicationSchema);

--- a/server/routes/careerRoutes.js
+++ b/server/routes/careerRoutes.js
@@ -1,0 +1,106 @@
+import express from "express";
+import multer from "multer";
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { fileURLToPath } from "url";
+import { createSubmitCareerApplicationHandler } from "../controllers/careerApplicationController.js";
+import { createCareersApplicationLimiter } from "../middleware/rateLimiter.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const uploadDir = path.join(__dirname, "..", "uploads", "careers");
+
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB — aligned with attachment uploads
+
+const ALLOWED_MIME_TYPES = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+
+const ALLOWED_EXTENSIONS = [".pdf", ".docx"];
+
+const fileFilter = (req, file, cb) => {
+  const ext = path.extname(file.originalname).toLowerCase();
+  if (
+    !ALLOWED_MIME_TYPES.includes(file.mimetype) ||
+    !ALLOWED_EXTENSIONS.includes(ext)
+  ) {
+    return cb(
+      new Error(
+        "Invalid resume file. Only PDF and DOCX files up to 10 MB are allowed.",
+      ),
+      false,
+    );
+  }
+  cb(null, true);
+};
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${crypto.randomUUID()}`;
+    const ext = path.extname(file.originalname).toLowerCase();
+    cb(null, `${uniqueSuffix}${ext}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: MAX_FILE_SIZE,
+    files: 1,
+  },
+});
+
+const handleResumeUpload = (req, res, next) => {
+  upload.single("resume")(req, res, (err) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(400).json({
+          success: false,
+          message: "Resume file is too large. Maximum allowed size is 10 MB.",
+        });
+      }
+      return res.status(400).json({
+        success: false,
+        message: err.message || "Resume upload failed.",
+      });
+    }
+    if (err) {
+      return res.status(400).json({
+        success: false,
+        message: err.message || "Resume upload failed.",
+      });
+    }
+    next();
+  });
+};
+
+/**
+ * @param {object} [options]
+ * @param {import("express").RequestHandler} [options.submitLimiter]
+ * @returns {import("express").Router}
+ */
+export const createCareerRoutes = (options = {}) => {
+  const router = express.Router();
+  const submitLimiter =
+    options.submitLimiter ?? createCareersApplicationLimiter();
+
+  router.post(
+    "/applications",
+    submitLimiter,
+    handleResumeUpload,
+    createSubmitCareerApplicationHandler(),
+  );
+
+  return router;
+};
+
+export default createCareerRoutes();

--- a/server/services/careerApplicationService.js
+++ b/server/services/careerApplicationService.js
@@ -1,0 +1,169 @@
+import fs from "fs/promises";
+import path from "path";
+import CareerApplication, {
+  CAREER_COVER_LETTER_MAX_LENGTH,
+} from "../models/careerApplicationModel.js";
+import { CAREER_JOBS, isValidCareerJobId } from "../constants/careerJobs.js";
+import { ValidationError, ConflictError } from "../utils/errors.js";
+
+const NAME_MIN_LENGTH = 2;
+const NAME_MAX_LENGTH = 120;
+const PORTFOLIO_MAX_LENGTH = 500;
+
+/**
+ * ReDoS-safe email validation aligned with invitationController.
+ * @param {string} email
+ * @returns {string|null}
+ */
+export const sanitizeEmail = (email) => {
+  if (!email || typeof email !== "string") return null;
+  const sanitized = email.trim().toLowerCase();
+  if (sanitized.length > 254) return null;
+  if (!sanitized.includes("@") || !sanitized.includes(".")) return null;
+  const parts = sanitized.split("@");
+  if (parts.length !== 2) return null;
+  const [local, domain] = parts;
+  if (!local || !domain) return null;
+  if (local.length > 64) return null;
+  if (domain.length > 255) return null;
+  if (domain.split(".").length < 2) return null;
+  return sanitized;
+};
+
+export const sanitizeName = (name) => {
+  if (!name || typeof name !== "string") return null;
+  const trimmed = name.trim().replace(/\s+/g, " ");
+  if (trimmed.length < NAME_MIN_LENGTH || trimmed.length > NAME_MAX_LENGTH) {
+    return null;
+  }
+  return trimmed;
+};
+
+export const sanitizePortfolio = (portfolio) => {
+  if (portfolio == null || portfolio === "") return "";
+  if (typeof portfolio !== "string") {
+    throw new ValidationError("Portfolio must be a valid http or https URL.");
+  }
+  const trimmed = portfolio.trim();
+  if (!trimmed) return "";
+  if (trimmed.length > PORTFOLIO_MAX_LENGTH) {
+    throw new ValidationError("Portfolio link is too long.");
+  }
+  try {
+    const url = new URL(trimmed);
+    if (!["http:", "https:"].includes(url.protocol)) {
+      throw new ValidationError("Portfolio must be a valid http or https URL.");
+    }
+  } catch (err) {
+    if (err instanceof ValidationError) throw err;
+    throw new ValidationError("Portfolio must be a valid http or https URL.");
+  }
+  return trimmed;
+};
+
+export const sanitizeCoverLetter = (coverLetter) => {
+  if (coverLetter == null || coverLetter === "") return "";
+  if (typeof coverLetter !== "string") {
+    throw new ValidationError("Cover letter must be text.");
+  }
+  const trimmed = coverLetter.trim();
+  if (trimmed.length > CAREER_COVER_LETTER_MAX_LENGTH) {
+    throw new ValidationError(
+      `Cover letter must be ${CAREER_COVER_LETTER_MAX_LENGTH} characters or fewer.`,
+    );
+  }
+  return trimmed;
+};
+
+export const buildResumeMetadata = (file) => {
+  if (!file) {
+    throw new ValidationError("Resume file is required.");
+  }
+  return {
+    originalName: file.originalname,
+    storedName: path.basename(file.filename || file.path),
+    mimeType: file.mimetype,
+    size: file.size,
+    filePath: file.path,
+  };
+};
+
+export async function removeUploadedFile(filePath) {
+  if (!filePath) return;
+  try {
+    await fs.unlink(filePath);
+  } catch {
+    // Best-effort cleanup for rejected or failed uploads.
+  }
+}
+
+/**
+ * @param {object} input
+ * @param {string} input.name
+ * @param {string} input.email
+ * @param {string} input.jobId
+ * @param {string} [input.portfolio]
+ * @param {string} [input.coverLetter]
+ * @param {import("multer").File} input.resumeFile
+ */
+export async function submitCareerApplication({
+  name,
+  email,
+  jobId,
+  portfolio,
+  coverLetter,
+  resumeFile,
+}) {
+  const sanitizedName = sanitizeName(name);
+  if (!sanitizedName) {
+    await removeUploadedFile(resumeFile?.path);
+    throw new ValidationError("Please provide a valid full name.");
+  }
+
+  const sanitizedEmail = sanitizeEmail(email);
+  if (!sanitizedEmail) {
+    await removeUploadedFile(resumeFile?.path);
+    throw new ValidationError("Please provide a valid email address.");
+  }
+
+  const normalizedJobId =
+    typeof jobId === "string" ? jobId.trim() : String(jobId ?? "");
+  if (!isValidCareerJobId(normalizedJobId)) {
+    await removeUploadedFile(resumeFile?.path);
+    throw new ValidationError("Please select a valid job opening.");
+  }
+
+  const resume = buildResumeMetadata(resumeFile);
+  const sanitizedPortfolio = sanitizePortfolio(portfolio);
+  const sanitizedCoverLetter = sanitizeCoverLetter(coverLetter);
+  const jobTitle = CAREER_JOBS[normalizedJobId].title;
+
+  try {
+    const application = await CareerApplication.create({
+      name: sanitizedName,
+      email: sanitizedEmail,
+      jobId: normalizedJobId,
+      jobTitle,
+      portfolio: sanitizedPortfolio,
+      coverLetter: sanitizedCoverLetter,
+      resume: {
+        originalName: resume.originalName,
+        storedName: resume.storedName,
+        mimeType: resume.mimeType,
+        size: resume.size,
+      },
+    });
+
+    return { id: application._id.toString() };
+  } catch (err) {
+    await removeUploadedFile(resume.filePath);
+    if (err?.code === 11000) {
+      throw new ConflictError(
+        "You have already submitted an application for this role.",
+      );
+    }
+    throw err;
+  }
+}
+
+export default submitCareerApplication;

--- a/server/tests/careerApplicationRoutes.test.js
+++ b/server/tests/careerApplicationRoutes.test.js
@@ -1,0 +1,155 @@
+/**
+ * Issue #1790 — public careers application route and resume upload.
+ */
+
+import { jest } from "@jest/globals";
+import request from "supertest";
+import express from "express";
+
+const mockSubmitCareerApplication = jest.fn();
+
+jest.unstable_mockModule("../services/careerApplicationService.js", () => ({
+  submitCareerApplication: (...args) => mockSubmitCareerApplication(...args),
+  removeUploadedFile: jest.fn(),
+}));
+
+const errorHandler = (await import("../middleware/errorHandler.js")).default;
+const { createCareerRoutes } = await import("../routes/careerRoutes.js");
+const { ValidationError, ConflictError } = await import("../utils/errors.js");
+
+const buildCareersApp = () => {
+  const app = express();
+  app.use(
+    "/api/careers",
+    createCareerRoutes({
+      submitLimiter: (_req, _res, next) => next(),
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+};
+
+describe("POST /api/careers/applications (#1790)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubmitCareerApplication.mockResolvedValue({ id: "app-123" });
+  });
+
+  it("accepts multipart applications with a resume file", async () => {
+    const app = buildCareersApp();
+
+    const res = await request(app)
+      .post("/api/careers/applications")
+      .field("name", "Jane Doe")
+      .field("email", "jane@example.com")
+      .field("jobId", "ai-engineer")
+      .field("portfolio", "https://github.com/jane")
+      .field("coverLetter", "I build AI products.")
+      .attach("resume", Buffer.from("%PDF-1.4 test"), {
+        filename: "resume.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: true,
+        message: "Application submitted successfully.",
+        applicationId: "app-123",
+      }),
+    );
+    expect(res.body).not.toHaveProperty("email");
+    expect(res.body).not.toHaveProperty("resume");
+
+    expect(mockSubmitCareerApplication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Jane Doe",
+        email: "jane@example.com",
+        jobId: "ai-engineer",
+        resumeFile: expect.objectContaining({
+          originalname: "resume.pdf",
+          mimetype: "application/pdf",
+        }),
+      }),
+    );
+  });
+
+  it("returns validation errors from the service layer", async () => {
+    mockSubmitCareerApplication.mockRejectedValueOnce(
+      new ValidationError("Please provide a valid email address."),
+    );
+
+    const app = buildCareersApp();
+    const res = await request(app)
+      .post("/api/careers/applications")
+      .field("name", "Jane Doe")
+      .field("email", "bad-email")
+      .field("jobId", "general")
+      .attach("resume", Buffer.from("%PDF-1.4 test"), {
+        filename: "resume.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        success: false,
+        message: "Please provide a valid email address.",
+      }),
+    );
+  });
+
+  it("returns conflict errors for duplicate applications", async () => {
+    mockSubmitCareerApplication.mockRejectedValueOnce(
+      new ConflictError(
+        "You have already submitted an application for this role.",
+      ),
+    );
+
+    const app = buildCareersApp();
+    const res = await request(app)
+      .post("/api/careers/applications")
+      .field("name", "Jane Doe")
+      .field("email", "jane@example.com")
+      .field("jobId", "general")
+      .attach("resume", Buffer.from("%PDF-1.4 test"), {
+        filename: "resume.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.message).toBe(
+      "You have already submitted an application for this role.",
+    );
+  });
+
+  it("rejects unsupported resume file types before hitting the service", async () => {
+    const app = buildCareersApp();
+    const res = await request(app)
+      .post("/api/careers/applications")
+      .field("name", "Jane Doe")
+      .field("email", "jane@example.com")
+      .field("jobId", "general")
+      .attach("resume", Buffer.from("not a resume"), {
+        filename: "resume.exe",
+        contentType: "application/octet-stream",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/Invalid resume file/i);
+    expect(mockSubmitCareerApplication).not.toHaveBeenCalled();
+  });
+
+  it("requires a resume attachment", async () => {
+    const app = buildCareersApp();
+    const res = await request(app)
+      .post("/api/careers/applications")
+      .field("name", "Jane Doe")
+      .field("email", "jane@example.com")
+      .field("jobId", "general");
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe("Resume file is required.");
+    expect(mockSubmitCareerApplication).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/careerApplicationService.test.js
+++ b/server/tests/careerApplicationService.test.js
@@ -1,0 +1,139 @@
+/**
+ * Issue #1790 — careers application service validation and persistence.
+ */
+
+import { jest } from "@jest/globals";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+jest.unstable_mockModule("../models/careerApplicationModel.js", () => ({
+  default: {
+    create: jest.fn(),
+  },
+  CAREER_COVER_LETTER_MAX_LENGTH: 2000,
+}));
+
+const CareerApplication = (await import("../models/careerApplicationModel.js"))
+  .default;
+
+const {
+  sanitizeEmail,
+  sanitizeName,
+  submitCareerApplication,
+  removeUploadedFile,
+} = await import("../services/careerApplicationService.js");
+
+describe("careerApplicationService (#1790)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sanitizes valid applicant emails", () => {
+    expect(sanitizeEmail("  Ada.Lovelace@Example.COM ")).toBe(
+      "ada.lovelace@example.com",
+    );
+  });
+
+  it("rejects invalid applicant emails", () => {
+    expect(sanitizeEmail("not-an-email")).toBeNull();
+  });
+
+  it("sanitizes applicant names", () => {
+    expect(sanitizeName("  Jane   Doe  ")).toBe("Jane Doe");
+    expect(sanitizeName("A")).toBeNull();
+  });
+
+  it("creates an application with server-derived job title", async () => {
+    CareerApplication.create.mockResolvedValueOnce({
+      _id: { toString: () => "app-123" },
+    });
+
+    const tmpFile = path.join(os.tmpdir(), `resume-${Date.now()}.pdf`);
+    await fs.writeFile(tmpFile, "dummy resume");
+
+    const result = await submitCareerApplication({
+      name: "Jane Doe",
+      email: "jane@example.com",
+      jobId: "sr-frontend",
+      portfolio: "https://github.com/jane",
+      coverLetter: "Excited to join MeetOnMemory.",
+      resumeFile: {
+        originalname: "resume.pdf",
+        filename: path.basename(tmpFile),
+        path: tmpFile,
+        mimetype: "application/pdf",
+        size: 12,
+      },
+    });
+
+    expect(result).toEqual({ id: "app-123" });
+    expect(CareerApplication.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Jane Doe",
+        email: "jane@example.com",
+        jobId: "sr-frontend",
+        jobTitle: "Senior Frontend Engineer",
+        portfolio: "https://github.com/jane",
+      }),
+    );
+  });
+
+  it("rejects invalid job identifiers and cleans up uploaded files", async () => {
+    const tmpFile = path.join(os.tmpdir(), `bad-job-${Date.now()}.pdf`);
+    await fs.writeFile(tmpFile, "dummy resume");
+
+    await expect(
+      submitCareerApplication({
+        name: "Jane Doe",
+        email: "jane@example.com",
+        jobId: "not-a-real-role",
+        resumeFile: {
+          originalname: "resume.pdf",
+          filename: path.basename(tmpFile),
+          path: tmpFile,
+          mimetype: "application/pdf",
+          size: 12,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "Please select a valid job opening.",
+      statusCode: 400,
+    });
+
+    await expect(fs.access(tmpFile)).rejects.toThrow();
+    expect(CareerApplication.create).not.toHaveBeenCalled();
+  });
+
+  it("maps duplicate applications to a conflict error", async () => {
+    const tmpFile = path.join(os.tmpdir(), `dup-${Date.now()}.pdf`);
+    await fs.writeFile(tmpFile, "dummy resume");
+    CareerApplication.create.mockRejectedValueOnce({ code: 11000 });
+
+    await expect(
+      submitCareerApplication({
+        name: "Jane Doe",
+        email: "jane@example.com",
+        jobId: "general",
+        resumeFile: {
+          originalname: "resume.pdf",
+          filename: path.basename(tmpFile),
+          path: tmpFile,
+          mimetype: "application/pdf",
+          size: 12,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "You have already submitted an application for this role.",
+      statusCode: 409,
+    });
+
+    await expect(fs.access(tmpFile)).rejects.toThrow();
+  });
+
+  it("removeUploadedFile is best-effort", async () => {
+    await expect(
+      removeUploadedFile(path.join(os.tmpdir(), "missing-career-resume.pdf")),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1790

Connects the Careers application form to a real backend endpoint and adds secure resume upload, validation, persistence, and error handling.

## Problem

Careers applications previously used a fake `setTimeout` success flow. Applicant data was never sent to the backend and uploaded resumes were not actually submitted.

## Changes Made

### Backend

Added a complete careers application pipeline:

- `POST /api/careers/applications`
- Application model and persistence
- Application service and validation
- Controller and route
- Server-side job allowlist
- Multipart resume upload
- Rate limiting

### Resume Upload

- Supports PDF and DOCX
- Maximum file size: 10 MB
- UUID-based filenames
- Stored under `server/uploads/careers/`
- Uploaded files are cleaned up when validation or persistence fails
- File paths are never exposed to clients

### Validation & Security

- Server validates applicant name, email, job ID, portfolio, and cover letter
- Job title is derived from the server-side job allowlist
- Duplicate applications return `409 Conflict`
- Public submissions are rate-limited to 5 per hour per IP
- No unnecessary applicant or resume data is returned in the API response

### Frontend

- Replaced the resume URL field with a file picker
- Submits applications using `FormData`
- Uses the existing `apiClient`
- Added submitting, success, and error states
- Prevents duplicate submissions
- Success is shown only after a `200`/`201` response

## Files Changed

### Modified

- `client/src/pages/Careers.jsx`
- `server/config/express.js`
- `server/middleware/rateLimiter.js`

### Added

- `client/src/services/careersApi.js`
- `client/src/pages/__tests__/Careers.test.jsx`
- `server/constants/careerJobs.js`
- `server/controllers/careerApplicationController.js`
- `server/models/careerApplicationModel.js`
- `server/routes/careerRoutes.js`
- `server/services/careerApplicationService.js`
- `server/tests/careerApplicationRoutes.test.js`
- `server/tests/careerApplicationService.test.js`

## API

`POST /api/careers/applications`

Content type:

`multipart/form-data`

Required fields:

- `name`
- `email`
- `jobId`
- `resume`

Optional fields:

- `portfolio`
- `coverLetter`

Successful submission returns `201` with an application ID and generic success message.

## Tests

Regression tests cover:

- Successful application submission
- Resume upload
- Validation failures
- Missing resume
- Invalid file type
- Duplicate applications
- Backend failures
- File cleanup
- Duplicate-submit prevention
- Success toast only after successful submission

## Expected Behavior

| Scenario | Result |
|---|---|
| Valid application + resume | `201 Created` |
| Missing required field | `400 Bad Request` |
| Invalid resume type | `400 Bad Request` |
| Resume over 10 MB | Rejected |
| Duplicate application | `409 Conflict` |
| Successful submission | Success message shown |
| Backend failure | Error shown, no false success |

## Security Impact

Careers submissions are now validated and persisted server-side instead of relying on client-side confirmation.

Resume uploads are restricted by file type and size, job IDs are validated against a server-side allowlist, duplicate submissions are prevented, and public submissions are rate-limited.

## Scope

This change is limited to the Careers application workflow and does not modify unrelated application functionality.