### PR TITLE
refactor: add /api prefix to speaker mapping request paths and alias routes (#1886)

### DIFF
--- a/client/src/services/__tests__/speakerMappingApi.test.js
+++ b/client/src/services/__tests__/speakerMappingApi.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { speakerMappingApi } from "../speakerMappingApi.js";
+import api from "../apiClient.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("speakerMappingApi (#1886)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends getMappings requests with /api/speaker-mapping prefix", async () => {
+    api.get.mockResolvedValue({ data: [] });
+    await speakerMappingApi.getMappings("meeting-123");
+    expect(api.get).toHaveBeenCalledWith("/api/speaker-mapping/meeting-123");
+  });
+
+  it("sends suggestMappings requests with /api/speaker-mapping prefix", async () => {
+    api.get.mockResolvedValue({ data: [] });
+    await speakerMappingApi.suggestMappings("meeting-123");
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/speaker-mapping/meeting-123/suggest",
+    );
+  });
+
+  it("sends saveAndApplyMapping requests with /api/speaker-mapping prefix", async () => {
+    api.post.mockResolvedValue({ data: {} });
+    await speakerMappingApi.saveAndApplyMapping(
+      "meeting-123",
+      "Speaker 1",
+      "John",
+    );
+    expect(api.post).toHaveBeenCalledWith("/api/speaker-mapping/meeting-123", {
+      originalLabel: "Speaker 1",
+      mappedName: "John",
+    });
+  });
+
+  it("sends revertMapping requests with /api/speaker-mapping prefix", async () => {
+    api.delete.mockResolvedValue({ data: {} });
+    await speakerMappingApi.revertMapping("meeting-123", "mapping-456");
+    expect(api.delete).toHaveBeenCalledWith(
+      "/api/speaker-mapping/meeting-123/mapping-456",
+    );
+  });
+});

--- a/client/src/services/speakerMappingApi.js
+++ b/client/src/services/speakerMappingApi.js
@@ -1,14 +1,17 @@
 import api from "./apiClient";
 
 export const speakerMappingApi = {
-  getMappings: (meetingId) => api.get(`/speaker-mappings/${meetingId}`),
+  getMappings: (meetingId) => api.get(`/api/speaker-mapping/${meetingId}`),
 
   suggestMappings: (meetingId) =>
-    api.get(`/speaker-mappings/${meetingId}/suggest`),
+    api.get(`/api/speaker-mapping/${meetingId}/suggest`),
 
   saveAndApplyMapping: (meetingId, originalLabel, mappedName) =>
-    api.post(`/speaker-mappings/${meetingId}`, { originalLabel, mappedName }),
+    api.post(`/api/speaker-mapping/${meetingId}`, {
+      originalLabel,
+      mappedName,
+    }),
 
   revertMapping: (meetingId, mappingId) =>
-    api.delete(`/speaker-mappings/${meetingId}/${mappingId}`),
+    api.delete(`/api/speaker-mapping/${meetingId}/${mappingId}`),
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -165,7 +165,10 @@ router.use("/api/scheduler", schedulerRoutes);
 // Recap schedule + delivery history (GET /history/deliveries) — Issue #1401
 router.use("/api/recap-schedule", recapScheduleRoutes);
 router.use("/api/clips", meetingClipRoutes);
-router.use("/api/speaker-mappings", speakerMappingRoutes);
+router.use(
+  ["/api/speaker-mapping", "/api/speaker-mappings"],
+  speakerMappingRoutes,
+);
 router.use("/api/note-versions", noteVersionRoutes);
 router.use("/api/reports", reportRoutes);
 router.use("/api/agenda-suggestions", agendaSuggestionRoutes);

--- a/server/tests/speakerMappingRouteAlias.test.js
+++ b/server/tests/speakerMappingRouteAlias.test.js
@@ -1,0 +1,49 @@
+import request from "supertest";
+import mongoose from "mongoose";
+
+const { default: express } = await import("express");
+const { default: routesIndex } = await import("../routes/index.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+
+describe("Speaker Mapping Route Alias Integration Tests (#1886)", () => {
+  const ORG_ID = new mongoose.Types.ObjectId();
+  const USER_ID = new mongoose.Types.ObjectId();
+  let app;
+  let meeting;
+
+  beforeAll(async () => {
+    app = express();
+    app.use(express.json());
+    // Inject mock req.user matching userAuth output
+    app.use((req, res, next) => {
+      req.user = {
+        _id: USER_ID,
+        organization: ORG_ID,
+        role: "member",
+      };
+      next();
+    });
+    app.use(routesIndex);
+
+    meeting = await Meeting.create({
+      uploadedBy: USER_ID,
+      organization: ORG_ID,
+      title: "Alias Test Meeting",
+      date: new Date(),
+    });
+  });
+
+  afterAll(async () => {
+    await Meeting.deleteMany({});
+  });
+
+  it("resolves singular /api/speaker-mapping GET mappings cleanly without 404", async () => {
+    const res = await request(app).get(`/api/speaker-mapping/${meeting._id}`);
+    expect(res.status).not.toBe(404);
+  });
+
+  it("resolves plural /api/speaker-mappings GET mappings cleanly without 404", async () => {
+    const res = await request(app).get(`/api/speaker-mappings/${meeting._id}`);
+    expect(res.status).not.toBe(404);
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR resolves the 404 errors during speaker renames by routing client-side requests through `/api/speaker-mapping/...` and aliasing both singular and plural endpoint variants on the server.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1886

---

## ✨ Changes Made
- **Client Path Prefixing**:
  - Prefixed endpoints in `client/src/services/speakerMappingApi.js` with `/api/speaker-mapping`.
- **Server Path Aliasing**:
  - Aliased both `/api/speaker-mapping` and `/api/speaker-mappings` in `server/routes/index.js`.
- **Unit and Integration Tests**:
  - Added `client/src/services/__tests__/speakerMappingApi.test.js` validating client-side prefix prepending.
  - Added `server/tests/speakerMappingRouteAlias.test.js` verifying server-side routing resolution.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Vitest and Jest tests:
```bash
npm run test client/src/services/__tests__/speakerMappingApi.test.js
cd server && npm run test tests/speakerMappingRouteAlias.test.js
