### PR TITLE
fix(ui): add dark-mode tokens to dashboard feature cards (#1797)

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -26,10 +26,14 @@ import StoryThumbnails from "../components/dashboard/StoryThumbnails.jsx";
 
 /* ─── Role Badge ──────────────────────────────────────────────────────────── */
 const ROLE_STYLES = {
-  admin: "bg-violet-50 text-violet-700 border-violet-200",
-  manager: "bg-blue-50 text-blue-700 border-blue-200",
-  member: "bg-sky-50 text-sky-700 border-sky-200",
-  guest: "bg-slate-100 text-slate-600 border-slate-200",
+  admin:
+    "bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border-violet-200 dark:border-violet-700",
+  manager:
+    "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-700",
+  member:
+    "bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300 border-sky-200 dark:border-sky-700",
+  guest:
+    "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700",
 };
 
 const ROUTE_MAP = {
@@ -71,11 +75,12 @@ const Dashboard = () => {
       icon: Upload,
       title: t("dashboard.uploadMeetings"),
       description: t("dashboard.uploadMeetingsDesc"),
-      iconBg: "bg-blue-50",
-      iconColor: "text-blue-600",
+      iconBg: "bg-blue-50 dark:bg-blue-900/30",
+      iconColor: "text-blue-600 dark:text-blue-400",
       tag: t("dashboard.transcription"),
-      tagColor: "bg-blue-50 text-blue-700 border-blue-100",
-      accentRing: "group-hover:ring-blue-100",
+      tagColor:
+        "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-100 dark:border-blue-800",
+      accentRing: "group-hover:ring-blue-100 dark:group-hover:ring-blue-900/40",
       requiresCreateMeeting: true,
     },
     {
@@ -83,11 +88,13 @@ const Dashboard = () => {
       icon: FileText,
       title: t("dashboard.meetingEventHub"),
       description: t("dashboard.meetingEventHubDesc"),
-      iconBg: "bg-emerald-50",
-      iconColor: "text-emerald-600",
+      iconBg: "bg-emerald-50 dark:bg-emerald-900/30",
+      iconColor: "text-emerald-600 dark:text-emerald-400",
       tag: t("dashboard.scheduling"),
-      tagColor: "bg-emerald-50 text-emerald-700 border-emerald-100",
-      accentRing: "group-hover:ring-emerald-100",
+      tagColor:
+        "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-100 dark:border-emerald-800",
+      accentRing:
+        "group-hover:ring-emerald-100 dark:group-hover:ring-emerald-900/40",
       requiresCreateMeeting: true,
     },
     {
@@ -95,33 +102,39 @@ const Dashboard = () => {
       icon: Brain,
       title: t("dashboard.aiSummarization"),
       description: t("dashboard.aiSummarizationDesc"),
-      iconBg: "bg-violet-50",
-      iconColor: "text-violet-600",
+      iconBg: "bg-violet-50 dark:bg-violet-900/30",
+      iconColor: "text-violet-600 dark:text-violet-400",
       tag: t("dashboard.aiPowered"),
-      tagColor: "bg-violet-50 text-violet-700 border-violet-100",
-      accentRing: "group-hover:ring-violet-100",
+      tagColor:
+        "bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border-violet-100 dark:border-violet-800",
+      accentRing:
+        "group-hover:ring-violet-100 dark:group-hover:ring-violet-900/40",
     },
     {
       id: "policies",
       icon: Shield,
       title: t("dashboard.policiesRepository"),
       description: t("dashboard.policiesRepositoryDesc"),
-      iconBg: "bg-amber-50",
-      iconColor: "text-amber-600",
+      iconBg: "bg-amber-50 dark:bg-amber-900/30",
+      iconColor: "text-amber-600 dark:text-amber-400",
       tag: t("dashboard.complianceTag"),
-      tagColor: "bg-amber-50 text-amber-700 border-amber-100",
-      accentRing: "group-hover:ring-amber-100",
+      tagColor:
+        "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-100 dark:border-amber-800",
+      accentRing:
+        "group-hover:ring-amber-100 dark:group-hover:ring-amber-900/40",
     },
     {
       id: "reports",
       icon: BarChart3,
       title: t("dashboard.reportsAnalytics"),
       description: t("dashboard.reportsAnalyticsDesc"),
-      iconBg: "bg-indigo-50",
-      iconColor: "text-indigo-600",
+      iconBg: "bg-indigo-50 dark:bg-indigo-900/30",
+      iconColor: "text-indigo-600 dark:text-indigo-400",
       tag: t("dashboard.analytics"),
-      tagColor: "bg-indigo-50 text-indigo-700 border-indigo-100",
-      accentRing: "group-hover:ring-indigo-100",
+      tagColor:
+        "bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 border-indigo-100 dark:border-indigo-800",
+      accentRing:
+        "group-hover:ring-indigo-100 dark:group-hover:ring-indigo-900/40",
     },
     {
       id: "attendance-analytics",
@@ -129,11 +142,12 @@ const Dashboard = () => {
       title: "Attendance Analytics",
       description:
         "Visualize per-member attendance rates, heatmap activity, and trends.",
-      iconBg: "bg-pink-50",
-      iconColor: "text-pink-600",
+      iconBg: "bg-pink-50 dark:bg-pink-900/30",
+      iconColor: "text-pink-600 dark:text-pink-400",
       tag: "Analytics",
-      tagColor: "bg-pink-50 text-pink-700 border-pink-100",
-      accentRing: "group-hover:ring-pink-100",
+      tagColor:
+        "bg-pink-50 dark:bg-pink-900/30 text-pink-700 dark:text-pink-300 border-pink-100 dark:border-pink-800",
+      accentRing: "group-hover:ring-pink-100 dark:group-hover:ring-pink-900/40",
     },
     {
       id: "meeting-cost-analytics",
@@ -141,10 +155,12 @@ const Dashboard = () => {
       title: "Meeting Cost Analytics",
       description:
         "Analyze organizational cost and time investment across all meetings.",
-      iconBg: "bg-blue-50",
-      iconColor: "text-blue-600",
+      iconBg: "bg-blue-50 dark:bg-blue-900/30",
+      iconColor: "text-blue-600 dark:text-blue-400",
       tag: "Cost",
-      tagColor: "bg-blue-50 text-blue-700 border-blue-100",
+      tagColor:
+        "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-100 dark:border-blue-800",
+      accentRing: "group-hover:ring-blue-100 dark:group-hover:ring-blue-900/40",
       adminOnly: true,
     },
     {
@@ -153,11 +169,13 @@ const Dashboard = () => {
       title: "Meeting Hygiene Leaderboard",
       description:
         "View top contributors with the best meeting hygiene scores and badges.",
-      iconBg: "bg-yellow-50",
-      iconColor: "text-yellow-600",
+      iconBg: "bg-yellow-50 dark:bg-yellow-900/30",
+      iconColor: "text-yellow-600 dark:text-yellow-400",
       tag: "Gamification",
-      tagColor: "bg-yellow-50 text-yellow-700 border-yellow-100",
-      accentRing: "group-hover:ring-yellow-100",
+      tagColor:
+        "bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 border-yellow-100 dark:border-yellow-800",
+      accentRing:
+        "group-hover:ring-yellow-100 dark:group-hover:ring-yellow-900/40",
     },
   ];
 

--- a/client/src/pages/__tests__/Dashboard.test.jsx
+++ b/client/src/pages/__tests__/Dashboard.test.jsx
@@ -116,4 +116,29 @@ describe("Dashboard", () => {
     // adminOnly cost card still matches role case-insensitively.
     expect(screen.getByText("Meeting Cost Analytics")).toBeInTheDocument();
   });
+
+  it("applies dark mode utility tokens to role badge and feature cards (#1797)", () => {
+    const { container } = renderDashboard(mockUserData);
+
+    // Check role badge has dark mode classes
+    const roleBadge = screen.getByText("Admin").closest("span");
+    expect(roleBadge?.className).toMatch(/dark:bg-violet-900\/30/);
+    expect(roleBadge?.className).toMatch(/dark:text-violet-300/);
+    expect(roleBadge?.className).toMatch(/dark:border-violet-700/);
+
+    // Check feature cards have dark mode classes on tags and icon containers
+    const cards = container.querySelectorAll(".dash-card");
+    expect(cards.length).toBeGreaterThan(0);
+
+    cards.forEach((card) => {
+      const header = card.firstElementChild;
+      const iconContainer = header?.querySelector("div");
+      expect(iconContainer?.className).toMatch(/dark:bg-/);
+
+      const tagBadge = header?.querySelector("span");
+      expect(tagBadge?.className).toMatch(/dark:bg-/);
+      expect(tagBadge?.className).toMatch(/dark:text-/);
+      expect(tagBadge?.className).toMatch(/dark:border-/);
+    });
+  });
 });


### PR DESCRIPTION
## Description
Fixes #1797

This PR adds dark-mode Tailwind utility tokens to the Dashboard feature cards and role badges. Previously, `ROLE_STYLES` and `FEATURE_CARDS` used hardcoded light pastel styles (`bg-blue-50`, `bg-violet-50`, etc.) without any `dark:` variants, causing chips and card icons to wash out and suffer from poor contrast against dark backgrounds (`dark:bg-gray-800`).

## Changes Made
- **Role Badges (`ROLE_STYLES`)**:
  - Added dark background, text, and border classes (`dark:bg-*-900/30`, `dark:text-*-300`, `dark:border-*-700`) for `admin`, `manager`, `member`, and `guest` roles.
- **Feature Cards (`FEATURE_CARDS`)**:
  - Added `dark:` utility variants across all feature cards for:
    - `iconBg`: `dark:bg-*-900/30`
    - `iconColor`: `dark:text-*-400`
    - `tagColor`: `dark:bg-*-900/30 dark:text-*-300 dark:border-*-800`
    - `accentRing`: `dark:group-hover:ring-*-900/40`
- **Unit Tests**:
  - Added unit test in `client/src/pages/__tests__/Dashboard.test.jsx` to ensure dark-mode tokens are present and properly applied on cards and badges.

## Verification
- [x] Ran unit tests: `npm run test:ci -- src/pages/__tests__/Dashboard.test.jsx` (5/5 passed)
- [x] Ran linter: `npx eslint src/pages/Dashboard.jsx src/pages/__tests__/Dashboard.test.jsx` (0 errors)
- [x] Production build verification: `npm run build` (Clean build)

## Checklist
- [x] Code adheres to the style guidelines of this project
- [x] Added automated tests covering the new changes
- [x] Verified dark-mode visual contrast and responsiveness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dark-mode styling for dashboard role badges, feature cards, icons, tags, and leaderboard elements while preserving the existing light theme.

* **Tests**
  * Added coverage to verify dark-mode classes are applied correctly across dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->