### PR TITLE
refactor: align pre-meeting briefing router imports with controller signatures (#1871)

### DIFF
--- a/server/routes/preMeetingBriefingRoutes.js
+++ b/server/routes/preMeetingBriefingRoutes.js
@@ -1,15 +1,15 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
 import {
-  triggerBriefingGeneration,
-  getBriefingByMeetingId,
+  generateBriefing,
+  getBriefing,
 } from "../controllers/preMeetingBriefingController.js";
 
 const router = express.Router();
 
 router.use(userAuth);
 
-router.post("/:meetingId/generate", triggerBriefingGeneration);
-router.get("/:meetingId", getBriefingByMeetingId);
+router.post("/:meetingId/generate", generateBriefing);
+router.get("/:meetingId", getBriefing);
 
 export default router;

--- a/server/tests/preMeetingBriefingRoutes.test.js
+++ b/server/tests/preMeetingBriefingRoutes.test.js
@@ -1,0 +1,36 @@
+import request from "supertest";
+import mongoose from "mongoose";
+
+const { default: express } = await import("express");
+const { default: preMeetingBriefingRoutes } =
+  await import("../routes/preMeetingBriefingRoutes.js");
+
+describe("Pre-Meeting Briefing Routes Integration Tests (#1871)", () => {
+  const ORG_ID = new mongoose.Types.ObjectId();
+  const USER_ID = new mongoose.Types.ObjectId();
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Mock userAuth middleware response
+    app.use((req, res, next) => {
+      req.user = {
+        _id: USER_ID,
+        organization: ORG_ID,
+      };
+      next();
+    });
+    app.use("/api/briefings", preMeetingBriefingRoutes);
+  });
+
+  it("resolves route integration paths successfully without undefined import crashes", async () => {
+    const resGenerate = await request(app).post(
+      "/api/briefings/invalid-meeting-id/generate",
+    );
+    expect(resGenerate.status).toBe(400); // Invalid ObjectId format check in controller
+
+    const resGet = await request(app).get("/api/briefings/invalid-meeting-id");
+    expect(resGet.status).toBe(400); // Invalid ObjectId format check in controller
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR aligns the imported function signatures inside the Pre-meeting Briefing API router with the actual exported functions from `preMeetingBriefingController.js`, resolving runtime undefined router mounting crashes.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #1871

---

## ✨ Changes Made
- **Router Import Alignment**:
  - Corrected imported handler function signatures and routes bindings in `server/routes/preMeetingBriefingRoutes.js`.
- **Integration Tests**:
  - Added `server/tests/preMeetingBriefingRoutes.test.js` validating successful route resolution and handling.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run Jest tests:
```bash
cd server
npm run test tests/preMeetingBriefingRoutes.test.js
