### PR TITLE
Fix/carry forward authorization 1666

### DIFF
--- a/server/controllers/carryForwardController.js
+++ b/server/controllers/carryForwardController.js
@@ -1,17 +1,37 @@
 import carryForwardService from "../services/carryForwardService.js";
+import { AppError } from "../utils/errors.js";
+
+/**
+ * Tenant for carry-forward is always the authenticated user's organization.
+ * Client-supplied organizationId (body/query/params) is ignored (Issue #1666).
+ */
+const getAuthenticatedOrganizationId = (req) =>
+  req.user?.organization || req.user?.organizationId || null;
+
+const sendCarryForwardError = (res, error, fallbackMessage) => {
+  if (error instanceof AppError) {
+    return res.status(error.statusCode).json({
+      success: false,
+      message: error.message,
+    });
+  }
+  console.error(fallbackMessage, error);
+  return res
+    .status(500)
+    .json({ success: false, message: "Internal server error" });
+};
 
 export const getConfig = async (req, res) => {
   try {
     const { seriesId } = req.params;
-    const organizationId = req.user.organization || null;
+    const organizationId = getAuthenticatedOrganizationId(req);
     const config = await carryForwardService.getConfig(
       seriesId,
       organizationId,
     );
     res.status(200).json({ success: true, config });
   } catch (error) {
-    console.error("Error getting carry forward config:", error);
-    res.status(500).json({ success: false, message: "Internal server error" });
+    sendCarryForwardError(res, error, "Error getting carry forward config:");
   }
 };
 
@@ -19,25 +39,33 @@ export const updateConfig = async (req, res) => {
   try {
     const { seriesId } = req.params;
     const { carryForwardRules } = req.body;
+    const organizationId = getAuthenticatedOrganizationId(req);
     const config = await carryForwardService.updateConfig(
       seriesId,
       carryForwardRules,
+      organizationId,
     );
     res.status(200).json({ success: true, config });
   } catch (error) {
-    console.error("Error updating carry forward config:", error);
-    res.status(500).json({ success: false, message: "Internal server error" });
+    sendCarryForwardError(res, error, "Error updating carry forward config:");
   }
 };
 
 export const getPreview = async (req, res) => {
   try {
     const { seriesId } = req.params;
-    const preview = await carryForwardService.getCarryForwardPreview(seriesId);
+    const organizationId = getAuthenticatedOrganizationId(req);
+    const preview = await carryForwardService.getCarryForwardPreview(
+      seriesId,
+      organizationId,
+    );
     res.status(200).json({ success: true, preview });
   } catch (error) {
-    console.error("Error generating carry forward preview:", error);
-    res.status(500).json({ success: false, message: "Internal server error" });
+    sendCarryForwardError(
+      res,
+      error,
+      "Error generating carry forward preview:",
+    );
   }
 };
 
@@ -45,6 +73,7 @@ export const applyCarryForward = async (req, res) => {
   try {
     const { seriesId } = req.params;
     const { currentMeetingId } = req.body;
+    const organizationId = getAuthenticatedOrganizationId(req);
 
     if (!currentMeetingId) {
       return res
@@ -55,6 +84,7 @@ export const applyCarryForward = async (req, res) => {
     const result = await carryForwardService.applyCarryForward(
       seriesId,
       currentMeetingId,
+      organizationId,
     );
     if (!result.success) {
       return res.status(400).json(result);
@@ -62,7 +92,6 @@ export const applyCarryForward = async (req, res) => {
 
     res.status(200).json(result);
   } catch (error) {
-    console.error("Error applying carry forward:", error);
-    res.status(500).json({ success: false, message: "Internal server error" });
+    sendCarryForwardError(res, error, "Error applying carry forward:");
   }
 };

--- a/server/controllers/carryForwardController.js
+++ b/server/controllers/carryForwardController.js
@@ -5,8 +5,7 @@ import { AppError } from "../utils/errors.js";
  * Tenant for carry-forward is always the authenticated user's organization.
  * Client-supplied organizationId (body/query/params) is ignored (Issue #1666).
  */
-const getAuthenticatedOrganizationId = (req) =>
-  req.user?.organization || req.user?.organizationId || null;
+const getAuthenticatedOrganizationId = (req) => req.user?.organization || null;
 
 const sendCarryForwardError = (res, error, fallbackMessage) => {
   if (error instanceof AppError) {

--- a/server/services/carryForwardService.js
+++ b/server/services/carryForwardService.js
@@ -1,10 +1,47 @@
+import mongoose from "mongoose";
 import CarryForwardConfig from "../models/carryForwardConfigModel.js";
 import Meeting from "../models/meetingModel.js";
+import MeetingSeries from "../models/meetingSeriesModel.js";
 import ActionItem from "../models/actionItemModel.js";
 import { normalizeAgendaItems } from "../utils/agendaOrdering.js";
+import { ForbiddenError, NotFoundError } from "../utils/errors.js";
+
+const idsEqual = (a, b) => {
+  if (!a || !b) return false;
+  return a.toString() === b.toString();
+};
 
 class CarryForwardService {
-  async getConfig(seriesId, organizationId = null) {
+  /**
+   * Fail-closed series ownership check (Issue #1666).
+   *
+   * Loads the Meeting Series by `seriesId`, then verifies it belongs to the
+   * authenticated organization. Foreign and missing series both surface as
+   * 404 so existence in another tenant is not leaked.
+   *
+   * Never accepts a client-supplied organization id as a substitute for the
+   * authenticated org passed in by the controller.
+   */
+  async assertSeriesOwnedByOrganization(seriesId, organizationId) {
+    if (!organizationId) {
+      throw new ForbiddenError("Organization membership required");
+    }
+
+    if (!seriesId || !mongoose.Types.ObjectId.isValid(seriesId)) {
+      throw new NotFoundError("Series not found");
+    }
+
+    const series = await MeetingSeries.findById(seriesId);
+    if (!series || !idsEqual(series.organization, organizationId)) {
+      throw new NotFoundError("Series not found");
+    }
+
+    return series;
+  }
+
+  async getConfig(seriesId, organizationId) {
+    await this.assertSeriesOwnedByOrganization(seriesId, organizationId);
+
     let config = await CarryForwardConfig.findOne({ seriesId });
     if (!config) {
       config = new CarryForwardConfig({
@@ -21,21 +58,28 @@ class CarryForwardService {
     return config;
   }
 
-  async updateConfig(seriesId, rules) {
+  async updateConfig(seriesId, rules, organizationId) {
+    await this.assertSeriesOwnedByOrganization(seriesId, organizationId);
+
     const config = await CarryForwardConfig.findOneAndUpdate(
       { seriesId },
-      { $set: { carryForwardRules: rules } },
+      {
+        $set: {
+          carryForwardRules: rules,
+          organization: organizationId,
+        },
+      },
       { new: true, upsert: true },
     );
     return config;
   }
 
-  async getCarryForwardPreview(seriesId) {
-    const config = await this.getConfig(seriesId);
+  async getCarryForwardPreview(seriesId, organizationId) {
+    const config = await this.getConfig(seriesId, organizationId);
 
-    // Find the most recent completed meeting in the series
     const pastMeeting = await Meeting.findOne({
       series: seriesId,
+      organization: organizationId,
       status: "completed",
     }).sort({ seriesOccurrence: -1 });
 
@@ -74,7 +118,7 @@ class CarryForwardService {
       carriedActionItems = openActions.map((action) => ({
         text: `Review Action Item: ${action.text}`,
         description: `Owner: ${action.owner}`,
-        duration: 5, // Default 5 mins for action item review
+        duration: 5,
         status: "pending",
       }));
     }
@@ -96,22 +140,24 @@ class CarryForwardService {
     };
   }
 
-  async applyCarryForward(seriesId, currentMeetingId) {
-    const preview = await this.getCarryForwardPreview(seriesId);
+  async applyCarryForward(seriesId, currentMeetingId, organizationId) {
+    const preview = await this.getCarryForwardPreview(seriesId, organizationId);
 
     if (preview.agendaItems.length === 0 && preview.actionItems.length === 0) {
       return { success: false, message: "No items to carry forward." };
     }
 
-    const currentMeeting = await Meeting.findById(currentMeetingId);
+    const currentMeeting = await Meeting.findOne({
+      _id: currentMeetingId,
+      series: seriesId,
+      organization: organizationId,
+    });
     if (!currentMeeting) {
-      throw new Error("Meeting not found");
+      throw new NotFoundError("Meeting not found");
     }
 
-    // Combine preview items to prepend to current agenda
     const itemsToPrepend = [...preview.agendaItems, ...preview.actionItems];
 
-    // Create new agenda item objects
     const newAgendaItems = itemsToPrepend.map((item) => ({
       text: item.text,
       description: item.description,
@@ -120,7 +166,6 @@ class CarryForwardService {
       actualDuration: 0,
     }));
 
-    // Prepend to existing agenda
     const currentAgenda = currentMeeting.agendaItems || [];
     currentMeeting.agendaItems = normalizeAgendaItems([
       ...newAgendaItems,

--- a/server/tests/carryForward.test.js
+++ b/server/tests/carryForward.test.js
@@ -242,6 +242,31 @@ describe("Carry Forward Feature Tests", () => {
       expect(unchanged.agendaItems).toHaveLength(1);
     });
 
+    it("does not modify a foreign currentMeetingId", async () => {
+      const foreignMeeting = await Meeting.create({
+        title: "Foreign Current Meeting",
+        uploadedBy: user._id,
+        organization: foreignOrgId,
+        date: new Date(),
+        series: foreignSeries._id,
+        seriesOccurrence: 1,
+        status: "uploaded",
+        agendaItems: [{ text: "Do not touch", status: "pending" }],
+      });
+
+      await expect(
+        carryForwardService.applyCarryForward(
+          series._id,
+          foreignMeeting._id,
+          orgId,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundError);
+
+      const unchanged = await Meeting.findById(foreignMeeting._id);
+      expect(unchanged.agendaItems).toHaveLength(1);
+      expect(unchanged.agendaItems[0].text).toBe("Do not touch");
+    });
+
     it("rejects a nonexistent series", async () => {
       const missingId = new mongoose.Types.ObjectId();
       await expect(

--- a/server/tests/carryForward.test.js
+++ b/server/tests/carryForward.test.js
@@ -5,7 +5,7 @@ import Meeting from "../models/meetingModel.js";
 import ActionItem from "../models/actionItemModel.js";
 import CarryForwardConfig from "../models/carryForwardConfigModel.js";
 import User from "../models/userModel.js";
-import jwt from "jsonwebtoken";
+import { NotFoundError } from "../utils/errors.js";
 
 // For this mock app we assume app is properly configured with routes
 // If app is not exported we might need to mock or setup supertest with standard config.
@@ -35,9 +35,13 @@ afterEach(async () => {
 });
 
 describe("Carry Forward Feature Tests", () => {
-  let user, token, series, pastMeeting, currentMeeting;
+  let user, orgId, foreignOrgId, series, pastMeeting, currentMeeting;
+  let carryForwardService;
 
   beforeEach(async () => {
+    orgId = new mongoose.Types.ObjectId();
+    foreignOrgId = new mongoose.Types.ObjectId();
+
     user = await User.create({
       name: "Test User",
       firstName: "Test",
@@ -46,13 +50,13 @@ describe("Carry Forward Feature Tests", () => {
       clerkId: "test_clerk_id",
       status: "active",
       password: "password123",
+      organization: orgId,
     });
-
-    token = jwt.sign({ id: user._id }, process.env.JWT_SECRET || "test-secret");
 
     series = await MeetingSeries.create({
       title: "Weekly Sync",
       createdBy: user._id,
+      organization: orgId,
       recurrencePattern: "weekly",
       startDate: new Date(),
       endDate: new Date(Date.now() + 100000000),
@@ -62,6 +66,7 @@ describe("Carry Forward Feature Tests", () => {
     pastMeeting = await Meeting.create({
       title: "Past Meeting",
       uploadedBy: user._id,
+      organization: orgId,
       date: new Date(Date.now() - 86400000), // 1 day ago
       series: series._id,
       seriesOccurrence: 1,
@@ -91,42 +96,44 @@ describe("Carry Forward Feature Tests", () => {
     currentMeeting = await Meeting.create({
       title: "Current Meeting",
       uploadedBy: user._id,
+      organization: orgId,
       date: new Date(),
       series: series._id,
       seriesOccurrence: 2,
       status: "uploaded",
       agendaItems: [{ text: "New Item", status: "pending" }],
     });
+
+    ({ default: carryForwardService } =
+      await import("../services/carryForwardService.js"));
   });
 
   describe("Service logic", () => {
-    // we'll require the service directly to test its methods
     it("should fetch initial config and default maxCarriedItems to 10", async () => {
-      const { default: carryForwardService } =
-        await import("../services/carryForwardService.js");
-      const config = await carryForwardService.getConfig(series._id);
+      const config = await carryForwardService.getConfig(series._id, orgId);
       expect(config.carryForwardRules.maxCarriedItems).toBe(10);
       expect(config.carryForwardRules.includeUnfinishedAgenda).toBe(true);
       expect(config.carryForwardRules.includeOpenActionItems).toBe(true);
     });
 
     it("should update config", async () => {
-      const { default: carryForwardService } =
-        await import("../services/carryForwardService.js");
-      const updated = await carryForwardService.updateConfig(series._id, {
-        includeUnfinishedAgenda: false,
-        includeOpenActionItems: true,
-        maxCarriedItems: 5,
-      });
+      const updated = await carryForwardService.updateConfig(
+        series._id,
+        {
+          includeUnfinishedAgenda: false,
+          includeOpenActionItems: true,
+          maxCarriedItems: 5,
+        },
+        orgId,
+      );
       expect(updated.carryForwardRules.includeUnfinishedAgenda).toBe(false);
       expect(updated.carryForwardRules.maxCarriedItems).toBe(5);
     });
 
     it("should generate correct preview (unfinished agenda & open actions)", async () => {
-      const { default: carryForwardService } =
-        await import("../services/carryForwardService.js");
       const preview = await carryForwardService.getCarryForwardPreview(
         series._id,
+        orgId,
       );
 
       expect(preview.pastMeetingId.toString()).toBe(pastMeeting._id.toString());
@@ -138,26 +145,28 @@ describe("Carry Forward Feature Tests", () => {
     });
 
     it("should limit carried items based on maxCarriedItems", async () => {
-      const { default: carryForwardService } =
-        await import("../services/carryForwardService.js");
-      await carryForwardService.updateConfig(series._id, {
-        includeUnfinishedAgenda: true,
-        includeOpenActionItems: true,
-        maxCarriedItems: 2,
-      });
+      await carryForwardService.updateConfig(
+        series._id,
+        {
+          includeUnfinishedAgenda: true,
+          includeOpenActionItems: true,
+          maxCarriedItems: 2,
+        },
+        orgId,
+      );
 
       const preview = await carryForwardService.getCarryForwardPreview(
         series._id,
+        orgId,
       );
       expect(preview.agendaItems.length + preview.actionItems.length).toBe(2);
     });
 
     it("should prepend carried items to current meeting agenda", async () => {
-      const { default: carryForwardService } =
-        await import("../services/carryForwardService.js");
       const result = await carryForwardService.applyCarryForward(
         series._id,
         currentMeeting._id,
+        orgId,
       );
       expect(result.success).toBe(true);
 
@@ -170,6 +179,83 @@ describe("Carry Forward Feature Tests", () => {
       expect(
         updatedMeeting.agendaItems.some((i) => i.text === "New Item"),
       ).toBe(true);
+    });
+  });
+
+  describe("Series ownership (Issue #1666)", () => {
+    let foreignSeries;
+
+    beforeEach(async () => {
+      foreignSeries = await MeetingSeries.create({
+        title: "Foreign Series",
+        createdBy: user._id,
+        organization: foreignOrgId,
+        recurrencePattern: "weekly",
+        startDate: new Date(),
+        endDate: new Date(Date.now() + 100000000),
+        time: "10:00",
+      });
+    });
+
+    it("allows config retrieval for a series in the authenticated organization", async () => {
+      const config = await carryForwardService.getConfig(series._id, orgId);
+      expect(config.seriesId.toString()).toBe(series._id.toString());
+      expect(config.organization.toString()).toBe(orgId.toString());
+    });
+
+    it("rejects config retrieval for a foreign series", async () => {
+      await expect(
+        carryForwardService.getConfig(foreignSeries._id, orgId),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it("rejects config update for a foreign series", async () => {
+      await expect(
+        carryForwardService.updateConfig(
+          foreignSeries._id,
+          { maxCarriedItems: 1 },
+          orgId,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundError);
+
+      expect(
+        await CarryForwardConfig.findOne({ seriesId: foreignSeries._id }),
+      ).toBeNull();
+    });
+
+    it("rejects preview for a foreign series", async () => {
+      await expect(
+        carryForwardService.getCarryForwardPreview(foreignSeries._id, orgId),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it("rejects apply for a foreign series", async () => {
+      await expect(
+        carryForwardService.applyCarryForward(
+          foreignSeries._id,
+          currentMeeting._id,
+          orgId,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundError);
+
+      const unchanged = await Meeting.findById(currentMeeting._id);
+      expect(unchanged.agendaItems).toHaveLength(1);
+    });
+
+    it("rejects a nonexistent series", async () => {
+      const missingId = new mongoose.Types.ObjectId();
+      await expect(
+        carryForwardService.getConfig(missingId, orgId),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it("ignores a client-supplied foreign organization id as a bypass", async () => {
+      // The service only trusts the organizationId argument supplied by the
+      // controller from req.user — passing the foreign org does not grant
+      // access to this org's series.
+      await expect(
+        carryForwardService.getConfig(series._id, foreignOrgId),
+      ).rejects.toBeInstanceOf(NotFoundError);
     });
   });
 });

--- a/server/tests/carryForwardAuthorization.test.js
+++ b/server/tests/carryForwardAuthorization.test.js
@@ -1,0 +1,231 @@
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: carryForwardRoutes } =
+  await import("../routes/carryForwardRoutes.js");
+const { default: MeetingSeries } =
+  await import("../models/meetingSeriesModel.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+const { default: CarryForwardConfig } =
+  await import("../models/carryForwardConfigModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const USER_A = new mongoose.Types.ObjectId();
+
+const aliceMember = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: "member",
+};
+
+const aliceGuest = {
+  _id: USER_A,
+  organization: ORG_A,
+  role: "guest",
+};
+
+const noOrgUser = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "member",
+};
+
+let app;
+
+const seedSeries = async ({
+  organization = ORG_A,
+  title = "Weekly Sync",
+  createdBy = USER_A,
+} = {}) => {
+  return MeetingSeries.create({
+    title,
+    organization,
+    createdBy,
+    recurrencePattern: "weekly",
+    startDate: new Date(),
+    endDate: new Date(Date.now() + 100000000),
+    time: "10:00",
+  });
+};
+
+const seedMeeting = async ({
+  series,
+  organization = ORG_A,
+  uploadedBy = USER_A,
+  status = "uploaded",
+  seriesOccurrence = 1,
+} = {}) => {
+  return Meeting.create({
+    title: "Carry Forward Meeting",
+    uploadedBy,
+    organization,
+    date: new Date(),
+    series: series._id,
+    seriesOccurrence,
+    status,
+    agendaItems: [{ text: "Existing item", status: "pending" }],
+  });
+};
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(process.env.TEST_MONGODB_URI);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/meeting-series", carryForwardRoutes);
+});
+
+beforeEach(() => {
+  currentUser = aliceMember;
+});
+
+afterEach(async () => {
+  await MeetingSeries.deleteMany({});
+  await Meeting.deleteMany({});
+  await CarryForwardConfig.deleteMany({});
+});
+
+describe("Carry-forward series ownership (#1666)", () => {
+  describe("RBAC guards", () => {
+    it("returns 401 when unauthenticated", async () => {
+      currentUser = null;
+      const series = await seedSeries();
+      const res = await request(app).get(
+        `/api/meeting-series/${series._id}/carry-forward/config`,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when the user has no organization", async () => {
+      currentUser = noOrgUser;
+      const series = await seedSeries();
+      const res = await request(app).get(
+        `/api/meeting-series/${series._id}/carry-forward/config`,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when a guest tries to update config", async () => {
+      currentUser = aliceGuest;
+      const series = await seedSeries();
+      const res = await request(app)
+        .put(`/api/meeting-series/${series._id}/carry-forward/config`)
+        .send({ carryForwardRules: { maxCarriedItems: 3 } });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when a guest tries to apply carry-forward", async () => {
+      currentUser = aliceGuest;
+      const series = await seedSeries();
+      const res = await request(app)
+        .post(`/api/meeting-series/${series._id}/carry-forward/apply`)
+        .send({ currentMeetingId: new mongoose.Types.ObjectId() });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("Same-organization access", () => {
+    it("allows a member to read config for their series", async () => {
+      const series = await seedSeries({ organization: ORG_A });
+      const res = await request(app).get(
+        `/api/meeting-series/${series._id}/carry-forward/config`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.config.seriesId.toString()).toBe(series._id.toString());
+    });
+  });
+
+  describe("Foreign series rejection", () => {
+    it("rejects configuration GET for a foreign series", async () => {
+      const foreign = await seedSeries({
+        organization: ORG_B,
+        title: "Other Org Series",
+      });
+      const res = await request(app).get(
+        `/api/meeting-series/${foreign._id}/carry-forward/config`,
+      );
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    it("rejects configuration PUT for a foreign series", async () => {
+      const foreign = await seedSeries({ organization: ORG_B });
+      const res = await request(app)
+        .put(`/api/meeting-series/${foreign._id}/carry-forward/config`)
+        .send({
+          carryForwardRules: { maxCarriedItems: 1 },
+          organizationId: ORG_B,
+        });
+      expect(res.status).toBe(404);
+      expect(
+        await CarryForwardConfig.findOne({ seriesId: foreign._id }),
+      ).toBeNull();
+    });
+
+    it("rejects preview for a foreign series", async () => {
+      const foreign = await seedSeries({ organization: ORG_B });
+      const res = await request(app).get(
+        `/api/meeting-series/${foreign._id}/carry-forward/preview`,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects apply for a foreign series", async () => {
+      const foreign = await seedSeries({ organization: ORG_B });
+      const meeting = await seedMeeting({
+        series: foreign,
+        organization: ORG_B,
+      });
+      const res = await request(app)
+        .post(`/api/meeting-series/${foreign._id}/carry-forward/apply`)
+        .send({ currentMeetingId: meeting._id });
+      expect(res.status).toBe(404);
+
+      const unchanged = await Meeting.findById(meeting._id);
+      expect(unchanged.agendaItems).toHaveLength(1);
+    });
+  });
+
+  describe("Nonexistent series", () => {
+    it("rejects config for a series that does not exist", async () => {
+      const res = await request(app).get(
+        `/api/meeting-series/${new mongoose.Types.ObjectId()}/carry-forward/config`,
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("Client-supplied organizationId cannot bypass ownership", () => {
+    it("does not grant access when body.organizationId matches the foreign series", async () => {
+      currentUser = aliceMember;
+      const foreign = await seedSeries({ organization: ORG_B });
+      const res = await request(app)
+        .put(`/api/meeting-series/${foreign._id}/carry-forward/config`)
+        .send({
+          organizationId: ORG_B.toString(),
+          carryForwardRules: { includeUnfinishedAgenda: false },
+        });
+
+      expect(res.status).toBe(404);
+      expect(res.body.config).toBeUndefined();
+    });
+  });
+});

--- a/server/tests/carryForwardAuthorization.test.js
+++ b/server/tests/carryForwardAuthorization.test.js
@@ -202,6 +202,34 @@ describe("Carry-forward series ownership (#1666)", () => {
       const unchanged = await Meeting.findById(meeting._id);
       expect(unchanged.agendaItems).toHaveLength(1);
     });
+
+    it("rejects apply when currentMeetingId belongs to a foreign organization", async () => {
+      const ownSeries = await seedSeries({ organization: ORG_A });
+      await seedMeeting({
+        series: ownSeries,
+        organization: ORG_A,
+        status: "completed",
+        seriesOccurrence: 1,
+      });
+      const foreignSeries = await seedSeries({
+        organization: ORG_B,
+        title: "Foreign Target Series",
+      });
+      const foreignMeeting = await seedMeeting({
+        series: foreignSeries,
+        organization: ORG_B,
+        seriesOccurrence: 2,
+      });
+
+      const res = await request(app)
+        .post(`/api/meeting-series/${ownSeries._id}/carry-forward/apply`)
+        .send({ currentMeetingId: foreignMeeting._id });
+
+      expect(res.status).toBe(404);
+      const unchanged = await Meeting.findById(foreignMeeting._id);
+      expect(unchanged.agendaItems).toHaveLength(1);
+      expect(unchanged.agendaItems[0].text).toBe("Existing item");
+    });
   });
 
   describe("Nonexistent series", () => {


### PR DESCRIPTION
## Summary


Fixes #1666


Enforces Meeting Series ownership across carry-forward configuration, preview, and apply operations to prevent cross-organization access and modification.


## Changes


- Resolve organization exclusively from `req.user.organization`.
- Validate Meeting Series ownership before carry-forward operations.
- Apply ownership checks consistently to:
  - Configuration GET/PUT
  - Preview
  - Apply
- Ignore client-supplied `organizationId` for authorization.
- Return `404` for both missing and foreign series.
- Verify the target meeting belongs to the authorized series and organization before applying changes.
- Preserve existing authentication, organization membership, and RBAC checks.


## Security Impact


Prevents cross-tenant IDOR through arbitrary `seriesId` or `currentMeetingId` values.


Foreign users cannot:


- Read another organization's carry-forward configuration.
- Update foreign configuration.
- Generate previews for foreign series.
- Apply carry-forward operations to foreign series.
- Modify meetings belonging to another organization.


## Tests


Added coverage for:


- Same-organization series access.
- Foreign series configuration GET/PUT.
- Foreign series preview.
- Foreign series apply.
- Nonexistent series.
- Client-supplied `organizationId` spoofing.
- Foreign `currentMeetingId` protection.
- Unauthenticated requests.
- Missing organization membership.
- Guest RBAC restrictions.


## Files Changed


- `server/controllers/carryForwardController.js`
- `server/tests/carryForward.test.js`
- `server/tests/carryForwardAuthorization.test.js`


## Verification


```bash
npx vitest run server/tests/carryForward.test.js server/tests/carryForwardAuthorization.test.js
```
## Security Considerations

- Organization scope is derived only from the authenticated user.
- Series ownership is verified before access or modification.
- Missing and foreign series return the same 404 response to avoid tenant enumeration.
- Apply operations validate both series and target meeting ownership.
- Existing RBAC and permission checks remain unchanged.