### PR TITLE
fix: send Gemini API key via header

### DIFF
--- a/server/routes/geminiRoutes.js
+++ b/server/routes/geminiRoutes.js
@@ -52,9 +52,14 @@ Use formal, data-driven tone.
 `;
 
       const response = await axios.post(
-        `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent?key=${process.env.GEMINI_API_KEY}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/${process.env.GEMINI_MODEL}:generateContent`,
         {
           contents: [{ parts: [{ text: prompt }] }],
+        },
+        {
+          headers: {
+            "x-goog-api-key": process.env.GEMINI_API_KEY,
+          },
         },
       );
 

--- a/server/services/PolicyService.js
+++ b/server/services/PolicyService.js
@@ -135,9 +135,14 @@ Return ONLY valid JSON (no commentary, no markdown fences). Use a professional, 
 `;
 
     const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`,
       { contents: [{ parts: [{ text: prompt }] }] },
-      { timeout: 30000 },
+      {
+        timeout: 30000,
+        headers: {
+          "x-goog-api-key": GEMINI_API_KEY,
+        },
+      },
     );
 
     const rawText =

--- a/server/services/policyComplianceService.js
+++ b/server/services/policyComplianceService.js
@@ -138,9 +138,14 @@ async function callGeminiClassifier(prompt) {
   // co-loaded with other large deps; Gemini calls only need it at runtime.
   const { default: axios } = await import("axios");
   const response = await axios.post(
-    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${GEMINI_API_KEY}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`,
     { contents: [{ parts: [{ text: prompt }] }] },
-    { timeout: 20000 },
+    {
+      timeout: 20000,
+      headers: {
+        "x-goog-api-key": GEMINI_API_KEY,
+      },
+    },
   );
 
   return response.data?.candidates?.[0]?.content?.parts?.[0]?.text || "{}";

--- a/server/services/speechService.js
+++ b/server/services/speechService.js
@@ -78,7 +78,7 @@ export const transcribeWithGemini = async (audioUrl) => {
     const mimeType = audioRes.headers["content-type"] || "audio/mpeg";
 
     const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`,
       {
         contents: [
           {
@@ -99,6 +99,7 @@ export const transcribeWithGemini = async (audioUrl) => {
       {
         headers: {
           "Content-Type": "application/json",
+          "x-goog-api-key": GEMINI_API_KEY,
         },
       },
     );

--- a/server/services/workspaceSyncService.js
+++ b/server/services/workspaceSyncService.js
@@ -7,7 +7,7 @@ class WorkspaceSyncService {
   constructor() {
     this.geminiApiKey = process.env.GEMINI_API_KEY;
     this.geminiModel = process.env.GEMINI_MODEL || "gemini-1.5-flash";
-    this.geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${this.geminiModel}:generateContent?key=${this.geminiApiKey}`;
+    this.geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${this.geminiModel}:generateContent`;
   }
 
   /**
@@ -180,7 +180,12 @@ class WorkspaceSyncService {
             responseMimeType: "application/json",
           },
         },
-        { timeout: 10000 },
+        {
+          timeout: 10000,
+          headers: {
+            "x-goog-api-key": this.geminiApiKey,
+          },
+        },
       );
 
       const rawText = response.data.candidates?.[0]?.content?.parts?.[0]?.text;

--- a/server/tests/gemini.test.js
+++ b/server/tests/gemini.test.js
@@ -179,6 +179,9 @@ describe("Gemini AI Endpoint Authentication and Authorization", () => {
     });
 
     it("should allow authenticated member with view reports permission to generate insights", async () => {
+      process.env.GEMINI_API_KEY = "test-gemini-secret-key";
+      process.env.GEMINI_MODEL = process.env.GEMINI_MODEL || "gemini-1.5-flash";
+
       const res = await request(app)
         .post("/api/gemini/insights")
         .set(authHeader(userToken))
@@ -189,6 +192,17 @@ describe("Gemini AI Endpoint Authentication and Authorization", () => {
       expect(res.body.insight).toBe(
         "This is a mocked professional analytics summary highlighting trends and insights.",
       );
+
+      expect(axiosSpy).toHaveBeenCalledTimes(1);
+      const [url, payload, config] = axiosSpy.mock.calls[0];
+      expect(url).toContain(
+        "https://generativelanguage.googleapis.com/v1beta/models/",
+      );
+      expect(url).toContain(":generateContent");
+      expect(url).not.toContain("key=");
+      expect(url).not.toContain("test-gemini-secret-key");
+      expect(config.headers["x-goog-api-key"]).toBe("test-gemini-secret-key");
+      expect(payload.contents[0].parts[0].text).toContain("totalMeetings");
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #1769.

Prevents the Gemini API key from being exposed through outbound request URLs by sending it through the recommended `x-goog-api-key` HTTP header instead.

Previously, `GEMINI_API_KEY` was included as a `?key=` query parameter, which could expose the secret through proxy logs, access logs, monitoring systems, and other URL-capturing infrastructure.

## What Changed

### 🔐 Gemini API Key Security

Updated Gemini `generateContent` requests to send:

```http
x-goog-api-key: <GEMINI_API_KEY>
```

instead of:

```text
?key=<GEMINI_API_KEY>
```

The API key is therefore no longer included in the request URL.

### 🔎 Other Gemini Callers

The same URL-based API-key pattern was found in additional `generateContent` callers and was updated consistently:

* `server/routes/geminiRoutes.js`
* `server/services/speechService.js`
* `server/services/PolicyService.js`
* `server/services/policyComplianceService.js`
* `server/services/workspaceSyncService.js`

### 🧪 Tests

Updated:

`server/tests/gemini.test.js`

The test verifies that:

* `x-goog-api-key` is present.
* The request URL does not contain `key=`.
* The Gemini API key is not exposed in the URL.
* Existing Gemini response behavior remains unchanged.

## Preserved Behavior

No changes were made to:

* Gemini endpoint/model configuration
* Request payloads
* Response handling
* Existing error handling
* Gemini insight functionality

SDK-based Gemini usage through `GoogleGenerativeAI` was already using constructor-based authentication and did not require changes.

Google Translate API key handling was also left unchanged because it is a separate API integration.

## Security Impact

This prevents the Gemini API key from being exposed through URL-based logging and infrastructure that records outbound request URLs.

The secret is now transmitted through the `x-goog-api-key` request header.

## Files Changed

* `server/routes/geminiRoutes.js`
* `server/services/speechService.js`
* `server/services/PolicyService.js`
* `server/services/policyComplianceService.js`
* `server/services/workspaceSyncService.js`
* `server/tests/gemini.test.js`

## Related Issue

Closes #1769
