### PR TITLE
fix(security): enforce safe organization ID handling and meeting ownership in meetingQualityController

### DIFF
--- a/server/controllers/__tests__/meetingQualitySecurity.test.js
+++ b/server/controllers/__tests__/meetingQualitySecurity.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import {
+  calculateScore,
+  getMeetingQualityEndpoint,
+  getOrganizationQualityEndpoint,
+  getRecommendations,
+} from "../meetingQualityController.js";
+import Meeting from "../../models/meetingModel.js";
+import {
+  calculateMeetingQuality,
+  getMeetingQuality,
+  getOrganizationQuality,
+} from "../../services/meetingQualityService.js";
+import { generateUserRecommendations } from "../../services/recommendationEngine.js";
+
+vi.mock("../../models/meetingModel.js");
+vi.mock("../../services/meetingQualityService.js");
+vi.mock("../../services/recommendationEngine.js");
+
+describe("Meeting Quality Security & Safe Org ID Handling (#1959)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validMeetingId = new mongoose.Types.ObjectId().toString();
+  const validOrgId = new mongoose.Types.ObjectId().toString();
+  const foreignOrgId = new mongoose.Types.ObjectId().toString();
+  const userId = new mongoose.Types.ObjectId();
+
+  const user = {
+    _id: userId,
+    organization: validOrgId,
+  };
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("handles unset user organization safely without TypeError crash in getOrganizationQualityEndpoint", async () => {
+    const req = {
+      params: { orgId: validOrgId },
+      query: { period: "monthly" },
+      user: { _id: userId }, // organization is undefined
+    };
+    const res = createMockRes();
+
+    await getOrganizationQualityEndpoint(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Forbidden: Not part of organization",
+    });
+  });
+
+  it("allows meeting uploader to trigger calculateScore even if org matching is different", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: validMeetingId,
+      uploadedBy: userId,
+      organization: foreignOrgId,
+    });
+    calculateMeetingQuality.mockResolvedValue({});
+
+    const req = {
+      params: { meetingId: validMeetingId },
+      user,
+    };
+    const res = createMockRes();
+
+    await calculateScore(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Quality calculation started",
+      }),
+    );
+  });
+
+  it("rejects calculateScore with 403 when user does not have meeting access", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: validMeetingId,
+      uploadedBy: new mongoose.Types.ObjectId(),
+      organization: foreignOrgId,
+    });
+
+    const req = {
+      params: { meetingId: validMeetingId },
+      user,
+    };
+    const res = createMockRes();
+
+    await calculateScore(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Forbidden: Not part of organization",
+    });
+  });
+
+  it("safely rejects getRecommendations when user lacks organization", async () => {
+    const req = {
+      params: { userId: userId.toString() },
+      user: { _id: userId, role: "member" }, // no org
+    };
+    const res = createMockRes();
+
+    await getRecommendations(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Organization required",
+    });
+  });
+});

--- a/server/controllers/meetingQualityController.js
+++ b/server/controllers/meetingQualityController.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import {
   calculateMeetingQuality,
   getMeetingQuality,
@@ -12,12 +13,16 @@ import {
 } from "../services/recommendationEngine.js";
 import QualityBenchmark from "../models/QualityBenchmark.js";
 import Meeting from "../models/meetingModel.js";
-import mongoose from "mongoose";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
 
 /**
  * Meeting Quality Controller
  * Handles HTTP requests for quality scoring and benchmarking
  */
+
+const getUserOrgId = (user) => {
+  return (user?.organization?._id || user?.organization)?.toString() || null;
+};
 
 /**
  * @desc Calculate meeting quality score
@@ -38,7 +43,7 @@ export const calculateScore = async (req, res) => {
       return res.status(404).json({ message: "Meeting not found" });
     }
 
-    if (meeting.organization.toString() !== req.user.organization.toString()) {
+    if (!canAccessMeetingDoc(meeting, req.user)) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -85,8 +90,13 @@ export const getMeetingQualityEndpoint = async (req, res) => {
       });
     }
 
+    const userOrgId = getUserOrgId(req.user);
+    const scoreOrgId = (
+      score.organization?._id || score.organization
+    )?.toString();
+
     // Check organization access
-    if (score.organization.toString() !== req.user.organization.toString()) {
+    if (!userOrgId || !scoreOrgId || scoreOrgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -113,7 +123,8 @@ export const getOrganizationQualityEndpoint = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -142,7 +153,8 @@ export const getBenchmarks = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -181,14 +193,22 @@ export const getRecommendations = async (req, res) => {
       return res.status(400).json({ message: "Invalid user ID" });
     }
 
+    const currentUserId = (req.user?._id || req.user?.id)?.toString();
+    const userRole = req.user?.role;
+    const userOrgId = getUserOrgId(req.user);
+
     // Users can only get their own recommendations (or admin)
-    if (userId !== req.user._id.toString() && req.user.role !== "admin") {
+    if (userId !== currentUserId && userRole !== "admin") {
       return res.status(403).json({ message: "Forbidden" });
+    }
+
+    if (!userOrgId) {
+      return res.status(400).json({ message: "Organization required" });
     }
 
     const recommendations = await generateUserRecommendations(
       userId,
-      req.user.organization,
+      userOrgId,
     );
 
     res.status(200).json(recommendations);
@@ -212,7 +232,8 @@ export const getLeaderboardEndpoint = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -241,7 +262,8 @@ export const getTrends = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
@@ -270,14 +292,15 @@ export const exportReport = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });
     }
 
     // Check admin access
-    if (req.user.role !== "admin" && req.user.role !== "owner") {
+    if (req.user?.role !== "admin" && req.user?.role !== "owner") {
       return res
         .status(403)
         .json({ message: "Forbidden: Admin access required" });
@@ -315,7 +338,8 @@ export const getBestPracticesEndpoint = async (req, res) => {
       return res.status(400).json({ message: "Invalid organization ID" });
     }
 
-    if (orgId !== req.user.organization.toString()) {
+    const userOrgId = getUserOrgId(req.user);
+    if (!userOrgId || orgId !== userOrgId) {
       return res
         .status(403)
         .json({ message: "Forbidden: Not part of organization" });


### PR DESCRIPTION
Fixes #1959

## Description
This PR eliminates unhandled TypeError exceptions when reading eq.user.organization across meetingQualityController.js and enforces tenant isolation and direct meeting ownership via canAccessMeetingDoc(meeting, req.user).

## Proposed Changes
- **Safe Organization ID Extraction**: Extracted and normalized user organization ID with null-safe guards, preventing 500 runtime crashes on unpopulated context.
- **Meeting Access Authorization**: Utilized canAccessMeetingDoc(meeting, req.user) to authorize meeting uploaders and members of the same organization.
- **Unit Test Coverage**: Added unit test suite server/controllers/__tests__/meetingQualitySecurity.test.js verifying safe handling of unset organizations, uploader authorization, and cross-organization access rejection.

## Checklist
- [x] Related Issue is linked (Fixes #1959).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization across meeting-quality scores, metrics, benchmarks, leaderboards, trends, exports, and best practices.
  * Added safer handling when organization information or user roles are missing.
  * Ensured authorized uploaders can calculate meeting quality even when organization details differ.
  * Restricted unauthorized meeting access and invalid recommendation requests with appropriate errors.

* **Tests**
  * Added security coverage for meeting-quality endpoints and authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->