### PR TITLE
fix(bug): add missing /api path prefix to meeting RSVP API requests (#1884)

### DIFF
--- a/client/src/services/meetingRsvpApi.js
+++ b/client/src/services/meetingRsvpApi.js
@@ -1,4 +1,4 @@
-import api from "./apiClient";
+import api from "./apiClient.js";
 
 const meetingRsvpApi = {
   /**
@@ -6,7 +6,7 @@ const meetingRsvpApi = {
    * @returns {Promise<Object>} Response data
    */
   getPendingRsvps: async () => {
-    return await api.get("/rsvps/pending");
+    return await api.get("/api/rsvps/pending");
   },
 
   /**
@@ -15,7 +15,7 @@ const meetingRsvpApi = {
    * @returns {Promise<Object>} Response data
    */
   getMeetingSummary: async (meetingId) => {
-    return await api.get(`/rsvps/meeting/${meetingId}`);
+    return await api.get(`/api/rsvps/meeting/${meetingId}`);
   },
 
   /**
@@ -25,7 +25,7 @@ const meetingRsvpApi = {
    * @returns {Promise<Object>} Response data
    */
   sendRsvpRequests: async (meetingId, userIds) => {
-    return await api.post(`/rsvps/send/${meetingId}`, { userIds });
+    return await api.post(`/api/rsvps/send/${meetingId}`, { userIds });
   },
 
   /**
@@ -35,7 +35,7 @@ const meetingRsvpApi = {
    * @returns {Promise<Object>} Response data
    */
   respondToRsvp: async (meetingId, responseData) => {
-    return await api.put(`/rsvps/${meetingId}/respond`, responseData);
+    return await api.put(`/api/rsvps/${meetingId}/respond`, responseData);
   },
 };
 

--- a/server/tests/meetingRsvpApiPrefix.test.js
+++ b/server/tests/meetingRsvpApiPrefix.test.js
@@ -1,0 +1,85 @@
+// server/tests/meetingRsvpApiPrefix.test.js
+import express from "express";
+import supertest from "supertest";
+import meetingRsvpRoutes from "../routes/meetingRsvpRoutes.js";
+
+// Mock userAuth middleware for testing
+jest.mock("../middleware/userAuth.js", () => {
+  return (req, res, next) => {
+    req.user = {
+      _id: "507f1f77bcf86cd799439011",
+      organization: "507f1f77bcf86cd799439022",
+    };
+    next();
+  };
+});
+
+// Mock controller methods
+jest.mock("../controllers/meetingRsvpController.js", () => ({
+  getPendingRsvps: jest
+    .fn()
+    .mockImplementation((req, res) =>
+      res.status(200).json({ success: true, data: [] }),
+    ),
+  getMeetingSummary: jest
+    .fn()
+    .mockImplementation((req, res) =>
+      res
+        .status(200)
+        .json({ success: true, data: { meetingId: req.params.meetingId } }),
+    ),
+  sendRsvpRequests: jest
+    .fn()
+    .mockImplementation((req, res) =>
+      res.status(200).json({ success: true, message: "RSVP requests sent" }),
+    ),
+  respondToRsvp: jest
+    .fn()
+    .mockImplementation((req, res) =>
+      res.status(200).json({ success: true, status: req.body.status }),
+    ),
+}));
+
+describe("RSVP API Route & Path Prefix Tests (#1884)", () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/rsvps", meetingRsvpRoutes);
+  });
+
+  it("GET /api/rsvps/pending should resolve under /api/rsvps prefix", async () => {
+    const res = await supertest(app).get("/api/rsvps/pending");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("GET /api/rsvps/meeting/:meetingId should resolve under /api/rsvps prefix", async () => {
+    const res = await supertest(app).get("/api/rsvps/meeting/meet-123");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.meetingId).toBe("meet-123");
+  });
+
+  it("POST /api/rsvps/send/:meetingId should resolve under /api/rsvps prefix", async () => {
+    const res = await supertest(app)
+      .post("/api/rsvps/send/meet-123")
+      .send({ userIds: ["user-1"] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("PUT /api/rsvps/:meetingId/respond should resolve under /api/rsvps prefix", async () => {
+    const res = await supertest(app)
+      .put("/api/rsvps/meet-123/respond")
+      .send({ status: "accepted" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.status).toBe("accepted");
+  });
+});


### PR DESCRIPTION
### Description
Fixes HTTP 404 errors during RSVP interactions on the Meeting Details page (#1884):
1. **Path Prefix Alignment**: Updated `meetingRsvpApi.js` to prepend `/api` to all endpoint URLs (`/api/rsvps/pending`, `/api/rsvps/meeting/:meetingId`, `/api/rsvps/send/:meetingId`, `/api/rsvps/:meetingId/respond`).
2. **Route Resolution**: Resolves client-side API requests against mounted backend routes in `meetingRsvpRoutes.js` (`/api/rsvps`), allowing RSVP confirmations, declines, and updates to succeed.

### Related Issue
Fixes #1884

### Checklist
- [x] All URL paths in `meetingRsvpApi.js` updated with `/api/rsvps` prefix
- [x] Prettier formatting and unit test suite verified