### PR TITLE
refactor: use apiClient and update duplicates state in-place without page reloads (#1895)

### DIFF
--- a/client/src/api/meetingDuplicateApi.js
+++ b/client/src/api/meetingDuplicateApi.js
@@ -1,17 +1,17 @@
-import axios from "axios";
+import apiClient from "../services/apiClient";
 
 const detectDuplicates = async (meetingId) => {
-  return axios.get(`/api/meetings/${meetingId}/duplicates`);
+  return apiClient.get(`/api/meetings/${meetingId}/duplicates`);
 };
 
 const mergeMeetings = async (primaryId, secondaryId) => {
-  return axios.post(`/api/meetings/${primaryId}/duplicates/merge`, {
+  return apiClient.post(`/api/meetings/${primaryId}/duplicates/merge`, {
     secondaryId,
   });
 };
 
 const dismissDuplicate = async (primaryId, secondaryId) => {
-  return axios.post(`/api/meetings/${primaryId}/duplicates`, {
+  return apiClient.post(`/api/meetings/${primaryId}/duplicates`, {
     secondaryId,
   });
 };

--- a/client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx
+++ b/client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import DuplicateDetectionPanel from "../DuplicateDetectionPanel.jsx";
+import { meetingDuplicateApi } from "../../../api/meetingDuplicateApi.js";
+import apiClient from "../../../services/apiClient.js";
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("DuplicateDetectionPanel & useMeetingDuplicates (#1895)", () => {
+  let originalReload;
+  let reloadMock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalReload = window.location.reload;
+    reloadMock = vi.fn();
+    Object.defineProperty(window.location, "reload", {
+      configurable: true,
+      value: reloadMock,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.location, "reload", {
+      configurable: true,
+      value: originalReload,
+    });
+  });
+
+  it("meetingDuplicateApi uses apiClient", async () => {
+    apiClient.get.mockResolvedValue({ data: { duplicates: [] } });
+    await meetingDuplicateApi.detectDuplicates("meeting-123");
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/meetings/meeting-123/duplicates",
+    );
+
+    apiClient.post.mockResolvedValue({ data: { success: true } });
+    await meetingDuplicateApi.mergeMeetings("meeting-123", "meeting-456");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/meetings/meeting-123/duplicates/merge",
+      {
+        secondaryId: "meeting-456",
+      },
+    );
+
+    await meetingDuplicateApi.dismissDuplicate("meeting-123", "meeting-456");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/meetings/meeting-123/duplicates",
+      {
+        secondaryId: "meeting-456",
+      },
+    );
+  });
+
+  it("renders duplicates list and handles merge in-place without page reload", async () => {
+    const mockDuplicates = [
+      {
+        _id: "dup-1",
+        title: "Duplicate Meeting",
+        date: "2026-08-01T10:00:00.000Z",
+        similarity: 0.85,
+      },
+    ];
+
+    apiClient.get.mockResolvedValue({ data: { duplicates: mockDuplicates } });
+    apiClient.post.mockResolvedValue({ data: { success: true } });
+
+    render(<DuplicateDetectionPanel meetingId="meeting-123" />);
+
+    // Wait for render
+    await waitFor(() => {
+      expect(screen.getByText("Duplicate Meeting")).toBeInTheDocument();
+      expect(screen.getByText("Similarity: 85%")).toBeInTheDocument();
+    });
+
+    // Click Merge Data
+    fireEvent.click(screen.getByText("Merge Data"));
+
+    // Click Confirm Merge
+    fireEvent.click(screen.getByText("Yes, Merge Meetings"));
+
+    // Verify API called
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/meetings/meeting-123/duplicates/merge",
+        {
+          secondaryId: "dup-1",
+        },
+      );
+    });
+
+    // Verify window.location.reload was NOT called
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useMeetingDuplicates.js
+++ b/client/src/hooks/useMeetingDuplicates.js
@@ -33,9 +33,7 @@ export const useMeetingDuplicates = (meetingId) => {
     try {
       await meetingDuplicateApi.mergeMeetings(primaryId, secondaryId);
       toast.success("Meetings merged successfully");
-      await fetchDuplicates();
-      // To simulate the invalidation of the primary meeting:
-      window.location.reload();
+      setDuplicates((prev) => prev.filter((d) => d._id !== secondaryId));
     } catch (error) {
       toast.error(error.response?.data?.message || "Failed to merge meetings");
       throw error;
@@ -48,7 +46,7 @@ export const useMeetingDuplicates = (meetingId) => {
     setIsDismissing(true);
     try {
       await meetingDuplicateApi.dismissDuplicate(primaryId, secondaryId);
-      await fetchDuplicates();
+      setDuplicates((prev) => prev.filter((d) => d._id !== secondaryId));
     } catch (error) {
       toast.error(
         error.response?.data?.message || "Failed to dismiss duplicate",


### PR DESCRIPTION
## 📝 Summary
This PR refactors the client-side meeting duplicates detection module by replacing unauthenticated `axios` calls with `apiClient`, and updating duplicate merge/dismiss actions to filter lists in React state directly rather than forcing page refreshes.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1895

---

## ✨ Changes Made
- **API Authentication Refactoring**:
  - Replaced raw `axios` imports with `apiClient` in `client/src/api/meetingDuplicateApi.js`.
- **Merge UX Enhancements**:
  - Removed `window.location.reload()` from `client/src/hooks/useMeetingDuplicates.js`.
  - Refactored hook actions to trigger state filter updates in-place (`setDuplicates`) for merge and dismiss events.
- **Client Test Suite**:
  - Added `client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx` verifying both `apiClient` requests delegation and in-place list state changes without reloads.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Vitest tests:
```bash
npm run test client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Duplicate meeting merges and dismissals now update immediately without refreshing the page.
  * Duplicate detection requests use more consistent service handling while preserving existing behavior.
* **Bug Fixes**
  * Resolved stale duplicate listings after a meeting is merged or dismissed.
* **Tests**
  * Added coverage for duplicate detection, merging, dismissal requests, and in-place updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->