### PR TITLE
fix(security): enforce organization isolation and access checks in favoriteController

### DIFF
--- a/server/controllers/__tests__/favoriteOrgIsolation.test.js
+++ b/server/controllers/__tests__/favoriteOrgIsolation.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import {
+  toggleFavorite,
+  getFavorites,
+  getFavoriteStatus,
+} from "../favoriteController.js";
+import Favorite from "../../models/favoriteModel.js";
+import Meeting from "../../models/meetingModel.js";
+
+vi.mock("../../models/favoriteModel.js");
+vi.mock("../../models/meetingModel.js");
+
+describe("Favorite Controller Organization Isolation (#1854)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validMeetingId = new mongoose.Types.ObjectId().toString();
+  const userOrgId = new mongoose.Types.ObjectId().toString();
+  const foreignOrgId = new mongoose.Types.ObjectId().toString();
+
+  const user = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: userOrgId,
+  };
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("returns 404 in getFavoriteStatus when meeting does not exist", async () => {
+    Meeting.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue(null),
+    });
+
+    const req = { params: { meetingId: validMeetingId }, user };
+    const res = createMockRes();
+
+    await getFavoriteStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ message: "Meeting not found" });
+  });
+
+  it("returns 403 in getFavoriteStatus when meeting belongs to another organization", async () => {
+    Meeting.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        _id: validMeetingId,
+        organization: foreignOrgId,
+      }),
+    });
+
+    const req = { params: { meetingId: validMeetingId }, user };
+    const res = createMockRes();
+
+    await getFavoriteStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Meeting does not belong to your organization",
+    });
+  });
+
+  it("returns 200 with favorited status when meeting is accessible", async () => {
+    Meeting.findById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({
+        _id: validMeetingId,
+        organization: userOrgId,
+      }),
+    });
+    Favorite.findOne.mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+    const req = { params: { meetingId: validMeetingId }, user };
+    const res = createMockRes();
+
+    await getFavoriteStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ favorited: true });
+  });
+
+  it("filters out favorites belonging to other organizations in getFavorites", async () => {
+    const meetingSameOrg = { _id: validMeetingId, organization: userOrgId };
+    const meetingForeignOrg = {
+      _id: new mongoose.Types.ObjectId().toString(),
+      organization: foreignOrgId,
+    };
+
+    Favorite.find.mockReturnValue({
+      populate: vi.fn().mockReturnValue({
+        sort: vi
+          .fn()
+          .mockResolvedValue([
+            { meeting: meetingSameOrg },
+            { meeting: meetingForeignOrg },
+          ]),
+      }),
+    });
+
+    const req = { user };
+    const res = createMockRes();
+
+    await getFavorites(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      favorites: [validMeetingId],
+    });
+  });
+});

--- a/server/controllers/favoriteController.js
+++ b/server/controllers/favoriteController.js
@@ -70,17 +70,35 @@ export const toggleFavorite = async (req, res) => {
   }
 };
 
-// Get all favorite meeting IDs for the current user.
+// Get all favorite meeting IDs for the current user in active organization.
 export const getFavorites = async (req, res) => {
   try {
+    const userOrgId = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+
     const favorites = await Favorite.find({
       user: req.user._id,
     })
-      .select("meeting")
+      .populate({
+        path: "meeting",
+        select: "organization _id",
+      })
       .sort({ createdAt: -1 });
 
+    const validFavorites = favorites
+      .filter((fav) => {
+        if (!fav.meeting) return false;
+        if (!userOrgId) return true;
+        const meetingOrgId = (
+          fav.meeting.organization?._id || fav.meeting.organization
+        )?.toString();
+        return meetingOrgId === userOrgId;
+      })
+      .map((fav) => fav.meeting._id || fav.meeting);
+
     return res.status(200).json({
-      favorites: favorites.map((favorite) => favorite.meeting),
+      favorites: validFavorites,
     });
   } catch (error) {
     console.error("Error fetching favorites:", error);
@@ -98,6 +116,19 @@ export const getFavoriteStatus = async (req, res) => {
 
     if (!mongoose.Types.ObjectId.isValid(meetingId)) {
       return res.status(400).json({ message: "Invalid meetingId" });
+    }
+
+    const meeting =
+      await Meeting.findById(meetingId).select("organization _id");
+
+    if (!meeting) {
+      return res.status(404).json({ message: "Meeting not found" });
+    }
+
+    if (!isSameOrganization(req.user, meeting)) {
+      return res.status(403).json({
+        message: "Meeting does not belong to your organization",
+      });
     }
 
     const favorite = await Favorite.findOne({


### PR DESCRIPTION
Fixes #1854

## Description
This PR enforces organization isolation and checks meeting existence in avoriteController.js before returning favorite status or list, preventing cross-organization favorite probing.

## Proposed Changes
- **Meeting Access Verification**: In getFavoriteStatus, fetched target meeting and enforced isSameOrganization(req.user, meeting), returning 404 for missing meetings and 403 for unauthorized cross-org meetings.
- **Organization-Scoped Favorites**: In getFavorites, populated and filtered favorite records so only meetings belonging to the user's active organization are returned.
- **Unit Test Coverage**: Added unit test suite server/controllers/__tests__/favoriteOrgIsolation.test.js verifying 404 on non-existent meetings, 403 on foreign-org meetings, and organization-scoped listing.

## Checklist
- [x] Related Issue is linked (Fixes #1854).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.