### PR TITLE
fix(create-meeting): add dark mode support across Create Meeting hub

### DIFF
--- a/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeeting.jsx
@@ -16,14 +16,14 @@ const LiveMeeting = ({ hookProps }) => {
   } = hookProps;
 
   return (
-    <div className="bg-white shadow-lg rounded-2xl p-8">
+    <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 shadow-lg rounded-2xl p-8">
       <div className="flex items-center gap-3 mb-6">
-        <Video className="text-indigo-600" size={28} />
+        <Video className="text-indigo-600 dark:text-indigo-400" size={28} />
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
             Start Live Meeting
           </h2>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             Add participants and start a live meeting with optional AI
             transcription
           </p>
@@ -45,7 +45,7 @@ const LiveMeeting = ({ hookProps }) => {
         type="button"
         onClick={handleStartLiveMeeting}
         disabled={liveParticipants.length === 0}
-        className={`w-full px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold transition flex items-center justify-center gap-2 shadow-md hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed enabled:hover:bg-indigo-700`}
+        className={`w-full px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold transition flex items-center justify-center gap-2 shadow-md hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed enabled:hover:bg-indigo-700 cursor-pointer`}
       >
         <Video size={18} /> 🚀 Start Live Meeting
       </button>

--- a/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeetingInfo.jsx
+++ b/client/src/pages/CreateMeeting/components/LiveMeeting/LiveMeetingInfo.jsx
@@ -2,16 +2,16 @@ import { Video } from "lucide-react";
 
 const LiveMeetingInfo = () => {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-indigo-200 bg-gradient-to-r from-indigo-50 via-white to-purple-50 p-6 shadow-lg mb-6">
+    <div className="relative overflow-hidden rounded-2xl border border-indigo-200 dark:border-indigo-800 bg-gradient-to-r from-indigo-50 via-white to-purple-50 dark:from-indigo-950/40 dark:via-slate-900 dark:to-purple-950/40 p-6 shadow-lg mb-6">
       <div className="absolute inset-0 opacity-10 bg-[url('https://www.transparenttextures.com/patterns/cubes.png')] pointer-events-none"></div>
 
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-6 relative z-10">
         <div className="flex-1">
-          <h3 className="text-xl font-bold text-indigo-700 flex items-center gap-2 mb-2">
-            <Video className="text-indigo-600" size={22} />
+          <h3 className="text-xl font-bold text-indigo-700 dark:text-indigo-300 flex items-center gap-2 mb-2">
+            <Video className="text-indigo-600 dark:text-indigo-400" size={22} />
             Live AI Meeting Connect
           </h3>
-          <p className="text-gray-700 mb-4 leading-relaxed">
+          <p className="text-gray-700 dark:text-gray-300 mb-4 leading-relaxed">
             🔴 Experience <strong>real-time video conferencing</strong>{" "}
             integrated with
             <strong> AI-powered transcription and live summarization</strong>.
@@ -19,7 +19,7 @@ const LiveMeetingInfo = () => {
             highlights.
           </p>
 
-          <ul className="text-sm text-gray-600 mb-4 space-y-1">
+          <ul className="text-sm text-gray-600 dark:text-gray-400 mb-4 space-y-1">
             <li>• Automatic speech-to-text in real-time</li>
             <li>• Live participant tracking & emotion insights</li>
             <li>• AI auto-summary after meeting ends</li>
@@ -30,7 +30,7 @@ const LiveMeetingInfo = () => {
           <img
             src="https://cdn.dribbble.com/users/23546/screenshots/20531077/media/0a5f35125d57a6eb88a6a0a2d3087b45.gif"
             alt="Live meeting animation"
-            className="w-56 rounded-xl border border-indigo-100 shadow-md"
+            className="w-56 rounded-xl border border-indigo-100 dark:border-indigo-900/50 shadow-md"
           />
         </div>
       </div>

--- a/client/src/pages/CreateMeeting/components/LiveMeeting/LiveParticipants.jsx
+++ b/client/src/pages/CreateMeeting/components/LiveMeeting/LiveParticipants.jsx
@@ -9,7 +9,7 @@ const LiveParticipants = ({
 }) => {
   return (
     <div className="mb-6">
-      <label className="block mb-3 font-semibold text-gray-700 flex items-center gap-2">
+      <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
         <Users size={18} /> Add Participants
       </label>
       <div className="grid md:grid-cols-2 gap-3 mb-3">
@@ -23,7 +23,7 @@ const LiveParticipants = ({
             })
           }
           placeholder="Full Name"
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none"
+          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
         <input
           type="email"
@@ -35,13 +35,13 @@ const LiveParticipants = ({
             })
           }
           placeholder="Email Address"
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none"
+          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
       </div>
       <button
         type="button"
         onClick={addLiveParticipant}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2"
+        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2 cursor-pointer"
       >
         <UserPlus size={16} /> Add Participant
       </button>
@@ -51,7 +51,7 @@ const LiveParticipants = ({
           {liveParticipants.map((p) => (
             <div
               key={p.id}
-              className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-lg"
+              className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-2 rounded-lg text-gray-900 dark:text-gray-100"
             >
               <span className="text-sm">
                 <strong>{p.name}</strong> - {p.email}
@@ -59,7 +59,7 @@ const LiveParticipants = ({
               <button
                 type="button"
                 onClick={() => removeLiveParticipant(p.id)}
-                className="text-red-600 hover:text-red-800"
+                className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 cursor-pointer"
               >
                 <X size={18} />
               </button>

--- a/client/src/pages/CreateMeeting/components/LiveMeeting/RecordingDialog.jsx
+++ b/client/src/pages/CreateMeeting/components/LiveMeeting/RecordingDialog.jsx
@@ -2,42 +2,46 @@ import { Video, CheckCircle } from "lucide-react";
 
 const RecordingDialog = ({ handleRecordingChoice }) => {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 animate-fade-in">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-xs flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl shadow-2xl max-w-md w-full p-6 animate-fade-in">
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-12 h-12 bg-indigo-100 rounded-full flex items-center justify-center">
-            <Video className="text-indigo-600" size={24} />
+          <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-950/50 rounded-full flex items-center justify-center">
+            <Video className="text-indigo-600 dark:text-indigo-400" size={24} />
           </div>
           <div>
-            <h3 className="text-xl font-bold text-gray-900">
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white">
               Recording Permission
             </h3>
-            <p className="text-sm text-gray-600">Choose recording option</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Choose recording option
+            </p>
           </div>
         </div>
 
         <div className="mb-6">
-          <p className="text-gray-700 mb-4">
+          <p className="text-gray-700 dark:text-gray-300 mb-4">
             Do you want to record this meeting for AI transcription and
             summarization?
           </p>
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-gray-700">
-            <strong>With Recording:</strong> AI will transcribe the meeting in
-            real-time and generate a summary with action items after the meeting
-            ends.
+          <div className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-800 rounded-lg p-3 text-sm text-gray-700 dark:text-gray-300">
+            <strong className="text-blue-900 dark:text-blue-200">
+              With Recording:
+            </strong>{" "}
+            AI will transcribe the meeting in real-time and generate a summary
+            with action items after the meeting ends.
           </div>
         </div>
 
         <div className="flex gap-3">
           <button
             onClick={() => handleRecordingChoice(false)}
-            className="flex-1 px-4 py-3 border-2 border-gray-300 text-gray-700 rounded-lg font-semibold hover:bg-gray-50 transition"
+            className="flex-1 px-4 py-3 border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 rounded-lg font-semibold hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
           >
             No, Skip Recording
           </button>
           <button
             onClick={() => handleRecordingChoice(true)}
-            className="flex-1 px-4 py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition flex items-center justify-center gap-2"
+            className="flex-1 px-4 py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition flex items-center justify-center gap-2 cursor-pointer"
           >
             <CheckCircle size={18} />
             Yes, Record

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/AgendaSection.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/AgendaSection.jsx
@@ -49,7 +49,7 @@ const AgendaSection = ({
 
   return (
     <div className="mb-6">
-      <label className="block mb-3 font-semibold text-gray-700">
+      <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300">
         Meeting Agenda
       </label>
       <div className="flex gap-3 mb-3">
@@ -61,12 +61,12 @@ const AgendaSection = ({
             e.key === "Enter" && (e.preventDefault(), addAgendaItem())
           }
           placeholder="Add agenda item..."
-          className="flex-grow px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+          className="flex-grow px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
         <button
           type="button"
           onClick={addAgendaItem}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 cursor-pointer"
           aria-label="Add agenda item"
         >
           <Plus size={18} />
@@ -74,7 +74,7 @@ const AgendaSection = ({
         <button
           type="button"
           onClick={() => setShowImportModal(true)}
-          className="px-4 py-2 bg-yellow-100 text-yellow-700 rounded-lg hover:bg-yellow-200 flex items-center gap-2 font-medium"
+          className="px-4 py-2 bg-yellow-100 dark:bg-yellow-950/40 text-yellow-700 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-800/60 rounded-lg hover:bg-yellow-200 dark:hover:bg-yellow-900/40 flex items-center gap-2 font-medium cursor-pointer"
           aria-label="Import from Parking Lot"
         >
           <Lightbulb size={18} />
@@ -99,10 +99,10 @@ const AgendaSection = ({
                 setDraggedIndex(null);
               }}
               onDragEnd={() => setDraggedIndex(null)}
-              className="flex items-center gap-2 bg-gray-50 px-3 py-2 rounded-lg border border-transparent focus-within:border-blue-300"
+              className="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 focus-within:border-blue-300 text-gray-900 dark:text-gray-100"
             >
               <span
-                className="text-gray-400 cursor-grab"
+                className="text-gray-400 dark:text-gray-500 cursor-grab"
                 aria-hidden="true"
                 title="Drag to reorder"
               >
@@ -114,12 +114,12 @@ const AgendaSection = ({
                   {index + 1}. {item.text || item.title}
                 </span>
                 {item.description && (
-                  <span className="text-xs text-gray-500 block truncate">
+                  <span className="text-xs text-gray-500 dark:text-gray-400 block truncate">
                     {item.description}
                   </span>
                 )}
                 {item.duration && (
-                  <span className="text-xs text-blue-600 block">
+                  <span className="text-xs text-blue-600 dark:text-blue-400 block">
                     {item.duration} min
                   </span>
                 )}
@@ -130,7 +130,7 @@ const AgendaSection = ({
                   type="button"
                   onClick={() => moveItem(index, index - 1)}
                   disabled={index === 0}
-                  className="p-1.5 rounded text-gray-600 hover:bg-white disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="p-1.5 rounded text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
                   aria-label={`Move ${item.text || item.title} up`}
                 >
                   <ArrowUp size={17} />
@@ -139,7 +139,7 @@ const AgendaSection = ({
                   type="button"
                   onClick={() => moveItem(index, index + 1)}
                   disabled={index === agendaItems.length - 1}
-                  className="p-1.5 rounded text-gray-600 hover:bg-white disabled:opacity-30 disabled:cursor-not-allowed"
+                  className="p-1.5 rounded text-gray-600 dark:text-gray-400 hover:bg-white dark:hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
                   aria-label={`Move ${item.text || item.title} down`}
                 >
                   <ArrowDown size={17} />
@@ -147,7 +147,7 @@ const AgendaSection = ({
                 <button
                   type="button"
                   onClick={() => removeAgendaItem(item.id || item._id)}
-                  className="p-1.5 rounded text-red-600 hover:bg-red-50"
+                  className="p-1.5 rounded text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 cursor-pointer"
                   aria-label={`Remove ${item.text || item.title}`}
                 >
                   <X size={18} />

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/AttachmentSection.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/AttachmentSection.jsx
@@ -7,27 +7,27 @@ const AttachmentSection = ({
 }) => {
   return (
     <div className="mb-6">
-      <label className="block mb-3 font-semibold text-gray-700 flex items-center gap-2">
+      <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
         <Paperclip size={18} /> Attach Supporting Documents
       </label>
       <input
         type="file"
         multiple
         onChange={handleAttachmentUpload}
-        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-blue-400"
+        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer hover:border-blue-400 dark:hover:border-blue-500 bg-gray-50/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300"
       />
       {attachments.length > 0 && (
         <div className="mt-3 space-y-2">
           {attachments.map((file, index) => (
             <div
               key={index}
-              className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-lg"
+              className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-2 rounded-lg text-gray-900 dark:text-gray-100"
             >
               <span className="text-sm">{file.name}</span>
               <button
                 type="button"
                 onClick={() => removeAttachment(index)}
-                className="text-red-600 hover:text-red-800"
+                className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 cursor-pointer"
               >
                 <X size={18} />
               </button>

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/CalendarNotice.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/CalendarNotice.jsx
@@ -2,12 +2,17 @@ import { CheckCircle } from "lucide-react";
 
 const CalendarNotice = () => {
   return (
-    <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-start gap-3">
-      <CheckCircle className="text-green-600 flex-shrink-0" size={20} />
-      <div className="text-sm text-gray-700">
-        <strong>Auto Calendar Sync:</strong> This meeting will be automatically
-        added to Google Calendar, Outlook, and participant calendars with email
-        invites.
+    <div className="mb-6 p-4 bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800 rounded-lg flex items-start gap-3">
+      <CheckCircle
+        className="text-green-600 dark:text-green-400 flex-shrink-0"
+        size={20}
+      />
+      <div className="text-sm text-gray-700 dark:text-gray-300">
+        <strong className="text-gray-900 dark:text-white">
+          Auto Calendar Sync:
+        </strong>{" "}
+        This meeting will be automatically added to Google Calendar, Outlook,
+        and participant calendars with email invites.
       </div>
     </div>
   );

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/DraftRecoveryBanner.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/DraftRecoveryBanner.jsx
@@ -35,18 +35,22 @@ const DraftRecoveryBanner = ({
   if (savedAt) {
     return (
       <section
-        className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-amber-950"
+        className="mb-6 rounded-xl border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/40 p-4 text-amber-950 dark:text-amber-100"
         aria-labelledby="meeting-draft-recovery-title"
         aria-live="polite"
       >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-start gap-3">
-            <Clock3 className="mt-0.5 shrink-0" size={20} aria-hidden="true" />
+            <Clock3
+              className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+              size={20}
+              aria-hidden="true"
+            />
             <div>
               <h3 id="meeting-draft-recovery-title" className="font-semibold">
                 Unfinished meeting draft found
               </h3>
-              <p className="mt-1 text-sm text-amber-800">
+              <p className="mt-1 text-sm text-amber-800 dark:text-amber-300">
                 This draft was saved {formatSavedTime(savedAt)}. Restore it or
                 discard it before continuing.
               </p>
@@ -57,7 +61,7 @@ const DraftRecoveryBanner = ({
             <button
               type="button"
               onClick={onRestore}
-              className="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-amber-700"
+              className="inline-flex items-center gap-2 rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-amber-700 cursor-pointer"
             >
               <RotateCcw size={16} aria-hidden="true" />
               Restore Draft
@@ -65,7 +69,7 @@ const DraftRecoveryBanner = ({
             <button
               type="button"
               onClick={onDiscard}
-              className="inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-semibold text-amber-900 transition hover:bg-amber-100"
+              className="inline-flex items-center gap-2 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-semibold text-amber-900 dark:text-amber-200 transition hover:bg-amber-100 dark:hover:bg-gray-700 cursor-pointer"
             >
               <Trash2 size={16} aria-hidden="true" />
               Discard
@@ -77,7 +81,10 @@ const DraftRecoveryBanner = ({
   }
 
   return (
-    <p className="mb-4 text-right text-xs text-gray-500" aria-live="polite">
+    <p
+      className="mb-4 text-right text-xs text-gray-500 dark:text-gray-400"
+      aria-live="polite"
+    >
       {status === "saving"
         ? "Saving draft…"
         : `Draft saved ${formatSavedTime(lastSavedAt)}`}

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/MeetingInformationForm.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/MeetingInformationForm.jsx
@@ -10,7 +10,7 @@ const MeetingInformationForm = ({
     <>
       {/* Meeting Type */}
       <div className="mb-6">
-        <label className="block mb-3 font-semibold text-gray-700">
+        <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300">
           Meeting Type
         </label>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -21,10 +21,10 @@ const MeetingInformationForm = ({
               onClick={() =>
                 setScheduleData({ ...scheduleData, meetingType: type })
               }
-              className={`px-4 py-2 rounded-lg border-2 transition capitalize ${
+              className={`px-4 py-2 rounded-lg border-2 transition capitalize cursor-pointer ${
                 scheduleData.meetingType === type
-                  ? "border-blue-600 bg-blue-50 text-blue-700"
-                  : "border-gray-200 hover:border-gray-300"
+                  ? "border-blue-600 bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300"
+                  : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
               }`}
             >
               {type}
@@ -35,7 +35,7 @@ const MeetingInformationForm = ({
 
       {/* Title & Description */}
       <div className="mb-6">
-        <label className="block mb-2 font-semibold text-gray-700">
+        <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
           Meeting Title *
         </label>
         <input
@@ -44,13 +44,13 @@ const MeetingInformationForm = ({
           value={scheduleData.title}
           onChange={handleScheduleChange}
           placeholder="e.g., Q4 Board Meeting, Policy Review"
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+          className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           required
         />
       </div>
 
       <div className="mb-6">
-        <label className="block mb-2 font-semibold text-gray-700">
+        <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
           Description & Objective
         </label>
         <textarea
@@ -59,14 +59,14 @@ const MeetingInformationForm = ({
           onChange={handleScheduleChange}
           placeholder="Brief overview and expected outcomes..."
           rows="3"
-          className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+          className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         ></textarea>
       </div>
 
       {/* Date & Time */}
       <div className="grid md:grid-cols-3 gap-4 mb-6">
         <div>
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Date *
           </label>
           <input
@@ -74,12 +74,12 @@ const MeetingInformationForm = ({
             name="date"
             value={scheduleData.date}
             onChange={handleScheduleChange}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
             required
           />
         </div>
         <div>
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Time *
           </label>
           <input
@@ -87,12 +87,12 @@ const MeetingInformationForm = ({
             name="time"
             value={scheduleData.time}
             onChange={handleScheduleChange}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
             required
           />
         </div>
         <div>
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Duration (min)
           </label>
           <input
@@ -101,7 +101,7 @@ const MeetingInformationForm = ({
             value={scheduleData.duration}
             onChange={handleScheduleChange}
             placeholder="60"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
         </div>
       </div>
@@ -109,7 +109,7 @@ const MeetingInformationForm = ({
       {/* Location */}
       <div className="grid md:grid-cols-2 gap-4 mb-6">
         <div>
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Location/Platform
           </label>
           <input
@@ -118,11 +118,11 @@ const MeetingInformationForm = ({
             value={scheduleData.location}
             onChange={handleScheduleChange}
             placeholder="e.g., Zoom, Conference Room A"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
         </div>
         <div>
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Venue Details
           </label>
           <input
@@ -131,7 +131,7 @@ const MeetingInformationForm = ({
             value={scheduleData.venue}
             onChange={handleScheduleChange}
             placeholder="Address or meeting link"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
         </div>
       </div>
@@ -144,7 +144,7 @@ const MeetingInformationForm = ({
       />
 
       {/* Sync to Calendar */}
-      <div className="mb-6 flex items-center gap-3 bg-blue-50/50 p-4 rounded-xl border border-blue-100">
+      <div className="mb-6 flex items-center gap-3 bg-blue-50/50 dark:bg-blue-950/30 p-4 rounded-xl border border-blue-100 dark:border-blue-900/50">
         <input
           type="checkbox"
           id="syncToCalendar"
@@ -156,11 +156,11 @@ const MeetingInformationForm = ({
               syncToCalendar: e.target.checked,
             })
           }
-          className="w-5 h-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+          className="w-5 h-5 text-blue-600 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:ring-blue-500"
         />
         <label
           htmlFor="syncToCalendar"
-          className="text-sm font-medium text-slate-800 cursor-pointer"
+          className="text-sm font-medium text-slate-800 dark:text-slate-200 cursor-pointer"
         >
           Sync to my connected calendars (Google/Outlook)
         </label>

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ParticipantsSection.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ParticipantsSection.jsx
@@ -9,7 +9,7 @@ const ParticipantsSection = ({
 }) => {
   return (
     <div className="mb-6">
-      <label className="block mb-3 font-semibold text-gray-700 flex items-center gap-2">
+      <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
         <Users size={18} /> Invite Participants
       </label>
       <div className="grid md:grid-cols-2 gap-3 mb-3">
@@ -23,7 +23,7 @@ const ParticipantsSection = ({
             })
           }
           placeholder="Full Name"
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
         <input
           type="email"
@@ -35,13 +35,13 @@ const ParticipantsSection = ({
             })
           }
           placeholder="Email Address"
-          className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none"
+          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
       </div>
       <button
         type="button"
         onClick={addParticipant}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2"
+        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2 cursor-pointer"
       >
         <UserPlus size={16} /> Add Participant
       </button>
@@ -51,7 +51,7 @@ const ParticipantsSection = ({
           {participants.map((p) => (
             <div
               key={p.id}
-              className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-lg"
+              className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-2 rounded-lg text-gray-900 dark:text-gray-100"
             >
               <span className="text-sm">
                 <strong>{p.name}</strong> - {p.email}
@@ -59,7 +59,7 @@ const ParticipantsSection = ({
               <button
                 type="button"
                 onClick={() => removeParticipant(p.id)}
-                className="text-red-600 hover:text-red-800"
+                className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 cursor-pointer"
               >
                 <X size={18} />
               </button>

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
@@ -47,12 +47,14 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
   } = hookProps;
 
   return (
-    <div className="bg-white shadow-lg rounded-2xl p-8">
+    <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 shadow-lg rounded-2xl p-8">
       <div className="flex items-center gap-3 mb-6">
-        <Calendar className="text-blue-600" size={28} />
+        <Calendar className="text-blue-600 dark:text-blue-400" size={28} />
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">Schedule Meeting</h2>
-          <p className="text-sm text-gray-600">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Schedule Meeting
+          </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             Create and manage meeting schedules with automatic calendar
             integration
           </p>
@@ -61,7 +63,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
 
       {loadingDuplicate && (
         <div
-          className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800"
+          className="mb-6 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/40 px-4 py-3 text-sm text-blue-800 dark:text-blue-300"
           role="status"
         >
           Loading reusable meeting details...
@@ -91,14 +93,14 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
         />
 
         {templates && templates.length > 0 && (
-          <div className="mb-6 bg-blue-50/50 p-4 rounded-xl border border-blue-100">
-            <label className="flex items-center gap-2 text-sm font-semibold text-blue-900 mb-2">
+          <div className="mb-6 bg-blue-50/50 dark:bg-blue-950/30 p-4 rounded-xl border border-blue-100 dark:border-blue-900/50">
+            <label className="flex items-center gap-2 text-sm font-semibold text-blue-900 dark:text-blue-300 mb-2">
               <FileText size={16} /> Load Meeting Template
             </label>
             <select
               value={selectedTemplateId}
               onChange={handleTemplateSelect}
-              className="w-full px-4 py-2 bg-white border border-blue-200 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none text-sm text-gray-700"
+              className="w-full px-4 py-2 bg-white dark:bg-slate-800 border border-blue-200 dark:border-blue-800 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none text-sm text-gray-700 dark:text-gray-200"
             >
               <option value="">
                 -- Select a template to populate agenda --
@@ -113,14 +115,14 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
         )}
 
         {aiSummaryTemplates && aiSummaryTemplates.length > 0 && (
-          <div className="mb-6 bg-indigo-50/50 p-4 rounded-xl border border-indigo-100">
-            <label className="flex items-center gap-2 text-sm font-semibold text-indigo-900 mb-2">
+          <div className="mb-6 bg-indigo-50/50 dark:bg-indigo-950/30 p-4 rounded-xl border border-indigo-100 dark:border-indigo-900/50">
+            <label className="flex items-center gap-2 text-sm font-semibold text-indigo-900 dark:text-indigo-300 mb-2">
               <FileText size={16} /> AI Summary Instructions
             </label>
             <select
               value={selectedAiSummaryTemplateId || ""}
               onChange={(e) => setSelectedAiSummaryTemplateId(e.target.value)}
-              className="w-full px-4 py-2 bg-white border border-indigo-200 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none text-sm text-gray-700"
+              className="w-full px-4 py-2 bg-white dark:bg-slate-800 border border-indigo-200 dark:border-indigo-800 rounded-lg focus:ring-2 focus:ring-indigo-400 outline-none text-sm text-gray-700 dark:text-gray-200"
             >
               <option value="">-- Standard Summary Format --</option>
               {aiSummaryTemplates.map((t) => (
@@ -129,7 +131,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
                 </option>
               ))}
             </select>
-            <p className="text-xs text-indigo-700 mt-2">
+            <p className="text-xs text-indigo-700 dark:text-indigo-400 mt-2">
               Custom instructions allow you to dictate exactly how the AI will
               write the MoM (e.g. Sales BANT, Sprint Retro).
             </p>
@@ -157,11 +159,11 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
           removeAttachment={removeAttachment}
         />
         {/* Meeting Reminder */}
-        <div className="mb-6 rounded-xl border border-blue-100 bg-blue-50/50 p-4">
+        <div className="mb-6 rounded-xl border border-blue-100 dark:border-blue-900/50 bg-blue-50/50 dark:bg-blue-950/30 p-4">
           <div className="flex items-center gap-2 mb-3">
-            <Calendar className="text-blue-600" size={18} />
+            <Calendar className="text-blue-600 dark:text-blue-400" size={18} />
 
-            <h3 className="text-sm font-semibold text-blue-900">
+            <h3 className="text-sm font-semibold text-blue-900 dark:text-blue-300">
               Meeting Reminder
             </h3>
           </div>
@@ -176,10 +178,10 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
                   reminderEnabled: e.target.checked,
                 }))
               }
-              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-blue-600 focus:ring-blue-500"
             />
 
-            <span className="text-sm text-gray-700">
+            <span className="text-sm text-gray-700 dark:text-gray-300">
               Send me a notification before this meeting starts
             </span>
           </label>
@@ -188,7 +190,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
             <div className="mt-4">
               <label
                 htmlFor="reminderMinutesBefore"
-                className="block text-sm font-medium text-gray-700 mb-2"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
               >
                 Remind me
               </label>
@@ -202,14 +204,14 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
                     reminderMinutesBefore: Number(e.target.value),
                   }))
                 }
-                className="w-full px-4 py-2 bg-white border border-blue-200 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none text-sm text-gray-700"
+                className="w-full px-4 py-2 bg-white dark:bg-slate-800 border border-blue-200 dark:border-blue-800 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none text-sm text-gray-700 dark:text-gray-200"
               >
                 <option value={10}>10 minutes before</option>
                 <option value={30}>30 minutes before</option>
                 <option value={60}>1 hour before</option>
               </select>
 
-              <p className="text-xs text-blue-700 mt-2">
+              <p className="text-xs text-blue-700 dark:text-blue-400 mt-2">
                 You will receive an in-app notification and email reminder.
               </p>
             </div>
@@ -226,7 +228,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
             loadingDuplicate ||
             (customFields && !customFields.isValid)
           }
-          className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition flex items-center justify-center gap-2 disabled:opacity-50"
+          className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition flex items-center justify-center gap-2 disabled:opacity-50 cursor-pointer"
         >
           {loading ? (
             <>

--- a/client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx
@@ -5,21 +5,23 @@ const GeneratedSessionCards = ({ generatedSessions }) => {
 
   return (
     <div className="mt-8">
-      <h3 className="text-xl font-bold text-gray-900 mb-4">
+      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
         ✨ Generated Session Cards
       </h3>
       <div className="space-y-4">
         {generatedSessions.map((session, index) => (
           <div
             key={index}
-            className="bg-gradient-to-r from-purple-50 to-blue-50 border border-purple-200 rounded-xl p-6"
+            className="bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-950/40 dark:to-blue-950/40 border border-purple-200 dark:border-purple-800 rounded-xl p-6"
           >
             <div className="flex items-start justify-between mb-3">
               <div>
-                <h4 className="text-lg font-bold text-gray-900">
+                <h4 className="text-lg font-bold text-gray-900 dark:text-white">
                   {session.sessionTitle}
                 </h4>
-                <p className="text-sm text-gray-600">{session.eventName}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  {session.eventName}
+                </p>
               </div>
               <span className="px-3 py-1 bg-purple-600 text-white text-xs rounded-full">
                 Session
@@ -27,19 +29,19 @@ const GeneratedSessionCards = ({ generatedSessions }) => {
             </div>
 
             {session.speaker && (
-              <div className="mb-3 p-3 bg-white rounded-lg">
-                <p className="text-sm font-semibold text-gray-900">
+              <div className="mb-3 p-3 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg">
+                <p className="text-sm font-semibold text-gray-900 dark:text-white">
                   {session.speaker}
                 </p>
                 {session.speakerTitle && (
-                  <p className="text-xs text-gray-600">
+                  <p className="text-xs text-gray-600 dark:text-gray-400">
                     {session.speakerTitle}
                   </p>
                 )}
               </div>
             )}
 
-            <p className="text-sm text-gray-700 mb-3">
+            <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">
               {session.summary || "AI-generated summary will appear here..."}
             </p>
 
@@ -48,7 +50,7 @@ const GeneratedSessionCards = ({ generatedSessions }) => {
                 {session.keywords.map((keyword, i) => (
                   <span
                     key={i}
-                    className="px-3 py-1 bg-purple-100 text-purple-700 text-xs rounded-full flex items-center gap-1"
+                    className="px-3 py-1 bg-purple-100 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-800/60 text-xs rounded-full flex items-center gap-1"
                   >
                     <Tag size={12} /> {keyword}
                   </span>
@@ -61,7 +63,7 @@ const GeneratedSessionCards = ({ generatedSessions }) => {
                 href={session.videoUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800"
+                className="inline-flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
               >
                 <ExternalLink size={16} /> Watch Video
               </a>

--- a/client/src/pages/CreateMeeting/components/SessionCards/SessionCards.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/SessionCards.jsx
@@ -19,14 +19,17 @@ const SessionCards = ({ hookProps }) => {
   } = hookProps;
 
   return (
-    <div className="bg-white shadow-lg rounded-2xl p-8">
+    <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 shadow-lg rounded-2xl p-8">
       <div className="flex items-center gap-3 mb-6">
-        <Presentation className="text-purple-600" size={28} />
+        <Presentation
+          className="text-purple-600 dark:text-purple-400"
+          size={28}
+        />
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
             Auto Session Card Generation
           </h2>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             Upload slides/videos from conferences and seminars - AI generates
             session cards with summaries, keywords, and speaker profiles
           </p>
@@ -36,7 +39,7 @@ const SessionCards = ({ hookProps }) => {
       <form onSubmit={handleSessionSubmit}>
         {/* Event & Session Info */}
         <div className="mb-6">
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Event Name
           </label>
           <input
@@ -45,12 +48,12 @@ const SessionCards = ({ hookProps }) => {
             value={sessionData.eventName}
             onChange={handleSessionChange}
             placeholder="e.g., TechCon 2025, Annual Research Symposium"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
           />
         </div>
 
         <div className="mb-6">
-          <label className="block mb-2 font-semibold text-gray-700">
+          <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
             Session Title *
           </label>
           <input
@@ -59,7 +62,7 @@ const SessionCards = ({ hookProps }) => {
             value={sessionData.sessionTitle}
             onChange={handleSessionChange}
             placeholder="e.g., AI in Healthcare: Future Perspectives"
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none"
+            className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
             required
           />
         </div>
@@ -84,7 +87,7 @@ const SessionCards = ({ hookProps }) => {
         <button
           type="submit"
           disabled={loading}
-          className="w-full px-6 py-3 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 transition flex items-center justify-center gap-2 disabled:opacity-50"
+          className="w-full px-6 py-3 bg-purple-600 text-white rounded-lg font-semibold hover:bg-purple-700 transition flex items-center justify-center gap-2 disabled:opacity-50 cursor-pointer"
         >
           {loading ? (
             <>

--- a/client/src/pages/CreateMeeting/components/SessionCards/SlideUploader.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/SlideUploader.jsx
@@ -3,7 +3,7 @@ import { FileText, X } from "lucide-react";
 const SlideUploader = ({ slideFiles, handleSlideUpload, removeSlideFile }) => {
   return (
     <div className="mb-6">
-      <label className="block mb-2 font-semibold text-gray-700 flex items-center gap-2">
+      <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
         <FileText size={18} /> Upload Presentation Slides (PDF/PPT) *
       </label>
       <input
@@ -11,23 +11,26 @@ const SlideUploader = ({ slideFiles, handleSlideUpload, removeSlideFile }) => {
         multiple
         accept=".pdf,.ppt,.pptx"
         onChange={handleSlideUpload}
-        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-purple-400"
+        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer hover:border-purple-400 dark:hover:border-purple-500 bg-gray-50/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300"
       />
       {slideFiles.length > 0 && (
         <div className="mt-3 space-y-2">
           {slideFiles.map((file, index) => (
             <div
               key={index}
-              className="flex items-center justify-between bg-gray-50 px-4 py-2 rounded-lg"
+              className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-2 rounded-lg text-gray-900 dark:text-gray-100"
             >
               <span className="text-sm flex items-center gap-2">
-                <FileText size={16} className="text-purple-600" />
+                <FileText
+                  size={16}
+                  className="text-purple-600 dark:text-purple-400"
+                />
                 {file.name}
               </span>
               <button
                 type="button"
                 onClick={() => removeSlideFile(index)}
-                className="text-red-600 hover:text-red-800"
+                className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 cursor-pointer"
               >
                 <X size={18} />
               </button>
@@ -35,7 +38,7 @@ const SlideUploader = ({ slideFiles, handleSlideUpload, removeSlideFile }) => {
           ))}
         </div>
       )}
-      <p className="mt-2 text-xs text-gray-500">
+      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
         AI will extract text from slides and generate summary with keywords
       </p>
     </div>

--- a/client/src/pages/CreateMeeting/components/SessionCards/SpeakerSection.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/SpeakerSection.jsx
@@ -2,13 +2,14 @@ import { Users } from "lucide-react";
 
 const SpeakerSection = ({ sessionData, handleSessionChange }) => {
   return (
-    <div className="mb-6 p-6 bg-purple-50 border border-purple-200 rounded-lg">
-      <h3 className="font-semibold text-gray-900 mb-4 flex items-center gap-2">
-        <Users size={20} className="text-purple-600" /> Speaker Profile
+    <div className="mb-6 p-6 bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-800 rounded-lg">
+      <h3 className="font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+        <Users size={20} className="text-purple-600 dark:text-purple-400" />{" "}
+        Speaker Profile
       </h3>
 
       <div className="mb-4">
-        <label className="block mb-2 font-medium text-gray-700">
+        <label className="block mb-2 font-medium text-gray-700 dark:text-gray-300">
           Speaker Name
         </label>
         <input
@@ -17,12 +18,12 @@ const SpeakerSection = ({ sessionData, handleSessionChange }) => {
           value={sessionData.speaker}
           onChange={handleSessionChange}
           placeholder="Dr. Jane Smith"
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none"
+          className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
       </div>
 
       <div className="mb-4">
-        <label className="block mb-2 font-medium text-gray-700">
+        <label className="block mb-2 font-medium text-gray-700 dark:text-gray-300">
           Speaker Title/Position
         </label>
         <input
@@ -31,12 +32,12 @@ const SpeakerSection = ({ sessionData, handleSessionChange }) => {
           value={sessionData.speakerTitle}
           onChange={handleSessionChange}
           placeholder="Chief AI Researcher at XYZ Corp"
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none"
+          className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         />
       </div>
 
       <div>
-        <label className="block mb-2 font-medium text-gray-700">
+        <label className="block mb-2 font-medium text-gray-700 dark:text-gray-300">
           Speaker Bio
         </label>
         <textarea
@@ -45,7 +46,7 @@ const SpeakerSection = ({ sessionData, handleSessionChange }) => {
           onChange={handleSessionChange}
           placeholder="Brief bio and expertise..."
           rows="3"
-          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none"
+          className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         ></textarea>
       </div>
     </div>

--- a/client/src/pages/CreateMeeting/components/SessionCards/VideoUploader.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/VideoUploader.jsx
@@ -3,21 +3,21 @@ import { FileVideo, CheckCircle } from "lucide-react";
 const VideoUploader = ({ videoFile, handleVideoUpload }) => {
   return (
     <div className="mb-6">
-      <label className="block mb-2 font-semibold text-gray-700 flex items-center gap-2">
+      <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
         <FileVideo size={18} /> Upload Session Video (Optional)
       </label>
       <input
         type="file"
         accept="video/*"
         onChange={handleVideoUpload}
-        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-purple-400"
+        className="w-full px-4 py-3 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer hover:border-purple-400 dark:hover:border-purple-500 bg-gray-50/50 dark:bg-gray-800/50 text-gray-700 dark:text-gray-300"
       />
       {videoFile && (
-        <p className="mt-2 text-sm text-green-600 flex items-center gap-2">
+        <p className="mt-2 text-sm text-green-600 dark:text-green-400 flex items-center gap-2">
           <CheckCircle size={16} /> {videoFile.name}
         </p>
       )}
-      <p className="mt-2 text-xs text-gray-500">
+      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
         AI will link video timestamps with slide content
       </p>
     </div>

--- a/client/src/pages/CreateMeeting/components/__tests__/CreateMeetingDarkMode.test.jsx
+++ b/client/src/pages/CreateMeeting/components/__tests__/CreateMeetingDarkMode.test.jsx
@@ -1,0 +1,145 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import ScheduleMeeting from "../ScheduleMeeting/ScheduleMeeting";
+import LiveMeeting from "../LiveMeeting/LiveMeeting";
+import SessionCards from "../SessionCards/SessionCards";
+import MeetingInformationForm from "../ScheduleMeeting/MeetingInformationForm";
+import AppContent from "../../../../context/AppContent";
+
+describe("CreateMeeting dark mode support", () => {
+  it("renders ScheduleMeeting with dark mode classes", () => {
+    const mockHookProps = {
+      scheduleData: {
+        title: "Test",
+        meetingType: "internal",
+        date: "2026-08-20",
+        time: "10:00",
+      },
+      setScheduleData: vi.fn(),
+      participants: [{ id: "1", name: "Alice", email: "alice@test.com" }],
+      newParticipant: { name: "", email: "" },
+      setNewParticipant: vi.fn(),
+      agendaItems: [{ id: "a1", text: "Agenda 1" }],
+      newAgenda: "",
+      setNewAgenda: vi.fn(),
+      attachments: [],
+      loading: false,
+      templates: [],
+      selectedTemplateId: "",
+      handleTemplateSelect: vi.fn(),
+      handleScheduleChange: vi.fn(),
+      addParticipant: vi.fn(),
+      removeParticipant: vi.fn(),
+      addAgendaItem: vi.fn(),
+      removeAgendaItem: vi.fn(),
+      reorderAgendaItem: vi.fn(),
+      handleAttachmentUpload: vi.fn(),
+      removeAttachment: vi.fn(),
+      handleScheduleSubmit: vi.fn((e) => e.preventDefault()),
+      recoverableDraft: null,
+      lastSavedAt: null,
+      draftStatus: "idle",
+      restoreDraft: vi.fn(),
+      discardDraft: vi.fn(),
+      aiSummaryTemplates: [],
+      selectedAiSummaryTemplateId: "",
+      setSelectedAiSummaryTemplateId: vi.fn(),
+      setAgendaItems: vi.fn(),
+      customFields: null,
+      setCustomFields: vi.fn(),
+      userData: { organization: "org-1" },
+    };
+
+    const { container } = render(
+      <AppContent.Provider value={{ userData: { organization: "org-1" } }}>
+        <ScheduleMeeting hookProps={mockHookProps} />
+      </AppContent.Provider>,
+    );
+
+    const scheduleCard = container.querySelector(".dark\\:bg-slate-900");
+    expect(scheduleCard).toBeTruthy();
+    expect(screen.getByText("Schedule Meeting")).toHaveClass("dark:text-white");
+  });
+
+  it("renders LiveMeeting with dark mode classes", () => {
+    const mockHookProps = {
+      liveParticipants: [{ id: "1", name: "Bob", email: "bob@test.com" }],
+      newLiveParticipant: { name: "", email: "" },
+      setNewLiveParticipant: vi.fn(),
+      showRecordingDialog: false,
+      addLiveParticipant: vi.fn(),
+      removeLiveParticipant: vi.fn(),
+      handleStartLiveMeeting: vi.fn(),
+      handleRecordingChoice: vi.fn(),
+    };
+
+    const { container } = render(<LiveMeeting hookProps={mockHookProps} />);
+    const liveCard = container.querySelector(".dark\\:bg-slate-900");
+    expect(liveCard).toBeTruthy();
+    expect(screen.getByText("Start Live Meeting")).toHaveClass(
+      "dark:text-white",
+    );
+  });
+
+  it("renders SessionCards with dark mode classes", () => {
+    const mockHookProps = {
+      sessionData: {
+        eventName: "Event 1",
+        sessionTitle: "Session 1",
+        speaker: "Dr. Who",
+        speakerTitle: "Time Lord",
+        speakerBio: "Bio",
+      },
+      slideFiles: [],
+      videoFile: null,
+      generatedSessions: [
+        {
+          eventName: "Event 1",
+          sessionTitle: "Session 1",
+          speaker: "Dr. Who",
+          speakerTitle: "Time Lord",
+          summary: "Summary text",
+          keywords: ["AI", "Future"],
+        },
+      ],
+      loading: false,
+      handleSessionChange: vi.fn(),
+      handleSlideUpload: vi.fn(),
+      handleVideoUpload: vi.fn(),
+      removeSlideFile: vi.fn(),
+      handleSessionSubmit: vi.fn((e) => e.preventDefault()),
+    };
+
+    const { container } = render(<SessionCards hookProps={mockHookProps} />);
+    const sessionCard = container.querySelector(".dark\\:bg-slate-900");
+    expect(sessionCard).toBeTruthy();
+    expect(screen.getByText("Auto Session Card Generation")).toHaveClass(
+      "dark:text-white",
+    );
+    expect(screen.getByText("✨ Generated Session Cards")).toHaveClass(
+      "dark:text-white",
+    );
+  });
+
+  it("renders MeetingInformationForm with dark inputs", () => {
+    const mockProps = {
+      scheduleData: {
+        title: "Title",
+        description: "Desc",
+        date: "2026-08-20",
+        time: "10:00",
+        duration: 60,
+        meetingType: "internal",
+      },
+      setScheduleData: vi.fn(),
+      handleScheduleChange: vi.fn(),
+    };
+
+    const { container } = render(<MeetingInformationForm {...mockProps} />);
+    const input = container.querySelector('input[name="title"]');
+    expect(input).toHaveClass("dark:bg-gray-800");
+    expect(input).toHaveClass("dark:text-gray-100");
+  });
+});


### PR DESCRIPTION
## Summary
Provide comprehensive dark mode support across the entire Create Meeting hub, including Schedule Meeting, Live Meeting, and Session Cards generation workflows.

## Changes Made
- Updated all subcomponents with Tailwind `dark:` variants:
  - `ScheduleMeeting.jsx`, `MeetingInformationForm.jsx`, `ParticipantsSection.jsx`, `AgendaSection.jsx`, `AttachmentSection.jsx`, `CalendarNotice.jsx`, `DraftRecoveryBanner.jsx`.
  - `LiveMeeting.jsx`, `LiveParticipants.jsx`, `LiveMeetingInfo.jsx`, `RecordingDialog.jsx`.
  - `SessionCards.jsx`, `SpeakerSection.jsx`, `SlideUploader.jsx`, `VideoUploader.jsx`, `GeneratedSessionCards.jsx`.
- Converted hardcoded light background colors (`bg-white`, `bg-gray-50`, `border-gray-200`, `text-gray-900`) to responsive dark variants (`dark:bg-slate-900`, `dark:bg-gray-800`, `dark:border-gray-700/800`, `dark:text-white`, `dark:text-gray-300`).
- Added unit tests in `client/src/pages/CreateMeeting/components/__tests__/CreateMeetingDarkMode.test.jsx` verifying dark mode classes render across all forms and subcomponents.

## Testing & Verification
- `npx vitest run src/pages/CreateMeeting/components/__tests__/CreateMeetingDarkMode.test.jsx` (4/4 tests passed).
- `npx vitest run src/pages/CreateMeeting/components/ScheduleMeeting/__tests__/AgendaSection.test.jsx` (2/2 tests passed).
- Passed Husky pre-commit lint and prettier checks.

Closes #1643
