### PR TITLE
feat(glossary): add pagination support to glossary list endpoint

### DIFF
--- a/client/src/pages/Glossary.jsx
+++ b/client/src/pages/Glossary.jsx
@@ -30,7 +30,8 @@ const Glossary = () => {
       setLoading(true);
       setError(null);
       const data = await fetchTerms({ search: searchTerm });
-      setTerms(data || []);
+      const termsList = Array.isArray(data) ? data : data?.terms || [];
+      setTerms(termsList);
     } catch (loadError) {
       console.error("Failed to load glossary terms:", loadError);
       setError("We couldn't load the glossary right now. Please try again.");

--- a/server/controllers/glossaryController.js
+++ b/server/controllers/glossaryController.js
@@ -4,6 +4,7 @@ import GlossaryTerm from "../models/glossaryTermModel.js";
 import glossaryService from "../services/glossaryService.js";
 import { caseInsensitiveEquals } from "../utils/regexUtils.js";
 import { AppError } from "../utils/errors.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 /**
  * Field limits (Issue #1273).
@@ -143,7 +144,29 @@ export const getTerms = async (req, res) => {
       query.$text = { $search: search };
     }
 
-    const terms = await GlossaryTerm.find(query).sort({ term: 1 });
+    // Pagination support (Issue #1679)
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 50,
+      maxLimit: 100,
+    });
+
+    const total = await GlossaryTerm.countDocuments(query);
+    const terms = await GlossaryTerm.find(query)
+      .sort({ term: 1 })
+      .skip(skip)
+      .limit(limit);
+
+    // If query specifically requested pagination (page or limit provided), return envelope;
+    // otherwise if unpaginated query, return envelope with array in terms property & support top-level array for backwards compatibility
+    if (req.query.page !== undefined || req.query.limit !== undefined) {
+      return res.status(200).json({
+        success: true,
+        terms,
+        pagination: buildPaginationMeta({ total, page, limit }),
+      });
+    }
+
+    // For backwards compatibility with existing clients expecting array directly or envelope
     res.status(200).json(terms);
   } catch (error) {
     console.error("Error fetching glossary terms:", error);

--- a/server/tests/glossaryPagination.test.js
+++ b/server/tests/glossaryPagination.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const glossaryTermFind = {
+  sort: vi.fn(),
+  skip: vi.fn(),
+  limit: vi.fn(),
+};
+
+const glossaryTermMock = {
+  find: vi.fn(() => glossaryTermFind),
+  countDocuments: vi.fn(),
+};
+
+vi.mock("../models/glossaryTermModel.js", () => ({
+  default: glossaryTermMock,
+}));
+
+vi.mock("../services/glossaryService.js", () => ({
+  default: {
+    detectTerms: vi.fn(),
+    aiExtractTerms: vi.fn(),
+  },
+}));
+
+const { getTerms } = await import("../controllers/glossaryController.js");
+
+function mockResponse() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("glossaryController pagination (Issue #1679)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    glossaryTermFind.sort.mockReturnValue(glossaryTermFind);
+    glossaryTermFind.skip.mockReturnValue(glossaryTermFind);
+    glossaryTermFind.limit.mockResolvedValue([
+      { _id: "1", term: "ROI", definition: "Return on Investment" },
+      { _id: "2", term: "KPI", definition: "Key Performance Indicator" },
+    ]);
+  });
+
+  it("returns unpaginated array for backward compatibility when no pagination params", async () => {
+    glossaryTermMock.countDocuments.mockResolvedValue(2);
+    const req = {
+      user: { organization: "org-1" },
+      query: {},
+    };
+    const res = mockResponse();
+
+    await getTerms(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith([
+      { _id: "1", term: "ROI", definition: "Return on Investment" },
+      { _id: "2", term: "KPI", definition: "Key Performance Indicator" },
+    ]);
+  });
+
+  it("returns paginated envelope when page or limit is specified", async () => {
+    glossaryTermMock.countDocuments.mockResolvedValue(100);
+    const req = {
+      user: { organization: "org-1" },
+      query: { page: "2", limit: "10" },
+    };
+    const res = mockResponse();
+
+    await getTerms(req, res);
+
+    expect(glossaryTermFind.skip).toHaveBeenCalledWith(10);
+    expect(glossaryTermFind.limit).toHaveBeenCalledWith(10);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      terms: [
+        { _id: "1", term: "ROI", definition: "Return on Investment" },
+        { _id: "2", term: "KPI", definition: "Key Performance Indicator" },
+      ],
+      pagination: {
+        total: 100,
+        page: 2,
+        limit: 10,
+        totalPages: 10,
+        hasMore: true,
+      },
+    });
+  });
+
+  it("clamps oversized limits to maxLimit (100)", async () => {
+    glossaryTermMock.countDocuments.mockResolvedValue(150);
+    const req = {
+      user: { organization: "org-1" },
+      query: { limit: "10000" },
+    };
+    const res = mockResponse();
+
+    await getTerms(req, res);
+
+    expect(glossaryTermFind.limit).toHaveBeenCalledWith(100);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pagination: expect.objectContaining({
+          limit: 100,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Add pagination support with ceiling clamping to the organization glossary list endpoint (`GET /api/glossary`) to prevent unbounded queries from overloading the database and memory heap.

## Changes Made
- Updated `server/controllers/glossaryController.js` (`getTerms`) to use `parsePagination` and `buildPaginationMeta` from `server/utils/pagination.js`.
- Configured safe defaults (`defaultLimit: 50`, `maxLimit: 100`).
- Handled both paginated responses (when `page` or `limit` query parameters are provided) and top-level array returns for backwards compatibility with existing clients.
- Updated `client/src/pages/Glossary.jsx` to safely parse responses whether returned as an array or a paginated envelope object (`{ terms, pagination }`).
- Added unit tests in `server/tests/glossaryPagination.test.js`.

## Testing & Verification
- `npx vitest run tests/glossaryPagination.test.js` (3/3 tests passed).
- `npx vitest run src/pages/__tests__/GlossaryConfirmModal.test.jsx` (1/1 passed).
- `npx vitest run src/pages/__tests__/GlossaryAccessibility.test.jsx` (4/4 passed).
- Passed all pre-commit hooks.

Closes #1679
