### PR TITLE
fix(security): enforce organization ownership and validate ObjectIds in speakerMappingController

### DIFF
--- a/server/controllers/__tests__/speakerMappingSecurity.test.js
+++ b/server/controllers/__tests__/speakerMappingSecurity.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import {
+  getMappings,
+  suggestMappings,
+  saveAndApplyMapping,
+  revertMapping,
+} from "../speakerMappingController.js";
+import Meeting from "../../models/meetingModel.js";
+import SpeakerMapping from "../../models/speakerMappingModel.js";
+import speakerIdentificationService from "../../services/speakerIdentificationService.js";
+
+vi.mock("../../models/meetingModel.js");
+vi.mock("../../models/speakerMappingModel.js");
+vi.mock("../../services/speakerIdentificationService.js");
+
+describe("Speaker Mapping Security & Validation (#1851)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validMeetingId = new mongoose.Types.ObjectId().toString();
+  const validMappingId = new mongoose.Types.ObjectId().toString();
+  const userOrgId = new mongoose.Types.ObjectId().toString();
+  const foreignOrgId = new mongoose.Types.ObjectId().toString();
+
+  const user = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: userOrgId,
+  };
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("returns 400 if meetingId is not a valid ObjectId", async () => {
+    const req = { params: { meetingId: "invalid-id" }, user };
+    const res = createMockRes();
+
+    await getMappings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid meeting ID format",
+      }),
+    );
+  });
+
+  it("returns 404 if meeting is not found", async () => {
+    Meeting.findById.mockResolvedValue(null);
+
+    const req = { params: { meetingId: validMeetingId }, user };
+    const res = createMockRes();
+
+    await suggestMappings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Meeting not found",
+      }),
+    );
+  });
+
+  it("returns 403 if meeting belongs to a different organization", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: validMeetingId,
+      organization: foreignOrgId,
+    });
+
+    const req = {
+      params: { meetingId: validMeetingId },
+      body: { originalLabel: "Speaker 1", mappedName: "Bob" },
+      user,
+    };
+    const res = createMockRes();
+
+    await saveAndApplyMapping(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Forbidden: You don't have access to this meeting",
+      }),
+    );
+  });
+
+  it("returns 400 in revertMapping if mappingId is invalid", async () => {
+    const req = {
+      params: { meetingId: validMeetingId, mappingId: "invalid-mapping-id" },
+      user,
+    };
+    const res = createMockRes();
+
+    await revertMapping(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid mapping ID format",
+      }),
+    );
+  });
+
+  it("allows access for meeting belonging to user organization", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: validMeetingId,
+      organization: userOrgId,
+    });
+    SpeakerMapping.find.mockResolvedValue([
+      {
+        meeting: validMeetingId,
+        originalLabel: "Speaker 1",
+        mappedName: "Alice",
+      },
+    ]);
+
+    const req = { params: { meetingId: validMeetingId }, user };
+    const res = createMockRes();
+
+    await getMappings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.any(Array),
+      }),
+    );
+  });
+});

--- a/server/controllers/speakerMappingController.js
+++ b/server/controllers/speakerMappingController.js
@@ -1,5 +1,31 @@
+import mongoose from "mongoose";
 import SpeakerMapping from "../models/speakerMappingModel.js";
+import Meeting from "../models/meetingModel.js";
 import speakerIdentificationService from "../services/speakerIdentificationService.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+
+/**
+ * Verify meeting existence and organization access
+ */
+const verifyMeetingAccess = async (meetingId, user) => {
+  if (!meetingId || !mongoose.Types.ObjectId.isValid(meetingId)) {
+    return { status: 400, message: "Invalid meeting ID format" };
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting) {
+    return { status: 404, message: "Meeting not found" };
+  }
+
+  if (!canAccessMeetingDoc(meeting, user)) {
+    return {
+      status: 403,
+      message: "Forbidden: You don't have access to this meeting",
+    };
+  }
+
+  return { meeting };
+};
 
 /**
  * Get mappings for a meeting
@@ -7,6 +33,14 @@ import speakerIdentificationService from "../services/speakerIdentificationServi
 export const getMappings = async (req, res) => {
   try {
     const { meetingId } = req.params;
+
+    const access = await verifyMeetingAccess(meetingId, req.user);
+    if (access.status) {
+      return res
+        .status(access.status)
+        .json({ success: false, message: access.message });
+    }
+
     const mappings = await SpeakerMapping.find({ meeting: meetingId });
     res.status(200).json({ success: true, data: mappings });
   } catch (error) {
@@ -21,6 +55,14 @@ export const getMappings = async (req, res) => {
 export const suggestMappings = async (req, res) => {
   try {
     const { meetingId } = req.params;
+
+    const access = await verifyMeetingAccess(meetingId, req.user);
+    if (access.status) {
+      return res
+        .status(access.status)
+        .json({ success: false, message: access.message });
+    }
+
     const suggestions =
       await speakerIdentificationService.suggestMappings(meetingId);
     res.status(200).json({ success: true, data: suggestions });
@@ -39,12 +81,19 @@ export const saveAndApplyMapping = async (req, res) => {
   try {
     const { meetingId } = req.params;
     const { originalLabel, mappedName } = req.body;
-    const userId = req.user._id;
+    const userId = req.user?._id;
 
     if (!originalLabel || !mappedName) {
       return res
         .status(400)
         .json({ success: false, message: "Missing required fields" });
+    }
+
+    const access = await verifyMeetingAccess(meetingId, req.user);
+    if (access.status) {
+      return res
+        .status(access.status)
+        .json({ success: false, message: access.message });
     }
 
     // Upsert the mapping record
@@ -73,12 +122,24 @@ export const saveAndApplyMapping = async (req, res) => {
 };
 
 /**
- * Revert a mapping (sets transcript back to original label, though practically it's hard to revert summaries without saving history.
- * For this task, we will just apply a reverse mapping).
+ * Revert a mapping
  */
 export const revertMapping = async (req, res) => {
   try {
     const { meetingId, mappingId } = req.params;
+
+    if (!mappingId || !mongoose.Types.ObjectId.isValid(mappingId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid mapping ID format" });
+    }
+
+    const access = await verifyMeetingAccess(meetingId, req.user);
+    if (access.status) {
+      return res
+        .status(access.status)
+        .json({ success: false, message: access.message });
+    }
 
     const mapping = await SpeakerMapping.findOne({
       _id: mappingId,


### PR DESCRIPTION
Fixes #1851

## Description
This PR validates meetingId and mappingId parameters in speakerMappingController.js using mongoose.Types.ObjectId.isValid(), and enforces tenant isolation by verifying meeting existence and organizational access (canAccessMeetingDoc(meeting, req.user)).

## Proposed Changes
- **ObjectId Validation**: Added ObjectId format validation for meetingId and mappingId across getMappings, suggestMappings, saveAndApplyMapping, and evertMapping.
- **Tenant Authorization**: Verified meeting existence and enforced same-organization access control (canAccessMeetingDoc(meeting, req.user)), rejecting unauthorized access with HTTP 403.
- **Unit Test Coverage**: Added unit test suite server/controllers/__tests__/speakerMappingSecurity.test.js verifying 400 invalid IDs, 404 missing meetings, 403 cross-org requests, and 200 valid queries.

## Checklist
- [x] Related Issue is linked (Fixes #1851).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for speaker-mapping operations.
  * Prevented access to mappings from meetings outside the user’s organization.
  * Added validation for invalid meeting and mapping identifiers.
  * Improved error responses for missing meetings and unauthorized access.
* **Tests**
  * Added coverage for speaker-mapping validation, authorization, successful access, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->