### PR TITLE
fix(stories): refactor recap story widgets to use apiClient and handl…

### DIFF
--- a/client/src/components/dashboard/StoryThumbnails.jsx
+++ b/client/src/components/dashboard/StoryThumbnails.jsx
@@ -1,33 +1,83 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
+import { Play, AlertCircle, RefreshCw } from "lucide-react";
+import apiClient from "../../services/apiClient";
 import RecapStoryViewer from "../summaries/RecapStoryViewer";
-import { Play } from "lucide-react";
 
 const StoryThumbnails = () => {
   const [meetings, setMeetings] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [activeMeetingId, setActiveMeetingId] = useState(null);
 
-  useEffect(() => {
-    const fetchRecentMeetings = async () => {
-      try {
-        const response = await axios.get("/api/meetings/stories/recent", {
-          withCredentials: true,
-        });
-        if (response.data.success && response.data.meetings) {
-          setMeetings(response.data.meetings);
-        }
-      } catch (err) {
-        console.error("Error fetching recent meetings for stories:", err);
-      } finally {
-        setLoading(false);
+  const fetchRecentMeetings = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await apiClient.get("/api/meetings/stories/recent");
+      if (response.data.success && response.data.meetings) {
+        setMeetings(response.data.meetings);
+      } else {
+        setMeetings(response.data.meetings || []);
       }
-    };
+    } catch (err) {
+      console.error("Error fetching recent meetings for stories:", err);
+      setError(
+        err.response?.data?.message ||
+          "Unable to load recent meeting stories. Please check your connection.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchRecentMeetings();
   }, []);
 
-  if (loading || meetings.length === 0) return null;
+  if (loading) {
+    return (
+      <div className="mb-6 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-slate-200/80 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wider">
+          Recent Meeting Stories
+        </h3>
+        <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
+          {[1, 2, 3].map((n) => (
+            <div
+              key={n}
+              className="flex flex-col items-center gap-2 flex-shrink-0 animate-pulse"
+            >
+              <div className="w-16 h-16 rounded-full bg-slate-200 dark:bg-gray-700" />
+              <div className="h-3 w-16 bg-slate-200 dark:bg-gray-700 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="mb-6 bg-red-50/80 dark:bg-red-900/20 rounded-xl p-4 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 flex items-center justify-between gap-4"
+      >
+        <div className="flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 shrink-0 text-red-500 dark:text-red-400" />
+          <p className="text-sm font-medium">{error}</p>
+        </div>
+        <button
+          type="button"
+          onClick={fetchRecentMeetings}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-red-100 dark:bg-red-800/40 text-red-800 dark:text-red-200 hover:bg-red-200 dark:hover:bg-red-800/60 transition-colors cursor-pointer"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          <span>Retry</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (meetings.length === 0) return null;
 
   return (
     <div className="mb-6 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-slate-200/80 dark:border-gray-700">
@@ -37,14 +87,22 @@ const StoryThumbnails = () => {
       <div className="flex gap-4 overflow-x-auto pb-2 scrollbar-hide">
         {meetings.map((meeting) => (
           <div
-            key={meeting._id}
-            className="flex flex-col items-center gap-2 cursor-pointer flex-shrink-0 group"
-            onClick={() => setActiveMeetingId(meeting._id)}
+            key={meeting._id || meeting.id}
+            role="button"
+            tabIndex={0}
+            aria-label={`Open story for ${meeting.title}`}
+            className="flex flex-col items-center gap-2 cursor-pointer flex-shrink-0 group focus:outline-none"
+            onClick={() => setActiveMeetingId(meeting._id || meeting.id)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setActiveMeetingId(meeting._id || meeting.id);
+              }
+            }}
           >
-            <div className="w-16 h-16 rounded-full p-[2px] bg-gradient-to-tr from-yellow-400 via-pink-500 to-purple-500 group-hover:scale-105 transition-transform duration-200">
+            <div className="w-16 h-16 rounded-full p-[2px] bg-gradient-to-tr from-yellow-400 via-pink-500 to-purple-500 group-hover:scale-105 group-focus:scale-105 transition-transform duration-200">
               <div className="w-full h-full rounded-full bg-white dark:bg-gray-900 flex items-center justify-center p-1">
                 <div className="w-full h-full rounded-full bg-slate-100 dark:bg-gray-700 flex items-center justify-center overflow-hidden relative">
-                  {/* We could use the org logo, but for now a gradient or icon works */}
                   <Play className="w-6 h-6 text-slate-400 dark:text-gray-400" />
                 </div>
               </div>

--- a/client/src/components/dashboard/__tests__/StoryThumbnails.test.jsx
+++ b/client/src/components/dashboard/__tests__/StoryThumbnails.test.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import StoryThumbnails from "../StoryThumbnails";
+import apiClient from "../../../services/apiClient";
+
+vi.mock("../../../services/apiClient", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../summaries/RecapStoryViewer", () => ({
+  default: ({ meetingId, onClose }) => (
+    <div data-testid="recap-story-viewer">
+      Story Viewer for {meetingId}
+      <button onClick={onClose}>Close Viewer</button>
+    </div>
+  ),
+}));
+
+describe("StoryThumbnails (#1800)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches recent meeting stories using apiClient and renders thumbnails", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [
+          { _id: "mtg-1", title: "Design Review" },
+          { _id: "mtg-2", title: "Sprint Retro" },
+        ],
+      },
+    });
+
+    render(<StoryThumbnails />);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/meetings/stories/recent");
+
+    await waitFor(() => {
+      expect(screen.getByText("Design Review")).toBeInTheDocument();
+      expect(screen.getByText("Sprint Retro")).toBeInTheDocument();
+    });
+  });
+
+  it("displays error UI and allows retry when apiClient call fails", async () => {
+    apiClient.get.mockRejectedValueOnce(new Error("Network Error"));
+
+    render(<StoryThumbnails />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Unable to load recent meeting stories/i),
+      ).toBeInTheDocument();
+    });
+
+    // Mock successful retry
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [{ _id: "mtg-1", title: "Design Review" }],
+      },
+    });
+
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Design Review")).toBeInTheDocument();
+    });
+  });
+
+  it("opens RecapStoryViewer when a story thumbnail is clicked", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [{ _id: "mtg-1", title: "Design Review" }],
+      },
+    });
+
+    render(<StoryThumbnails />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Design Review")).toBeInTheDocument();
+    });
+
+    const thumbnail = screen.getByRole("button", {
+      name: /open story for design review/i,
+    });
+    fireEvent.click(thumbnail);
+
+    expect(screen.getByTestId("recap-story-viewer")).toBeInTheDocument();
+    expect(screen.getByText("Story Viewer for mtg-1")).toBeInTheDocument();
+
+    const closeBtn = screen.getByRole("button", { name: /close viewer/i });
+    fireEvent.click(closeBtn);
+
+    expect(
+      screen.queryByTestId("recap-story-viewer"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/summaries/RecapStoryViewer.jsx
+++ b/client/src/components/summaries/RecapStoryViewer.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Stories from "react-insta-stories";
-import { X, Play, Pause, ChevronLeft, ChevronRight } from "lucide-react";
-import axios from "axios";
+import { X, AlertCircle, RefreshCw } from "lucide-react";
+import apiClient from "../../services/apiClient";
 
 const THEMES = {
   blue: "bg-blue-600 text-white",
@@ -18,7 +18,9 @@ const SlideContent = ({ slide }) => {
       className={`w-full h-full flex flex-col justify-center items-center p-8 text-center ${THEMES[slide.theme] || THEMES.dark}`}
     >
       <h2 className="text-3xl font-bold mb-6 drop-shadow-md">{slide.title}</h2>
-      <p className="text-xl leading-relaxed opacity-90">{slide.content}</p>
+      <p className="text-xl leading-relaxed opacity-90">
+        {slide.content || slide.summary}
+      </p>
     </div>
   );
 };
@@ -28,39 +30,53 @@ const RecapStoryViewer = ({ meetingId, onClose }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    const fetchStory = async () => {
-      try {
-        setLoading(true);
-        // Using axios directly with credentials if meetingApi doesn't have a method yet
-        const response = await axios.get(`/api/meetings/${meetingId}/story`, {
-          withCredentials: true,
-        });
+  const fetchStory = useCallback(async () => {
+    if (!meetingId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await apiClient.get(`/api/meetings/${meetingId}/story`);
 
-        if (response.data.success && response.data.story) {
-          const formattedStories = response.data.story.map((slide) => ({
-            content: (props) => <SlideContent slide={slide} {...props} />,
-          }));
-          setStories(formattedStories);
-        } else {
-          setError("Failed to load story");
-        }
-      } catch (err) {
-        console.error("Error fetching story:", err);
-        setError("Failed to load story. Please try again later.");
-      } finally {
-        setLoading(false);
+      const rawStory = response.data?.story || response.data?.recapStory;
+      if (response.data?.success && rawStory) {
+        const slides = Array.isArray(rawStory)
+          ? rawStory
+          : rawStory.slides || [
+              {
+                title: rawStory.title || "Meeting Recap",
+                content: rawStory.summary || "Summary of the meeting",
+                theme: "blue",
+              },
+            ];
+        const formattedStories = slides.map((slide) => ({
+          content: (props) => <SlideContent slide={slide} {...props} />,
+        }));
+        setStories(formattedStories);
+      } else {
+        setError("Failed to load story");
       }
-    };
-
-    if (meetingId) {
-      fetchStory();
+    } catch (err) {
+      console.error("Error fetching story:", err);
+      setError(
+        err.response?.data?.message ||
+          "Failed to load story. Please try again later.",
+      );
+    } finally {
+      setLoading(false);
     }
   }, [meetingId]);
 
+  useEffect(() => {
+    fetchStory();
+  }, [fetchStory]);
+
   if (loading) {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
+      <div
+        role="dialog"
+        aria-label="Loading recap story"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/90"
+      >
         <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
       </div>
     );
@@ -68,25 +84,54 @@ const RecapStoryViewer = ({ meetingId, onClose }) => {
 
   if (error || stories.length === 0) {
     return (
-      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/90 text-white p-4">
-        <p className="mb-4">
-          {error || "No story available for this meeting."}
-        </p>
-        <button
-          onClick={onClose}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600"
-        >
-          Close
-        </button>
+      <div
+        role="dialog"
+        aria-label="Recap story error"
+        className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/90 text-white p-4"
+      >
+        <div className="max-w-md w-full bg-gray-900 border border-gray-800 rounded-2xl p-6 flex flex-col items-center text-center shadow-2xl">
+          <AlertCircle className="w-12 h-12 text-red-400 mb-3" />
+          <h3 className="text-lg font-bold text-white mb-2">
+            {error ? "Unable to Load Story" : "No Story Available"}
+          </h3>
+          <p className="text-sm text-gray-400 mb-6">
+            {error || "No recap story is currently available for this meeting."}
+          </p>
+          <div className="flex gap-3">
+            {error && (
+              <button
+                type="button"
+                onClick={fetchStory}
+                className="inline-flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-xl text-sm font-semibold text-white transition-colors cursor-pointer"
+              >
+                <RefreshCw className="w-4 h-4" />
+                <span>Retry</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-800 hover:bg-gray-700 rounded-xl text-sm font-semibold text-gray-200 transition-colors cursor-pointer"
+            >
+              Close
+            </button>
+          </div>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/95 backdrop-blur-sm">
+    <div
+      role="dialog"
+      aria-label="Meeting recap story viewer"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/95 backdrop-blur-sm"
+    >
       <button
+        type="button"
         onClick={onClose}
-        className="absolute top-4 right-4 z-[110] p-2 bg-black/20 hover:bg-black/40 rounded-full text-white transition-colors"
+        aria-label="Close story viewer"
+        className="absolute top-4 right-4 z-[110] p-2 bg-black/20 hover:bg-black/40 rounded-full text-white transition-colors cursor-pointer"
       >
         <X className="w-6 h-6" />
       </button>

--- a/client/src/components/summaries/__tests__/RecapStoryViewer.test.jsx
+++ b/client/src/components/summaries/__tests__/RecapStoryViewer.test.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RecapStoryViewer from "../RecapStoryViewer";
+import apiClient from "../../../services/apiClient";
+
+vi.mock("../../../services/apiClient", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("react-insta-stories", () => ({
+  default: ({ stories, onAllStoriesEnd }) => (
+    <div data-testid="react-insta-stories">
+      <span>Stories count: {stories.length}</span>
+      <button onClick={onAllStoriesEnd}>End Stories</button>
+    </div>
+  ),
+}));
+
+describe("RecapStoryViewer (#1800)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches story data via apiClient and renders the stories viewer", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        story: [
+          { title: "Key Discussion", content: "Discussed Q3 goals", theme: "blue" },
+          { title: "Action Items", content: "Alice to draft RFC", theme: "green" },
+        ],
+      },
+    });
+
+    const onClose = vi.fn();
+    render(<RecapStoryViewer meetingId="mtg-123" onClose={onClose} />);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/meetings/mtg-123/story");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("react-insta-stories")).toBeInTheDocument();
+      expect(screen.getByText("Stories count: 2")).toBeInTheDocument();
+    });
+  });
+
+  it("displays error dialog and allows retry when story fetch fails", async () => {
+    apiClient.get.mockRejectedValueOnce(new Error("Network Error"));
+
+    const onClose = vi.fn();
+    render(<RecapStoryViewer meetingId="mtg-123" onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: /recap story error/i })).toBeInTheDocument();
+      expect(screen.getByText("Unable to Load Story")).toBeInTheDocument();
+    });
+
+    // Mock successful retry
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        recapStory: {
+          title: "Meeting Summary",
+          summary: "Summary content here",
+        },
+      },
+    });
+
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("react-insta-stories")).toBeInTheDocument();
+    });
+  });
+
+  it("triggers onClose when close button is clicked", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        story: [{ title: "Intro", content: "Welcome" }],
+      },
+    });
+
+    const onClose = vi.fn();
+    render(<RecapStoryViewer meetingId="mtg-123" onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("react-insta-stories")).toBeInTheDocument();
+    });
+
+    const closeBtn = screen.getByRole("button", { name: /close story viewer/i });
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description
Fixes #1800

Previously, `StoryThumbnails` and `RecapStoryViewer` used raw `axios` calls with relative endpoints rather than the shared `apiClient`. This caused requests to lack automatic authentication headers, standard timeout handling, retry logic, and backend base URL configuration. When network or authorization errors occurred, they were caught solely via `console.error` without updating component state, causing the widgets to silently unmount or disappear.

This PR refactors both components to use `apiClient`, introduces proper loading skeletons, and adds interactive error states with retry actions.

## Changes Made
- **`StoryThumbnails.jsx`**:
  - Replaced raw `axios` with `apiClient.get("/api/meetings/stories/recent")`.
  - Added loading skeleton placeholders to prevent layout shifts.
  - Added dedicated `error` state rendering a styled alert UI with a **Retry** action button.
  - Added keyboard navigation (`Enter` / `Space`) and ARIA roles for accessibility.
- **`RecapStoryViewer.jsx`**:
  - Replaced raw `axios` with `apiClient.get(`/api/meetings/${meetingId}/story`)`.
  - Normalized story responses supporting both `response.data.story` and `response.data.recapStory`.
  - Built an accessible error modal dialog with clear messaging, **Retry**, and **Close** controls.
  - Wrapped `fetchStory` in `useCallback` to satisfy ESLint hook dependencies.
- **Unit Tests**:
  - Added `StoryThumbnails.test.jsx` testing `apiClient` fetching, error state rendering, retry mechanism, and modal launching.
  - Added `RecapStoryViewer.test.jsx` testing story rendering, error recovery flow, and modal dismissal.

## Verification
- [x] Ran unit tests: `npm run test:ci -- src/components/dashboard/__tests__/StoryThumbnails.test.jsx src/components/summaries/__tests__/RecapStoryViewer.test.jsx` (6/6 passed)
- [x] Ran linter: `npx eslint src/components/dashboard/StoryThumbnails.jsx src/components/summaries/RecapStoryViewer.jsx` (0 errors)
- [x] Production build verification: `npm run build` (Clean build)

## Checklist
- [x] Code adheres to the style guidelines of this project
- [x] Added automated unit tests covering the new functionality
- [x] Verified error state recovery and retry actions