### PR TITLE
refactor: fix pollsection swallow errors and votes length evaluation crash (#1804)

### DIFF
--- a/client/src/components/meeting-details/PollSection.jsx
+++ b/client/src/components/meeting-details/PollSection.jsx
@@ -14,6 +14,7 @@ import { toast } from "react-toastify";
 const PollSection = ({ meetingId }) => {
   const { userData, backendUrl } = useContext(AppContent);
   const [polls, setPolls] = useState([]);
+  const [error, setError] = useState(null);
 
   // Create Poll State
   const [isCreating, setIsCreating] = useState(false);
@@ -31,10 +32,12 @@ const PollSection = ({ meetingId }) => {
   useEffect(() => {
     const fetchPolls = async () => {
       try {
+        setError(null);
         const data = await getPollsByMeeting(meetingId);
         setPolls(data || []);
       } catch (error) {
         console.error("Failed to fetch polls", error);
+        setError("Failed to load polls. Please try again later.");
       }
     };
     fetchPolls();
@@ -222,7 +225,7 @@ const PollSection = ({ meetingId }) => {
 
   const renderPoll = (poll) => {
     const totalVotes = poll.options.reduce((sum, opt) => {
-      return sum + (poll.isAnonymous ? opt.voteCount : opt.votes.length);
+      return sum + (opt.votes?.length ?? opt.voteCount ?? 0);
     }, 0);
 
     const isCreator = poll.createdBy?._id === userData?._id;
@@ -232,7 +235,9 @@ const PollSection = ({ meetingId }) => {
     const hasVoted = poll.isAnonymous
       ? poll.options.some((opt) => opt.hasVoted)
       : poll.options.some((opt) =>
-          opt.votes.some((v) => v._id === userData?._id || v === userData?._id),
+          (opt.votes || []).some(
+            (v) => v._id === userData?._id || v === userData?._id,
+          ),
         );
 
     return (
@@ -280,7 +285,7 @@ const PollSection = ({ meetingId }) => {
               </div>
             )}
             {poll.options.map((opt) => {
-              const votes = poll.isAnonymous ? opt.voteCount : opt.votes.length;
+              const votes = opt.votes?.length ?? opt.voteCount ?? 0;
               const percentage =
                 totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
               return (
@@ -308,9 +313,7 @@ const PollSection = ({ meetingId }) => {
             ) : (
               <div className="space-y-3">
                 {poll.options.map((opt) => {
-                  const votes = poll.isAnonymous
-                    ? opt.voteCount
-                    : opt.votes.length;
+                  const votes = opt.votes?.length ?? opt.voteCount ?? 0;
                   const percentage =
                     totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
                   return (
@@ -320,8 +323,7 @@ const PollSection = ({ meetingId }) => {
                       tabIndex={0}
                       aria-label={`Vote for ${opt.text}`}
                       className={`relative overflow-hidden rounded-md border p-3 cursor-pointer transition-colors ${
-                        !poll.isAnonymous &&
-                        opt.votes.some(
+                        (opt.votes || []).some(
                           (v) => v._id === userData?._id || v === userData?._id,
                         )
                           ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
@@ -388,6 +390,12 @@ const PollSection = ({ meetingId }) => {
           </button>
         )}
       </div>
+
+      {error && (
+        <div className="mb-4 p-4 rounded-lg bg-red-50 border border-red-200 dark:bg-red-950/20 dark:border-red-800 text-red-700 dark:text-red-300 text-center text-sm font-medium">
+          {error}
+        </div>
+      )}
 
       {isCreating && (
         <form

--- a/client/src/components/meeting-details/__tests__/PollSectionErrorAndVotes.test.jsx
+++ b/client/src/components/meeting-details/__tests__/PollSectionErrorAndVotes.test.jsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPollsByMeeting } from "../../../api/pollApi";
+import AppContent from "../../../context/AppContent";
+import PollSection from "../PollSection";
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../../api/pollApi", () => ({
+  createPoll: vi.fn(),
+  getPollsByMeeting: vi.fn(),
+  castVote: vi.fn(),
+  closePoll: vi.fn(),
+  deletePoll: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("PollSection error states and missing votes array safety (#1804)", () => {
+  const mockUser = {
+    _id: "user-123",
+    name: "John Doe",
+    role: "member",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("displays visual error banner when fetchPolls fails", async () => {
+    getPollsByMeeting.mockRejectedValue(new Error("API Server Error"));
+
+    render(
+      <AppContent.Provider
+        value={{ userData: mockUser, backendUrl: "http://localhost:5000" }}
+      >
+        <PollSection meetingId="meeting-123" />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load polls. Please try again later."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("safely handles polls with missing votes array (e.g. flat voteCount or anonymous polls)", async () => {
+    const anonymousPoll = {
+      _id: "poll-anon",
+      question: "Is this safe?",
+      createdBy: { _id: "user-creator", name: "Creator" },
+      createdAt: "2026-08-01T10:00:00.000Z",
+      isAnonymous: true,
+      isClosed: false,
+      options: [
+        { _id: "opt-1", text: "Yes", voteCount: 5 },
+        { _id: "opt-2", text: "No", voteCount: 2 },
+      ],
+    };
+
+    getPollsByMeeting.mockResolvedValue([anonymousPoll]);
+
+    render(
+      <AppContent.Provider
+        value={{ userData: mockUser, backendUrl: "http://localhost:5000" }}
+      >
+        <PollSection meetingId="meeting-123" />
+      </AppContent.Provider>,
+    );
+
+    // Wait for the poll to render and assert it doesn't crash on missing opt.votes
+    await waitFor(() => {
+      expect(screen.getByText("Is this safe?")).toBeInTheDocument();
+      expect(screen.getByText("Yes")).toBeInTheDocument();
+      expect(screen.getByText("No")).toBeInTheDocument();
+    });
+
+    // Check that vote percentages and counts are calculated correctly
+    expect(screen.getByText("Total Votes: 7")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR fixes two key issues inside the `PollSection` component: it adds visual error state banner feedback upon fetch failure and prevents `TypeError` crashes on missing `votes` properties by evaluating counts defensively.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1804

---

## ✨ Changes Made
- **Visual Error Banner**:
  - Implemented `error` state inside `client/src/components/meeting-details/PollSection.jsx` and rendered a styled warning banner when poll data fetching fails.
- **Defensive Property Access**:
  - Replaced `opt.votes.length` with `opt.votes?.length ?? opt.voteCount ?? 0` and checked arrays using `(opt.votes || []).some(...)` to support anonymous polls safely.
- **Unit Testing**:
  - Created `client/src/components/meeting-details/__tests__/PollSectionErrorAndVotes.test.jsx` covering fetch errors and votes structure fallback safety.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Vitest tests:
```bash
npm run test client/src/components/meeting-details/__tests__/PollSectionErrorAndVotes.test.jsx
