### PR TITLE
fix(validation): validate organization identifier and query boundaries in activityController

### DIFF
--- a/server/controllers/__tests__/activityValidation.test.js
+++ b/server/controllers/__tests__/activityValidation.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { getActivities, getActivityStats } from "../activityController.js";
+import * as activityService from "../../services/activityService.js";
+
+vi.mock("../../services/activityService.js");
+
+describe("Activity Controller Validation (#1853)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validOrgId = new mongoose.Types.ObjectId().toString();
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("returns 400 when organization ID is missing in getActivities", async () => {
+    const req = { query: {}, user: {} };
+    const res = createMockRes();
+
+    await getActivities(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Valid organization ID is required.",
+    });
+  });
+
+  it("returns 400 when organization ID is invalid format in getActivities", async () => {
+    const req = { query: {}, user: { organization: "invalid-id" } };
+    const res = createMockRes();
+
+    await getActivities(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Valid organization ID is required.",
+    });
+  });
+
+  it("returns 400 when organization ID is invalid in getActivityStats", async () => {
+    const req = { user: { organization: "not-an-objectid" } };
+    const res = createMockRes();
+
+    await getActivityStats(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Valid organization ID is required.",
+    });
+  });
+
+  it("successfully returns activities for valid organization", async () => {
+    activityService.getOrgActivities.mockResolvedValue({
+      activities: [],
+      pagination: { total: 0, page: 1, limit: 20, totalPages: 0 },
+    });
+
+    const req = {
+      query: { page: "1", limit: "20" },
+      user: { organization: validOrgId },
+    };
+    const res = createMockRes();
+
+    await getActivities(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(activityService.getOrgActivities).toHaveBeenCalledWith(
+      validOrgId,
+      expect.objectContaining({
+        page: 1,
+        limit: 20,
+      }),
+    );
+  });
+});

--- a/server/controllers/activityController.js
+++ b/server/controllers/activityController.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import * as activityService from "../services/activityService.js";
 import { parsePagination } from "../utils/pagination.js";
 
@@ -7,10 +8,14 @@ import { parsePagination } from "../utils/pagination.js";
  */
 export const getActivities = async (req, res) => {
   try {
-    const orgId = req.user.organization;
+    const orgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
 
-    if (!orgId) {
-      return res.status(400).json({ error: "No organization selected." });
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res
+        .status(400)
+        .json({ error: "Valid organization ID is required." });
     }
 
     const { action, actor } = req.query;
@@ -21,11 +26,16 @@ export const getActivities = async (req, res) => {
       maxLimit: 100,
     });
 
+    const sanitizedAction =
+      typeof action === "string" ? action.trim().slice(0, 100) : undefined;
+    const sanitizedActor =
+      typeof actor === "string" ? actor.trim().slice(0, 100) : undefined;
+
     const result = await activityService.getOrgActivities(orgId, {
       page,
       limit,
-      action,
-      actor,
+      action: sanitizedAction,
+      actor: sanitizedActor,
     });
 
     res.status(200).json(result);
@@ -41,10 +51,14 @@ export const getActivities = async (req, res) => {
  */
 export const getActivityStats = async (req, res) => {
   try {
-    const orgId = req.user.organization;
+    const orgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
 
-    if (!orgId) {
-      return res.status(400).json({ error: "No organization selected." });
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res
+        .status(400)
+        .json({ error: "Valid organization ID is required." });
     }
 
     const stats = await activityService.getActivityStats(orgId);


### PR DESCRIPTION
Fixes #1853

## Description
This PR validates orgId in ctivityController.js using mongoose.Types.ObjectId.isValid(), preventing unhandled 500 CastErrors on malformed organization IDs, and sanitizes action/actor filter strings.

## Proposed Changes
- **ObjectId Validation**: Added format validation for orgId across getActivities and getActivityStats, returning HTTP 400 when invalid.
- **Filter Sanitization**: Sanitized and bounded ction and ctor query strings in getActivities.
- **Unit Test Coverage**: Added unit test suite server/controllers/__tests__/activityValidation.test.js verifying 400 responses on missing/invalid organization IDs.

## Checklist
- [x] Related Issue is linked (Fixes #1853).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.