### PR TITLE
fix: remove hardcoded calendar encryption key

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -41,6 +41,8 @@ MS_CLIENT_ID=
 MS_CLIENT_SECRET=
 MS_TENANT_ID=common
 MS_REDIRECT_URI=http://localhost:4000/api/calendar/outlook/callback
+# Required to encrypt Google/Microsoft OAuth tokens. No default — the process
+# fails closed if this (or CALENDAR_ENCRYPTION_KEY) is unset.
 CALENDAR_ENCRYPTION_KEY=
 TOKEN_ENCRYPTION_KEY=
 

--- a/server/services/calendarService.js
+++ b/server/services/calendarService.js
@@ -5,23 +5,22 @@ import { ClientSecretCredential } from "@azure/identity"; // eslint-disable-line
 import { Client } from "@microsoft/microsoft-graph-client";
 import CalendarConnection from "../models/calendarConnectionModel.js";
 
-// Encryption key from environment
-const ENCRYPTION_KEY =
-  process.env.CALENDAR_ENCRYPTION_KEY || process.env.TOKEN_ENCRYPTION_KEY;
-
-if (!ENCRYPTION_KEY) {
-  console.warn(
-    "Calendar encryption key is not configured. Set CALENDAR_ENCRYPTION_KEY or TOKEN_ENCRYPTION_KEY to enable calendar token encryption.",
-  );
-}
+// Encryption key from environment — resolved at use time so a missing or
+// empty value cannot be cached as a silent default (Issue #1768).
+const getCalendarEncryptionKey = () => {
+  const key =
+    process.env.CALENDAR_ENCRYPTION_KEY || process.env.TOKEN_ENCRYPTION_KEY;
+  if (typeof key !== "string" || !key.trim()) {
+    throw new Error("Calendar encryption key is not configured");
+  }
+  return key;
+};
 
 /**
  * Encrypt a token for storage
  */
 export const encryptToken = (token) => {
-  if (!ENCRYPTION_KEY) {
-    throw new Error("Calendar encryption key is not configured");
-  }
+  const ENCRYPTION_KEY = getCalendarEncryptionKey();
 
   return CryptoJS.AES.encrypt(token, ENCRYPTION_KEY).toString();
 };
@@ -40,9 +39,7 @@ export const getGoogleOAuthClient = () => {
 export const decryptToken = (encryptedToken) => {
   if (!encryptedToken) return null;
 
-  if (!ENCRYPTION_KEY) {
-    throw new Error("Calendar encryption key is not configured");
-  }
+  const ENCRYPTION_KEY = getCalendarEncryptionKey();
 
   try {
     const bytes = CryptoJS.AES.decrypt(encryptedToken, ENCRYPTION_KEY);

--- a/server/services/calendarSyncService.js
+++ b/server/services/calendarSyncService.js
@@ -9,17 +9,31 @@ import {
   getGoogleOAuthClient,
 } from "./calendarService.js";
 
-// Encryption setup (kept for backwards compatibility of exported helpers, but internal code uses calendarService crypt)
 const ALGORITHM = "aes-256-gcm";
-const ENCRYPTION_KEY =
-  process.env.TOKEN_ENCRYPTION_KEY || "12345678901234567890123456789012";
+
+/**
+ * Resolve the calendar-sync encryption key (Issue #1768).
+ *
+ * There is no hardcoded fallback. Missing or empty TOKEN_ENCRYPTION_KEY
+ * fails closed so Google/Microsoft OAuth tokens cannot be encrypted with
+ * a well-known default.
+ *
+ * @returns {string}
+ */
+export const getTokenEncryptionKey = () => {
+  const key = process.env.TOKEN_ENCRYPTION_KEY;
+  if (typeof key !== "string" || !key.trim()) {
+    throw new Error("TOKEN_ENCRYPTION_KEY is not configured");
+  }
+  return key;
+};
 
 const encrypt = (text) => {
   if (!text) return text;
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv(
     ALGORITHM,
-    Buffer.from(ENCRYPTION_KEY),
+    Buffer.from(getTokenEncryptionKey()),
     iv,
   );
   let encrypted = cipher.update(text, "utf8", "hex");
@@ -35,7 +49,7 @@ const decrypt = (encryptedData) => {
   const [ivHex, encryptedText, authTagHex] = parts;
   const decipher = crypto.createDecipheriv(
     ALGORITHM,
-    Buffer.from(ENCRYPTION_KEY),
+    Buffer.from(getTokenEncryptionKey()),
     Buffer.from(ivHex, "hex"),
   );
   decipher.setAuthTag(Buffer.from(authTagHex, "hex"));

--- a/server/tests/calendarEncryptionKey.test.js
+++ b/server/tests/calendarEncryptionKey.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  encrypt,
+  decrypt,
+  getTokenEncryptionKey,
+} from "../services/calendarSyncService.js";
+import { encryptToken, decryptToken } from "../services/calendarService.js";
+
+const CONFIGURED_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HARDCODED_FALLBACK = "12345678901234567890123456789012";
+
+describe("Calendar encryption key (#1768)", () => {
+  const originalTokenKey = process.env.TOKEN_ENCRYPTION_KEY;
+  const originalCalendarKey = process.env.CALENDAR_ENCRYPTION_KEY;
+
+  const restoreEnv = () => {
+    if (originalTokenKey === undefined) {
+      delete process.env.TOKEN_ENCRYPTION_KEY;
+    } else {
+      process.env.TOKEN_ENCRYPTION_KEY = originalTokenKey;
+    }
+    if (originalCalendarKey === undefined) {
+      delete process.env.CALENDAR_ENCRYPTION_KEY;
+    } else {
+      process.env.CALENDAR_ENCRYPTION_KEY = originalCalendarKey;
+    }
+  };
+
+  beforeEach(() => {
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+    delete process.env.CALENDAR_ENCRYPTION_KEY;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  describe("calendarSyncService", () => {
+    it("fails closed when TOKEN_ENCRYPTION_KEY is missing", () => {
+      expect(() => getTokenEncryptionKey()).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+      expect(() => encrypt("google-oauth-token")).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+    });
+
+    it("fails closed when TOKEN_ENCRYPTION_KEY is empty or whitespace", () => {
+      process.env.TOKEN_ENCRYPTION_KEY = "";
+      expect(() => getTokenEncryptionKey()).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+
+      process.env.TOKEN_ENCRYPTION_KEY = "   ";
+      expect(() => getTokenEncryptionKey()).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+    });
+
+    it("does not fall back to the previous hardcoded secret", () => {
+      expect(() => encrypt("microsoft-oauth-token")).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+      expect(() => decrypt("iv:cipher:tag")).toThrowError(
+        "TOKEN_ENCRYPTION_KEY is not configured",
+      );
+    });
+
+    it("encrypts and decrypts when TOKEN_ENCRYPTION_KEY is configured", () => {
+      process.env.TOKEN_ENCRYPTION_KEY = CONFIGURED_KEY;
+      const plaintext = "ya29.google_access_token_example";
+
+      const encrypted = encrypt(plaintext);
+      expect(encrypted).not.toBe(plaintext);
+      expect(encrypted).not.toContain(plaintext);
+      expect(decrypt(encrypted)).toBe(plaintext);
+    });
+
+    it("uses the configured key, not the retired hardcoded fallback", () => {
+      process.env.TOKEN_ENCRYPTION_KEY = CONFIGURED_KEY;
+      const encrypted = encrypt("outlook_refresh_token");
+
+      process.env.TOKEN_ENCRYPTION_KEY = HARDCODED_FALLBACK;
+      expect(() => decrypt(encrypted)).toThrow();
+    });
+  });
+
+  describe("calendarService token helpers (Google / Microsoft)", () => {
+    it("fails closed when neither calendar encryption key is configured", () => {
+      expect(() => encryptToken("google_token")).toThrowError(
+        "Calendar encryption key is not configured",
+      );
+      expect(() => decryptToken("ciphertext")).toThrowError(
+        "Calendar encryption key is not configured",
+      );
+    });
+
+    it("round-trips Google tokens when TOKEN_ENCRYPTION_KEY is set", () => {
+      process.env.TOKEN_ENCRYPTION_KEY = CONFIGURED_KEY;
+      const googleToken = "ya29.a0AfH6SMD_google_access_token";
+      const encrypted = encryptToken(googleToken);
+      expect(encrypted).not.toBe(googleToken);
+      expect(decryptToken(encrypted)).toBe(googleToken);
+    });
+
+    it("round-trips Microsoft Outlook tokens when CALENDAR_ENCRYPTION_KEY is set", () => {
+      process.env.CALENDAR_ENCRYPTION_KEY = CONFIGURED_KEY;
+      const msToken = "EwBwA8l6BAAU-outlook_access_token";
+      const encrypted = encryptToken(msToken);
+      expect(encrypted).not.toBe(msToken);
+      expect(decryptToken(encrypted)).toBe(msToken);
+    });
+
+    it("returns null for missing ciphertext without throwing", () => {
+      process.env.TOKEN_ENCRYPTION_KEY = CONFIGURED_KEY;
+      expect(decryptToken(null)).toBeNull();
+      expect(decryptToken(undefined)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1768.

Removes the hardcoded encryption-key fallback from the calendar synchronization flow and makes Google Calendar and Microsoft Outlook token encryption fail closed when no encryption key is configured.

Previously, the application could silently encrypt OAuth tokens using a publicly known hardcoded key when `TOKEN_ENCRYPTION_KEY` was missing.

## What Changed

### 🔐 Removed Hardcoded Encryption Key

Removed the insecure fallback:

```js
process.env.TOKEN_ENCRYPTION_KEY || "12345678901234567890123456789012"
```

Calendar encryption now requires a configured encryption key.

Missing, empty, or whitespace-only encryption keys result in a clear configuration error instead of silently using an insecure default.

### 🔑 Calendar Token Encryption

Updated:

* `server/services/calendarSyncService.js`
* `server/services/calendarService.js`

The encryption key is resolved at use time so that:

* Google Calendar token encryption remains protected.
* Microsoft Outlook token encryption remains protected.
* Missing configuration fails closed.
* No secret is logged or exposed.

Existing configured-key encryption/decryption behavior is preserved.

### ⚙️ Environment Configuration

Updated:

* `server/.env.example`

Documented that the calendar OAuth token encryption key is required and that the application fails closed when it is not configured.

No real or production secret was added.

### 🧪 Tests

Added:

`server/tests/calendarEncryptionKey.test.js`

Coverage includes:

* Missing encryption key
* Empty encryption key
* Whitespace-only encryption key
* No fallback to the retired hardcoded key
* Encryption/decryption round-trip with a configured key
* Configured-key protection against the retired fallback
* Google Calendar token encryption/decryption
* Microsoft Outlook token encryption/decryption
* Failure when no calendar encryption key is configured

## Security Impact

Before this fix, an attacker with database access could potentially decrypt stored calendar OAuth tokens because the application used a publicly known fallback encryption key.

After this fix:

* No hardcoded encryption secret is used.
* Missing encryption configuration fails closed.
* OAuth tokens continue to be encrypted with the configured secret.
* Encryption keys and OAuth tokens are never logged.

## Files Changed

* `server/services/calendarSyncService.js`
* `server/services/calendarService.js`
* `server/.env.example`
* `server/tests/calendarEncryptionKey.test.js`

## Verification

The following checks were run manually:

```bash
npx vitest run server/tests/calendarEncryptionKey.test.js server/tests/calendar.test.js server/tests/calendarConnectionSync.test.js
```

All relevant calendar encryption and token-flow tests should pass before merging.

## Related Issue

Closes #1768
