### PR TITLE
fix(followup): wire follow-up dashboard, threads component, and API routes (#1875)

### DIFF
--- a/client/src/components/meeting-details/FollowUpThreads.jsx
+++ b/client/src/components/meeting-details/FollowUpThreads.jsx
@@ -13,7 +13,7 @@ import { toast } from "react-toastify";
 import { createClerkSocketOptions } from "../../services/apiClient.js";
 
 const FollowUpThreads = ({ meetingId }) => {
-  const { userData, backendUrl } = useContext(AppContent);
+  const { userData, backendUrl } = useContext(AppContent) || {};
   const [threads, setThreads] = useState([]);
   const [activeTab, setActiveTab] = useState("all"); // 'all', 'decision', 'action_item', 'agenda_item'
   const [newThreadContent, setNewThreadContent] = useState("");
@@ -26,10 +26,12 @@ const FollowUpThreads = ({ meetingId }) => {
   const socketRef = useRef(null);
 
   useEffect(() => {
+    if (!meetingId) return;
+
     const fetchThreads = async () => {
       try {
         const data = await getFollowUpThreads(meetingId);
-        if (data.success) {
+        if (data?.success) {
           setThreads(data.threads || []);
         }
       } catch (error) {
@@ -38,57 +40,63 @@ const FollowUpThreads = ({ meetingId }) => {
     };
     fetchThreads();
 
+    if (!backendUrl) return;
+
     let cancelled = false;
 
     (async () => {
-      const opts = await createClerkSocketOptions({
-        transports: ["websocket"],
-      });
-      if (cancelled) return;
-
-      socketRef.current = io(backendUrl, opts);
-
-      socketRef.current.on("connect", () => {
-        socketRef.current.emit("join-meeting", {
-          roomId: meetingId,
-          userInfo: { name: userData?.name },
+      try {
+        const opts = await createClerkSocketOptions({
+          transports: ["websocket"],
         });
-      });
+        if (cancelled) return;
 
-      socketRef.current.on("thread:created", ({ thread, reply }) => {
-        setThreads((prev) => {
-          const exists = prev.find((t) => t._id === thread._id);
-          if (exists) return prev;
-          return [...prev, { ...thread, replies: [reply] }];
+        socketRef.current = io(backendUrl, opts);
+
+        socketRef.current.on("connect", () => {
+          socketRef.current.emit("join-meeting", {
+            roomId: meetingId,
+            userInfo: { name: userData?.name },
+          });
         });
-      });
 
-      socketRef.current.on("thread:reply", ({ reply }) => {
-        setThreads((prev) =>
-          prev.map((t) => {
-            if (t._id === reply.threadId) {
-              // Check if reply already exists
-              const replyExists = t.replies.find((r) => r._id === reply._id);
-              if (replyExists) {
-                return {
-                  ...t,
-                  replies: t.replies.map((r) =>
-                    r._id === reply._id ? reply : r,
-                  ),
-                };
+        socketRef.current.on("thread:created", ({ thread, reply }) => {
+          setThreads((prev) => {
+            const exists = prev.find((t) => t._id === thread._id);
+            if (exists) return prev;
+            return [...prev, { ...thread, replies: reply ? [reply] : [] }];
+          });
+        });
+
+        socketRef.current.on("thread:reply", ({ reply }) => {
+          setThreads((prev) =>
+            prev.map((t) => {
+              if (t._id === reply.threadId) {
+                // Check if reply already exists
+                const replyExists = t.replies.find((r) => r._id === reply._id);
+                if (replyExists) {
+                  return {
+                    ...t,
+                    replies: t.replies.map((r) =>
+                      r._id === reply._id ? reply : r,
+                    ),
+                  };
+                }
+                return { ...t, replies: [...t.replies, reply] };
               }
-              return { ...t, replies: [...t.replies, reply] };
-            }
-            return t;
-          }),
-        );
-      });
+              return t;
+            }),
+          );
+        });
 
-      socketRef.current.on("thread:resolved", ({ thread }) => {
-        setThreads((prev) =>
-          prev.map((t) => (t._id === thread._id ? { ...t, ...thread } : t)),
-        );
-      });
+        socketRef.current.on("thread:resolved", ({ thread }) => {
+          setThreads((prev) =>
+            prev.map((t) => (t._id === thread._id ? { ...t, ...thread } : t)),
+          );
+        });
+      } catch (err) {
+        console.warn("Could not connect to thread socket", err);
+      }
     })();
 
     return () => {
@@ -188,7 +196,9 @@ const FollowUpThreads = ({ meetingId }) => {
   const filteredThreads =
     activeTab === "all"
       ? threads
-      : threads.filter((t) => t.anchorType === activeTab);
+      : threads.filter(
+          (t) => t.anchorType === activeTab || t.type === activeTab,
+        );
 
   return (
     <div className="mt-8 bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
@@ -259,7 +269,10 @@ const FollowUpThreads = ({ meetingId }) => {
             <div className="flex justify-between items-start mb-3">
               <div className="flex items-center gap-2">
                 <span className="px-2 py-1 text-xs font-semibold uppercase bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded">
-                  {thread.anchorType.replace("_", " ")}
+                  {(thread.anchorType || thread.type || "general").replace(
+                    "_",
+                    " ",
+                  )}
                 </span>
                 {thread.status === "resolved" && (
                   <span className="px-2 py-1 text-xs font-semibold bg-green-100 text-green-700 rounded">
@@ -279,19 +292,24 @@ const FollowUpThreads = ({ meetingId }) => {
 
             {/* Replies */}
             <div className="space-y-4">
-              {thread.replies?.map((reply) => (
-                <div key={reply._id} className="flex gap-3">
-                  <div className="w-8 h-8 rounded-full bg-blue-500 flex-shrink-0 flex items-center justify-center text-white text-sm font-bold mt-1">
-                    {reply.author?.name
-                      ? reply.author.name.charAt(0).toUpperCase()
-                      : "?"}
-                  </div>
-                  <div className="flex-1">
-                    <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded-lg">
-                      <div className="flex justify-between items-center mb-1">
-                        <span className="font-semibold text-sm dark:text-gray-200">
-                          {reply.author?.name || "Unknown"}
-                        </span>
+              {thread.replies?.map((reply) => {
+                const authorName =
+                  reply.author?.name ||
+                  reply.sender?.name ||
+                  reply.author ||
+                  "Unknown";
+                return (
+                  <div key={reply._id} className="flex gap-3">
+                    <div className="w-8 h-8 rounded-full bg-blue-500 flex-shrink-0 flex items-center justify-center text-white text-sm font-bold mt-1">
+                      {authorName.charAt(0).toUpperCase()}
+                    </div>
+                    <div className="flex-1">
+                      <div className="bg-gray-100 dark:bg-gray-700 p-3 rounded-lg">
+                        <div className="flex justify-between items-center mb-1">
+                          <span className="font-semibold text-sm dark:text-gray-200">
+                            {authorName}
+                          </span>
+                        </div>
                         <span className="text-xs text-gray-500 dark:text-gray-400">
                           {new Date(reply.createdAt).toLocaleTimeString([], {
                             hour: "2-digit",
@@ -333,36 +351,36 @@ const FollowUpThreads = ({ meetingId }) => {
                           {reply.content}
                         </p>
                       )}
-                    </div>
 
-                    {userData &&
-                      reply.author &&
-                      (userData._id === reply.author._id ||
-                        userData._id === reply.author) &&
-                      !editingReply && (
-                        <div className="flex gap-3 mt-1 ml-1">
-                          <button
-                            onClick={() => {
-                              setEditingReply(reply._id);
-                              setEditContent(reply.content);
-                            }}
-                            className="text-xs text-gray-500 hover:text-blue-500"
-                          >
-                            Edit
-                          </button>
-                          <button
-                            onClick={() =>
-                              handleDeleteReply(reply._id, thread._id)
-                            }
-                            className="text-xs text-gray-500 hover:text-red-500"
-                          >
-                            Delete
-                          </button>
-                        </div>
-                      )}
+                      {userData &&
+                        reply.author &&
+                        (userData._id === reply.author._id ||
+                          userData._id === reply.author) &&
+                        !editingReply && (
+                          <div className="flex gap-3 mt-1 ml-1">
+                            <button
+                              onClick={() => {
+                                setEditingReply(reply._id);
+                                setEditContent(reply.content);
+                              }}
+                              className="text-xs text-gray-500 hover:text-blue-500"
+                            >
+                              Edit
+                            </button>
+                            <button
+                              onClick={() =>
+                                handleDeleteReply(reply._id, thread._id)
+                              }
+                              className="text-xs text-gray-500 hover:text-red-500"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
 
             {/* Reply Input */}

--- a/client/src/components/meeting-details/__tests__/FollowUpThreads.test.jsx
+++ b/client/src/components/meeting-details/__tests__/FollowUpThreads.test.jsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import FollowUpThreads from "../FollowUpThreads.jsx";
+import AppContent from "../../../context/AppContent.js";
+import * as followUpThreadApi from "../../../services/followUpThreadApi.js";
+
+vi.mock("../../../services/followUpThreadApi.js", () => ({
+  getFollowUpThreads: vi.fn(),
+  createFollowUpThread: vi.fn(),
+  createThreadReply: vi.fn(),
+  updateThreadReply: vi.fn(),
+  deleteThreadReply: vi.fn(),
+  resolveFollowUpThread: vi.fn(),
+}));
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockUserData = {
+  _id: "user-1",
+  name: "Jane Doe",
+  email: "jane@example.com",
+};
+
+const mockThreads = [
+  {
+    _id: "thread-1",
+    content: "Need clarification on deployment schedule",
+    type: "decision",
+    status: "open",
+    createdAt: new Date().toISOString(),
+    creator: { _id: "user-1", name: "Jane Doe" },
+    replies: [
+      {
+        _id: "reply-1",
+        content: "Deploying next Tuesday after review.",
+        sender: { _id: "user-2", name: "John Smith" },
+        createdAt: new Date().toISOString(),
+      },
+    ],
+  },
+];
+
+describe("FollowUpThreads Component (#1875)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    followUpThreadApi.getFollowUpThreads.mockResolvedValue({
+      success: true,
+      threads: mockThreads,
+    });
+  });
+
+  it("fetches and renders follow-up threads for the meeting", async () => {
+    render(
+      <AppContent.Provider
+        value={{ userData: mockUserData, backendUrl: "http://localhost:4000" }}
+      >
+        <FollowUpThreads meetingId="meet-999" />
+      </AppContent.Provider>,
+    );
+
+    expect(followUpThreadApi.getFollowUpThreads).toHaveBeenCalledWith(
+      "meet-999",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Deploying next Tuesday after review."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("John Smith")).toBeInTheDocument();
+    });
+  });
+
+  it("allows submitting a new thread", async () => {
+    followUpThreadApi.createFollowUpThread.mockResolvedValueOnce({
+      success: true,
+      thread: {
+        _id: "thread-2",
+        anchorType: "general",
+        status: "open",
+        creator: mockUserData,
+      },
+      reply: {
+        _id: "reply-2",
+        content: "Budget approval status?",
+        author: mockUserData,
+      },
+    });
+
+    render(
+      <AppContent.Provider
+        value={{ userData: mockUserData, backendUrl: "http://localhost:4000" }}
+      >
+        <FollowUpThreads meetingId="meet-999" />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/start a new thread/i),
+      ).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByPlaceholderText(/start a new thread/i);
+    fireEvent.change(textarea, {
+      target: { value: "Budget approval status?" },
+    });
+
+    const postBtn = screen.getByRole("button", { name: /start thread/i });
+    fireEvent.click(postBtn);
+
+    await waitFor(() => {
+      expect(followUpThreadApi.createFollowUpThread).toHaveBeenCalledWith(
+        "meet-999",
+        {
+          content: "Budget approval status?",
+          anchorType: "general",
+          mentions: [],
+        },
+      );
+    });
+  });
+
+  it("allows resolving an open thread", async () => {
+    followUpThreadApi.resolveFollowUpThread.mockResolvedValueOnce({
+      success: true,
+      thread: {
+        ...mockThreads[0],
+        status: "resolved",
+      },
+    });
+
+    render(
+      <AppContent.Provider
+        value={{ userData: mockUserData, backendUrl: "http://localhost:4000" }}
+      >
+        <FollowUpThreads meetingId="meet-999" />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Mark Resolved")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Mark Resolved"));
+
+    await waitFor(() => {
+      expect(followUpThreadApi.resolveFollowUpThread).toHaveBeenCalledWith(
+        "thread-1",
+      );
+    });
+  });
+});

--- a/client/src/pages/FollowUpDashboard.jsx
+++ b/client/src/pages/FollowUpDashboard.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import apiClient from "../services/apiClient.js";
 import Navbar from "../components/Navbar.jsx";
+import TaskDetailsModal from "../components/tasks/TaskDetailsModal.jsx";
 import {
   BarChart,
   Bar,
@@ -35,8 +36,10 @@ import { toast } from "react-toastify";
 
 const FollowUpDashboard = () => {
   const navigate = useNavigate();
+  const { id: taskIdFromParams } = useParams();
 
   const [tasks, setTasks] = useState([]);
+  const [selectedTask, setSelectedTask] = useState(null);
   const [analytics, setAnalytics] = useState(null);
   const [loading, setLoading] = useState(true);
   const [statusFilter, setStatusFilter] = useState("all");
@@ -79,6 +82,30 @@ const FollowUpDashboard = () => {
     fetchTasks();
     fetchAnalytics();
   }, [fetchTasks, fetchAnalytics]);
+
+  useEffect(() => {
+    if (taskIdFromParams) {
+      const found = tasks.find((t) => t._id === taskIdFromParams);
+      if (found) {
+        setSelectedTask(found);
+      } else {
+        (async () => {
+          try {
+            const { data } = await apiClient.get(
+              `/api/followup/tasks/${taskIdFromParams}`,
+            );
+            if (data?.task || data) {
+              setSelectedTask(data.task || data);
+            }
+          } catch (err) {
+            console.error("Error fetching task details:", err);
+          }
+        })();
+      }
+    } else {
+      setSelectedTask(null);
+    }
+  }, [taskIdFromParams, tasks]);
 
   const updateTaskStatus = async (taskId, status) => {
     try {
@@ -492,6 +519,39 @@ const FollowUpDashboard = () => {
           )}
         </div>
       </div>
+
+      <TaskDetailsModal
+        selectedTask={
+          selectedTask
+            ? {
+                ...selectedTask,
+                priority:
+                  selectedTask.priority ||
+                  selectedTask.metadata?.priority ||
+                  "medium",
+                dueDate: selectedTask.dueDate || selectedTask.deadline,
+                owner:
+                  selectedTask.owner ||
+                  selectedTask.assignee?.name ||
+                  selectedTask.assignee ||
+                  "Unassigned",
+                meetingTitle:
+                  selectedTask.meetingTitle || selectedTask.meeting?.title,
+                meetingId:
+                  selectedTask.meetingId ||
+                  selectedTask.meeting?._id ||
+                  selectedTask.meeting,
+              }
+            : null
+        }
+        setSelectedTask={(task) => {
+          setSelectedTask(task);
+          if (!task && taskIdFromParams) {
+            navigate("/followup");
+          }
+        }}
+        navigate={navigate}
+      />
     </div>
   );
 };

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -32,6 +32,7 @@ import AgendaBuilder from "../components/meetings/AgendaBuilder";
 import { getBriefing } from "../services/briefingApi";
 import GuestAccessManager from "../components/meetings/GuestAccessManager";
 import MeetingReadiness from "../components/MeetingReadiness";
+import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
 
 const MeetingDetails = () => {
   const { id } = useParams();
@@ -357,6 +358,10 @@ const MeetingDetails = () => {
 
           <MeetingTranscript meeting={meeting} />
           <TranscriptAnnotations meeting={meeting} />
+
+          <div className="mt-6 mb-6">
+            <FollowUpThreads meetingId={meeting._id} />
+          </div>
 
           <div className="mt-6 mb-6">
             <SentimentTimeline meetingId={meeting._id} />

--- a/client/src/pages/__tests__/FollowUpDashboard.test.jsx
+++ b/client/src/pages/__tests__/FollowUpDashboard.test.jsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import FollowUpDashboard from "../FollowUpDashboard.jsx";
+import apiClient from "../../services/apiClient.js";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="app-navbar">App Navbar</div>,
+}));
+
+vi.mock("../../components/tasks/TaskDetailsModal.jsx", () => ({
+  default: ({ selectedTask, setSelectedTask }) =>
+    selectedTask ? (
+      <div data-testid="task-details-modal">
+        <span>Modal: {selectedTask.title}</span>
+        <button onClick={() => setSelectedTask(null)}>Close Modal</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockAnalytics = {
+  summary: {
+    totalTasks: 10,
+    completedTasks: 8,
+    pendingTasks: 1,
+    inProgressTasks: 1,
+    overdueTasks: 0,
+    completionRate: 80.0,
+    avgTimeToCompletion: 2.5,
+    overdueRate: 0.0,
+    onTimeRate: 100.0,
+  },
+  trends: [
+    { week: "W1", created: 5, completed: 4, overdue: 0 },
+    { week: "W2", created: 5, completed: 4, overdue: 0 },
+  ],
+};
+
+const mockTasks = [
+  {
+    _id: "task-101",
+    title: "Implement Auth Flow",
+    status: "pending",
+    deadline: new Date(Date.now() + 86400000).toISOString(),
+    acknowledged: false,
+    meeting: { title: "Sprint Planning", _id: "meet-1" },
+    metadata: { priority: "high" },
+  },
+  {
+    _id: "task-102",
+    title: "Database Migration",
+    status: "in-progress",
+    deadline: new Date(Date.now() + 172800000).toISOString(),
+    acknowledged: true,
+    meeting: { title: "Architecture Review", _id: "meet-2" },
+    metadata: { priority: "medium" },
+  },
+];
+
+describe("FollowUpDashboard Page (#1875)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockImplementation((url) => {
+      if (url === "/api/followup/analytics") {
+        return Promise.resolve({ data: mockAnalytics });
+      }
+      if (url === "/api/followup/tasks") {
+        return Promise.resolve({
+          data: {
+            tasks: mockTasks,
+            pagination: { total: 2, totalPages: 1 },
+          },
+        });
+      }
+      if (url.startsWith("/api/followup/tasks/")) {
+        return Promise.resolve({
+          data: { task: mockTasks[0] },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  it("renders FollowUpDashboard header, Navbar, metrics, and tasks list", async () => {
+    render(
+      <MemoryRouter initialEntries={["/followup"]}>
+        <Routes>
+          <Route path="/followup" element={<FollowUpDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("app-navbar")).toBeInTheDocument();
+    expect(screen.getByText("Follow-Up Dashboard")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Implement Auth Flow")).toBeInTheDocument();
+      expect(screen.getByText("Database Migration")).toBeInTheDocument();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/followup/tasks", {
+      params: { page: "1", limit: "20" },
+    });
+    expect(apiClient.get).toHaveBeenCalledWith("/api/followup/analytics");
+  });
+
+  it("filters tasks when clicking status filter buttons", async () => {
+    render(
+      <MemoryRouter initialEntries={["/followup"]}>
+        <Routes>
+          <Route path="/followup" element={<FollowUpDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Implement Auth Flow")).toBeInTheDocument();
+    });
+
+    const pendingFilterBtn = screen.getByRole("button", { name: /^pending$/i });
+    fireEvent.click(pendingFilterBtn);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/api/followup/tasks", {
+        params: { page: "1", limit: "20", status: "pending" },
+      });
+    });
+  });
+
+  it("opens task detail modal on task card click and supports /followup/tasks/:id route", async () => {
+    render(
+      <MemoryRouter initialEntries={["/followup/tasks/task-101"]}>
+        <Routes>
+          <Route path="/followup" element={<FollowUpDashboard />} />
+          <Route path="/followup/tasks/:id" element={<FollowUpDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-details-modal")).toBeInTheDocument();
+      expect(
+        screen.getByText("Modal: Implement Auth Flow"),
+      ).toBeInTheDocument();
+    });
+
+    const closeBtn = screen.getByRole("button", { name: /close modal/i });
+    fireEvent.click(closeBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("task-details-modal"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("allows acknowledging a pending task", async () => {
+    apiClient.post.mockResolvedValueOnce({ data: { success: true } });
+
+    render(
+      <MemoryRouter initialEntries={["/followup"]}>
+        <Routes>
+          <Route path="/followup" element={<FollowUpDashboard />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Acknowledge")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Acknowledge"));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/followup/tasks/task-101/acknowledge",
+      );
+    });
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -70,6 +70,7 @@ import MeetingPatterns from "../pages/MeetingPatterns.jsx";
 import FocusTime from "../pages/FocusTime.jsx";
 import SeriesRetrospective from "../pages/SeriesRetrospective.jsx";
 import DataRetentionSettings from "../pages/DataRetentionSettings.jsx";
+import FollowUpDashboard from "../pages/FollowUpDashboard.jsx";
 
 const ProtectedRoutes = (
   <React.Fragment>
@@ -456,6 +457,38 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="tasks" action="view">
           <ActionItemsDashboard />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/followup"
+      element={
+        <ProtectedRoute resource="tasks" action="view">
+          <FollowUpDashboard />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/follow-up-dashboard"
+      element={
+        <ProtectedRoute resource="tasks" action="view">
+          <FollowUpDashboard />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/followup-dashboard"
+      element={
+        <ProtectedRoute resource="tasks" action="view">
+          <FollowUpDashboard />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/followup/tasks/:id"
+      element={
+        <ProtectedRoute resource="tasks" action="view">
+          <FollowUpDashboard />
         </ProtectedRoute>
       }
     />

--- a/client/src/services/__tests__/followUpThreadApi.test.js
+++ b/client/src/services/__tests__/followUpThreadApi.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import api from "../apiClient.js";
+import {
+  getFollowUpThreads,
+  createFollowUpThread,
+  createThreadReply,
+  updateThreadReply,
+  deleteThreadReply,
+  resolveFollowUpThread,
+} from "../followUpThreadApi.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("followUpThreadApi (#1875)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches follow-up threads with /api/follow-up-threads/meeting/:meetingId", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, threads: [{ _id: "thread-1" }] },
+    });
+
+    const result = await getFollowUpThreads("meet-123");
+
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/follow-up-threads/meeting/meet-123",
+    );
+    expect(result).toEqual({
+      success: true,
+      threads: [{ _id: "thread-1" }],
+    });
+  });
+
+  it("creates a follow-up thread with /api/follow-up-threads/meeting/:meetingId", async () => {
+    const payload = { content: "New question", type: "decision" };
+    api.post.mockResolvedValueOnce({
+      data: { success: true, thread: { _id: "thread-2", ...payload } },
+    });
+
+    const result = await createFollowUpThread("meet-123", payload);
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/follow-up-threads/meeting/meet-123",
+      payload,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("creates a thread reply with /api/follow-up-threads/:threadId/replies", async () => {
+    const replyPayload = { content: "This is a reply" };
+    api.post.mockResolvedValueOnce({
+      data: { success: true, reply: { _id: "reply-1", ...replyPayload } },
+    });
+
+    const result = await createThreadReply("thread-1", replyPayload);
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/follow-up-threads/thread-1/replies",
+      replyPayload,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("updates a thread reply with /api/follow-up-threads/replies/:replyId", async () => {
+    const updatePayload = { content: "Updated content" };
+    api.put.mockResolvedValueOnce({
+      data: { success: true, reply: { _id: "reply-1", ...updatePayload } },
+    });
+
+    const result = await updateThreadReply("reply-1", updatePayload);
+
+    expect(api.put).toHaveBeenCalledWith(
+      "/api/follow-up-threads/replies/reply-1",
+      updatePayload,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("deletes a thread reply with /api/follow-up-threads/replies/:replyId", async () => {
+    api.delete.mockResolvedValueOnce({
+      data: { success: true, message: "Deleted" },
+    });
+
+    const result = await deleteThreadReply("reply-1");
+
+    expect(api.delete).toHaveBeenCalledWith(
+      "/api/follow-up-threads/replies/reply-1",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("resolves a follow-up thread with /api/follow-up-threads/:threadId/resolve", async () => {
+    api.put.mockResolvedValueOnce({
+      data: { success: true, thread: { _id: "thread-1", status: "resolved" } },
+    });
+
+    const result = await resolveFollowUpThread("thread-1");
+
+    expect(api.put).toHaveBeenCalledWith(
+      "/api/follow-up-threads/thread-1/resolve",
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/client/src/services/followUpThreadApi.js
+++ b/client/src/services/followUpThreadApi.js
@@ -1,13 +1,13 @@
 import api from "./apiClient";
 
 export const getFollowUpThreads = async (meetingId) => {
-  const response = await api.get(`/follow-up-threads/meeting/${meetingId}`);
+  const response = await api.get(`/api/follow-up-threads/meeting/${meetingId}`);
   return response.data;
 };
 
 export const createFollowUpThread = async (meetingId, data) => {
   const response = await api.post(
-    `/follow-up-threads/meeting/${meetingId}`,
+    `/api/follow-up-threads/meeting/${meetingId}`,
     data,
   );
   return response.data;
@@ -15,23 +15,28 @@ export const createFollowUpThread = async (meetingId, data) => {
 
 export const createThreadReply = async (threadId, data) => {
   const response = await api.post(
-    `/follow-up-threads/${threadId}/replies`,
+    `/api/follow-up-threads/${threadId}/replies`,
     data,
   );
   return response.data;
 };
 
 export const updateThreadReply = async (replyId, data) => {
-  const response = await api.put(`/follow-up-threads/replies/${replyId}`, data);
+  const response = await api.put(
+    `/api/follow-up-threads/replies/${replyId}`,
+    data,
+  );
   return response.data;
 };
 
 export const deleteThreadReply = async (replyId) => {
-  const response = await api.delete(`/follow-up-threads/replies/${replyId}`);
+  const response = await api.delete(
+    `/api/follow-up-threads/replies/${replyId}`,
+  );
   return response.data;
 };
 
 export const resolveFollowUpThread = async (threadId) => {
-  const response = await api.put(`/follow-up-threads/${threadId}/resolve`);
+  const response = await api.put(`/api/follow-up-threads/${threadId}/resolve`);
   return response.data;
 };


### PR DESCRIPTION
## Description
Fixes #1875 by resolving unwired follow-up components, missing routes, and API prefixes:

1. **API Prefixing**: Updated all paths in \ollowUpThreadApi.js\ to correctly use \/api/follow-up-threads\ matching backend route definitions.
2. **Dashboard & Detail Routing**: Registered \FollowUpDashboard\ in \ProtectedRoutes.jsx\ under \/followup\, \/follow-up-dashboard\, \/followup-dashboard\, and \/followup/tasks/:id\. Enhanced \FollowUpDashboard\ to support direct task viewing and detail modals for \/followup/tasks/:id\.
3. **FollowUpThreads Component**: Mounted \FollowUpThreads\ within \MeetingDetails.jsx\ and safeguarded context, socket connections, and thread attribute access.
4. **Testing**: Added unit test coverage for \ollowUpThreadApi\, \FollowUpDashboard\, and \FollowUpThreads\.

## Verification
- \
pm run test:ci --prefix client\: All test suites passing.
- \
pm run lint --prefix client\: Passed without errors.
- Prettier code style verified.
- \
pm run build --prefix client\: Vite build succeeded.