### PR TITLE
security: remove unprotected duplicate meeting-templates route to enf…

### DIFF
--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -510,7 +510,6 @@ const ProtectedRoutes = (
         </ProtectedRoute>
       }
     />
-    <Route path="/meeting-templates" element={<MeetingTemplates />} />
     <Route
       path="/ai-summary-templates"
       element={


### PR DESCRIPTION
…orce RBAC compliance

# Pull Request

## Description

Provide a brief description of the changes introduced in this pull request.

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #

## Testing

Describe the testing performed.

- [ ] Tested locally
- [ ] Existing functionality verified
- [ ] No new warnings or errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [ ] Code follows project conventions
- [ ] Documentation updated where required
- [ ] No unnecessary files included
- [ ] Changes have been tested
- [ ] Ready for review
## Description
Addresses a critical security regression where the meeting template configuration console was exposed to unauthenticated public traffic via URL injection. A loose, bare route definition bypasses established authorization constraints. This PR purges the duplicate block to restore RBAC enforcement.

## Key Changes
- Audited `client/src/routes/ProtectedRoutes.jsx` to locate structural regression gaps.
- Removed the raw, unprotected duplicate `/meeting-templates` route definition situated at the end of the routing switch architecture.
- Enforced complete reliance on the guarded line container definition which wraps `<MeetingTemplates />` inside `<ProtectedRoute>` and `<RoleGuard>` elements.

## Verification & Testing Done
- Manually verified that attempting to navigate directly to `/meeting-templates` without active authorization headers successfully drops the request context and forces an expected redirect to `/login`.
- Confirmed that logged-in administrative tokens retain functional layout privileges as defined by role parameters.

Closes #1899


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a duplicate unprotected meeting templates route.
  * Meeting templates are now consistently accessible through the protected route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->