### PR TITLE
fix(ui): add error boundary, disabled controls during run, and WAI-ARIA landmarks in MemoryConsolidation

### DIFF
--- a/client/src/pages/MemoryConsolidation.jsx
+++ b/client/src/pages/MemoryConsolidation.jsx
@@ -31,16 +31,25 @@ const MemoryConsolidation = () => {
   const [report, setReport] = useState(null);
   const [history, setHistory] = useState([]);
   const [historyLoading, setHistoryLoading] = useState(true);
+  const [historyError, setHistoryError] = useState(null);
 
   const loadHistory = useCallback(async () => {
     setHistoryLoading(true);
+    setHistoryError(null);
     try {
       const res = await knowledgeApi.getConsolidationHistory(selectedModel);
       if (res.data?.success) {
         setHistory(res.data.memories || []);
+      } else {
+        setHistoryError(
+          res.data?.message || "Failed to load consolidation history",
+        );
       }
     } catch (err) {
       console.error("Failed to load consolidation history", err);
+      setHistoryError(
+        "Failed to load consolidation history. Please try again.",
+      );
     } finally {
       setHistoryLoading(false);
     }
@@ -82,64 +91,76 @@ const MemoryConsolidation = () => {
   const modelReport = report?.results?.[selectedModel];
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 pt-20">
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200">
       <Navbar />
 
-      <div className="p-6 max-w-4xl mx-auto space-y-6">
-        <div className="flex items-start justify-between gap-4 flex-wrap">
-          <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
-              <GitMerge className="w-6 h-6 text-blue-600 dark:text-blue-400" />
-              Memory Consolidation
-            </h1>
-            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-              Find duplicate or paraphrased memories and merge them into one
-              canonical record without losing history.
-            </p>
+      <div className="pt-28 pb-16 p-6 max-w-4xl mx-auto space-y-6">
+        <div
+          role="region"
+          aria-label="Memory Consolidation Controls"
+          className="space-y-6"
+        >
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+                <GitMerge className="w-6 h-6 text-blue-600 dark:text-blue-400" />
+                Memory Consolidation
+              </h1>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                Find duplicate or paraphrased memories and merge them into one
+                canonical record without losing history.
+              </p>
+            </div>
+
+            <select
+              aria-label="Select Memory Type"
+              value={selectedModel}
+              disabled={running}
+              onChange={(e) => setSelectedModel(e.target.value)}
+              className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {MODEL_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
           </div>
 
-          <select
-            value={selectedModel}
-            onChange={(e) => setSelectedModel(e.target.value)}
-            className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-sm"
-          >
-            {MODEL_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="flex flex-wrap gap-3">
-          <button
-            onClick={() => runEngine(true)}
-            disabled={running}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
-          >
-            {running ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Sparkles className="w-4 h-4" />
-            )}
-            Preview merges
-          </button>
-          <button
-            onClick={() => runEngine(false)}
-            disabled={running}
-            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
-          >
-            {running ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <GitMerge className="w-4 h-4" />
-            )}
-            Consolidate now
-          </button>
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={() => runEngine(true)}
+              disabled={running}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            >
+              {running ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Sparkles className="w-4 h-4" />
+              )}
+              Preview merges
+            </button>
+            <button
+              onClick={() => runEngine(false)}
+              disabled={running}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            >
+              {running ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <GitMerge className="w-4 h-4" />
+              )}
+              Consolidate now
+            </button>
+          </div>
         </div>
 
         {modelReport && (
-          <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 p-5">
+          <div
+            role="region"
+            aria-label="Consolidation Results"
+            className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 p-5"
+          >
             <div className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
               <ShieldCheck className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
               {report.dryRun ? "Preview" : "Consolidation"} results
@@ -200,7 +221,11 @@ const MemoryConsolidation = () => {
           </div>
         )}
 
-        <div>
+        <div
+          role="region"
+          aria-label="Consolidated Memories History"
+          className="space-y-3"
+        >
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2">
               <History className="w-5 h-5" />
@@ -208,8 +233,8 @@ const MemoryConsolidation = () => {
             </h2>
             <button
               onClick={loadHistory}
-              className="text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-              aria-label="Refresh"
+              className="text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 cursor-pointer p-1"
+              aria-label="Refresh history"
             >
               <RefreshCw className="w-4 h-4" />
             </button>
@@ -221,36 +246,56 @@ const MemoryConsolidation = () => {
             </p>
           )}
 
-          {!historyLoading && history.length === 0 && (
+          {historyError && !historyLoading && (
+            <div
+              data-testid="history-error-state"
+              className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4 text-center"
+            >
+              <p className="text-sm text-red-600 dark:text-red-400 mb-3">
+                {historyError}
+              </p>
+              <button
+                data-testid="history-retry-button"
+                onClick={loadHistory}
+                className="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded text-xs font-medium transition-colors cursor-pointer"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {!historyLoading && !historyError && history.length === 0 && (
             <p className="text-sm text-slate-500 dark:text-slate-400">
               No memories have been consolidated yet.
             </p>
           )}
 
-          <div className="space-y-3">
-            {history.map((memory) => (
-              <div
-                key={memory._id}
-                className="rounded-lg border border-slate-100 dark:border-slate-800 p-4 bg-white dark:bg-slate-900/50"
-              >
-                <p className="font-medium text-slate-900 dark:text-white">
-                  {memory.text}
-                </p>
-                {memory.aliases?.length > 0 && (
-                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-                    Aliases: {memory.aliases.join(", ")}
+          {!historyLoading && !historyError && (
+            <div className="space-y-3">
+              {history.map((memory) => (
+                <div
+                  key={memory._id}
+                  className="rounded-lg border border-slate-100 dark:border-slate-800 p-4 bg-white dark:bg-slate-900/50"
+                >
+                  <p className="font-medium text-slate-900 dark:text-white">
+                    {memory.text}
                   </p>
-                )}
-                <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
-                  {memory.mergedFrom?.length || 0} memories merged • last
-                  consolidated{" "}
-                  {memory.lastConsolidatedAt
-                    ? new Date(memory.lastConsolidatedAt).toLocaleDateString()
-                    : "—"}
-                </p>
-              </div>
-            ))}
-          </div>
+                  {memory.aliases?.length > 0 && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                      Aliases: {memory.aliases.join(", ")}
+                    </p>
+                  )}
+                  <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+                    {memory.mergedFrom?.length || 0} memories merged • last
+                    consolidated{" "}
+                    {memory.lastConsolidatedAt
+                      ? new Date(memory.lastConsolidatedAt).toLocaleDateString()
+                      : "—"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/pages/__tests__/MemoryConsolidationAccessibility.test.jsx
+++ b/client/src/pages/__tests__/MemoryConsolidationAccessibility.test.jsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import MemoryConsolidation from "../MemoryConsolidation.jsx";
+import { knowledgeApi } from "../../services";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="shared-navbar">Shared Navbar</nav>,
+}));
+
+vi.mock("../../services", () => ({
+  knowledgeApi: {
+    getConsolidationHistory: vi.fn(),
+    runConsolidation: vi.fn(),
+  },
+}));
+
+describe("MemoryConsolidation Accessibility & Error Boundary (#1963)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders Navbar and ARIA regions with history list", async () => {
+    knowledgeApi.getConsolidationHistory.mockResolvedValueOnce({
+      data: {
+        success: true,
+        memories: [
+          {
+            _id: "m_1",
+            text: "Approved product roadmap for Q3",
+            aliases: ["Q3 Roadmap plan"],
+            mergedFrom: ["m_old1"],
+            lastConsolidatedAt: "2026-08-20",
+          },
+        ],
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <MemoryConsolidation />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shared-navbar")).toBeInTheDocument();
+      expect(
+        screen.getByText("Approved product roadmap for Q3"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Memory Consolidation Controls" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Consolidated Memories History" }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays error state when history fails and retries successfully", async () => {
+    knowledgeApi.getConsolidationHistory.mockRejectedValueOnce(
+      new Error("Network Error"),
+    );
+
+    render(
+      <BrowserRouter>
+        <MemoryConsolidation />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("history-error-state")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Failed to load consolidation history. Please try again.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("history-retry-button")).toBeInTheDocument();
+    });
+
+    knowledgeApi.getConsolidationHistory.mockResolvedValueOnce({
+      data: {
+        success: true,
+        memories: [],
+      },
+    });
+
+    fireEvent.click(screen.getByTestId("history-retry-button"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("history-error-state"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("No memories have been consolidated yet."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("disables select dropdown and buttons while consolidation is running", async () => {
+    knowledgeApi.getConsolidationHistory.mockResolvedValue({
+      data: { success: true, memories: [] },
+    });
+
+    // Make runConsolidation stay unresolved to inspect running state
+    let resolveRun;
+    knowledgeApi.runConsolidation.mockReturnValue(
+      new Promise((res) => {
+        resolveRun = res;
+      }),
+    );
+
+    render(
+      <BrowserRouter>
+        <MemoryConsolidation />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /preview merges/i }),
+      ).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText("Select Memory Type");
+    const previewBtn = screen.getByRole("button", { name: /preview merges/i });
+
+    expect(select).not.toBeDisabled();
+    expect(previewBtn).not.toBeDisabled();
+
+    fireEvent.click(previewBtn);
+
+    expect(select).toBeDisabled();
+    expect(previewBtn).toBeDisabled();
+
+    resolveRun({
+      data: {
+        success: true,
+        report: { dryRun: true, results: { decision: { merges: [] } } },
+      },
+    });
+
+    await waitFor(() => {
+      expect(select).not.toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1963

## Description
This PR adds disabled state handling to the model selector during active runs in MemoryConsolidation.jsx, implements a user-facing error state and retry mechanism when consolidation history fails to load, and adds accessible WAI-ARIA ole="region" landmark attributes.

## Proposed Changes
- **Disable Controls During Runs**: Disabled the model <select> dropdown and execution buttons while unning === true to prevent state corruption.
- **History Error & Retry State**: Added explicit error tracking and a dedicated retry button when consolidation history fails to load.
- **WAI-ARIA Accessibility**: Added ole="region" and descriptive ria-label landmarks on controls, results, and history sections.
- **Unit Test Coverage**: Added unit test suite client/src/pages/__tests__/MemoryConsolidationAccessibility.test.jsx verifying disabled controls, error/retry state, and ARIA landmarks.

## Checklist
- [x] Related Issue is linked (Fixes #1963).
- [x] Issue was assigned before starting work.
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Code passes lint checks.
- [x] Unit tests added and passing cleanly.
- [x] Existing functionality is not broken.