### PR TITLE
fix(security): enforce signature verification on inbound Jira and Linear webhooks (#1810)

### DIFF
--- a/server/controllers/issueTrackerWebhookController.js
+++ b/server/controllers/issueTrackerWebhookController.js
@@ -2,12 +2,123 @@ import ActionItem from "../models/actionItemModel.js";
 import crypto from "crypto";
 
 /**
+ * Helper to verify Linear webhook signature using HMAC-SHA256 and timing-safe comparison.
+ * Linear passes the HMAC digest in the `Linear-Signature` header.
+ */
+export const verifyLinearSignature = (req) => {
+  const secret = process.env.LINEAR_WEBHOOK_SECRET;
+  if (!secret) {
+    return {
+      isValid: false,
+      reason: "LINEAR_WEBHOOK_SECRET is not configured",
+    };
+  }
+
+  const signature =
+    req.headers["linear-signature"] || req.headers["x-linear-signature"];
+  if (!signature) {
+    return { isValid: false, reason: "Missing Linear signature header" };
+  }
+
+  const rawPayload = req.rawBody
+    ? req.rawBody
+    : typeof req.body === "string"
+      ? req.body
+      : JSON.stringify(req.body);
+
+  const computedHex = crypto
+    .createHmac("sha256", secret)
+    .update(rawPayload)
+    .digest("hex");
+
+  const sigBuf = Buffer.from(String(signature).toLowerCase());
+  const compBuf = Buffer.from(computedHex.toLowerCase());
+
+  if (
+    sigBuf.length !== compBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, compBuf)
+  ) {
+    return { isValid: false, reason: "Invalid Linear signature" };
+  }
+
+  return { isValid: true };
+};
+
+/**
+ * Helper to verify Jira webhook signature or bearer token authorization.
+ * Jira passes authorization tokens or signatures in `authorization` or `x-jira-signature` headers.
+ */
+export const verifyJiraSignature = (req) => {
+  const secret = process.env.JIRA_WEBHOOK_SECRET;
+  if (!secret) {
+    return { isValid: false, reason: "JIRA_WEBHOOK_SECRET is not configured" };
+  }
+
+  const signature =
+    req.headers["x-jira-signature"] ||
+    req.headers["x-hub-signature"] ||
+    req.headers["authorization"] ||
+    req.headers["x-atlassian-webhook-secret"];
+
+  if (!signature) {
+    return {
+      isValid: false,
+      reason: "Missing Jira authorization header or signature",
+    };
+  }
+
+  const rawPayload = req.rawBody
+    ? req.rawBody
+    : typeof req.body === "string"
+      ? req.body
+      : JSON.stringify(req.body);
+
+  if (signature.startsWith("sha256=")) {
+    const signatureHash = signature.slice(7);
+    const computedHash = crypto
+      .createHmac("sha256", secret)
+      .update(rawPayload)
+      .digest("hex");
+
+    const sigBuf = Buffer.from(signatureHash.toLowerCase());
+    const compBuf = Buffer.from(computedHash.toLowerCase());
+
+    if (
+      sigBuf.length !== compBuf.length ||
+      !crypto.timingSafeEqual(sigBuf, compBuf)
+    ) {
+      return { isValid: false, reason: "Invalid Jira HMAC signature" };
+    }
+  } else {
+    const token = signature.replace(/^Bearer\s+/i, "");
+    const tokenBuf = Buffer.from(token);
+    const secretBuf = Buffer.from(secret);
+
+    if (
+      tokenBuf.length !== secretBuf.length ||
+      !crypto.timingSafeEqual(tokenBuf, secretBuf)
+    ) {
+      return { isValid: false, reason: "Invalid Jira secret token" };
+    }
+  }
+
+  return { isValid: true };
+};
+
+/**
  * Handle incoming webhooks from Jira
  */
 export const handleJiraWebhook = async (req, res) => {
   try {
-    // In a real app, verify webhook signature using req.headers and integration.webhookSecret
-    // For simplicity, we just process the payload.
+    // Verify webhook signature / authorization
+    const verification = verifyJiraSignature(req);
+    if (!verification.isValid) {
+      return res.status(401).json({
+        success: false,
+        message: verification.reason,
+      });
+    }
+
     const payload = req.body;
 
     // Jira webhook payloads usually have `webhookEvent`, `issue`, etc.
@@ -44,10 +155,10 @@ export const handleJiraWebhook = async (req, res) => {
       }
     }
 
-    res.status(200).send("OK");
+    return res.status(200).send("OK");
   } catch (error) {
     console.error("Error processing Jira webhook:", error);
-    res.status(500).send("Server Error");
+    return res.status(500).send("Server Error");
   }
 };
 
@@ -56,12 +167,18 @@ export const handleJiraWebhook = async (req, res) => {
  */
 export const handleLinearWebhook = async (req, res) => {
   try {
-    // Linear sends a signature in the 'Linear-Signature' header
-    // In production, we'd verify using crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
+    // Verify webhook signature using Linear-Signature header
+    const verification = verifyLinearSignature(req);
+    if (!verification.isValid) {
+      return res.status(401).json({
+        success: false,
+        message: verification.reason,
+      });
+    }
 
     const payload = req.body;
 
-    if (payload.action === "update" && payload.type === "Issue") {
+    if (payload && payload.action === "update" && payload.type === "Issue") {
       const issueId = payload.data?.id;
       const stateName = payload.data?.state?.name?.toLowerCase();
 
@@ -93,9 +210,9 @@ export const handleLinearWebhook = async (req, res) => {
       }
     }
 
-    res.status(200).send("OK");
+    return res.status(200).send("OK");
   } catch (error) {
     console.error("Error processing Linear webhook:", error);
-    res.status(500).send("Server Error");
+    return res.status(500).send("Server Error");
   }
 };

--- a/server/tests/issueTrackerWebhookController.test.js
+++ b/server/tests/issueTrackerWebhookController.test.js
@@ -1,0 +1,101 @@
+// server/tests/issueTrackerWebhookController.test.js
+import express from "express";
+import supertest from "supertest";
+import crypto from "crypto";
+import issueTrackerWebhookRoutes from "../routes/issueTrackerWebhookRoutes.js";
+
+// Mock ActionItem model
+jest.mock("../models/actionItemModel.js", () => ({
+  findOne: jest.fn().mockResolvedValue({
+    status: "open",
+    save: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
+describe("Jira & Linear Webhook Signature Verification Tests (#1810)", () => {
+  let app;
+  const oldEnv = process.env;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/webhooks", issueTrackerWebhookRoutes);
+  });
+
+  beforeEach(() => {
+    process.env = { ...oldEnv };
+  });
+
+  afterAll(() => {
+    process.env = oldEnv;
+  });
+
+  it("POST /api/webhooks/linear should return 401 when LINEAR_WEBHOOK_SECRET is unconfigured", async () => {
+    delete process.env.LINEAR_WEBHOOK_SECRET;
+
+    const res = await supertest(app)
+      .post("/api/webhooks/linear")
+      .send({ action: "update", type: "Issue" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain("not configured");
+  });
+
+  it("POST /api/webhooks/linear should return 401 for forged signature", async () => {
+    process.env.LINEAR_WEBHOOK_SECRET = "secret_linear_key_123";
+
+    const res = await supertest(app)
+      .post("/api/webhooks/linear")
+      .set("Linear-Signature", "forged_signature_hex")
+      .send({ action: "update", type: "Issue" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain("Invalid Linear signature");
+  });
+
+  it("POST /api/webhooks/linear should return 200 for valid HMAC signature", async () => {
+    process.env.LINEAR_WEBHOOK_SECRET = "secret_linear_key_123";
+    const payload = {
+      action: "update",
+      type: "Issue",
+      data: { id: "LIN-10", state: { name: "Done" } },
+    };
+    const rawPayload = JSON.stringify(payload);
+    const validSig = crypto
+      .createHmac("sha256", process.env.LINEAR_WEBHOOK_SECRET)
+      .update(rawPayload)
+      .digest("hex");
+
+    const res = await supertest(app)
+      .post("/api/webhooks/linear")
+      .set("Linear-Signature", validSig)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("POST /api/webhooks/jira should return 401 when JIRA_WEBHOOK_SECRET is unconfigured", async () => {
+    delete process.env.JIRA_WEBHOOK_SECRET;
+
+    const res = await supertest(app)
+      .post("/api/webhooks/jira")
+      .send({ issue: { key: "PROJ-1" } });
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain("not configured");
+  });
+
+  it("POST /api/webhooks/jira should return 200 for valid secret token header", async () => {
+    process.env.JIRA_WEBHOOK_SECRET = "secret_jira_token_456";
+
+    const res = await supertest(app)
+      .post("/api/webhooks/jira")
+      .set("Authorization", "Bearer secret_jira_token_456")
+      .send({ issue: { key: "PROJ-1", fields: { status: { name: "Done" } } } });
+
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
### Description
Enforces signature and authorization token verification on inbound Jira and Linear webhooks (#1810):
1. **Linear Webhook Verification**: Implemented `verifyLinearSignature` to compute HMAC-SHA256 digests of payload buffers against `LINEAR_WEBHOOK_SECRET` and validate `Linear-Signature` headers using `crypto.timingSafeEqual`.
2. **Jira Webhook Verification**: Implemented `verifyJiraSignature` supporting HMAC signatures (`x-jira-signature` / `x-hub-signature`) or authorization secret headers against `JIRA_WEBHOOK_SECRET`.
3. **Unauthorized Request Prevention**: Rejects missing or invalid webhook signatures with HTTP 401 Unauthorized before updating external issue action items.

### Related Issue
Fixes #1810

### Checklist
- [x] `verifyLinearSignature` implemented with `crypto.timingSafeEqual`
- [x] `verifyJiraSignature` implemented with `crypto.timingSafeEqual`
- [x] HTTP 401 response returned on unconfigured secrets or forged signatures
- [x] Prettier formatting and unit test suite verified