### PR TITLE
fix: improve careers accessibility

### DIFF
--- a/client/src/pages/Careers.jsx
+++ b/client/src/pages/Careers.jsx
@@ -345,6 +345,13 @@ const Careers = () => {
     setExpandedJob(expandedJob === id ? null : id);
   };
 
+  const handleJobHeaderKeyDown = (event, jobId) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggleJob(jobId);
+    }
+  };
+
   // Expand FAQ accordion
   const toggleFaq = (index) => {
     setExpandedFaq(expandedFaq === index ? null : index);
@@ -435,7 +442,7 @@ const Careers = () => {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 transition-colors duration-300 flex flex-col font-sans select-none">
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 transition-colors duration-300 flex flex-col font-sans">
       <Navbar />
 
       {/* Hero Section */}
@@ -595,8 +602,16 @@ const Careers = () => {
                   >
                     {/* Header Card */}
                     <div
+                      role="button"
+                      tabIndex={0}
+                      aria-expanded={isOpen}
+                      aria-controls={`job-panel-${job.id}`}
+                      aria-label={`Toggle details for ${job.title}`}
                       onClick={() => toggleJob(job.id)}
-                      className="p-6 flex flex-col md:flex-row md:items-center justify-between gap-4 cursor-pointer hover:bg-slate-50/50 dark:hover:bg-slate-800/10 transition-colors"
+                      onKeyDown={(event) =>
+                        handleJobHeaderKeyDown(event, job.id)
+                      }
+                      className="p-6 flex flex-col md:flex-row md:items-center justify-between gap-4 cursor-pointer hover:bg-slate-50/50 dark:hover:bg-slate-800/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
                     >
                       <div className="space-y-1.5">
                         <div className="flex flex-wrap items-center gap-2">
@@ -650,6 +665,8 @@ const Careers = () => {
 
                     {/* Expandable Panel */}
                     <div
+                      id={`job-panel-${job.id}`}
+                      aria-hidden={!isOpen}
                       className={`transition-all duration-300 ease-in-out overflow-hidden ${
                         isOpen
                           ? "max-h-[800px] border-t border-slate-100 dark:border-slate-800/60"

--- a/client/src/pages/__tests__/CareersAccessibility.test.jsx
+++ b/client/src/pages/__tests__/CareersAccessibility.test.jsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Careers from "../Careers.jsx";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav>Navbar</nav>,
+}));
+
+vi.mock("../../services/careersApi.js", () => ({
+  submitCareerApplication: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <span />;
+  return new Proxy(
+    {},
+    {
+      get: () => Icon,
+    },
+  );
+});
+
+const SR_FRONTEND_LABEL = /Toggle details for Senior Frontend Engineer/i;
+const SR_FRONTEND_DESCRIPTION =
+  /Join us in crafting the frontend architecture for our real-time meeting transcription/i;
+
+const getSeniorFrontendToggle = () =>
+  screen.getByRole("button", { name: SR_FRONTEND_LABEL });
+
+const assertNoSelectNoneAncestor = (element) => {
+  let node = element;
+  while (node) {
+    expect(node.className || "").not.toMatch(/\bselect-none\b/);
+    node = node.parentElement;
+  }
+};
+
+describe("Careers accessibility (#1791)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not apply select-none at the page root", () => {
+    const { container } = render(<Careers />);
+    const root = container.firstChild;
+    expect(root.className).not.toMatch(/\bselect-none\b/);
+  });
+
+  it("allows job descriptions to be highlighted and copied", () => {
+    render(<Careers />);
+
+    fireEvent.click(getSeniorFrontendToggle());
+
+    const description = screen.getByText(SR_FRONTEND_DESCRIPTION);
+    assertNoSelectNoneAncestor(description);
+    expect(description.tagName).toBe("P");
+  });
+
+  it("exposes job rows as keyboard-focusable controls", () => {
+    render(<Careers />);
+
+    const jobToggles = screen.getAllByRole("button", {
+      name: /Toggle details for/i,
+    });
+
+    expect(jobToggles.length).toBeGreaterThan(0);
+    jobToggles.forEach((toggle) => {
+      expect(toggle).toHaveAttribute("tabindex", "0");
+      expect(toggle).toHaveAttribute("aria-expanded");
+      expect(toggle).toHaveAttribute("aria-controls");
+    });
+  });
+
+  it("expands and collapses a job row when Enter is pressed", () => {
+    render(<Careers />);
+
+    const toggle = getSeniorFrontendToggle();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(SR_FRONTEND_DESCRIPTION)).toBeInTheDocument();
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("expands and collapses a job row when Space is pressed", () => {
+    render(<Careers />);
+
+    const toggle = getSeniorFrontendToggle();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.keyDown(toggle, { key: " " });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(SR_FRONTEND_DESCRIPTION)).toBeInTheDocument();
+
+    fireEvent.keyDown(toggle, { key: " " });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("preserves mouse click behavior for expanding job rows", () => {
+    render(<Careers />);
+
+    const toggle = getSeniorFrontendToggle();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(SR_FRONTEND_DESCRIPTION)).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does not nest the apply action inside the job toggle control", () => {
+    render(<Careers />);
+
+    fireEvent.click(getSeniorFrontendToggle());
+
+    const applyButton = screen.getByRole("button", {
+      name: "Apply for this Position",
+    });
+    const jobToggle = getSeniorFrontendToggle();
+
+    expect(jobToggle).not.toContainElement(applyButton);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1791

Improves Careers page accessibility by restoring text selection and making expandable job rows keyboard accessible.

## Problem

The Careers page had two accessibility issues:

- `select-none` prevented users from selecting and copying job descriptions.
- Clickable job rows were `<div>` elements without keyboard accessibility or appropriate ARIA attributes.

## Changes Made

### Text Selection

- Removed the root-level `select-none` class.
- Job descriptions, requirements, and other page content can now be selected and copied normally.

### Keyboard Accessibility

Job rows now support:

- `role="button"`
- `tabIndex={0}`
- `aria-expanded`
- `aria-controls`
- Descriptive `aria-label`
- `Enter` to expand/collapse
- `Space` to expand/collapse
- `preventDefault()` for Space to prevent page scrolling
- Visible keyboard focus styles

Expandable panels now expose matching IDs and `aria-hidden` state.

The Apply button remains outside the job-row toggle to avoid nested interactive controls.

## Preserved

- Existing Careers UI and styling
- Click-to-expand behavior
- Job filtering
- Application modal
- Resume upload
- Animations
- Responsive behavior
- Existing application functionality

## Files Changed

### Modified

- `client/src/pages/Careers.jsx`

### Added

- `client/src/pages/__tests__/CareersAccessibility.test.jsx`

## Tests Added

Regression coverage includes:

- Job content remains selectable
- Job rows are keyboard focusable
- Correct ARIA attributes are present
- `Enter` expands/collapses jobs
- `Space` expands/collapses jobs
- Mouse click behavior remains functional
- Apply button is not nested inside the toggle

## Accessibility Impact

Users can now copy Careers content normally and operate job expand/collapse controls using keyboard navigation.

## Scope

This change is limited to the Careers page accessibility issues described in #1791. No backend or unrelated functionality was changed.