### PR TITLE
fix(ui): mount shared Navbar, add error states, and implement WAI-ARIA accessibility in TopicExplorer

### DIFF
--- a/client/src/pages/TopicExplorer.jsx
+++ b/client/src/pages/TopicExplorer.jsx
@@ -1,6 +1,13 @@
-import React, { useState, useEffect, useContext, useMemo } from "react";
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useMemo,
+  useCallback,
+} from "react";
 import AppContent from "../context/AppContent.js";
 import apiClient from "../services/apiClient.js";
+import Navbar from "../components/Navbar.jsx";
 import {
   ScatterChart,
   Scatter,
@@ -25,29 +32,39 @@ const TopicExplorer = () => {
   const { userData } = useContext(AppContent);
   const [clusters, setClusters] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [selectedCluster, setSelectedCluster] = useState(null);
 
   const orgId = userData?.organization?._id || userData?.organization;
 
-  useEffect(() => {
-    if (orgId) {
-      fetchClusters();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId]);
-
-  const fetchClusters = async () => {
+  const fetchClusters = useCallback(async () => {
     try {
-      if (!orgId) return;
+      if (!orgId) {
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      setError(null);
 
       const res = await apiClient.get(`/api/topics/clusters/org/${orgId}`);
-      setClusters(res.data.data);
-    } catch (error) {
-      console.error("Error fetching clusters", error);
+      if (res.data?.success && Array.isArray(res.data?.data)) {
+        setClusters(res.data.data);
+      } else if (Array.isArray(res.data?.data)) {
+        setClusters(res.data.data);
+      } else {
+        setClusters([]);
+      }
+    } catch (err) {
+      console.error("Error fetching clusters", err);
+      setError("Failed to load topic clusters. Please try again.");
     } finally {
       setLoading(false);
     }
-  };
+  }, [orgId]);
+
+  useEffect(() => {
+    fetchClusters();
+  }, [fetchClusters]);
 
   const renameCluster = async (clusterId, newLabel) => {
     try {
@@ -55,145 +72,207 @@ const TopicExplorer = () => {
         label: newLabel,
       });
       fetchClusters(); // Refresh
-    } catch (error) {
-      console.error("Error renaming cluster", error);
+    } catch (err) {
+      console.error("Error renaming cluster", err);
     }
   };
 
-  // Prepare data for bubble chart
+  // Prepare deterministic coordinates for bubble chart
   const chartData = useMemo(() => {
-    return clusters.map((c, index) => ({
-      name: c.label,
-      count: c.meetingCount,
-      // Assign random x/y for scatter plot visualization to spread them out
-      x: Math.random() * 100,
-      y: Math.random() * 100,
-      fill: COLORS[index % COLORS.length],
-      ...c,
-    }));
+    return clusters.map((c, index) => {
+      // Deterministic layout angle & radius to keep clusters stable
+      const angle = (index * 137.5 * Math.PI) / 180;
+      const radius = 20 + ((index * 15) % 30);
+      const x = 50 + radius * Math.cos(angle);
+      const y = 50 + radius * Math.sin(angle);
+
+      return {
+        name: c.label,
+        count: c.meetingCount,
+        x: Math.max(10, Math.min(90, x)),
+        y: Math.max(10, Math.min(90, y)),
+        fill: COLORS[index % COLORS.length],
+        ...c,
+      };
+    });
   }, [clusters]);
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
-      <h1 className="text-3xl font-bold mb-6">Topic Explorer</h1>
+    <div className="min-h-screen bg-slate-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <Navbar />
+      <div className="pt-28 pb-16 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold mb-6">Topic Explorer</h1>
 
-      {loading ? (
-        <div>Loading...</div>
-      ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-6">
-            <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow h-96">
-              <h2 className="text-xl font-semibold mb-4">
-                Topic Clusters Overview
-              </h2>
-              <ResponsiveContainer width="100%" height="100%">
-                <ScatterChart
-                  margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
-                >
-                  <XAxis type="number" dataKey="x" name="x" hide />
-                  <YAxis type="number" dataKey="y" name="y" hide />
-                  <ZAxis
-                    type="number"
-                    dataKey="count"
-                    range={[100, 1000]}
-                    name="Meetings"
-                  />
-                  <Tooltip
-                    cursor={{ strokeDasharray: "3 3" }}
-                    content={({ payload }) => {
-                      if (payload && payload.length) {
-                        const data = payload[0].payload;
-                        return (
-                          <div className="bg-white p-2 border shadow rounded text-sm text-gray-800">
-                            <p className="font-bold">{data.name}</p>
-                            <p>Meetings: {data.count}</p>
-                          </div>
-                        );
-                      }
-                      return null;
-                    }}
-                  />
-                  <Scatter
-                    name="Topics"
-                    data={chartData}
-                    onClick={(e) => setSelectedCluster(e.payload)}
-                  >
-                    {chartData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.fill} />
-                    ))}
-                  </Scatter>
-                </ScatterChart>
-              </ResponsiveContainer>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {clusters.map((cluster) => (
-                <div
-                  key={cluster._id}
-                  className={`bg-white dark:bg-gray-800 p-4 rounded-lg shadow cursor-pointer transition ${selectedCluster?._id === cluster._id ? "ring-2 ring-blue-500" : "hover:shadow-md"}`}
-                  onClick={() => setSelectedCluster(cluster)}
-                >
-                  <div className="flex justify-between items-start mb-2">
-                    <h3 className="font-semibold text-lg">{cluster.label}</h3>
-                    <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
-                      {cluster.meetingCount} meetings
-                    </span>
-                  </div>
-                  <div className="text-sm text-gray-500 mb-2">
-                    {cluster.canonicalTopicNames?.slice(0, 3).join(", ")}
-                  </div>
-                </div>
-              ))}
-            </div>
+        {loading && (
+          <div className="p-8 text-center text-gray-500">
+            Loading Topic Clusters...
           </div>
+        )}
 
-          <div className="lg:col-span-1">
-            {selectedCluster ? (
-              <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow sticky top-6">
-                <h2 className="text-2xl font-bold mb-2">
-                  {selectedCluster.label}
+        {error && !loading && (
+          <div
+            data-testid="topic-error-state"
+            className="p-8 max-w-md mx-auto text-center bg-white dark:bg-gray-800 rounded-xl shadow border border-red-200 dark:border-red-800"
+          >
+            <h2 className="text-xl font-bold mb-2">Failed to Load Topics</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+              {error}
+            </p>
+            <button
+              data-testid="retry-button"
+              onClick={fetchClusters}
+              className="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl text-sm transition-colors cursor-pointer"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2 space-y-6">
+              <div
+                role="region"
+                aria-label="Topic Clusters Overview Chart"
+                className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow h-96"
+              >
+                <h2 className="text-xl font-semibold mb-4">
+                  Topic Clusters Overview
                 </h2>
-                <button
-                  className="text-sm text-blue-500 hover:underline mb-4"
-                  onClick={() => {
-                    const newLabel = prompt(
-                      "Enter new label:",
-                      selectedCluster.label,
-                    );
-                    if (newLabel && newLabel !== selectedCluster.label) {
-                      renameCluster(selectedCluster._id, newLabel);
-                    }
-                  }}
-                >
-                  Rename Cluster
-                </button>
-                <div className="mb-4">
-                  <h4 className="font-semibold text-gray-700 dark:text-gray-300">
-                    Meetings
-                  </h4>
-                  <p className="text-3xl font-bold text-blue-600">
-                    {selectedCluster.meetingCount}
+                <ResponsiveContainer width="100%" height="100%">
+                  <ScatterChart
+                    margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+                  >
+                    <XAxis
+                      type="number"
+                      dataKey="x"
+                      name="x"
+                      domain={[0, 100]}
+                      hide
+                    />
+                    <YAxis
+                      type="number"
+                      dataKey="y"
+                      name="y"
+                      domain={[0, 100]}
+                      hide
+                    />
+                    <ZAxis
+                      type="number"
+                      dataKey="count"
+                      range={[100, 1000]}
+                      name="Meetings"
+                    />
+                    <Tooltip
+                      cursor={{ strokeDasharray: "3 3" }}
+                      content={({ payload }) => {
+                        if (payload && payload.length) {
+                          const data = payload[0].payload;
+                          return (
+                            <div className="bg-white p-2 border shadow rounded text-sm text-gray-800">
+                              <p className="font-bold">{data.name}</p>
+                              <p>Meetings: {data.count}</p>
+                            </div>
+                          );
+                        }
+                        return null;
+                      }}
+                    />
+                    <Scatter
+                      name="Topics"
+                      data={chartData}
+                      onClick={(e) => setSelectedCluster(e.payload)}
+                    >
+                      {chartData.map((entry, index) => (
+                        <Cell key={`cell-${index}`} fill={entry.fill} />
+                      ))}
+                    </Scatter>
+                  </ScatterChart>
+                </ResponsiveContainer>
+              </div>
+
+              <div
+                role="region"
+                aria-label="Topic Clusters Grid"
+                className="grid grid-cols-1 md:grid-cols-2 gap-4"
+              >
+                {clusters.map((cluster) => (
+                  <div
+                    key={cluster._id}
+                    className={`bg-white dark:bg-gray-800 p-4 rounded-lg shadow cursor-pointer transition ${selectedCluster?._id === cluster._id ? "ring-2 ring-blue-500" : "hover:shadow-md"}`}
+                    onClick={() => setSelectedCluster(cluster)}
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <h3 className="font-semibold text-lg">{cluster.label}</h3>
+                      <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
+                        {cluster.meetingCount} meetings
+                      </span>
+                    </div>
+                    <div className="text-sm text-gray-500 mb-2">
+                      {cluster.canonicalTopicNames?.slice(0, 3).join(", ")}
+                    </div>
+                  </div>
+                ))}
+                {clusters.length === 0 && (
+                  <p className="text-sm text-gray-500 col-span-2 text-center py-6">
+                    No topic clusters found.
                   </p>
-                </div>
-                <div>
-                  <h4 className="font-semibold text-gray-700 dark:text-gray-300 mb-2">
-                    Canonical Names
-                  </h4>
-                  <ul className="list-disc pl-5 text-sm space-y-1">
-                    {selectedCluster.canonicalTopicNames?.map((name, i) => (
-                      <li key={i}>{name}</li>
-                    ))}
-                  </ul>
-                </div>
+                )}
               </div>
-            ) : (
-              <div className="bg-gray-50 dark:bg-gray-900 p-6 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-700 h-full flex items-center justify-center text-gray-500 text-center">
-                Select a cluster to view details
-              </div>
-            )}
+            </div>
+
+            <div className="lg:col-span-1">
+              {selectedCluster ? (
+                <div
+                  role="region"
+                  aria-label="Selected Cluster Details"
+                  className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow sticky top-28"
+                >
+                  <h2 className="text-2xl font-bold mb-2">
+                    {selectedCluster.label}
+                  </h2>
+                  <button
+                    className="text-sm text-blue-500 hover:underline mb-4"
+                    onClick={() => {
+                      const newLabel = window.prompt(
+                        "Enter new label:",
+                        selectedCluster.label,
+                      );
+                      if (newLabel && newLabel !== selectedCluster.label) {
+                        renameCluster(selectedCluster._id, newLabel);
+                      }
+                    }}
+                  >
+                    Rename Cluster
+                  </button>
+                  <div className="mb-4">
+                    <h4 className="font-semibold text-gray-700 dark:text-gray-300">
+                      Meetings
+                    </h4>
+                    <p className="text-3xl font-bold text-blue-600">
+                      {selectedCluster.meetingCount}
+                    </p>
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                      Canonical Names
+                    </h4>
+                    <ul className="list-disc pl-5 text-sm space-y-1">
+                      {selectedCluster.canonicalTopicNames?.map((name, i) => (
+                        <li key={i}>{name}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ) : (
+                <div className="bg-gray-50 dark:bg-gray-900 p-6 rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-700 h-full flex items-center justify-center text-gray-500 text-center">
+                  Select a cluster to view details
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/client/src/pages/__tests__/TopicExplorerAccessibility.test.jsx
+++ b/client/src/pages/__tests__/TopicExplorerAccessibility.test.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import TopicExplorer from "../TopicExplorer.jsx";
+import apiClient from "../../services/apiClient.js";
+import AppContent from "../../context/AppContent.js";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="shared-navbar">Shared Navbar</nav>,
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe("TopicExplorer Accessibility & Error Handling (#1962)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockUserContext = {
+    userData: {
+      _id: "u_1",
+      organization: "org_123",
+    },
+  };
+
+  it("renders Navbar and accessible ARIA regions when data loads", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [
+          {
+            _id: "c_1",
+            label: "Sprint Planning",
+            meetingCount: 5,
+            canonicalTopicNames: ["Sprint Goals", "Backlog"],
+          },
+        ],
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <AppContent.Provider value={mockUserContext}>
+          <TopicExplorer />
+        </AppContent.Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shared-navbar")).toBeInTheDocument();
+      expect(screen.getByText("Sprint Planning")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Topic Clusters Overview Chart" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Topic Clusters Grid" }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays dedicated error state on API failure and retries successfully", async () => {
+    apiClient.get.mockRejectedValueOnce(new Error("API Error"));
+
+    render(
+      <BrowserRouter>
+        <AppContent.Provider value={mockUserContext}>
+          <TopicExplorer />
+        </AppContent.Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("topic-error-state")).toBeInTheDocument();
+      expect(screen.getByText("Failed to Load Topics")).toBeInTheDocument();
+      expect(screen.getByTestId("retry-button")).toBeInTheDocument();
+    });
+
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [],
+      },
+    });
+
+    fireEvent.click(screen.getByTestId("retry-button"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("topic-error-state")).not.toBeInTheDocument();
+      expect(screen.getByText("No topic clusters found.")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1962

## Description
This PR integrates the shared Navbar layout chrome into TopicExplorer.jsx, adds WAI-ARIA landmark roles (ole="region" and ria-label), and introduces a dedicated error and retry state on API failure.

## Proposed Changes
- **Navbar Layout Chrome**: Mounted <Navbar /> with standard page padding layout (pt-28 pb-16).
- **WAI-ARIA Accessibility**: Added ole="region" and accessible ria-label landmarks on overview chart, clusters grid, and details panel.
- **Error & Retry State**: Added an accessible error card with working "Retry" action on API failure.
- **Unit Test Coverage**: Added unit test suite client/src/pages/__tests__/TopicExplorerAccessibility.test.jsx verifying Navbar rendering, ARIA attributes, and error/retry behavior.

## Checklist
- [x] Related Issue is linked (Fixes #1962).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.