### PR TITLE
fix: improve careers application modal accessibility

### DIFF
--- a/client/src/pages/Careers.jsx
+++ b/client/src/pages/Careers.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import React, { useState, useMemo, useEffect, useRef, useId } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
@@ -24,6 +24,9 @@ import {
   Globe,
   HelpCircle,
 } from "lucide-react";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 // Curated Mock Job Listings
 const initialJobs = [
@@ -280,6 +283,12 @@ const Careers = () => {
   const resumeInputRef = useRef(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // Modal accessibility refs and IDs
+  const modalDialogRef = useRef(null);
+  const modalCloseButtonRef = useRef(null);
+  const modalTriggerRef = useRef(null);
+  const modalTitleId = useId();
+
   const resetApplicationForm = () => {
     setFormData({
       name: "",
@@ -294,21 +303,46 @@ const Careers = () => {
     }
   };
 
-  // Accessibility Enhancement: Close modal on Escape key press
+  // Focus management: trap focus, handle Escape, restore focus on close
   useEffect(() => {
     if (!isModalOpen) return;
 
+    const animationFrame = window.requestAnimationFrame(() => {
+      modalCloseButtonRef.current?.focus();
+    });
+
     const handleKeyDown = (e) => {
       if (e.key === "Escape") {
-        setIsModalOpen(false);
-        setActiveJobForModal(null);
-        resetApplicationForm();
+        e.preventDefault();
+        closeModal();
+        return;
+      }
+
+      if (e.key !== "Tab" || !modalDialogRef.current) return;
+
+      const focusables = [
+        ...modalDialogRef.current.querySelectorAll(FOCUSABLE_SELECTOR),
+      ];
+      if (!focusables.length) return;
+
+      const firstElement = focusables[0];
+      const lastElement = focusables[focusables.length - 1];
+
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
+
     return () => {
+      window.cancelAnimationFrame(animationFrame);
       document.removeEventListener("keydown", handleKeyDown);
+      modalTriggerRef.current?.focus?.();
     };
   }, [isModalOpen]);
 
@@ -359,6 +393,7 @@ const Careers = () => {
 
   // Open modal
   const openApplication = (job) => {
+    modalTriggerRef.current = document.activeElement;
     setActiveJobForModal(job);
     setIsModalOpen(true);
   };
@@ -881,10 +916,22 @@ const Careers = () => {
 
       {/* Application Form Modal */}
       {isModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-950/60 backdrop-blur-xs transition-opacity duration-300">
-          <div className="relative w-full max-w-xl bg-white dark:bg-slate-900 rounded-3xl border border-slate-200 dark:border-slate-800 shadow-2xl p-6 sm:p-8 animate-in fade-in zoom-in-95 duration-200">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-950/60 backdrop-blur-xs transition-opacity duration-300"
+          role="presentation"
+          onClick={closeModal}
+        >
+          <div
+            ref={modalDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={modalTitleId}
+            className="relative w-full max-w-xl bg-white dark:bg-slate-900 rounded-3xl border border-slate-200 dark:border-slate-800 shadow-2xl p-6 sm:p-8 animate-in fade-in zoom-in-95 duration-200"
+            onClick={(e) => e.stopPropagation()}
+          >
             {/* Modal Close */}
             <button
+              ref={modalCloseButtonRef}
               onClick={closeModal}
               className="absolute top-4 right-4 p-2 rounded-full text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800/80 transition-colors cursor-pointer"
               aria-label="Close modal"
@@ -897,7 +944,10 @@ const Careers = () => {
               <span className="text-[10px] font-extrabold tracking-wider text-blue-600 dark:text-blue-400 uppercase bg-blue-50 dark:bg-blue-900/30 border border-blue-100 dark:border-blue-800/30 px-2 py-0.5 rounded-md">
                 Application Form
               </span>
-              <h3 className="text-2xl font-extrabold text-slate-900 dark:text-white mt-2">
+              <h3
+                id={modalTitleId}
+                className="text-2xl font-extrabold text-slate-900 dark:text-white mt-2"
+              >
                 Apply for {activeJobForModal?.title}
               </h3>
               <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">

--- a/client/src/pages/__tests__/CareersApplyModalA11y.test.jsx
+++ b/client/src/pages/__tests__/CareersApplyModalA11y.test.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Careers from "../Careers.jsx";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav>Navbar</nav>,
+}));
+
+vi.mock("../../services/careersApi.js", () => ({
+  submitCareerApplication: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, ...props }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <span />;
+  return new Proxy(
+    {},
+    {
+      get: () => Icon,
+    },
+  );
+});
+
+const openModalViaFirstJob = () => {
+  fireEvent.click(screen.getByText("Senior Frontend Engineer"));
+  const applyButton = screen.getByRole("button", {
+    name: "Apply for this Position",
+  });
+  fireEvent.click(applyButton);
+  return applyButton;
+};
+
+describe("Careers Apply Modal Accessibility (#1792)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the modal with dialog semantics and an accessible name", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+
+    const titleId = dialog.getAttribute("aria-labelledby");
+    const titleEl = document.getElementById(titleId);
+    expect(titleEl).toBeInTheDocument();
+    expect(titleEl).toHaveTextContent(/Apply for Senior Frontend Engineer/i);
+  });
+
+  it("moves focus into the modal when it opens", async () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it("traps Tab focus inside the modal", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const dialog = screen.getByRole("dialog");
+    const focusables = [
+      ...dialog.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+    expect(focusables.length).toBeGreaterThan(1);
+
+    const lastFocusable = focusables[focusables.length - 1];
+    lastFocusable.focus();
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: false });
+    expect(document.activeElement).toBe(focusables[0]);
+  });
+
+  it("wraps Shift+Tab from the first focusable to the last", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const dialog = screen.getByRole("dialog");
+    const focusables = [
+      ...dialog.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+    expect(focusables.length).toBeGreaterThan(1);
+
+    const firstFocusable = focusables[0];
+    const lastFocusable = focusables[focusables.length - 1];
+
+    firstFocusable.focus();
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(lastFocusable);
+  });
+
+  it("closes the modal on Escape", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the modal when the backdrop overlay is clicked", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const backdrop = screen.getByRole("dialog").parentElement;
+    fireEvent.click(backdrop);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not close the modal when clicking inside the dialog", () => {
+    render(<Careers />);
+    openModalViaFirstJob();
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(dialog);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("returns focus to the trigger element after the modal closes", async () => {
+    render(<Careers />);
+
+    fireEvent.click(screen.getByText("Senior Frontend Engineer"));
+    const applyButton = screen.getByRole("button", {
+      name: "Apply for this Position",
+    });
+    applyButton.focus();
+    fireEvent.click(applyButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(applyButton);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1792

Improves the Careers application modal with proper dialog semantics, keyboard focus management, and accessible overlay behavior.

## Problem

The Careers application modal previously lacked:

- Proper dialog semantics
- `aria-modal` and accessible labeling
- Focus management
- Focus trapping
- Focus restoration
- Backdrop click-to-close behavior

This could allow keyboard focus to escape the modal and made the dialog less accessible to assistive technologies.

## Changes Made

### Dialog Semantics

Added:

- `role="dialog"`
- `aria-modal="true"`
- `aria-labelledby`
- Accessible title association

### Focus Management

- Focus moves to the modal close button when opened.
- `Tab` and `Shift+Tab` remain trapped inside the modal.
- Focus is restored to the element that opened the modal after closing.
- Existing Escape-to-close behavior is preserved.
- Focus listeners and animation frames are cleaned up correctly.

### Overlay Behavior

- Clicking the backdrop closes the modal.
- Clicking inside the dialog does not close it.
- Existing application form behavior remains unchanged.

## Files Changed

### Modified

- `client/src/pages/Careers.jsx`

### Added

- `client/src/pages/__tests__/CareersApplyModalA11y.test.jsx`

## Tests Added

Regression coverage includes:

- Dialog semantics and ARIA labeling
- Initial focus
- `Tab` focus wrapping
- `Shift+Tab` focus wrapping
- Escape-to-close
- Backdrop click-to-close
- Preventing dialog-content clicks from closing the modal
- Focus restoration after closing

## Preserved

- Existing Careers application flow
- Resume upload
- Validation
- Submit/loading/error states
- Existing styling and responsive behavior
- No new dependencies

## Accessibility Impact

The Careers application modal now provides a proper accessible dialog experience for keyboard and assistive-technology users while preventing focus from escaping into the page behind the modal.

## Scope

This change is limited to the Careers application modal accessibility issues described in #1792.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation and focus management in the careers application modal.
  * Added support for closing the modal with Escape or by clicking the backdrop.
  * Added accessible dialog labeling and focus restoration after closing.

* **Tests**
  * Added coverage for dialog semantics, focus trapping, keyboard dismissal, backdrop behavior, and focus restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->