### PR TITLE
fix(i18n): fix translation endpoint routes and decouple error state i…

### DIFF
--- a/client/src/pages/LanguagePreferences.jsx
+++ b/client/src/pages/LanguagePreferences.jsx
@@ -1,13 +1,23 @@
 import React, { useState, useEffect, useCallback } from "react";
 import apiClient from "../services/apiClient.js";
 import Navbar from "../components/Navbar.jsx";
-import { Languages, Save, Plus, Trash2, Globe, Settings } from "lucide-react";
+import {
+  Languages,
+  Save,
+  Plus,
+  Trash2,
+  Globe,
+  Settings,
+  AlertCircle,
+  RefreshCw,
+} from "lucide-react";
 import { toast } from "react-toastify";
 
 const LanguagePreferences = () => {
   const [preferences, setPreferences] = useState(null);
   const [languages, setLanguages] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [saving, setSaving] = useState(false);
   const [newGlossary, setNewGlossary] = useState({
     source: "",
@@ -18,10 +28,12 @@ const LanguagePreferences = () => {
   const fetchPreferences = useCallback(async () => {
     try {
       setLoading(true);
-      const { data } = await apiClient.get("/api/translation/preferences");
-      setPreferences(data);
-    } catch (error) {
-      console.error("Error fetching preferences:", error);
+      setError(null);
+      const { data } = await apiClient.get("/api/translations/preferences");
+      setPreferences(data.preferences || data);
+    } catch (err) {
+      console.error("Error fetching preferences:", err);
+      setError(err.response?.data?.message || "Failed to load preferences");
       toast.error("Failed to load preferences");
     } finally {
       setLoading(false);
@@ -30,10 +42,10 @@ const LanguagePreferences = () => {
 
   const fetchLanguages = useCallback(async () => {
     try {
-      const { data } = await apiClient.get("/api/translation/languages");
+      const { data } = await apiClient.get("/api/translations/languages");
       setLanguages(data.languages || []);
-    } catch (error) {
-      console.error("Error fetching languages:", error);
+    } catch (err) {
+      console.error("Error fetching languages:", err);
     }
   }, []);
 
@@ -46,13 +58,13 @@ const LanguagePreferences = () => {
     try {
       setSaving(true);
       const { data } = await apiClient.put(
-        "/api/translation/preferences",
+        "/api/translations/preferences",
         preferences,
       );
-      setPreferences(data);
+      setPreferences(data.preferences || data);
       toast.success("Preferences saved successfully");
-    } catch (error) {
-      console.error("Error saving preferences:", error);
+    } catch (err) {
+      console.error("Error saving preferences:", err);
       toast.error("Failed to save preferences");
     } finally {
       setSaving(false);
@@ -68,7 +80,7 @@ const LanguagePreferences = () => {
     setPreferences((prev) => ({
       ...prev,
       customGlossary: [
-        ...prev.customGlossary,
+        ...(prev.customGlossary || []),
         { ...newGlossary, addedAt: new Date().toISOString() },
       ],
     }));
@@ -80,7 +92,7 @@ const LanguagePreferences = () => {
   const removeGlossaryEntry = (index) => {
     setPreferences((prev) => ({
       ...prev,
-      customGlossary: prev.customGlossary.filter((_, i) => i !== index),
+      customGlossary: (prev.customGlossary || []).filter((_, i) => i !== index),
     }));
     toast.success("Glossary entry removed");
   };
@@ -103,16 +115,47 @@ const LanguagePreferences = () => {
     });
   };
 
-  if (loading || !preferences) {
+  if (loading) {
     return (
       <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
         <Navbar />
-        <div className="pt-20 flex items-center justify-center">
+        <div className="pt-20 flex items-center justify-center min-h-[60vh]">
           <div className="text-center">
             <Languages className="w-12 h-12 text-blue-600 animate-pulse mx-auto mb-4" />
             <p className="text-slate-600 dark:text-slate-400">
               Loading preferences...
             </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !preferences) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+        <Navbar />
+        <div className="pt-20 max-w-xl mx-auto px-4 py-16 flex items-center justify-center min-h-[60vh]">
+          <div
+            role="alert"
+            className="w-full bg-white dark:bg-slate-900 rounded-2xl shadow-lg border border-red-200 dark:border-red-800 p-8 text-center"
+          >
+            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+            <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+              Unable to Load Preferences
+            </h2>
+            <p className="text-slate-600 dark:text-slate-400 mb-6 text-sm">
+              {error ||
+                "An unexpected error occurred while loading your language preferences."}
+            </p>
+            <button
+              type="button"
+              onClick={fetchPreferences}
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 text-white rounded-xl hover:bg-blue-700 font-semibold text-sm transition-colors cursor-pointer"
+            >
+              <RefreshCw className="w-4 h-4" />
+              <span>Retry</span>
+            </button>
           </div>
         </div>
       </div>

--- a/client/src/pages/__tests__/LanguagePreferencesApiClient.test.jsx
+++ b/client/src/pages/__tests__/LanguagePreferencesApiClient.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import LanguagePreferences from "../LanguagePreferences.jsx";
 
@@ -24,11 +24,11 @@ vi.mock("../../services/apiClient.js", () => ({
   },
 }));
 
-describe("LanguagePreferences uses Clerk-aware apiClient (#1407)", () => {
+describe("LanguagePreferences (#1407, #1802)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGet.mockImplementation((url) => {
-      if (url === "/api/translation/preferences") {
+      if (url === "/api/translations/preferences") {
         return Promise.resolve({
           data: {
             autoTranslate: true,
@@ -40,7 +40,7 @@ describe("LanguagePreferences uses Clerk-aware apiClient (#1407)", () => {
           },
         });
       }
-      if (url === "/api/translation/languages") {
+      if (url === "/api/translations/languages") {
         return Promise.resolve({
           data: { languages: [{ code: "en", name: "English" }] },
         });
@@ -49,14 +49,62 @@ describe("LanguagePreferences uses Clerk-aware apiClient (#1407)", () => {
     });
   });
 
-  it("loads preferences and languages through apiClient instead of raw fetch", async () => {
+  it("loads preferences and languages through plural /api/translations endpoints", async () => {
     render(<LanguagePreferences />);
 
     await waitFor(() => {
       expect(screen.getByText("Language Preferences")).toBeInTheDocument();
     });
 
-    expect(mockGet).toHaveBeenCalledWith("/api/translation/preferences");
-    expect(mockGet).toHaveBeenCalledWith("/api/translation/languages");
+    expect(mockGet).toHaveBeenCalledWith("/api/translations/preferences");
+    expect(mockGet).toHaveBeenCalledWith("/api/translations/languages");
+  });
+
+  it("decouples error state from loading and renders error UI on fetch failure (#1802)", async () => {
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.reject(new Error("Network Error"));
+      }
+      return Promise.resolve({ data: { languages: [] } });
+    });
+
+    render(<LanguagePreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(
+        screen.getByText("Unable to Load Preferences"),
+      ).toBeInTheDocument();
+    });
+
+    // Make sure it doesn't get stuck in "Loading preferences..."
+    expect(
+      screen.queryByText("Loading preferences..."),
+    ).not.toBeInTheDocument();
+
+    // Verify retry recovers successfully
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: {
+            autoTranslate: false,
+            showConfidenceScores: false,
+            preferredProvider: "auto",
+            defaultSourceLanguage: "en",
+            defaultTargetLanguages: [],
+            customGlossary: [],
+          },
+        });
+      }
+      return Promise.resolve({ data: { languages: [] } });
+    });
+
+    const retryBtn = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Language Preferences")).toBeInTheDocument();
+    });
   });
 });
+


### PR DESCRIPTION
## Description
Fixes #1802

This PR resolves two issues in `LanguagePreferences.jsx`:
1. **Infinite Loading State on Error**: Previously, the render guard `if (loading || !preferences)` caused the component to display the `"Loading preferences..."` spinner indefinitely when API requests failed (since `preferences` remained `null` even after `loading` turned `false`).
2. **Singular vs. Plural Path Mismatch**: The page queried `/api/translation/*` (singular) rather than `/api/translations/*` (plural) as defined in the server routes and shared services.

## Changes Made
- **Endpoint Route Updates**:
  - Updated GET/PUT preferences requests to `/api/translations/preferences`.
  - Updated GET languages requests to `/api/translations/languages`.
- **Decoupled Loading and Error States**:
  - Added dedicated `error` state.
  - Separated loading spinner guard from error rendering.
  - Implemented an accessible alert dialog with an explanation and a **Retry** action button to recover when requests fail.
- **Unit Tests**:
  - Updated and expanded `LanguagePreferencesApiClient.test.jsx` to test plural endpoint queries, verify the elimination of infinite loading on error, and assert retry recovery.

## Verification
- [x] Ran unit tests: `npm run test:ci -- src/pages/__tests__/LanguagePreferencesApiClient.test.jsx` (2/2 passed)
- [x] Ran linter: `npx eslint src/pages/LanguagePreferences.jsx src/pages/__tests__/LanguagePreferencesApiClient.test.jsx` (0 errors)
- [x] Production build verification: `npm run build` (Clean build)

## Checklist
- [x] Code adheres to the style guidelines of this project
- [x] Added automated unit tests covering the new functionality
- [x] Verified error recovery and retry flow