### PR TITLE
fix(auth): protect AI summary templates route

### DIFF
--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -502,7 +502,18 @@ const ProtectedRoutes = (
       }
     />
     <Route path="/meeting-templates" element={<MeetingTemplates />} />
-    <Route path="/ai-summary-templates" element={<AiSummaryTemplates />} />
+    <Route
+      path="/ai-summary-templates"
+      element={
+        <ProtectedRoute
+          resource="admin_panel"
+          action="view"
+          forbiddenFallback={<AccessDenied />}
+        >
+          <AiSummaryTemplates />
+        </ProtectedRoute>
+      }
+    />
     <Route path="/access-denied" element={<AccessDenied />} />
     <Route
       path="/leaderboard"

--- a/client/src/routes/__tests__/AiSummaryTemplatesRoute.test.jsx
+++ b/client/src/routes/__tests__/AiSummaryTemplatesRoute.test.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { readFileSync } from "node:fs";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ProtectedRoute from "../../components/ProtectedRoute.jsx";
+import AppContent from "../../context/AppContent.js";
+
+let permissionGranted = true;
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => permissionGranted,
+  }),
+}));
+
+const renderRoute = ({ isLoggedin, userData, loading = false }) => {
+  return render(
+    <MemoryRouter initialEntries={["/ai-summary-templates"]}>
+      <AppContent.Provider value={{ isLoggedin, userData, loading }}>
+        <Routes>
+          <Route
+            path="/ai-summary-templates"
+            element={
+              <ProtectedRoute
+                resource="admin_panel"
+                action="view"
+                forbiddenFallback={<div>Access Denied</div>}
+              >
+                <div>AI Summary Templates</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </AppContent.Provider>
+    </MemoryRouter>,
+  );
+};
+
+describe("AI Summary Templates route protection (#1657)", () => {
+  beforeEach(() => {
+    permissionGranted = true;
+  });
+
+  it("registers the route behind the admin_panel view permission", () => {
+    const source = readFileSync(
+      new URL("../ProtectedRoutes.jsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /path="\/ai-summary-templates"[\s\S]*?resource="admin_panel"[\s\S]*?action="view"[\s\S]*?AiSummaryTemplates/,
+    );
+  });
+
+  it("redirects unauthenticated direct navigation to login", () => {
+    renderRoute({
+      isLoggedin: false,
+      userData: null,
+    });
+
+    expect(screen.getByText("Login")).toBeInTheDocument();
+    expect(screen.queryByText("AI Summary Templates")).not.toBeInTheDocument();
+  });
+
+  it("allows an authenticated user with admin_panel view permission", () => {
+    renderRoute({
+      isLoggedin: true,
+      userData: { hasCompletedOnboarding: true },
+    });
+
+    expect(screen.getByText("AI Summary Templates")).toBeInTheDocument();
+  });
+
+  it("shows Access Denied when an authenticated user lacks permission", () => {
+    permissionGranted = false;
+
+    renderRoute({
+      isLoggedin: true,
+      userData: { hasCompletedOnboarding: true },
+    });
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(screen.queryByText("AI Summary Templates")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Protect the AI Summary Templates route with the application's standard authentication and RBAC guards. Unauthenticated users are redirected to authentication, while authenticated users without the required permission receive the standard Access Denied experience.

## Type of Change

* [ ] New Feature
* [x] Bug Fix
* [ ] Documentation Update
* [ ] Refactor
* [ ] Performance Improvement
* [x] Security Improvement
* [ ] Other

## Related Issue

Closes #1657

## Testing

Added router authorization coverage for unauthenticated, authorized, unauthorized, and direct URL navigation scenarios.

* [ ] Tested locally
* [ ] Existing functionality verified
* [x] No new warnings or errors

Static validation was completed successfully. The dependency-based test suite could not be executed because the Vitest executable was unavailable in the provided environment.

## Screenshots

Not applicable.

## Checklist

* [x] Code follows project conventions
* [ ] Documentation updated where required
* [x] No unnecessary files included
* [ ] Changes have been tested
* [x] Ready for review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to AI Summary Templates based on admin panel permissions.
  * Unauthenticated visitors are redirected to sign in.
  * Visitors without the required permission now see an access-denied message.

* **Tests**
  * Added coverage for authorized, unauthorized, and unauthenticated access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->