### PR TITLE
fix: prevent MongoDB regex injection

### DIFF
--- a/server/controllers/decisionGraphController.js
+++ b/server/controllers/decisionGraphController.js
@@ -1,5 +1,6 @@
 import Decision from "../models/decisionModel.js";
 import mongoose from "mongoose";
+import { escapeRegex } from "../utils/regex.js";
 
 /**
  * @desc    Get the decision dependency graph for the current organization
@@ -29,8 +30,8 @@ export const getDecisionGraph = async (req, res) => {
 
     if (search && typeof search === "string") {
       // Escape regex metacharacters so user input can't be compiled as a live
-      // regex (ReDoS / regex injection), matching tagController's escaping.
-      const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      // regex (ReDoS / regex injection). See `utils/regex.js` (Issue #1770).
+      const escapedSearch = escapeRegex(search);
       filter.text = { $regex: escapedSearch, $options: "i" };
     }
 

--- a/server/controllers/personalNoteController.js
+++ b/server/controllers/personalNoteController.js
@@ -3,6 +3,7 @@ import PersonalNote from "../models/personalNoteModel.js";
 import Meeting from "../models/meetingModel.js";
 import { hasPermission } from "../utils/rbacPermissions.js";
 import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
+import { escapeRegex } from "../utils/regex.js";
 
 // Re-export for existing personal-note tests and callers (Issue #1389).
 export { resolveAccessibleMeeting };
@@ -644,7 +645,7 @@ export const searchNotes = async (req, res) => {
         });
       }
       // Escape regex special characters to prevent ReDoS and regex injection
-      const escapedQuery = query.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
+      const escapedQuery = escapeRegex(query);
       filter.$or = [
         { title: { $regex: escapedQuery, $options: "i" } },
         { content: { $regex: escapedQuery, $options: "i" } },

--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -4,7 +4,8 @@ import Meeting from "../models/meetingModel.js";
 import { sendSuccess } from "../utils/responseHandler.js";
 import { ValidationError, NotFoundError } from "../utils/errors.js";
 import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
-import { caseInsensitiveEquals, escapeRegExp } from "../utils/regexUtils.js";
+import { caseInsensitiveEquals } from "../utils/regexUtils.js";
+import { escapeRegex } from "../utils/regex.js";
 import mongoose from "mongoose";
 
 // Validation schemas
@@ -257,11 +258,11 @@ export const autocomplete = async (req, res, next) => {
     }
 
     // Prefix matching is a genuine pattern query, so this one stays a regex —
-    // it just uses the shared helper rather than a fourth open-coded copy of
-    // the same character class (Issue #1157).
+    // user input is escaped via `escapeRegex` so `.*` / `C++` stay literal
+    // (Issues #1157 / #1770).
     const tags = await Tag.find({
       organization: orgId,
-      name: { $regex: new RegExp(`^${escapeRegExp(q)}`, "i") },
+      name: { $regex: `^${escapeRegex(q)}`, $options: "i" },
     })
       .limit(10)
       .sort({ usageCount: -1 });

--- a/server/services/OrganizationService.js
+++ b/server/services/OrganizationService.js
@@ -22,17 +22,11 @@ import {
   ValidationError,
 } from "../utils/errors.js";
 import { normalizeImageUrl } from "../utils/imageUrl.js";
+import { escapeRegex } from "../utils/regex.js";
 
 // ═══════════════════════════════════════════════════════════════
 // Private helpers
 // ═══════════════════════════════════════════════════════════════
-
-/**
- * Escape special regex characters to prevent ReDoS attacks
- */
-const escapeRegex = (string) => {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-};
 
 /**
  * Validate MongoDB ObjectId

--- a/server/services/keywordAlertService.js
+++ b/server/services/keywordAlertService.js
@@ -1,10 +1,7 @@
 import KeywordAlert from "../models/keywordAlertModel.js";
 import { createNotifications } from "./notificationService.js";
 import EmailService from "./EmailService.js";
-
-const escapeRegex = (string) => {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
-};
+import { escapeRegex } from "../utils/regex.js";
 
 export const scanTranscriptForKeywords = async (meeting, transcript) => {
   if (!transcript || !meeting || !meeting.organization) return;

--- a/server/services/realtimeTranslationService.js
+++ b/server/services/realtimeTranslationService.js
@@ -1,6 +1,7 @@
 import RealtimeTranslationCache from "../models/TranslationCache.js";
 import UserLanguagePreference from "../models/UserLanguagePreference.js";
 import Meeting from "../models/meetingModel.js";
+import { escapeRegex } from "../utils/regex.js";
 
 /**
  * Real-time Translation Service
@@ -146,13 +147,6 @@ const applyGlossary = async (
     console.error("Glossary application error:", error);
     return text;
   }
-};
-
-/**
- * Escape regex special characters
- */
-const escapeRegex = (string) => {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 };
 
 /**

--- a/server/services/savedFilterService.js
+++ b/server/services/savedFilterService.js
@@ -1,5 +1,6 @@
 import SavedFilter from "../models/savedFilterModel.js";
 import Meeting from "../models/meetingModel.js";
+import { escapeRegex } from "../utils/regex.js";
 
 class SavedFilterService {
   /**
@@ -14,7 +15,10 @@ class SavedFilterService {
 
     // Search Query
     if (filters.searchQuery && filters.searchQuery.trim()) {
-      const searchRegex = new RegExp(filters.searchQuery.trim(), "i");
+      const searchRegex = new RegExp(
+        escapeRegex(filters.searchQuery.trim()),
+        "i",
+      );
       query.$or = [
         { title: searchRegex },
         { summary: searchRegex },

--- a/server/tests/OrganizationService.test.js
+++ b/server/tests/OrganizationService.test.js
@@ -531,6 +531,27 @@ describe("OrganizationService", () => {
         }),
       );
     });
+
+    it("escapes regex metacharacters so '.*' is literal (Issue #1770)", async () => {
+      const mockQueryChain = {
+        sort: vi.fn().mockReturnThis(),
+        skip: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        lean: vi.fn().mockResolvedValue([]),
+      };
+      Organization.find.mockReturnValue(mockQueryChain);
+      Organization.countDocuments.mockResolvedValue(0);
+
+      await OrganizationService.searchOrganizations(".*", 1, 12);
+
+      const filterArg = Organization.find.mock.calls[0][0];
+      expect(filterArg.visibility).toBe("public");
+      expect(filterArg.$or[0].name).toBeInstanceOf(RegExp);
+      expect(filterArg.$or[0].name.source).toBe("\\.\\*");
+      expect(filterArg.$or[0].name.test("Acme Corp")).toBe(false);
+      expect(filterArg.$or[0].name.test(".*")).toBe(true);
+    });
   });
 
   // ── getOrganizationSettings ──────────────────────────────

--- a/server/tests/knowledgeController.test.js
+++ b/server/tests/knowledgeController.test.js
@@ -210,6 +210,27 @@ describe("knowledgeController - NoSQL Injection & Query Validation", () => {
       });
       expect(res.status).toHaveBeenCalledWith(200);
     });
+
+    it("should escape '.*' in decision search rather than matching every document", async () => {
+      req.query = { sortBy: "createdAt", search: ".*" };
+
+      const mockPopulate = jest.fn().mockReturnValue({
+        sort: jest.fn().mockResolvedValue([]),
+      });
+      Decision.find.mockReturnValue({
+        populate: mockPopulate,
+      });
+
+      await getDecisions(req, res);
+
+      expect(Decision.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: "org123",
+          text: { $regex: "\\.\\*", $options: "i" },
+          lifecycleState: { $nin: ["archived", "expired"] },
+        }),
+      );
+    });
   });
 
   describe("getOpenActionItems", () => {
@@ -323,6 +344,27 @@ describe("knowledgeController - NoSQL Injection & Query Validation", () => {
           $or: expect.arrayContaining([
             { text: { $regex: "C\\+\\+", $options: "i" } },
             { owner: { $regex: "C\\+\\+", $options: "i" } },
+          ]),
+        }),
+      );
+    });
+
+    it("should treat '.*' as literal search text, not a wildcard", async () => {
+      req.query = { status: "all", sortBy: "createdAt", search: ".*" };
+      mockFindChain();
+
+      await getOpenActionItems(req, res);
+
+      expect(Meeting.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: { $regex: "\\.\\*", $options: "i" },
+        }),
+      );
+      expect(ActionItem.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          $or: expect.arrayContaining([
+            { text: { $regex: "\\.\\*", $options: "i" } },
+            { owner: { $regex: "\\.\\*", $options: "i" } },
           ]),
         }),
       );

--- a/server/tests/mongodbRegexInjection.test.js
+++ b/server/tests/mongodbRegexInjection.test.js
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for Issue #1770 — MongoDB regex injection via unsanitized
+ * user input.
+ *
+ * User-controlled values must be escaped before they reach `$regex` / `RegExp`.
+ * Inputs such as `.*`, `(a+)+b`, `^admin$`, `foo|bar`, `[abc]`, and `\w+` must
+ * be treated as literal text, not executable patterns.
+ */
+
+import mongoose from "mongoose";
+import { escapeRegex } from "../utils/regex.js";
+import { escapeRegExp } from "../utils/regexUtils.js";
+import savedFilterService from "../services/savedFilterService.js";
+import {
+  createTag,
+  updateTag,
+  autocomplete,
+} from "../controllers/tagController.js";
+import Tag from "../models/tagModel.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: undefined };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    res.body = payload;
+    return res;
+  };
+  return res;
+};
+
+const invoke = async (handler, req) => {
+  const res = mockRes();
+  let error = null;
+  await handler(req, res, (err) => {
+    error = err;
+  });
+  return { res, error };
+};
+
+const asUser = (body = {}, extra = {}) => ({
+  body,
+  params: {},
+  query: {},
+  user: { _id: USER_A, organization: ORG_A },
+  ...extra,
+});
+
+const payloadRows = (body) =>
+  Object.entries(body ?? {})
+    .filter(([key]) => /^\d+$/.test(key))
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([, value]) => value);
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+});
+
+describe("escapeRegex (Issue #1770)", () => {
+  it("is the single shared implementation re-exported as escapeRegExp", () => {
+    expect(escapeRegex).toBe(escapeRegExp);
+  });
+
+  it.each([
+    [".*", "\\.\\*"],
+    ["(a+)+b", "\\(a\\+\\)\\+b"],
+    ["^admin$", "\\^admin\\$"],
+    ["foo|bar", "foo\\|bar"],
+    ["[abc]", "\\[abc\\]"],
+    ["\\w+", "\\\\w\\+"],
+  ])("escapes %p as literal text", (input, escaped) => {
+    expect(escapeRegex(input)).toBe(escaped);
+    const re = new RegExp(`^${escapeRegex(input)}$`);
+    expect(re.test(input)).toBe(true);
+  });
+
+  it("does not let '.*' match arbitrary strings", () => {
+    const re = new RegExp(escapeRegex(".*"));
+    expect(re.test("anything at all")).toBe(false);
+    expect(re.test(".*")).toBe(true);
+  });
+
+  it("does not let '^admin$' anchor an equality bypass", () => {
+    const re = new RegExp(escapeRegex("^admin$"));
+    expect(re.test("admin")).toBe(false);
+    expect(re.test("^admin$")).toBe(true);
+  });
+
+  it("does not let 'foo|bar' match either alternative", () => {
+    const re = new RegExp(escapeRegex("foo|bar"));
+    expect(re.test("foo")).toBe(false);
+    expect(re.test("bar")).toBe(false);
+    expect(re.test("foo|bar")).toBe(true);
+  });
+
+  it("still matches ordinary search text", () => {
+    const re = new RegExp(escapeRegex("budget"), "i");
+    expect(re.test("Q4 Budget Review")).toBe(true);
+  });
+});
+
+describe("saved filter searchQuery (Issue #1770)", () => {
+  it("keeps organization scoping while escaping metacharacters", () => {
+    const orgId = new mongoose.Types.ObjectId();
+    const query = savedFilterService.buildQuery(
+      { searchQuery: "foo|bar" },
+      orgId,
+    );
+
+    expect(query.organization).toBe(orgId);
+    expect(query.deletedAt).toBeNull();
+    expect(query.$or[0].title.source).toBe("foo\\|bar");
+    expect(query.$or[0].title.test("foo")).toBe(false);
+    expect(query.$or[0].title.test("foo|bar")).toBe(true);
+  });
+});
+
+describe("tag names (Issue #1770)", () => {
+  it("creates a tag named '.*' without matching every existing tag", async () => {
+    await invoke(createTag, asUser({ name: "Engineering" }));
+
+    const { res, error } = await invoke(createTag, asUser({ name: ".*" }));
+
+    expect(error).toBeNull();
+    expect(res.statusCode).toBe(201);
+    expect(
+      await Tag.findOne({ organization: ORG_A, name: ".*" }),
+    ).not.toBeNull();
+    expect(await Tag.countDocuments({ organization: ORG_A })).toBe(2);
+  });
+
+  it("renames a tag to 'C++' without a compile error", async () => {
+    const created = await invoke(createTag, asUser({ name: "Cpp" }));
+    const tag = await Tag.findOne({ organization: ORG_A, name: "Cpp" });
+
+    const renamed = await invoke(
+      updateTag,
+      asUser({ name: "C++" }, { params: { id: tag._id.toString() } }),
+    );
+
+    expect(created.error).toBeNull();
+    expect(renamed.error).toBeNull();
+    expect((await Tag.findById(tag._id)).name).toBe("C++");
+  });
+
+  it("autocomplete treats 'B.' as a literal prefix, not 'B' + any char", async () => {
+    await Tag.create([
+      { name: "Budget", organization: ORG_A, createdBy: USER_A },
+      { name: "B.dget", organization: ORG_A, createdBy: USER_A },
+    ]);
+
+    const { res, error } = await invoke(
+      autocomplete,
+      asUser({}, { query: { q: "B." } }),
+    );
+
+    expect(error).toBeNull();
+    expect(payloadRows(res.body).map((t) => t.name)).toEqual(["B.dget"]);
+  });
+
+  it("does not leak tags across organizations during autocomplete", async () => {
+    await Tag.create([
+      { name: "Shared", organization: ORG_A, createdBy: USER_A },
+      {
+        name: "Shared",
+        organization: ORG_B,
+        createdBy: new mongoose.Types.ObjectId(),
+      },
+    ]);
+
+    const { res, error } = await invoke(
+      autocomplete,
+      asUser({}, { query: { q: "Sha" } }),
+    );
+
+    expect(error).toBeNull();
+    const rows = payloadRows(res.body);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organization.toString()).toBe(ORG_A.toString());
+  });
+});

--- a/server/tests/regexEscaping.test.js
+++ b/server/tests/regexEscaping.test.js
@@ -24,6 +24,7 @@ import mongoose from "mongoose";
 
 import {
   escapeRegExp,
+  escapeRegex,
   literalRegExp,
   wordBoundaryRegExp,
   caseInsensitiveEquals,
@@ -128,6 +129,10 @@ describe("regexUtils", () => {
 
     it("is still exported from meetingSoftDelete for existing importers", () => {
       expect(reExportedEscape).toBe(escapeRegExp);
+    });
+
+    it("is the same function as escapeRegex (Issue #1770)", () => {
+      expect(escapeRegex).toBe(escapeRegExp);
     });
   });
 

--- a/server/tests/savedFilter.test.js
+++ b/server/tests/savedFilter.test.js
@@ -19,6 +19,18 @@ describe("SavedFilterService", () => {
       expect(query.$or).toBeDefined();
       expect(query.$or.length).toBe(4);
       expect(query.$or[0].title).toBeInstanceOf(RegExp);
+      expect(query.$or[0].title.source).toBe("policy");
+    });
+
+    it("should escape regex metacharacters in searchQuery (Issue #1770)", () => {
+      const orgId = new mongoose.Types.ObjectId();
+      const query = savedFilterService.buildQuery({ searchQuery: ".*" }, orgId);
+
+      expect(query.organization).toBe(orgId);
+      expect(query.$or[0].title).toBeInstanceOf(RegExp);
+      expect(query.$or[0].title.source).toBe("\\.\\*");
+      expect(query.$or[0].title.test("any meeting title")).toBe(false);
+      expect(query.$or[0].title.test("contains .* literally")).toBe(true);
     });
 
     it("should handle status filters", () => {

--- a/server/utils/regex.js
+++ b/server/utils/regex.js
@@ -1,0 +1,18 @@
+/**
+ * Escape user-controlled strings before they are interpolated into MongoDB
+ * `$regex` patterns or `RegExp` constructors (Issue #1770).
+ *
+ * Without this, inputs such as `.*`, `^admin$`, `foo|bar`, and `(a+)+b` are
+ * compiled as live patterns: they match unintended documents, can bypass
+ * prefix/equality intent, and can cause ReDoS.
+ *
+ * This is the single implementation. Other modules re-export it — do not
+ * copy the character class elsewhere.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export const escapeRegex = (value = "") =>
+  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export default escapeRegex;

--- a/server/utils/regexUtils.js
+++ b/server/utils/regexUtils.js
@@ -1,13 +1,14 @@
 /**
- * Regex helpers (Issue #1157).
+ * Regex helpers (Issue #1157 / #1770).
  *
  * Seven call sites built a `RegExp` by interpolating user-controlled text
  * without escaping it. The helper to prevent that already existed — it just
  * lived in `utils/meetingSoftDelete.js`, which is not somewhere you look when
  * you are writing a tag uniqueness check.
  *
- * It lives here now, next to the other things that operate on patterns, and
- * `meetingSoftDelete.js` re-exports it so existing importers are unaffected.
+ * Literal escaping lives in `utils/regex.js` (`escapeRegex`). This module
+ * re-exports it as `escapeRegExp` so existing importers are unaffected, and
+ * adds the higher-level helpers (equality, word-boundary, `$regex` fragments).
  *
  * Two rules for anything that reaches for this module:
  *
@@ -22,15 +23,19 @@
  *      given a pathological pattern, and it says what it means.
  */
 
+import { escapeRegex } from "./regex.js";
+
 /**
  * Escapes every character that carries meaning inside a regular expression, so
  * the result matches `value` literally.
  *
+ * Alias of `escapeRegex` (Issue #1770) — one implementation, two names.
+ *
  * @param {string} value
  * @returns {string}
  */
-export const escapeRegExp = (value = "") =>
-  String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+export const escapeRegExp = escapeRegex;
+export { escapeRegex };
 
 /**
  * Builds an anchored, case-insensitive regex that matches `value` literally.
@@ -188,6 +193,7 @@ export const literalContainsFilter = (
 };
 
 export default {
+  escapeRegex,
   escapeRegExp,
   literalRegExp,
   caseInsensitiveEquals,


### PR DESCRIPTION
## Summary


Fixes #1770


Prevents MongoDB regex injection and ReDoS risks by consistently escaping user-controlled input before it is used in regex queries.


## Problem


User-supplied search values could be interpreted as MongoDB regular expressions, allowing patterns such as `.*`, `(a+)+b`, `^admin$`, and `foo|bar` to match unintended data or cause excessive regex processing.


## Changes


- Added shared `escapeRegex()` utility.
- Applied regex escaping across affected controllers and services.
- Reused the shared implementation through `regexUtils.js`.
- Removed duplicate regex escaping logic from `OrganizationService`.
- Secured saved-filter, knowledge, tag, organization, decision graph, personal note, keyword alert, and realtime translation regex usage.
- Preserved existing organization and tenant filtering.


## Security Impact


User input is now treated as literal text rather than executable regex syntax.


This prevents:


- Regex injection
- ReDoS through malicious patterns
- Unintended document matching
- Regex-based query manipulation


Special characters remain searchable as literal characters.


## Tests


Added regression coverage for:


- Regex metacharacters
- `.*` searches
- `(a+)+b` patterns
- `C++` input
- `foo|bar` input
- Tag autocomplete
- Knowledge search
- Saved-filter search
- Organization search
- Existing organization scoping
- Normal searches


## Files Added


- `server/utils/regex.js`
- `server/tests/mongodbRegexInjection.test.js`


## Files Modified


- `server/controllers/decisionGraphController.js`
- `server/controllers/personalNoteController.js`
- `server/controllers/tagController.js`
- `server/services/OrganizationService.js`
- `server/services/keywordAlertService.js`
- `server/services/realtimeTranslationService.js`
- `server/services/savedFilterService.js`
- `server/utils/regexUtils.js`
- Related regression tests


## Verification


```bash
npx vitest run server/tests/mongodbRegexInjection.test.js server/tests/regexEscaping.test.js server/tests/knowledgeSearchRegexSafety.test.js server/tests/knowledgeController.test.js server/tests/savedFilter.test.js server/tests/OrganizationService.test.js
```

## Security Notes

- A single shared regex escaping implementation is used.
- Existing authorization and organization/tenant filters remain unchanged.
- No client-provided organization scope is trusted or modified by this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search queries containing special characters are now treated as literal text instead of being interpreted as regular-expression patterns.
  * Improved protection against regex injection and unintended wildcard matches across search, filtering, autocomplete, tags, notes, and organization features.

* **Tests**
  * Added regression coverage for safe search behavior, literal special-character handling, and data isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->