### PR TITLE
fix(security): implement HMAC-SHA256 OAuth state signing in GitHub integration (#1808)

### DIFF
--- a/server/controllers/githubIntegrationController.js
+++ b/server/controllers/githubIntegrationController.js
@@ -6,6 +6,86 @@ import { sendSuccess, sendError } from "../utils/responseHandler.js";
 import { ValidationError } from "../utils/errors.js";
 import axios from "axios";
 import logger from "../utils/logger.js";
+import crypto from "crypto";
+
+const getOAuthStateSecret = () => {
+  return (
+    process.env.GITHUB_OAUTH_STATE_SECRET ||
+    process.env.JWT_SECRET ||
+    process.env.SESSION_SECRET ||
+    "github-oauth-state-secret-default"
+  );
+};
+
+/**
+ * Generate HMAC-SHA256 signed OAuth state parameter to prevent state tampering and CSRF attacks.
+ *
+ * @param {Object} payload - { organizationId, userId, repositoryFullName }
+ * @returns {string} Signed state token formatted as `<base64urlData>.<hmacSignature>`
+ */
+export const generateSignedState = (payload) => {
+  const secret = getOAuthStateSecret();
+  const jsonStr = JSON.stringify({
+    ...payload,
+    timestamp: Date.now(),
+    nonce: crypto.randomBytes(16).toString("hex"),
+  });
+  const base64Data = Buffer.from(jsonStr).toString("base64url");
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(base64Data)
+    .digest("hex");
+
+  return `${base64Data}.${signature}`;
+};
+
+/**
+ * Verify HMAC-SHA256 signed OAuth state parameter using timing-safe comparison.
+ *
+ * @param {string} stateToken
+ * @returns {Object|null} Decoded payload or null if invalid, tampered, or expired.
+ */
+export const verifySignedState = (stateToken) => {
+  if (
+    !stateToken ||
+    typeof stateToken !== "string" ||
+    !stateToken.includes(".")
+  ) {
+    return null;
+  }
+
+  const [base64Data, signature] = stateToken.split(".");
+  const secret = getOAuthStateSecret();
+
+  const expectedSig = crypto
+    .createHmac("sha256", secret)
+    .update(base64Data)
+    .digest("hex");
+
+  const sigBuf = Buffer.from(signature.toLowerCase());
+  const expBuf = Buffer.from(expectedSig.toLowerCase());
+
+  if (
+    sigBuf.length !== expBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expBuf)
+  ) {
+    return null;
+  }
+
+  try {
+    const jsonStr = Buffer.from(base64Data, "base64url").toString("utf-8");
+    const payload = JSON.parse(jsonStr);
+
+    // Expire state tokens older than 15 minutes (900,000 ms)
+    if (payload.timestamp && Date.now() - payload.timestamp > 15 * 60 * 1000) {
+      return null;
+    }
+
+    return payload;
+  } catch {
+    return null;
+  }
+};
 
 export const initiateOAuth = async (req, res) => {
   try {
@@ -13,6 +93,14 @@ export const initiateOAuth = async (req, res) => {
       req.query.organizationId || req.user?.organization?.toString();
     if (!organizationId) {
       return sendError(res, 400, "organizationId is required.");
+    }
+
+    // Ensure requesting user belongs to the targeted organization
+    if (
+      req.user?.organization &&
+      req.user.organization.toString() !== organizationId.toString()
+    ) {
+      return sendError(res, 403, "Forbidden: Organization access mismatch.");
     }
 
     const clientId = process.env.GITHUB_CLIENT_ID;
@@ -24,9 +112,10 @@ export const initiateOAuth = async (req, res) => {
       );
     }
 
-    const state = Buffer.from(JSON.stringify({ organizationId })).toString(
-      "base64",
-    );
+    const state = generateSignedState({
+      organizationId,
+      userId: req.user?._id?.toString(),
+    });
 
     const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&scope=repo&state=${state}`;
     res.redirect(githubAuthUrl);
@@ -43,14 +132,25 @@ export const handleCallback = async (req, res) => {
       return sendError(res, 400, "Authorization code is missing.");
     }
 
-    let decodedState;
-    try {
-      decodedState = JSON.parse(Buffer.from(state, "base64").toString("utf-8"));
-    } catch {
-      return sendError(res, 400, "Invalid state parameter.");
+    // Verify HMAC-SHA256 signature on state parameter
+    const decodedState = verifySignedState(state);
+    if (!decodedState || !decodedState.organizationId) {
+      return sendError(res, 400, "Invalid or tampered state parameter.");
     }
 
-    const { organizationId, repositoryFullName } = decodedState;
+    const { organizationId, repositoryFullName, userId } = decodedState;
+
+    // Verify organization ownership if authenticated user is present
+    if (
+      req.user?.organization &&
+      req.user.organization.toString() !== organizationId.toString()
+    ) {
+      return sendError(
+        res,
+        403,
+        "Forbidden: State organization does not match user organization.",
+      );
+    }
 
     const tokenResponse = await axios.post(
       "https://github.com/login/oauth/access_token",
@@ -73,7 +173,7 @@ export const handleCallback = async (req, res) => {
         organization: organizationId,
         accessToken: encryptToken(accessToken),
         repositoryFullName: repositoryFullName || "",
-        connectedBy: req.user?._id || null,
+        connectedBy: req.user?._id || userId || null,
       },
       { upsert: true, new: true },
     );

--- a/server/tests/githubOAuthState.test.js
+++ b/server/tests/githubOAuthState.test.js
@@ -1,0 +1,102 @@
+// server/tests/githubOAuthState.test.js
+import express from "express";
+import supertest from "supertest";
+import {
+  generateSignedState,
+  verifySignedState,
+  initiateOAuth,
+  handleCallback,
+} from "../controllers/githubIntegrationController.js";
+
+// Mock models and dependencies
+jest.mock("../models/githubIntegrationModel.js", () => ({
+  findOneAndUpdate: jest.fn().mockResolvedValue(true),
+}));
+jest.mock("../utils/crypto.js", () => ({
+  encryptToken: jest.fn().mockReturnValue("encrypted_token"),
+  decryptToken: jest.fn().mockReturnValue("decrypted_token"),
+}));
+jest.mock("axios", () => ({
+  post: jest
+    .fn()
+    .mockResolvedValue({ data: { access_token: "gho_mock_access_token_123" } }),
+}));
+
+describe("GitHub OAuth State Parameter Signing Security Tests (#1808)", () => {
+  let app;
+  const mockOrgId = "507f1f77bcf86cd799439011";
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.get(
+      "/auth",
+      (req, res, next) => {
+        req.user = { _id: "user-1", organization: mockOrgId };
+        next();
+      },
+      initiateOAuth,
+    );
+    app.get(
+      "/callback",
+      (req, res, next) => {
+        req.user = { _id: "user-1", organization: mockOrgId };
+        next();
+      },
+      handleCallback,
+    );
+
+    process.env.GITHUB_CLIENT_ID = "mock_client_id";
+    process.env.GITHUB_CLIENT_SECRET = "mock_client_secret";
+  });
+
+  it("generateSignedState should return signed state formatted as data.signature", () => {
+    const stateToken = generateSignedState({ organizationId: mockOrgId });
+
+    expect(typeof stateToken).toBe("string");
+    expect(stateToken).toContain(".");
+  });
+
+  it("verifySignedState should verify valid signed state token", () => {
+    const stateToken = generateSignedState({ organizationId: mockOrgId });
+    const decoded = verifySignedState(stateToken);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded.organizationId).toBe(mockOrgId);
+  });
+
+  it("verifySignedState should reject unsigned raw Base64 state parameter", () => {
+    // Attack vector: raw Base64 string containing organizationId
+    const forgedState = Buffer.from(
+      JSON.stringify({ organizationId: mockOrgId }),
+    ).toString("base64");
+    const decoded = verifySignedState(forgedState);
+
+    expect(decoded).toBeNull();
+  });
+
+  it("GET /callback with forged unsigned Base64 state should return HTTP 400 Bad Request", async () => {
+    const forgedState = Buffer.from(
+      JSON.stringify({ organizationId: mockOrgId }),
+    ).toString("base64");
+
+    const res = await supertest(app).get(
+      `/callback?code=mock_code&state=${forgedState}`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain("Invalid or tampered state parameter");
+  });
+
+  it("GET /callback with valid signed state should succeed and redirect", async () => {
+    const validState = generateSignedState({ organizationId: mockOrgId });
+
+    const res = await supertest(app).get(
+      `/callback?code=mock_code&state=${validState}`,
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain("github_success=true");
+  });
+});


### PR DESCRIPTION
### Description
Fixes unsigned Base64 OAuth state parameter vulnerability in GitHub integration (#1808):
1. **HMAC-SHA256 OAuth State Signing**: Implemented `generateSignedState` embedding nonces, timestamps, and HMAC signatures (`<base64urlData>.<hmacSignature>`).
2. **Timing-Safe Verification**: Implemented `verifySignedState` with 15-minute token expiration and `crypto.timingSafeEqual` signature checks.
3. **Cross-Tenant Account Takeover Protection**: Enforced organization membership checks in `initiateOAuth` and `handleCallback` preventing attackers from forging state tokens to bind credentials to victim organizations.

### Related Issue
Fixes #1808

### Checklist
- [x] HMAC-SHA256 state signing implemented in `githubIntegrationController.js`
- [x] Timing-safe signature verification & expiration checks added
- [x] Organization membership validation enforced on OAuth callback
- [x] Prettier formatting and unit test suite verified