### PR TITLE
feat(org-settings): Add Custom Field management UI and definition CRUD endpoints (#1903)

### DIFF
--- a/client/src/api/customFieldApi.js
+++ b/client/src/api/customFieldApi.js
@@ -1,28 +1,35 @@
-import apiClient from "../services/apiClient";
+import apiClient from '../services/apiClient'
 export const customFieldApi = {
   getDefinitions: async (orgId) => {
-    const res = await apiClient.get(`/api/custom-fields/org/${orgId}`);
-    return res.data;
+    const res = await apiClient.get(`/api/custom-fields/org/${orgId}`)
+    return res.data
   },
 
   createDefinition: async (orgId, data) => {
-    const res = await apiClient.post(`/api/custom-fields/org/${orgId}`, data);
-    return res.data;
+    const res = await apiClient.post(`/api/custom-fields/org/${orgId}`, data)
+    return res.data
+  },
+
+  updateDefinition: async (orgId, id, data) => {
+    const res = await apiClient.put(`/api/custom-fields/org/${orgId}/definition/${id}`, data)
+    return res.data
+  },
+
+  deleteDefinition: async (orgId, id) => {
+    const res = await apiClient.delete(`/api/custom-fields/org/${orgId}/definition/${id}`)
+    return res.data
   },
 
   getMeetingFields: async (meetingId) => {
-    const res = await apiClient.get(`/api/custom-fields/meeting/${meetingId}`);
-    return res.data;
+    const res = await apiClient.get(`/api/custom-fields/meeting/${meetingId}`)
+    return res.data
   },
 
   setMeetingFields: async (meetingId, orgId, fields) => {
-    const res = await apiClient.post(
-      `/api/custom-fields/meeting/${meetingId}`,
-      {
-        orgId,
-        fields,
-      },
-    );
-    return res.data;
+    const res = await apiClient.post(`/api/custom-fields/meeting/${meetingId}`, {
+      orgId,
+      fields,
+    })
+    return res.data
   },
-};
+}

--- a/client/src/components/organization/OrgCustomFieldsManager.jsx
+++ b/client/src/components/organization/OrgCustomFieldsManager.jsx
@@ -1,0 +1,477 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  Plus,
+  Trash2,
+  Edit2,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Loader2,
+  Sliders,
+  Type,
+  Hash,
+  ListFilter,
+  Calendar as CalendarIcon,
+  CheckSquare,
+  HelpCircle,
+} from 'lucide-react'
+import { toast } from 'react-toastify'
+import { customFieldApi } from '../../api/customFieldApi.js'
+
+const FIELD_TYPES = [
+  { label: 'Text', value: 'text', icon: Type, description: 'Single-line string field' },
+  { label: 'Number', value: 'number', icon: Hash, description: 'Numeric value' },
+  {
+    label: 'Dropdown',
+    value: 'dropdown',
+    icon: ListFilter,
+    description: 'Select from predefined list',
+  },
+  { label: 'Date', value: 'date', icon: CalendarIcon, description: 'Date picker selection' },
+  {
+    label: 'Checkbox',
+    value: 'checkbox',
+    icon: CheckSquare,
+    description: 'Boolean true/false toggle',
+  },
+]
+
+const OrgCustomFieldsManager = ({ orgId, canEdit = true }) => {
+  const [definitions, setDefinitions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  // Modal / Form state
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [editingId, setEditingId] = useState(null)
+  const [fieldForm, setFieldForm] = useState({
+    name: '',
+    type: 'text',
+    required: false,
+    active: true,
+    optionsInput: '',
+  })
+
+  const loadDefinitions = useCallback(async () => {
+    if (!orgId) return
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await customFieldApi.getDefinitions(orgId)
+      setDefinitions(res.data || [])
+    } catch (err) {
+      console.error('Failed to load organization custom fields', err)
+      setError('Unable to load custom field definitions.')
+      toast.error('Failed to load custom fields')
+    } finally {
+      setLoading(false)
+    }
+  }, [orgId])
+
+  useEffect(() => {
+    loadDefinitions()
+  }, [loadDefinitions])
+
+  const resetForm = () => {
+    setFieldForm({
+      name: '',
+      type: 'text',
+      required: false,
+      active: true,
+      optionsInput: '',
+    })
+    setEditingId(null)
+  }
+
+  const handleOpenCreateModal = () => {
+    resetForm()
+    setIsModalOpen(true)
+  }
+
+  const handleOpenEditModal = (def) => {
+    setEditingId(def._id)
+    setFieldForm({
+      name: def.name || '',
+      type: def.type || 'text',
+      required: Boolean(def.required),
+      active: def.active !== undefined ? def.active : true,
+      optionsInput: Array.isArray(def.options) ? def.options.join(', ') : '',
+    })
+    setIsModalOpen(true)
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!fieldForm.name.trim()) {
+      toast.error('Field name is required')
+      return
+    }
+
+    let parsedOptions = undefined
+    if (fieldForm.type === 'dropdown') {
+      parsedOptions = fieldForm.optionsInput
+        .split(',')
+        .map((opt) => opt.trim())
+        .filter((opt) => opt.length > 0)
+
+      if (parsedOptions.length === 0) {
+        toast.error('Dropdown type requires at least one option')
+        return
+      }
+    }
+
+    try {
+      setSubmitting(true)
+      if (editingId) {
+        // Update
+        const payload = {
+          name: fieldForm.name.trim(),
+          required: fieldForm.required,
+          active: fieldForm.active,
+        }
+        if (fieldForm.type === 'dropdown') {
+          payload.options = parsedOptions
+        }
+        await customFieldApi.updateDefinition(orgId, editingId, payload)
+        toast.success('Custom field definition updated')
+      } else {
+        // Create
+        const payload = {
+          name: fieldForm.name.trim(),
+          type: fieldForm.type,
+          required: fieldForm.required,
+          options: parsedOptions,
+        }
+        await customFieldApi.createDefinition(orgId, payload)
+        toast.success('Custom field definition created')
+      }
+
+      setIsModalOpen(false)
+      resetForm()
+      await loadDefinitions()
+    } catch (err) {
+      console.error('Failed to save custom field definition', err)
+      const msg = err.response?.data?.message || err.message || 'Failed to save definition'
+      toast.error(typeof msg === 'string' ? msg : 'Invalid field definition')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (defId, name) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete custom field "${name}"? This action removes all stored values for meetings.`,
+      )
+    ) {
+      return
+    }
+    try {
+      setLoading(true)
+      await customFieldApi.deleteDefinition(orgId, defId)
+      toast.success(`Custom field "${name}" deleted`)
+      await loadDefinitions()
+    } catch (err) {
+      console.error('Failed to delete custom field', err)
+      toast.error(err.response?.data?.message || 'Failed to delete custom field')
+      setLoading(false)
+    }
+  }
+
+  const handleToggleActive = async (def) => {
+    try {
+      await customFieldApi.updateDefinition(orgId, def._id, {
+        active: !def.active,
+      })
+      toast.success(`Custom field "${def.name}" ${def.active ? 'deactivated' : 'activated'}`)
+      await loadDefinitions()
+    } catch (err) {
+      console.error('Failed to toggle field active status', err)
+      toast.error('Failed to update status')
+    }
+  }
+
+  if (!orgId) return null
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden mb-8">
+      {/* Header */}
+      <div className="p-6 border-b border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Sliders className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+              Organization Custom Fields
+            </h2>
+          </div>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Define custom metadata attributes collectable across all organization meetings.
+          </p>
+        </div>
+
+        {canEdit && (
+          <button
+            onClick={handleOpenCreateModal}
+            className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 rounded-lg shadow-sm transition-colors gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            Add Custom Field
+          </button>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="p-6">
+        {loading ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+            <Loader2 className="w-8 h-8 animate-spin text-indigo-600 dark:text-indigo-400 mb-2" />
+            <p className="text-sm">Loading field definitions...</p>
+          </div>
+        ) : error ? (
+          <div className="p-4 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 rounded-lg flex items-center gap-3">
+            <AlertCircle className="w-5 h-5 shrink-0" />
+            <p className="text-sm">{error}</p>
+          </div>
+        ) : definitions.length === 0 ? (
+          <div className="text-center py-12 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl">
+            <Sliders className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-500 mb-3" />
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              No Custom Fields Defined
+            </h3>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 max-w-md mx-auto">
+              Create custom fields like Project ID, Cost Center, or Sprint Number to organize
+              meeting metadata.
+            </p>
+            {canEdit && (
+              <button
+                onClick={handleOpenCreateModal}
+                className="mt-4 inline-flex items-center px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 rounded-lg transition-colors gap-2"
+              >
+                <Plus className="w-4 h-4" />
+                Define First Field
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm text-gray-600 dark:text-gray-300">
+              <thead className="bg-gray-50 dark:bg-gray-700/50 text-xs uppercase font-semibold text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                <tr>
+                  <th className="px-4 py-3">Field Name</th>
+                  <th className="px-4 py-3">Data Type</th>
+                  <th className="px-4 py-3">Options / Validation</th>
+                  <th className="px-4 py-3">Required</th>
+                  <th className="px-4 py-3">Status</th>
+                  {canEdit && <th className="px-4 py-3 text-right">Actions</th>}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {definitions.map((def) => {
+                  const typeObj = FIELD_TYPES.find((t) => t.value === def.type)
+                  const Icon = typeObj?.icon || Type
+
+                  return (
+                    <tr
+                      key={def._id}
+                      className="hover:bg-gray-50/50 dark:hover:bg-gray-700/30 transition-colors"
+                    >
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-white">
+                        {def.name}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                          <Icon className="w-3.5 h-3.5" />
+                          {typeObj?.label || def.type}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
+                        {def.type === 'dropdown' && def.options ? (
+                          <span className="truncate max-w-xs block" title={def.options.join(', ')}>
+                            Options: {def.options.join(', ')}
+                          </span>
+                        ) : (
+                          <span className="italic">N/A</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {def.required ? (
+                          <span className="inline-flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded">
+                            Required
+                          </span>
+                        ) : (
+                          <span className="text-xs text-gray-400">Optional</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          disabled={!canEdit}
+                          onClick={() => handleToggleActive(def)}
+                          className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded transition-colors ${
+                            def.active !== false
+                              ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400'
+                              : 'bg-gray-100 dark:bg-gray-700 text-gray-500'
+                          }`}
+                        >
+                          {def.active !== false ? (
+                            <>
+                              <CheckCircle2 className="w-3 h-3" /> Active
+                            </>
+                          ) : (
+                            <>
+                              <XCircle className="w-3 h-3" /> Inactive
+                            </>
+                          )}
+                        </button>
+                      </td>
+                      {canEdit && (
+                        <td className="px-4 py-3 text-right">
+                          <div className="flex items-center justify-end gap-2">
+                            <button
+                              onClick={() => handleOpenEditModal(def)}
+                              className="p-1.5 text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                              title="Edit Field"
+                            >
+                              <Edit2 className="w-4 h-4" />
+                            </button>
+                            <button
+                              onClick={() => handleDelete(def._id, def.name)}
+                              className="p-1.5 text-gray-500 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                              title="Delete Field"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          </div>
+                        </td>
+                      )}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Modal Dialog */}
+      {isModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+          <div className="bg-white dark:bg-gray-800 rounded-2xl max-w-lg w-full p-6 shadow-2xl border border-gray-200 dark:border-gray-700">
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
+              {editingId ? 'Edit Custom Field' : 'Create Custom Field'}
+            </h3>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Field Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={fieldForm.name}
+                  onChange={(e) => setFieldForm({ ...fieldForm, name: e.target.value })}
+                  placeholder="e.g. Project Code, Sprint ID"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Field Type
+                </label>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {FIELD_TYPES.map((ft) => {
+                    const Icon = ft.icon
+                    const isSelected = fieldForm.type === ft.value
+                    return (
+                      <button
+                        type="button"
+                        key={ft.value}
+                        disabled={Boolean(editingId)} // Type cannot be changed after creation
+                        onClick={() => setFieldForm({ ...fieldForm, type: ft.value })}
+                        className={`flex flex-col items-center justify-center p-3 rounded-lg border text-xs font-medium transition-all ${
+                          isSelected
+                            ? 'border-indigo-600 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400'
+                            : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-700/50 text-gray-600 dark:text-gray-300 hover:border-gray-300'
+                        } ${editingId ? 'opacity-60 cursor-not-allowed' : ''}`}
+                      >
+                        <Icon className="w-5 h-5 mb-1" />
+                        {ft.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                {editingId && (
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Field data type cannot be changed after creation.
+                  </p>
+                )}
+              </div>
+
+              {fieldForm.type === 'dropdown' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    Dropdown Options (comma-separated) <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    value={fieldForm.optionsInput}
+                    onChange={(e) => setFieldForm({ ...fieldForm, optionsInput: e.target.value })}
+                    placeholder="Option 1, Option 2, Option 3"
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                  />
+                </div>
+              )}
+
+              <div className="flex items-center justify-between pt-2">
+                <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={fieldForm.required}
+                    onChange={(e) => setFieldForm({ ...fieldForm, required: e.target.checked })}
+                    className="w-4 h-4 text-indigo-600 rounded border-gray-300 focus:ring-indigo-500"
+                  />
+                  Mark as Required field
+                </label>
+
+                {editingId && (
+                  <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <input
+                      type="checkbox"
+                      checked={fieldForm.active}
+                      onChange={(e) => setFieldForm({ ...fieldForm, active: e.target.checked })}
+                      className="w-4 h-4 text-indigo-600 rounded border-gray-300 focus:ring-indigo-500"
+                    />
+                    Active Field
+                  </label>
+                )}
+              </div>
+
+              <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(false)}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={submitting}
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg shadow-sm transition-colors"
+                >
+                  {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {editingId ? 'Save Changes' : 'Create Field'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default OrgCustomFieldsManager

--- a/client/src/components/organization/__tests__/OrgCustomFieldsManager.test.jsx
+++ b/client/src/components/organization/__tests__/OrgCustomFieldsManager.test.jsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import OrgCustomFieldsManager from '../OrgCustomFieldsManager'
+import { customFieldApi } from '../../api/customFieldApi'
+
+vi.mock('../../api/customFieldApi', () => ({
+  customFieldApi: {
+    getDefinitions: vi.fn(),
+    createDefinition: vi.fn(),
+    updateDefinition: vi.fn(),
+    deleteDefinition: vi.fn(),
+  },
+}))
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('OrgCustomFieldsManager', () => {
+  const orgId = 'org-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders empty state when no custom fields exist', async () => {
+    customFieldApi.getDefinitions.mockResolvedValue({ data: [] })
+
+    render(<OrgCustomFieldsManager orgId={orgId} canEdit={true} />)
+
+    expect(screen.getByText('Loading field definitions...')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('No Custom Fields Defined')).toBeInTheDocument()
+    })
+  })
+
+  it('renders custom field definitions in a table', async () => {
+    const mockDefs = [
+      { _id: 'def-1', name: 'Cost Center', type: 'text', required: true, active: true },
+      {
+        _id: 'def-2',
+        name: 'Priority',
+        type: 'dropdown',
+        options: ['High', 'Low'],
+        required: false,
+        active: true,
+      },
+    ]
+    customFieldApi.getDefinitions.mockResolvedValue({ data: mockDefs })
+
+    render(<OrgCustomFieldsManager orgId={orgId} canEdit={true} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Cost Center')).toBeInTheDocument()
+      expect(screen.getByText('Priority')).toBeInTheDocument()
+      expect(screen.getByText('Options: High, Low')).toBeInTheDocument()
+    })
+  })
+
+  it('opens modal and creates a new custom field definition', async () => {
+    customFieldApi.getDefinitions.mockResolvedValue({ data: [] })
+    customFieldApi.createDefinition.mockResolvedValue({
+      success: true,
+      data: { _id: 'def-3', name: 'Project ID', type: 'text' },
+    })
+
+    render(<OrgCustomFieldsManager orgId={orgId} canEdit={true} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No Custom Fields Defined')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Custom Field/i }))
+
+    expect(screen.getByText('Create Custom Field')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. Project Code/i), {
+      target: { value: 'Project ID' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Create Field/i }))
+
+    await waitFor(() => {
+      expect(customFieldApi.createDefinition).toHaveBeenCalledWith(orgId, {
+        name: 'Project ID',
+        type: 'text',
+        required: false,
+        options: undefined,
+      })
+    })
+  })
+})

--- a/client/src/components/organization/__tests__/OrgCustomFieldsManager.test.jsx
+++ b/client/src/components/organization/__tests__/OrgCustomFieldsManager.test.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import OrgCustomFieldsManager from '../OrgCustomFieldsManager'
-import { customFieldApi } from '../../api/customFieldApi'
+import { customFieldApi } from '../../../api/customFieldApi'
 
-vi.mock('../../api/customFieldApi', () => ({
+vi.mock('../../../api/customFieldApi', () => ({
   customFieldApi: {
     getDefinitions: vi.fn(),
     createDefinition: vi.fn(),

--- a/client/src/pages/OrganizationSettings.jsx
+++ b/client/src/pages/OrganizationSettings.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useContext } from "react";
-import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import React, { useState, useEffect, useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'react-toastify'
 import {
   Building2,
   Shield,
@@ -24,357 +24,347 @@ import {
   Image as ImageIcon,
   PanelsTopLeft,
   Blocks,
-} from "lucide-react";
-import Navbar from "../components/Navbar.jsx";
-import AppContent from "../context/AppContent";
-import { organizationApi } from "../services/organizationApi.js";
-import OrganizationLogo from "../components/organization/OrganizationLogo.jsx";
-import OrganizationBanner from "../components/organization/OrganizationBanner.jsx";
-import { validateImageUrl } from "../utils/imageUrl.js";
-import NotionConnectPanel from "../components/integrations/NotionConnectPanel.jsx";
-import GitHubConnectPanel from "../components/integrations/GitHubConnectPanel.jsx";
-import IssueTrackerConfig from "../components/integrations/IssueTrackerConfig.jsx";
+} from 'lucide-react'
+import Navbar from '../components/Navbar.jsx'
+import AppContent from '../context/AppContent'
+import { organizationApi } from '../services/organizationApi.js'
+import OrganizationLogo from '../components/organization/OrganizationLogo.jsx'
+import OrganizationBanner from '../components/organization/OrganizationBanner.jsx'
+import { validateImageUrl } from '../utils/imageUrl.js'
+import NotionConnectPanel from '../components/integrations/NotionConnectPanel.jsx'
+import GitHubConnectPanel from '../components/integrations/GitHubConnectPanel.jsx'
+import IssueTrackerConfig from '../components/integrations/IssueTrackerConfig.jsx'
+import OrgCustomFieldsManager from '../components/organization/OrgCustomFieldsManager.jsx'
 
 const OrganizationSettings = () => {
-  const navigate = useNavigate();
-  const { getUserData, setUserData } = useContext(AppContent);
+  const navigate = useNavigate()
+  const { getUserData, setUserData } = useContext(AppContent)
 
   // Loading & state management
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [copiedId, setCopiedId] = useState(false);
-  const [userRole, setUserRole] = useState("member");
-  const [canEdit, setCanEdit] = useState(false);
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [copiedId, setCopiedId] = useState(false)
+  const [userRole, setUserRole] = useState('member')
+  const [canEdit, setCanEdit] = useState(false)
 
   // Original fetched data for dirty state detection
-  const [initialData, setInitialData] = useState(null);
+  const [initialData, setInitialData] = useState(null)
 
   // Form State
   const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    about: "",
-    website: "",
-    contactEmail: "",
-    industry: "",
-    location: "",
-    logo: "",
-    bannerUrl: "",
-    visibility: "private",
-    joinPolicy: "open",
-  });
+    name: '',
+    description: '',
+    about: '',
+    website: '',
+    contactEmail: '',
+    industry: '',
+    location: '',
+    logo: '',
+    bannerUrl: '',
+    visibility: 'private',
+    joinPolicy: 'open',
+  })
 
   // Metadata State
   const [metadata, setMetadata] = useState({
-    _id: "",
-    slug: "",
+    _id: '',
+    slug: '',
     createdAt: null,
     updatedAt: null,
     owner: null,
     memberCount: 0,
-  });
+  })
 
   // Validation Errors
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState({})
 
   // Industry options
   const industryOptions = [
-    "Technology & Software",
-    "Education & Academics",
-    "Healthcare & Life Sciences",
-    "Financial Services",
-    "Marketing & Advertising",
-    "Non-Profit & Community",
-    "Media & Entertainment",
-    "Professional Services",
-    "Real Estate",
-    "Retail & E-commerce",
-    "Manufacturing",
-    "Other",
-  ];
+    'Technology & Software',
+    'Education & Academics',
+    'Healthcare & Life Sciences',
+    'Financial Services',
+    'Marketing & Advertising',
+    'Non-Profit & Community',
+    'Media & Entertainment',
+    'Professional Services',
+    'Real Estate',
+    'Retail & E-commerce',
+    'Manufacturing',
+    'Other',
+  ]
 
   // Fetch organization settings
   const fetchOrgSettings = async () => {
     try {
-      setLoading(true);
-      const { data } = await organizationApi.getOrganizationSettings();
+      setLoading(true)
+      const { data } = await organizationApi.getOrganizationSettings()
 
       if (data.success && data.organization) {
-        const org = data.organization;
+        const org = data.organization
         const loadedForm = {
-          name: org.name || "",
-          description: org.description || "",
-          about: org.about || "",
-          website: org.website || "",
-          contactEmail: org.contactEmail || "",
-          industry: org.industry || "",
-          location: org.location || "",
-          logo: org.logoUrl || org.logo || "",
-          bannerUrl: org.bannerUrl || "",
-          visibility: org.visibility || "private",
-          joinPolicy: org.joinPolicy || "open",
-        };
+          name: org.name || '',
+          description: org.description || '',
+          about: org.about || '',
+          website: org.website || '',
+          contactEmail: org.contactEmail || '',
+          industry: org.industry || '',
+          location: org.location || '',
+          logo: org.logoUrl || org.logo || '',
+          bannerUrl: org.bannerUrl || '',
+          visibility: org.visibility || 'private',
+          joinPolicy: org.joinPolicy || 'open',
+        }
 
-        setFormData(loadedForm);
-        setInitialData(loadedForm);
+        setFormData(loadedForm)
+        setInitialData(loadedForm)
 
         setMetadata({
-          _id: org._id || "",
-          slug: org.slug || "",
+          _id: org._id || '',
+          slug: org.slug || '',
           createdAt: org.createdAt || null,
           updatedAt: org.updatedAt || null,
           owner: org.owner || null,
           memberCount: org.memberCount || 0,
-        });
+        })
 
-        setUserRole(data.userRole || "member");
-        setCanEdit(data.canEdit !== undefined ? data.canEdit : false);
+        setUserRole(data.userRole || 'member')
+        setCanEdit(data.canEdit !== undefined ? data.canEdit : false)
       } else {
-        toast.error("Failed to load organization settings.");
+        toast.error('Failed to load organization settings.')
       }
     } catch (error) {
-      console.error("Error fetching organization settings:", error);
+      console.error('Error fetching organization settings:', error)
       const msg =
-        error.response?.data?.message ||
-        error.message ||
-        "Failed to load organization settings.";
-      toast.error(msg);
+        error.response?.data?.message || error.message || 'Failed to load organization settings.'
+      toast.error(msg)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchOrgSettings();
-  }, []);
+    fetchOrgSettings()
+  }, [])
 
   // Detect unsaved changes (isDirty)
-  const isDirty =
-    initialData && JSON.stringify(initialData) !== JSON.stringify(formData);
+  const isDirty = initialData && JSON.stringify(initialData) !== JSON.stringify(formData)
 
   // Real-time client-side field validation
   const validateField = (field, value) => {
-    let newErrors = { ...errors };
+    let newErrors = { ...errors }
 
     switch (field) {
-      case "name":
+      case 'name':
         if (!value.trim()) {
-          newErrors.name = "Organization name is required.";
+          newErrors.name = 'Organization name is required.'
         } else if (value.trim().length > 100) {
-          newErrors.name = "Organization name cannot exceed 100 characters.";
+          newErrors.name = 'Organization name cannot exceed 100 characters.'
         } else {
-          delete newErrors.name;
+          delete newErrors.name
         }
-        break;
+        break
 
-      case "description":
+      case 'description':
         if (value && value.length > 500) {
-          newErrors.description =
-            "Short description cannot exceed 500 characters.";
+          newErrors.description = 'Short description cannot exceed 500 characters.'
         } else {
-          delete newErrors.description;
+          delete newErrors.description
         }
-        break;
+        break
 
-      case "about":
+      case 'about':
         if (value && value.length > 2000) {
-          newErrors.about = "About bio cannot exceed 2000 characters.";
+          newErrors.about = 'About bio cannot exceed 2000 characters.'
         } else {
-          delete newErrors.about;
+          delete newErrors.about
         }
-        break;
+        break
 
-      case "contactEmail":
+      case 'contactEmail':
         if (value && value.trim()) {
-          const emailPattern = /^[^\s@]+@[^\s@.]+\.[^\s@.]+$/;
+          const emailPattern = /^[^\s@]+@[^\s@.]+\.[^\s@.]+$/
           if (!emailPattern.test(value.trim())) {
-            newErrors.contactEmail = "Please enter a valid email address.";
+            newErrors.contactEmail = 'Please enter a valid email address.'
           } else {
-            delete newErrors.contactEmail;
+            delete newErrors.contactEmail
           }
         } else {
-          delete newErrors.contactEmail;
+          delete newErrors.contactEmail
         }
-        break;
+        break
 
-      case "website":
+      case 'website':
         if (value && value.trim()) {
-          const urlPattern = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/.*)?$/i;
+          const urlPattern = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/.*)?$/i
           if (!urlPattern.test(value.trim())) {
-            newErrors.website =
-              "Please enter a valid URL (e.g. https://example.com).";
+            newErrors.website = 'Please enter a valid URL (e.g. https://example.com).'
           } else {
-            delete newErrors.website;
+            delete newErrors.website
           }
         } else {
-          delete newErrors.website;
+          delete newErrors.website
         }
-        break;
+        break
 
-      case "logo": {
-        const logoError = validateImageUrl(value, "Logo URL");
-        if (logoError) newErrors.logo = logoError;
-        else delete newErrors.logo;
-        break;
+      case 'logo': {
+        const logoError = validateImageUrl(value, 'Logo URL')
+        if (logoError) newErrors.logo = logoError
+        else delete newErrors.logo
+        break
       }
 
-      case "bannerUrl": {
-        const bannerError = validateImageUrl(value, "Banner URL");
-        if (bannerError) newErrors.bannerUrl = bannerError;
-        else delete newErrors.bannerUrl;
-        break;
+      case 'bannerUrl': {
+        const bannerError = validateImageUrl(value, 'Banner URL')
+        if (bannerError) newErrors.bannerUrl = bannerError
+        else delete newErrors.bannerUrl
+        break
       }
 
       default:
-        break;
+        break
     }
 
-    setErrors(newErrors);
-  };
+    setErrors(newErrors)
+  }
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-    validateField(name, value);
-  };
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+    validateField(name, value)
+  }
 
   // Validate entire form before submission
   const validateForm = () => {
-    const newErrors = {};
+    const newErrors = {}
 
     if (!formData.name.trim()) {
-      newErrors.name = "Organization name is required.";
+      newErrors.name = 'Organization name is required.'
     } else if (formData.name.trim().length > 100) {
-      newErrors.name = "Organization name cannot exceed 100 characters.";
+      newErrors.name = 'Organization name cannot exceed 100 characters.'
     }
 
     if (formData.description && formData.description.length > 500) {
-      newErrors.description = "Short description cannot exceed 500 characters.";
+      newErrors.description = 'Short description cannot exceed 500 characters.'
     }
 
     if (formData.about && formData.about.length > 2000) {
-      newErrors.about = "About bio cannot exceed 2000 characters.";
+      newErrors.about = 'About bio cannot exceed 2000 characters.'
     }
 
     if (formData.contactEmail && formData.contactEmail.trim()) {
-      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       if (!emailPattern.test(formData.contactEmail.trim())) {
-        newErrors.contactEmail = "Please enter a valid email address.";
+        newErrors.contactEmail = 'Please enter a valid email address.'
       }
     }
 
     if (formData.website && formData.website.trim()) {
-      const urlPattern = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/.*)?$/i;
+      const urlPattern = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/.*)?$/i
       if (!urlPattern.test(formData.website.trim())) {
-        newErrors.website =
-          "Please enter a valid URL (e.g. https://example.com).";
+        newErrors.website = 'Please enter a valid URL (e.g. https://example.com).'
       }
     }
 
-    const logoError = validateImageUrl(formData.logo, "Logo URL");
-    if (logoError) newErrors.logo = logoError;
+    const logoError = validateImageUrl(formData.logo, 'Logo URL')
+    if (logoError) newErrors.logo = logoError
 
-    const bannerError = validateImageUrl(formData.bannerUrl, "Banner URL");
-    if (bannerError) newErrors.bannerUrl = bannerError;
+    const bannerError = validateImageUrl(formData.bannerUrl, 'Banner URL')
+    if (bannerError) newErrors.bannerUrl = bannerError
 
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
 
   // Handle Save
   const handleSave = async (e) => {
-    if (e) e.preventDefault();
+    if (e) e.preventDefault()
 
     if (!canEdit) {
-      toast.error("You do not have permission to edit organization settings.");
-      return;
+      toast.error('You do not have permission to edit organization settings.')
+      return
     }
 
     if (!validateForm()) {
-      toast.error("Please fix validation errors before saving.");
-      return;
+      toast.error('Please fix validation errors before saving.')
+      return
     }
 
     try {
-      setSaving(true);
-      const { data } = await organizationApi.updateOrganizationSettings(
-        metadata._id,
-        {
-          ...formData,
-          // Persist under both names for compatibility with existing `logo` field.
-          logo: formData.logo,
-          logoUrl: formData.logo,
-          bannerUrl: formData.bannerUrl,
-        },
-      );
+      setSaving(true)
+      const { data } = await organizationApi.updateOrganizationSettings(metadata._id, {
+        ...formData,
+        // Persist under both names for compatibility with existing `logo` field.
+        logo: formData.logo,
+        logoUrl: formData.logo,
+        bannerUrl: formData.bannerUrl,
+      })
 
       if (data.success) {
-        toast.success("Organization settings updated successfully!");
-        setInitialData(formData);
+        toast.success('Organization settings updated successfully!')
+        setInitialData(formData)
 
         // Update user context if user's selected org name changed
         if (getUserData) {
-          const updatedUser = await getUserData();
+          const updatedUser = await getUserData()
           if (updatedUser && setUserData) {
-            setUserData(updatedUser);
-            localStorage.setItem("userData", JSON.stringify(updatedUser));
+            setUserData(updatedUser)
+            localStorage.setItem('userData', JSON.stringify(updatedUser))
           }
         }
       } else {
-        toast.error(data.message || "Failed to update settings.");
+        toast.error(data.message || 'Failed to update settings.')
       }
     } catch (error) {
-      console.error("Error updating organization settings:", error);
+      console.error('Error updating organization settings:', error)
       const msg =
-        error.response?.data?.message ||
-        error.message ||
-        "Failed to update organization settings.";
-      toast.error(msg);
+        error.response?.data?.message || error.message || 'Failed to update organization settings.'
+      toast.error(msg)
     } finally {
-      setSaving(false);
+      setSaving(false)
     }
-  };
+  }
 
   // Reset/Discard changes
   const handleDiscard = () => {
     if (initialData) {
-      setFormData(initialData);
-      setErrors({});
-      toast.info("Changes discarded.");
+      setFormData(initialData)
+      setErrors({})
+      toast.info('Changes discarded.')
     }
-  };
+  }
 
   // Copy Org ID to clipboard
   const handleCopyId = () => {
     if (metadata._id) {
-      navigator.clipboard.writeText(metadata._id);
-      setCopiedId(true);
-      toast.success("Organization ID copied to clipboard!");
-      setTimeout(() => setCopiedId(false), 2000);
+      navigator.clipboard.writeText(metadata._id)
+      setCopiedId(true)
+      toast.success('Organization ID copied to clipboard!')
+      setTimeout(() => setCopiedId(false), 2000)
     }
-  };
+  }
 
   // Format date helper
   const formatDate = (dateStr) => {
-    if (!dateStr) return "N/A";
-    const date = new Date(dateStr);
-    return date.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
+    if (!dateStr) return 'N/A'
+    const date = new Date(dateStr)
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
 
   const getRoleBadgeStyle = (role) => {
     switch (role?.toLowerCase()) {
-      case "owner":
-        return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-700";
-      case "admin":
-        return "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300 border-purple-200 dark:border-purple-700";
+      case 'owner':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-700'
+      case 'admin':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300 border-purple-200 dark:border-purple-700'
       default:
-        return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300 border-blue-200 dark:border-blue-700";
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300 border-blue-200 dark:border-blue-700'
     }
-  };
+  }
 
   if (loading) {
     return (
@@ -387,7 +377,7 @@ const OrganizationSettings = () => {
           </p>
         </div>
       </div>
-    );
+    )
   }
 
   return (
@@ -398,22 +388,20 @@ const OrganizationSettings = () => {
         {/* Breadcrumbs Navigation */}
         <nav className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 mb-6">
           <button
-            onClick={() => navigate("/dashboard")}
+            onClick={() => navigate('/dashboard')}
             className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer"
           >
             Dashboard
           </button>
           <ChevronRight className="w-3.5 h-3.5" />
           <button
-            onClick={() => navigate("/organizations")}
+            onClick={() => navigate('/organizations')}
             className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer"
           >
             Organization
           </button>
           <ChevronRight className="w-3.5 h-3.5" />
-          <span className="font-semibold text-slate-900 dark:text-slate-100">
-            Settings
-          </span>
+          <span className="font-semibold text-slate-900 dark:text-slate-100">Settings</span>
         </nav>
 
         {/* Header Title & Subtitle */}
@@ -428,10 +416,9 @@ const OrganizationSettings = () => {
               </h1>
             </div>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Manage information, contact details, and administration settings
-              for{" "}
+              Manage information, contact details, and administration settings for{' '}
               <span className="font-semibold text-slate-700 dark:text-slate-300">
-                {formData.name || "your organization"}
+                {formData.name || 'your organization'}
               </span>
               .
             </p>
@@ -457,9 +444,8 @@ const OrganizationSettings = () => {
             <div>
               <h4 className="text-sm font-semibold">Read-Only Access</h4>
               <p className="text-xs mt-0.5 text-amber-700 dark:text-amber-400">
-                You are viewing this organization in read-only mode. Only
-                Organization Owners and Administrators have permissions to edit
-                organization information.
+                You are viewing this organization in read-only mode. Only Organization Owners and
+                Administrators have permissions to edit organization information.
               </p>
             </div>
           </div>
@@ -530,8 +516,8 @@ const OrganizationSettings = () => {
                   placeholder="e.g. Acme Corporation"
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.name
-                      ? "border-red-500 dark:border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 dark:border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                 />
                 {errors.name ? (
@@ -560,8 +546,8 @@ const OrganizationSettings = () => {
                   placeholder="Brief tagline or summary of the organization (e.g. Leading AI Research Team)"
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.description
-                      ? "border-red-500 dark:border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 dark:border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                 />
                 {errors.description ? (
@@ -590,8 +576,8 @@ const OrganizationSettings = () => {
                   placeholder="Detailed information about the organization's mission, goals, background, or overview..."
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.about
-                      ? "border-red-500 dark:border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 dark:border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed resize-y`}
                 />
                 {errors.about ? (
@@ -619,8 +605,8 @@ const OrganizationSettings = () => {
                   Organization Branding
                 </h2>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
-                  Logo and banner image URLs with live preview. Upload support
-                  can plug into these same fields later.
+                  Logo and banner image URLs with live preview. Upload support can plug into these
+                  same fields later.
                 </p>
               </div>
             </div>
@@ -631,7 +617,7 @@ const OrganizationSettings = () => {
                 <div className="flex flex-col items-center gap-3">
                   <OrganizationLogo
                     src={formData.logo}
-                    name={formData.name || "Organization"}
+                    name={formData.name || 'Organization'}
                     size="xl"
                   />
                   <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
@@ -655,39 +641,33 @@ const OrganizationSettings = () => {
                     disabled={!canEdit || saving}
                     placeholder="https://cdn.example.com/logo.png"
                     aria-invalid={Boolean(errors.logo)}
-                    aria-describedby={
-                      errors.logo ? "org-logo-error" : undefined
-                    }
+                    aria-describedby={errors.logo ? 'org-logo-error' : undefined}
                     className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                       errors.logo
-                        ? "border-red-500 focus:ring-red-500"
-                        : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                        ? 'border-red-500 focus:ring-red-500'
+                        : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                     } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                   />
                   {errors.logo ? (
-                    <p
-                      id="org-logo-error"
-                      className="text-xs text-red-500 flex items-center gap-1"
-                    >
+                    <p id="org-logo-error" className="text-xs text-red-500 flex items-center gap-1">
                       <AlertCircle className="w-3.5 h-3.5" />
                       {errors.logo}
                     </p>
                   ) : (
                     <p className="text-xs text-slate-500 dark:text-slate-400">
-                      Square image recommended. Leave empty to use the default
-                      placeholder.
+                      Square image recommended. Leave empty to use the default placeholder.
                     </p>
                   )}
                   {canEdit && (
                     <button
                       type="button"
                       onClick={() => {
-                        setFormData((prev) => ({ ...prev, logo: "" }));
+                        setFormData((prev) => ({ ...prev, logo: '' }))
                         setErrors((prev) => {
-                          const next = { ...prev };
-                          delete next.logo;
-                          return next;
-                        });
+                          const next = { ...prev }
+                          delete next.logo
+                          return next
+                        })
                       }}
                       disabled={!formData.logo || saving}
                       className="inline-flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-blue-600 disabled:opacity-40 cursor-pointer"
@@ -711,7 +691,7 @@ const OrganizationSettings = () => {
                 <div className="rounded-xl overflow-hidden border border-slate-200 dark:border-slate-700">
                   <OrganizationBanner
                     src={formData.bannerUrl}
-                    name={formData.name || "Organization"}
+                    name={formData.name || 'Organization'}
                     heightClass="h-36 sm:h-44"
                   />
                 </div>
@@ -727,39 +707,33 @@ const OrganizationSettings = () => {
                   disabled={!canEdit || saving}
                   placeholder="https://cdn.example.com/banner.jpg"
                   aria-invalid={Boolean(errors.bannerUrl)}
-                  aria-describedby={
-                    errors.bannerUrl ? "org-banner-error" : undefined
-                  }
+                  aria-describedby={errors.bannerUrl ? 'org-banner-error' : undefined}
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.bannerUrl
-                      ? "border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                 />
                 {errors.bannerUrl ? (
-                  <p
-                    id="org-banner-error"
-                    className="text-xs text-red-500 flex items-center gap-1"
-                  >
+                  <p id="org-banner-error" className="text-xs text-red-500 flex items-center gap-1">
                     <AlertCircle className="w-3.5 h-3.5" />
                     {errors.bannerUrl}
                   </p>
                 ) : (
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Wide cover image (roughly 3:1). Leave empty to use the
-                    default gradient.
+                    Wide cover image (roughly 3:1). Leave empty to use the default gradient.
                   </p>
                 )}
                 {canEdit && (
                   <button
                     type="button"
                     onClick={() => {
-                      setFormData((prev) => ({ ...prev, bannerUrl: "" }));
+                      setFormData((prev) => ({ ...prev, bannerUrl: '' }))
                       setErrors((prev) => {
-                        const next = { ...prev };
-                        delete next.bannerUrl;
-                        return next;
-                      });
+                        const next = { ...prev }
+                        delete next.bannerUrl
+                        return next
+                      })
                     }}
                     disabled={!formData.bannerUrl || saving}
                     className="inline-flex items-center gap-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-blue-600 disabled:opacity-40 cursor-pointer"
@@ -804,8 +778,8 @@ const OrganizationSettings = () => {
                   placeholder="https://example.com"
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.website
-                      ? "border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                 />
                 {errors.website && (
@@ -831,8 +805,8 @@ const OrganizationSettings = () => {
                   placeholder="contact@organization.com"
                   className={`w-full px-4 py-2.5 text-sm rounded-xl bg-slate-50 dark:bg-slate-800/80 border ${
                     errors.contactEmail
-                      ? "border-red-500 focus:ring-red-500"
-                      : "border-slate-200 dark:border-slate-700 focus:ring-blue-500"
+                      ? 'border-red-500 focus:ring-red-500'
+                      : 'border-slate-200 dark:border-slate-700 focus:ring-blue-500'
                   } text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 transition-all disabled:opacity-60 disabled:cursor-not-allowed`}
                 />
                 {errors.contactEmail && (
@@ -908,7 +882,7 @@ const OrganizationSettings = () => {
                 </p>
                 <div className="flex items-center justify-between mt-1.5">
                   <span className="font-mono text-xs font-semibold text-slate-900 dark:text-slate-200 truncate mr-2">
-                    {metadata._id || "N/A"}
+                    {metadata._id || 'N/A'}
                   </span>
                   <button
                     type="button"
@@ -931,7 +905,7 @@ const OrganizationSettings = () => {
                   Organization Slug
                 </p>
                 <p className="font-mono text-xs font-semibold text-slate-900 dark:text-slate-200 mt-1.5 truncate">
-                  {metadata.slug || "N/A"}
+                  {metadata.slug || 'N/A'}
                 </p>
               </div>
 
@@ -954,7 +928,7 @@ const OrganizationSettings = () => {
                 <p className="text-xs font-semibold text-slate-900 dark:text-slate-200 mt-1.5 truncate">
                   {metadata.owner?.name
                     ? `${metadata.owner.name} (${metadata.owner.email})`
-                    : "N/A"}
+                    : 'N/A'}
                 </p>
               </div>
 
@@ -967,7 +941,7 @@ const OrganizationSettings = () => {
                   </span>
                   <button
                     type="button"
-                    onClick={() => navigate("/team-members")}
+                    onClick={() => navigate('/team-members')}
                     className="text-[10px] text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-0.5 cursor-pointer"
                   >
                     Manage <ExternalLink className="w-2.5 h-2.5" />
@@ -984,22 +958,23 @@ const OrganizationSettings = () => {
                   Last Updated
                 </p>
                 <p className="text-xs font-semibold text-slate-900 dark:text-slate-200 mt-1.5">
-                  {metadata.updatedAt ? formatDate(metadata.updatedAt) : "N/A"}
+                  {metadata.updatedAt ? formatDate(metadata.updatedAt) : 'N/A'}
                 </p>
               </div>
             </div>
           </div>
 
-          {/* SECTION 4: INTEGRATIONS */}
+          {/* SECTION 4: CUSTOM FIELDS */}
+          <OrgCustomFieldsManager orgId={metadata._id} canEdit={canEdit} />
+
+          {/* SECTION 5: INTEGRATIONS */}
           <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm">
             <div className="flex items-center gap-3 mb-6 pb-4 border-b border-slate-100 dark:border-slate-800">
               <div className="p-2 bg-orange-50 dark:bg-orange-900/30 rounded-xl text-orange-600 dark:text-orange-400">
                 <Blocks className="w-5 h-5" />
               </div>
               <div>
-                <h2 className="text-lg font-bold text-slate-900 dark:text-white">
-                  Integrations
-                </h2>
+                <h2 className="text-lg font-bold text-slate-900 dark:text-white">Integrations</h2>
                 <p className="text-xs text-slate-500 dark:text-slate-400">
                   Connect third-party tools to extend functionality
                 </p>
@@ -1059,7 +1034,7 @@ const OrganizationSettings = () => {
         </form>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default OrganizationSettings;
+export default OrganizationSettings

--- a/server/controllers/customFieldController.js
+++ b/server/controllers/customFieldController.js
@@ -1,66 +1,95 @@
-import { z } from "zod";
-import customFieldService from "../services/customFieldService.js";
+import { z } from 'zod'
+import customFieldService from '../services/customFieldService.js'
 
 const createDefinitionSchema = z.object({
   name: z.string().min(1),
-  type: z.enum(["text", "number", "dropdown", "date", "checkbox"]),
+  type: z.enum(['text', 'number', 'dropdown', 'date', 'checkbox']),
   options: z.array(z.string()).optional(),
   required: z.boolean().optional(),
-});
+})
 
 export const createDefinition = async (req, res) => {
   try {
-    const orgId = req.params.orgId;
+    const orgId = req.params.orgId
 
     // Auth Check: only admins/owners should do this (handled by middleware ideally)
-    const payload = createDefinitionSchema.parse(req.body);
+    const payload = createDefinitionSchema.parse(req.body)
 
-    const def = await customFieldService.createDefinition(orgId, payload);
-    res.status(201).json({ success: true, data: def });
+    const def = await customFieldService.createDefinition(orgId, payload)
+    res.status(201).json({ success: true, data: def })
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ success: false, message: error.errors });
+      return res.status(400).json({ success: false, message: error.errors })
     }
-    res.status(400).json({ success: false, message: error.message });
+    res.status(400).json({ success: false, message: error.message })
   }
-};
+}
 
 export const getDefinitions = async (req, res) => {
   try {
-    const orgId = req.params.orgId;
-    const defs = await customFieldService.getDefinitions(orgId);
-    res.status(200).json({ success: true, data: defs });
+    const orgId = req.params.orgId
+    const defs = await customFieldService.getDefinitions(orgId, false)
+    res.status(200).json({ success: true, data: defs })
   } catch (error) {
-    res.status(500).json({ success: false, message: error.message });
+    res.status(500).json({ success: false, message: error.message })
   }
-};
+}
+
+const updateDefinitionSchema = z.object({
+  name: z.string().min(1).optional(),
+  options: z.array(z.string()).optional(),
+  required: z.boolean().optional(),
+  active: z.boolean().optional(),
+})
+
+export const updateDefinition = async (req, res) => {
+  try {
+    const { orgId, id } = req.params
+    const payload = updateDefinitionSchema.parse(req.body)
+    const updated = await customFieldService.updateDefinition(id, orgId, payload)
+    res.status(200).json({ success: true, data: updated })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ success: false, message: error.errors })
+    }
+    res.status(400).json({ success: false, message: error.message })
+  }
+}
+
+export const deleteDefinition = async (req, res) => {
+  try {
+    const { orgId, id } = req.params
+    const deleted = await customFieldService.deleteDefinition(id, orgId)
+    res.status(200).json({ success: true, data: deleted })
+  } catch (error) {
+    res.status(400).json({ success: false, message: error.message })
+  }
+}
 
 export const setMeetingFields = async (req, res) => {
   try {
-    const { meetingId } = req.params;
+    const { meetingId } = req.params
     // Assume req.meeting is populated by middleware and we can check org
-    const orgId = req.body.orgId || req.user?.organization;
-    const fieldsData = req.body.fields; // array of { definitionId, value }
+    const orgId = req.body.orgId || req.user?.organization
+    const fieldsData = req.body.fields // array of { definitionId, value }
 
     if (!orgId) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Organization ID is required" });
+      return res.status(400).json({ success: false, message: 'Organization ID is required' })
     }
 
-    await customFieldService.setMeetingFields(meetingId, orgId, fieldsData);
-    res.status(200).json({ success: true, message: "Fields updated" });
+    await customFieldService.setMeetingFields(meetingId, orgId, fieldsData)
+    res.status(200).json({ success: true, message: 'Fields updated' })
   } catch (error) {
-    res.status(400).json({ success: false, message: error.message });
+    res.status(400).json({ success: false, message: error.message })
   }
-};
+}
 
 export const getMeetingFields = async (req, res) => {
   try {
-    const { meetingId } = req.params;
-    const fields = await customFieldService.getMeetingFields(meetingId);
-    res.status(200).json({ success: true, data: fields });
+    const { meetingId } = req.params
+    const fields = await customFieldService.getMeetingFields(meetingId)
+    res.status(200).json({ success: true, data: fields })
   } catch (error) {
-    res.status(500).json({ success: false, message: error.message });
+    res.status(500).json({ success: false, message: error.message })
   }
-};
+}

--- a/server/routes/customFieldRoutes.js
+++ b/server/routes/customFieldRoutes.js
@@ -1,26 +1,30 @@
-import express from "express";
+import express from 'express'
 import {
   createDefinition,
   getDefinitions,
+  updateDefinition,
+  deleteDefinition,
   setMeetingFields,
   getMeetingFields,
-} from "../controllers/customFieldController.js";
-import requireAuth from "../middleware/userAuth.js";
+} from '../controllers/customFieldController.js'
+import requireAuth from '../middleware/userAuth.js'
 // Assume role checks for admin exist, otherwise just use requireAuth
-import { requireRole } from "../middleware/roleAuth.js";
+import { requireRole } from '../middleware/roleAuth.js'
 
-const router = express.Router();
+const router = express.Router()
 
-router.use(requireAuth);
+router.use(requireAuth)
 
 // Organization level definitions
 // Example path: /api/custom-fields/org/:orgId
-router.post("/org/:orgId", requireRole(["admin", "owner"]), createDefinition);
-router.get("/org/:orgId", getDefinitions);
+router.post('/org/:orgId', requireRole(['admin', 'owner']), createDefinition)
+router.get('/org/:orgId', getDefinitions)
+router.put('/org/:orgId/definition/:id', requireRole(['admin', 'owner']), updateDefinition)
+router.delete('/org/:orgId/definition/:id', requireRole(['admin', 'owner']), deleteDefinition)
 
 // Meeting level values
 // Example path: /api/custom-fields/meeting/:meetingId
-router.post("/meeting/:meetingId", setMeetingFields);
-router.get("/meeting/:meetingId", getMeetingFields);
+router.post('/meeting/:meetingId', setMeetingFields)
+router.get('/meeting/:meetingId', getMeetingFields)
 
-export default router;
+export default router

--- a/server/services/customFieldService.js
+++ b/server/services/customFieldService.js
@@ -1,65 +1,73 @@
-import CustomFieldDefinition from "../models/customFieldDefinitionModel.js";
-import CustomFieldValue from "../models/customFieldValueModel.js";
+import CustomFieldDefinition from '../models/customFieldDefinitionModel.js'
+import CustomFieldValue from '../models/customFieldValueModel.js'
 
 class CustomFieldService {
   async createDefinition(orgId, data) {
     if (
-      data.type === "dropdown" &&
-      (!data.options ||
-        !Array.isArray(data.options) ||
-        data.options.length === 0)
+      data.type === 'dropdown' &&
+      (!data.options || !Array.isArray(data.options) || data.options.length === 0)
     ) {
-      throw new Error("Dropdown fields require options");
+      throw new Error('Dropdown fields require options')
     }
     const def = new CustomFieldDefinition({
       organization: orgId,
       ...data,
-    });
-    await def.save();
-    return def;
+    })
+    await def.save()
+    return def
   }
 
   async getDefinitions(orgId, activeOnly = true) {
-    const query = { organization: orgId };
+    const query = { organization: orgId }
     if (activeOnly) {
-      query.active = true;
+      query.active = true
     }
-    return CustomFieldDefinition.find(query).sort({ createdAt: 1 });
+    return CustomFieldDefinition.find(query).sort({ createdAt: 1 })
   }
 
   async updateDefinition(id, orgId, data) {
     const def = await CustomFieldDefinition.findOne({
       _id: id,
       organization: orgId,
-    });
-    if (!def) throw new Error("Definition not found");
+    })
+    if (!def) throw new Error('Definition not found')
 
-    if (data.options !== undefined) def.options = data.options;
-    if (data.name !== undefined) def.name = data.name;
-    if (data.required !== undefined) def.required = data.required;
-    if (data.active !== undefined) def.active = data.active;
+    if (data.options !== undefined) def.options = data.options
+    if (data.name !== undefined) def.name = data.name
+    if (data.required !== undefined) def.required = data.required
+    if (data.active !== undefined) def.active = data.active
 
-    await def.save();
-    return def;
+    await def.save()
+    return def
+  }
+
+  async deleteDefinition(id, orgId) {
+    const def = await CustomFieldDefinition.findOneAndDelete({
+      _id: id,
+      organization: orgId,
+    })
+    if (!def) throw new Error('Definition not found')
+    await CustomFieldValue.deleteMany({ fieldDefinition: id })
+    return def
   }
 
   async setMeetingFields(meetingId, orgId, fieldsData) {
     const definitions = await CustomFieldDefinition.find({
       organization: orgId,
       active: true,
-    });
-    const defMap = new Map(definitions.map((d) => [d._id.toString(), d]));
+    })
+    const defMap = new Map(definitions.map((d) => [d._id.toString(), d]))
 
-    const bulkOps = [];
-    const providedFields = new Set();
+    const bulkOps = []
+    const providedFields = new Set()
 
     for (const field of fieldsData) {
-      const def = defMap.get(field.definitionId);
-      if (!def) continue;
+      const def = defMap.get(field.definitionId)
+      if (!def) continue
 
-      providedFields.add(field.definitionId);
+      providedFields.add(field.definitionId)
 
-      this.validateValue(field.value, def);
+      this.validateValue(field.value, def)
 
       bulkOps.push({
         updateOne: {
@@ -67,75 +75,67 @@ class CustomFieldService {
           update: { $set: { value: field.value } },
           upsert: true,
         },
-      });
+      })
     }
 
     for (const def of definitions) {
       if (def.required && !providedFields.has(def._id.toString())) {
-        throw new Error(`Field ${def.name} is required`);
+        throw new Error(`Field ${def.name} is required`)
       }
     }
 
     // Always try to remove missing required fields and others if needed?
     // Actually if a field is not provided, maybe we delete it if not required?
     // Let's delete fields that are not provided
-    const providedIds = Array.from(providedFields);
+    const providedIds = Array.from(providedFields)
     await CustomFieldValue.deleteMany({
       meeting: meetingId,
       fieldDefinition: { $nin: providedIds },
-    });
+    })
 
     if (bulkOps.length > 0) {
-      await CustomFieldValue.bulkWrite(bulkOps);
+      await CustomFieldValue.bulkWrite(bulkOps)
     }
   }
 
   validateValue(value, definition) {
-    if (value === null || value === undefined || value === "") {
+    if (value === null || value === undefined || value === '') {
       if (definition.required) {
-        throw new Error(`Field ${definition.name} is required`);
+        throw new Error(`Field ${definition.name} is required`)
       }
-      return;
+      return
     }
 
     switch (definition.type) {
-      case "number":
-        if (typeof value !== "number" && isNaN(Number(value))) {
-          throw new Error(`Field ${definition.name} must be a number`);
+      case 'number':
+        if (typeof value !== 'number' && isNaN(Number(value))) {
+          throw new Error(`Field ${definition.name} must be a number`)
         }
-        break;
-      case "checkbox":
-        if (
-          typeof value !== "boolean" &&
-          value !== "true" &&
-          value !== "false"
-        ) {
-          throw new Error(`Field ${definition.name} must be a boolean`);
+        break
+      case 'checkbox':
+        if (typeof value !== 'boolean' && value !== 'true' && value !== 'false') {
+          throw new Error(`Field ${definition.name} must be a boolean`)
         }
-        break;
-      case "date":
+        break
+      case 'date':
         if (isNaN(Date.parse(value))) {
-          throw new Error(`Field ${definition.name} must be a valid date`);
+          throw new Error(`Field ${definition.name} must be a valid date`)
         }
-        break;
-      case "dropdown":
+        break
+      case 'dropdown':
         if (definition.options && !definition.options.includes(value)) {
-          throw new Error(
-            `Value ${value} is not a valid option for ${definition.name}`,
-          );
+          throw new Error(`Value ${value} is not a valid option for ${definition.name}`)
         }
-        break;
-      case "text":
+        break
+      case 'text':
       default:
-        break;
+        break
     }
   }
 
   async getMeetingFields(meetingId) {
-    return CustomFieldValue.find({ meeting: meetingId }).populate(
-      "fieldDefinition",
-    );
+    return CustomFieldValue.find({ meeting: meetingId }).populate('fieldDefinition')
   }
 }
 
-export default new CustomFieldService();
+export default new CustomFieldService()


### PR DESCRIPTION
Fixes #1903

### Summary of Changes:
- **Management UI Component (`client/src/components/organization/OrgCustomFieldsManager.jsx`)**: Built a full-featured management dashboard for organization administrators to define, view, edit, activate/deactivate, and delete custom field definitions (text, number, dropdown, date, checkbox).
- **Organization Settings Integration (`client/src/pages/OrganizationSettings.jsx`)**: Integrated `OrgCustomFieldsManager` section into the main settings dashboard with RBAC protection (`canEdit`).
- **Client API Service (`client/src/api/customFieldApi.js`)**: Added `updateDefinition` and `deleteDefinition` methods.
- **Backend Endpoints & Controller (`server/routes/customFieldRoutes.js`, `server/controllers/customFieldController.js`, `server/services/customFieldService.js`)**: Implemented PUT & DELETE routes for org field definitions with proper admin/owner role checks, zod validation schemas, and cascading cleanup of stored meeting values upon deletion.
- **Unit Test Coverage (`client/src/components/organization/__tests__/OrgCustomFieldsManager.test.jsx`)**: Added Vitest test suite covering empty states, field rendering, and creation modal workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Organization Settings section for creating and managing custom fields.
  * Custom fields support text, number, dropdown, date, and checkbox types.
  * Administrators can edit, delete, activate, deactivate, and configure required fields and dropdown options.
  * Added validation, loading, empty, and error states.

* **Access Control**
  * Editing and deletion controls are limited to authorized administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->