### PR TITLE
refactor: resolve organizationId property drift in controllers (#1893)

### DIFF
--- a/server/controllers/gamificationController.js
+++ b/server/controllers/gamificationController.js
@@ -4,7 +4,7 @@ import { calculateLeaderboards } from "../jobs/leaderboardAggregationJob.js";
 
 export const getLeaderboard = async (req, res) => {
   try {
-    const orgId = req.user.organizationId;
+    const orgId = req.user.organization;
     if (!orgId) {
       return res.status(400).json({
         success: false,
@@ -46,7 +46,7 @@ export const getLeaderboard = async (req, res) => {
 export const getUserScore = async (req, res) => {
   try {
     const userId = req.user.id;
-    const orgId = req.user.organizationId;
+    const orgId = req.user.organization;
 
     const score = await GamificationScore.findOne({
       user: userId,

--- a/server/controllers/issueTrackerController.js
+++ b/server/controllers/issueTrackerController.js
@@ -6,7 +6,7 @@ import IssueTrackerIntegration from "../models/issueTrackerIntegrationModel.js";
 export const getConfig = async (req, res) => {
   try {
     const { provider } = req.params;
-    const orgId = req.user.organizationId;
+    const orgId = req.user.organization;
 
     if (!["jira", "linear"].includes(provider)) {
       return res
@@ -40,7 +40,7 @@ export const getConfig = async (req, res) => {
 export const updateConfig = async (req, res) => {
   try {
     const { provider } = req.params;
-    const orgId = req.user.organizationId;
+    const orgId = req.user.organization;
     const userId = req.user.id;
     const { accessToken, config } = req.body;
 
@@ -99,7 +99,7 @@ export const updateConfig = async (req, res) => {
 export const disconnect = async (req, res) => {
   try {
     const { provider } = req.params;
-    const orgId = req.user.organizationId;
+    const orgId = req.user.organization;
 
     if (!["jira", "linear"].includes(provider)) {
       return res

--- a/server/tests/orgPropertyDriftFix.test.js
+++ b/server/tests/orgPropertyDriftFix.test.js
@@ -1,0 +1,85 @@
+import request from "supertest";
+import mongoose from "mongoose";
+
+const { default: express } = await import("express");
+const { getConfig, updateConfig } =
+  await import("../controllers/issueTrackerController.js");
+const { getUserScore } =
+  await import("../controllers/gamificationController.js");
+const { default: IssueTrackerIntegration } =
+  await import("../models/issueTrackerIntegrationModel.js");
+const { default: GamificationScore } =
+  await import("../models/gamificationScoreModel.js");
+
+describe("Organization Schema Property Drift Fix Integration Tests (#1893)", () => {
+  const ORG_ID = new mongoose.Types.ObjectId();
+  const USER_ID = new mongoose.Types.ObjectId();
+  let app;
+
+  beforeEach(async () => {
+    await IssueTrackerIntegration.deleteMany({});
+    await GamificationScore.deleteMany({});
+
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      // Mock the logged-in user matching User model format (uses organization instead of organizationId)
+      req.user = {
+        _id: USER_ID,
+        id: USER_ID.toString(),
+        organization: ORG_ID,
+      };
+      next();
+    });
+
+    app.get("/api/issue-tracker/config/:provider", getConfig);
+    app.post("/api/issue-tracker/config/:provider", updateConfig);
+    app.get("/api/gamification/score", getUserScore);
+  });
+
+  describe("Issue Tracker Controller", () => {
+    it("successfully creates and retrieves config scoped by req.user.organization", async () => {
+      // 1. Create config
+      const createRes = await request(app)
+        .post("/api/issue-tracker/config/jira")
+        .send({
+          accessToken: "valid-token-123",
+          config: { projectKey: "PROJ" },
+        });
+
+      expect(createRes.status).toBe(200);
+      expect(createRes.body.success).toBe(true);
+      expect(createRes.body.data.organization).toBe(ORG_ID.toString());
+
+      // Verify record exists in DB using ORG_ID
+      const dbRecord = await IssueTrackerIntegration.findOne({
+        organization: ORG_ID,
+        provider: "jira",
+      });
+      expect(dbRecord).not.toBeNull();
+      expect(dbRecord.accessToken).toBe("valid-token-123");
+
+      // 2. Retrieve config
+      const getRes = await request(app).get("/api/issue-tracker/config/jira");
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.success).toBe(true);
+      expect(getRes.body.data.config.projectKey).toBe("PROJ");
+    });
+  });
+
+  describe("Gamification Controller", () => {
+    it("retrieves user score scoped by req.user.organization", async () => {
+      // Create user score in DB
+      await GamificationScore.create({
+        user: USER_ID,
+        organization: ORG_ID,
+        totalPoints: 150,
+      });
+
+      const res = await request(app).get("/api/gamification/score");
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.totalPoints).toBe(150);
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR resolves the user organization schema property drift in the `issueTrackerController.js` and `gamificationController.js` by mapping lookup operations to `req.user.organization` instead of the non-existent `req.user.organizationId`.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1893

---

## ✨ Changes Made
- **Controllers Organization Key Mapping**:
  - Replaced all calls to `req.user.organizationId` with `req.user.organization` in `server/controllers/issueTrackerController.js`.
  - Replaced all calls to `req.user.organizationId` with `req.user.organization` in `server/controllers/gamificationController.js`.
- **Integration Tests**:
  - Created `server/tests/orgPropertyDriftFix.test.js` validating configuration creation/getter actions and user scores scoped under `req.user.organization`.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Jest tests:
```bash
cd server
npm run test tests/orgPropertyDriftFix.test.js
