### PR TITLE
fix(validation): validate user ObjectIds and clamp pagination in participantEngagementController

### DIFF
--- a/server/controllers/__tests__/participantEngagementValidation.test.js
+++ b/server/controllers/__tests__/participantEngagementValidation.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import {
+  getParticipantScorecard,
+  getOrganizationRankings,
+  recalculateScorecard,
+} from "../participantEngagementController.js";
+import ParticipantEngagement from "../../models/participantEngagementModel.js";
+import ParticipantEngagementService from "../../services/participantEngagementService.js";
+
+vi.mock("../../models/participantEngagementModel.js");
+vi.mock("../../services/participantEngagementService.js");
+
+describe("Participant Engagement Validation & Security (#1852)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validUserId = new mongoose.Types.ObjectId().toString();
+  const validOrgId = new mongoose.Types.ObjectId().toString();
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("returns 400 if userId is not a valid ObjectId in getParticipantScorecard", async () => {
+    const req = {
+      params: { userId: "not-an-id" },
+      user: { organization: validOrgId },
+    };
+    const res = createMockRes();
+
+    await getParticipantScorecard(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid user ID format",
+      }),
+    );
+  });
+
+  it("returns 400 if user has no valid organization in getOrganizationRankings", async () => {
+    const req = {
+      query: { page: 1, limit: 10 },
+      user: { organization: "invalid-org" },
+    };
+    const res = createMockRes();
+
+    await getOrganizationRankings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Organization ID is required and must be valid",
+      }),
+    );
+  });
+
+  it("clamps limit to 100 when oversized limit is requested", async () => {
+    ParticipantEngagementService.getOrganizationRankings.mockResolvedValue({
+      rankings: [],
+      pagination: { total: 0, page: 1, limit: 100, totalPages: 0 },
+    });
+
+    const req = {
+      query: { page: 1, limit: 500 },
+      user: { organization: validOrgId },
+    };
+    const res = createMockRes();
+
+    await getOrganizationRankings(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(
+      ParticipantEngagementService.getOrganizationRankings,
+    ).toHaveBeenCalledWith(
+      validOrgId,
+      expect.objectContaining({
+        page: 1,
+        limit: 100,
+      }),
+    );
+  });
+
+  it("returns 400 if userId is not a valid ObjectId in recalculateScorecard", async () => {
+    const req = {
+      params: { userId: "bad-user-id" },
+      user: { organization: validOrgId },
+    };
+    const res = createMockRes();
+
+    await recalculateScorecard(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid user ID format",
+      }),
+    );
+  });
+
+  it("allows valid requests and returns scorecard", async () => {
+    ParticipantEngagement.findOne.mockReturnValue({
+      populate: vi.fn().mockResolvedValue({
+        _id: new mongoose.Types.ObjectId(),
+        userId: { name: "John" },
+        organizationId: validOrgId,
+      }),
+    });
+
+    const req = {
+      params: { userId: validUserId },
+      user: { organization: validOrgId },
+    };
+    const res = createMockRes();
+
+    await getParticipantScorecard(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.any(Object),
+      }),
+    );
+  });
+});

--- a/server/controllers/participantEngagementController.js
+++ b/server/controllers/participantEngagementController.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import ParticipantEngagementService from "../services/participantEngagementService.js";
 import ParticipantEngagement from "../models/participantEngagementModel.js";
 
@@ -7,7 +8,22 @@ import ParticipantEngagement from "../models/participantEngagementModel.js";
 export const getParticipantScorecard = async (req, res) => {
   try {
     const { userId } = req.params;
-    const orgId = req.user.organization; // Assuming userAuth middleware sets req.user
+    const orgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Organization ID is required and must be valid",
+      });
+    }
+
+    if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid user ID format" });
+    }
 
     let scorecard = await ParticipantEngagement.findOne({
       userId,
@@ -39,7 +55,17 @@ export const getParticipantScorecard = async (req, res) => {
  */
 export const getOrganizationRankings = async (req, res) => {
   try {
-    const orgId = req.user.organization;
+    const orgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Organization ID is required and must be valid",
+      });
+    }
+
     const {
       page = 1,
       limit = 20,
@@ -47,13 +73,18 @@ export const getOrganizationRankings = async (req, res) => {
       order = -1,
     } = req.query;
 
+    const parsedPage = Math.max(1, parseInt(page, 10) || 1);
+    const parsedLimit = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+    const parsedOrder =
+      order === 1 || order === "1" || order === "asc" ? 1 : -1;
+
     const result = await ParticipantEngagementService.getOrganizationRankings(
       orgId,
       {
-        page: parseInt(page, 10),
-        limit: parseInt(limit, 10),
-        sortBy,
-        order: parseInt(order, 10),
+        page: parsedPage,
+        limit: parsedLimit,
+        sortBy: typeof sortBy === "string" ? sortBy : "overallScore",
+        order: parsedOrder,
       },
     );
 
@@ -70,7 +101,22 @@ export const getOrganizationRankings = async (req, res) => {
 export const recalculateScorecard = async (req, res) => {
   try {
     const { userId } = req.params;
-    const orgId = req.user.organization;
+    const orgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Organization ID is required and must be valid",
+      });
+    }
+
+    if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid user ID format" });
+    }
 
     const scorecard = await ParticipantEngagementService.updateScorecard(
       userId,


### PR DESCRIPTION
Fixes #1852

## Description
This PR validates userId parameters and active user organization ID in participantEngagementController.js using mongoose.Types.ObjectId.isValid(), preventing unhandled 500 CastErrors, and clamps pagination limits safely (1-100) to prevent unbounded queries.

## Proposed Changes
- **ObjectId Validation**: Added ObjectId format validation for userId in getParticipantScorecard and ecalculateScorecard.
- **Organization Presence & Format Check**: Validated eq.user.organization before querying scores and rankings.
- **Pagination Boundary Clamping**: Clamped page (min 1) and limit (1-100) and sanitized sort order values in getOrganizationRankings.
- **Unit Test Coverage**: Added unit test suite server/controllers/__tests__/participantEngagementValidation.test.js verifying 400 responses on invalid user IDs and pagination clamping.

## Checklist
- [x] Related Issue is linked (Fixes #1852).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.