### PR TITLE
feat: add notification grouping, mute-per-meeting, and digest toggle

### DIFF
--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -8,15 +8,20 @@ import {
   Bookmark,
   MessageSquare,
   Link2,
+  BellOff,
+  Bell,
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { toggleBookmarkAPI, getBookmarkStatusAPI } from "../../api/bookmarkApi";
 import { askAssistantAbout } from "../../utils/askAssistant.js";
+import { notificationApi } from "../../services/notificationApi.js";
 
 const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
   const navigate = useNavigate();
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [isLoadingBookmark, setIsLoadingBookmark] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [muteLoading, setMuteLoading] = useState(false);
 
   useEffect(() => {
     if (meeting?._id) {
@@ -25,6 +30,16 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
           setIsBookmarked(data.bookmarked);
         })
         .catch((err) => console.error("Error fetching bookmark status:", err));
+
+      notificationApi
+        .getPreferences()
+        .then(({ data }) => {
+          const muted = (data?.preferences?.mutedMeetingIds || []).map(String);
+          setIsMuted(muted.includes(String(meeting._id)));
+        })
+        .catch(() => {
+          // Mute state is best-effort
+        });
     }
   }, [meeting]);
 
@@ -40,6 +55,27 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
       toast.error("Failed to toggle bookmark");
     } finally {
       setIsLoadingBookmark(false);
+    }
+  };
+
+  const handleToggleMute = async () => {
+    if (!meeting?._id) return;
+    setMuteLoading(true);
+    try {
+      if (isMuted) {
+        await notificationApi.unmuteMeeting(meeting._id);
+        setIsMuted(false);
+        toast.success("Meeting notifications unmuted");
+      } else {
+        await notificationApi.muteMeeting(meeting._id);
+        setIsMuted(true);
+        toast.success("Meeting notifications muted");
+      }
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to update meeting mute");
+    } finally {
+      setMuteLoading(false);
     }
   };
 
@@ -158,6 +194,29 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
               fill={isBookmarked ? "currentColor" : "none"}
             />
             {isBookmarked ? "Saved" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={handleToggleMute}
+            disabled={muteLoading}
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              isMuted
+                ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                : "bg-gray-50 text-gray-700 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            }`}
+            aria-pressed={isMuted}
+            title={
+              isMuted
+                ? "Unmute notifications for this meeting"
+                : "Mute notifications for this meeting"
+            }
+          >
+            {isMuted ? (
+              <BellOff className="w-4 h-4" />
+            ) : (
+              <Bell className="w-4 h-4" />
+            )}
+            {isMuted ? "Unmute" : "Mute"}
           </button>
           <button
             onClick={onPresent}

--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -12,7 +12,6 @@ import {
   Trash2,
   Filter,
   Calendar,
-  FileText,
   Brain,
   Building2,
   ListChecks,
@@ -24,7 +23,12 @@ import {
   ChevronLeft,
   ChevronRight,
   CheckSquare,
+  Layers,
 } from "lucide-react";
+import {
+  groupNotifications,
+  notificationId,
+} from "../utils/groupNotifications.js";
 import NudgeInbox from "../components/NudgeInbox";
 
 /**
@@ -119,6 +123,9 @@ const Notifications = () => {
   // Filter states
   const [filter, setFilter] = useState("all"); // all, read, unread
   const [categoryFilter, setCategoryFilter] = useState("all"); // all, meetings, tasks, ai_processing, organizations, policies, reports, system
+  const [groupBy, setGroupBy] = useState("day"); // none, day, meeting, type
+  const [dailyDigest, setDailyDigest] = useState(false);
+  const [digestSaving, setDigestSaving] = useState(false);
 
   // Pagination state
   const [page, setPage] = useState(1);
@@ -180,17 +187,35 @@ const Notifications = () => {
     }
   }, [userData, fetchNotifications]);
 
+  useEffect(() => {
+    if (!userData) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await notificationApi.getPreferences();
+        if (!cancelled && data?.success) {
+          setDailyDigest(Boolean(data.preferences?.emailDailyDigest));
+        }
+      } catch {
+        // Preferences are optional for viewing the list
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userData]);
+
   /**
    * Mark a single notification as read
-   * @param {string} notificationId - ID of notification to mark as read
+   * @param {string} id - ID of notification to mark as read
    */
-  const handleMarkAsRead = async (notificationId) => {
+  const handleMarkAsRead = async (id) => {
     try {
-      const { data } = await notificationApi.markAsRead(notificationId);
+      const { data } = await notificationApi.markAsRead(id);
       if (data.success) {
         setNotifications((prev) =>
           prev.map((n) =>
-            n._id === notificationId ? { ...n, isRead: true } : n,
+            notificationId(n) === String(id) ? { ...n, isRead: true } : n,
           ),
         );
         setUnreadCount((prev) => Math.max(0, prev - 1));
@@ -198,6 +223,57 @@ const Notifications = () => {
     } catch (err) {
       console.error("Error marking as read:", err);
       toast.error("Failed to mark as read");
+    }
+  };
+
+  /**
+   * Mark all notifications in a group as read (Issue #2064)
+   */
+  const handleMarkGroupAsRead = async (items) => {
+    const unreadIds = items
+      .filter((n) => !n.isRead)
+      .map((n) => notificationId(n))
+      .filter(Boolean);
+    if (unreadIds.length === 0) return;
+
+    try {
+      const { data } = await notificationApi.markGroupAsRead(unreadIds);
+      if (data.success) {
+        const idSet = new Set(unreadIds);
+        setNotifications((prev) =>
+          prev.map((n) =>
+            idSet.has(notificationId(n)) ? { ...n, isRead: true } : n,
+          ),
+        );
+        setUnreadCount((prev) => Math.max(0, prev - unreadIds.length));
+        toast.success("Group marked as read");
+      }
+    } catch (err) {
+      console.error("Error marking group as read:", err);
+      toast.error("Failed to mark group as read");
+    }
+  };
+
+  const handleDailyDigestToggle = async () => {
+    const next = !dailyDigest;
+    setDigestSaving(true);
+    try {
+      const { data } = await notificationApi.updatePreferences({
+        emailDailyDigest: next,
+      });
+      if (data.success) {
+        setDailyDigest(next);
+        toast.success(
+          next
+            ? "Daily notification digest enabled"
+            : "Daily notification digest disabled",
+        );
+      }
+    } catch (err) {
+      console.error("Error updating digest preference:", err);
+      toast.error("Failed to update digest preference");
+    } finally {
+      setDigestSaving(false);
     }
   };
 
@@ -222,12 +298,12 @@ const Notifications = () => {
    * Delete a notification
    * @param {string} notificationId - ID of notification to delete
    */
-  const handleDelete = async (notificationId) => {
+  const handleDelete = async (id) => {
     try {
-      const { data } = await notificationApi.deleteNotification(notificationId);
+      const { data } = await notificationApi.deleteNotification(id);
       if (data.success) {
         setNotifications((prev) =>
-          prev.filter((n) => n._id !== notificationId),
+          prev.filter((n) => notificationId(n) !== String(id)),
         );
         toast.success("Notification deleted");
       }
@@ -242,8 +318,9 @@ const Notifications = () => {
    * @param {Object} notification - Notification object
    */
   const handleNotificationClick = (notification) => {
-    if (!notification.isRead) {
-      handleMarkAsRead(notification._id);
+    const id = notificationId(notification);
+    if (!notification.isRead && id) {
+      handleMarkAsRead(id);
     }
     if (notification.actionUrl) {
       const safeUrl = validateRedirect(notification.actionUrl, null);
@@ -254,6 +331,8 @@ const Notifications = () => {
       }
     }
   };
+
+  const groupedNotifications = groupNotifications(notifications, groupBy);
 
   // Redirect to login if not authenticated
   if (!userData) {
@@ -292,7 +371,7 @@ const Notifications = () => {
 
           <NudgeInbox organizationId={userData?.currentOrganization} />
 
-          {/* Filters Section - Issue #1214: Tasks filter added */}
+          {/* Filters Section - Issue #1214: Tasks filter added; #2064 grouping + digest */}
           <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
             <div className="flex items-center gap-2 mb-3">
               <Filter className="w-4 h-4 text-slate-500 dark:text-slate-400" />
@@ -301,7 +380,7 @@ const Notifications = () => {
               </span>
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {/* Status Filter (Read/Unread) */}
               <div>
                 <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
@@ -338,6 +417,35 @@ const Notifications = () => {
                   <option value="system">System</option>
                 </select>
               </div>
+
+              <div>
+                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
+                  Group by
+                </label>
+                <select
+                  value={groupBy}
+                  onChange={(e) => setGroupBy(e.target.value)}
+                  className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                >
+                  <option value="day">Day</option>
+                  <option value="meeting">Meeting</option>
+                  <option value="type">Type</option>
+                  <option value="none">None</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={dailyDigest}
+                  disabled={digestSaving}
+                  onChange={handleDailyDigestToggle}
+                  className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                />
+                Daily notification digest
+              </label>
             </div>
 
             {/* Active Filter Indicators */}
@@ -437,112 +545,144 @@ const Notifications = () => {
           </div>
         )}
 
-        {/* Notifications List */}
+        {/* Notifications List (grouped — Issue #2064) */}
         {!loading && !error && notifications.length > 0 && (
-          <div className="space-y-3">
-            {notifications.map((notification) => {
-              const IconComponent =
-                CATEGORY_ICONS[notification.category] || AlertCircle;
-              const colorClass =
-                CATEGORY_COLORS[notification.category] ||
-                CATEGORY_COLORS.system;
+          <div className="space-y-6">
+            {groupedNotifications.map((group) => {
+              const unreadInGroup = group.items.filter((n) => !n.isRead).length;
+              const typeLabel =
+                groupBy === "type"
+                  ? CATEGORY_LABELS[group.label] || group.label
+                  : group.label;
 
               return (
-                <div
-                  key={notification._id}
-                  onClick={() => handleNotificationClick(notification)}
-                  className={`group relative bg-white dark:bg-slate-800 rounded-2xl border transition-all cursor-pointer hover:shadow-lg ${
-                    notification.isRead
-                      ? "border-slate-200 dark:border-slate-700"
-                      : "border-blue-300 dark:border-blue-700 shadow-md"
-                  }`}
-                >
-                  <div className="p-5">
-                    <div className="flex items-start gap-4">
-                      {/* Category Icon */}
-                      <div
-                        className={`flex-shrink-0 w-12 h-12 rounded-xl border-2 flex items-center justify-center ${colorClass}`}
-                      >
-                        <IconComponent className="w-6 h-6" />
-                      </div>
-
-                      {/* Content */}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between gap-2 mb-1">
-                          <h3
-                            className={`text-base font-semibold ${
-                              notification.isRead
-                                ? "text-slate-700 dark:text-slate-300"
-                                : "text-slate-900 dark:text-white"
-                            }`}
-                          >
-                            {notification.title}
-                          </h3>
-                          <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
-                            {formatTimeAgo(notification.createdAt)}
-                          </span>
-                        </div>
-
-                        <p className="text-sm text-slate-600 dark:text-slate-400 line-clamp-2 mb-2">
-                          {notification.description}
-                        </p>
-
-                        <div className="flex items-center gap-2">
-                          <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300">
-                            {CATEGORY_LABELS[notification.category] || "System"}
-                          </span>
-                          {!notification.isRead && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300">
-                              New
-                            </span>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* Actions */}
-                      <div className="flex-shrink-0 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
-                        {!notification.isRead && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleMarkAsRead(notification._id);
-                            }}
-                            aria-label={`Mark "${notification.title}" as read`}
-                            className="p-3 sm:p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-                            title="Mark as read"
-                          >
-                            <Check className="w-4 h-4" />
-                          </button>
-                        )}
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleDelete(notification._id);
-                          }}
-                          aria-label={`Delete notification "${notification.title}"`}
-                          className="p-3 sm:p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
-                          title="Delete"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Action Button */}
-                    {notification.actionUrl && (
+                <section key={group.key} className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                      <Layers className="w-4 h-4 text-slate-400" />
+                      {typeLabel}
+                      <span className="text-xs font-medium text-slate-500">
+                        ({group.items.length})
+                      </span>
+                    </h2>
+                    {unreadInGroup > 0 && (
                       <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleNotificationClick(notification);
-                        }}
-                        className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                        type="button"
+                        onClick={() => handleMarkGroupAsRead(group.items)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-100 dark:hover:bg-blue-950/50 rounded-lg transition-colors"
                       >
-                        {notification.actionLabel || "View Details"}
-                        <ArrowRight className="w-4 h-4" />
+                        <CheckSquare className="w-3.5 h-3.5" />
+                        Mark group as read
                       </button>
                     )}
                   </div>
-                </div>
+
+                  <div className="space-y-3">
+                    {group.items.map((notification) => {
+                      const id = notificationId(notification);
+                      const IconComponent =
+                        CATEGORY_ICONS[notification.category] || AlertCircle;
+                      const colorClass =
+                        CATEGORY_COLORS[notification.category] ||
+                        CATEGORY_COLORS.system;
+
+                      return (
+                        <div
+                          key={id}
+                          onClick={() => handleNotificationClick(notification)}
+                          className={`group relative bg-white dark:bg-slate-800 rounded-2xl border transition-all cursor-pointer hover:shadow-lg ${
+                            notification.isRead
+                              ? "border-slate-200 dark:border-slate-700"
+                              : "border-blue-300 dark:border-blue-700 shadow-md"
+                          }`}
+                        >
+                          <div className="p-5">
+                            <div className="flex items-start gap-4">
+                              <div
+                                className={`flex-shrink-0 w-12 h-12 rounded-xl border-2 flex items-center justify-center ${colorClass}`}
+                              >
+                                <IconComponent className="w-6 h-6" />
+                              </div>
+
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-start justify-between gap-2 mb-1">
+                                  <h3
+                                    className={`text-base font-semibold ${
+                                      notification.isRead
+                                        ? "text-slate-700 dark:text-slate-300"
+                                        : "text-slate-900 dark:text-white"
+                                    }`}
+                                  >
+                                    {notification.title}
+                                  </h3>
+                                  <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                                    {formatTimeAgo(notification.createdAt)}
+                                  </span>
+                                </div>
+
+                                <p className="text-sm text-slate-600 dark:text-slate-400 line-clamp-2 mb-2">
+                                  {notification.description}
+                                </p>
+
+                                <div className="flex items-center gap-2">
+                                  <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300">
+                                    {CATEGORY_LABELS[notification.category] ||
+                                      "System"}
+                                  </span>
+                                  {!notification.isRead && (
+                                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300">
+                                      New
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+
+                              <div className="flex-shrink-0 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
+                                {!notification.isRead && (
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleMarkAsRead(id);
+                                    }}
+                                    aria-label={`Mark "${notification.title}" as read`}
+                                    className="p-3 sm:p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                                    title="Mark as read"
+                                  >
+                                    <Check className="w-4 h-4" />
+                                  </button>
+                                )}
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleDelete(id);
+                                  }}
+                                  aria-label={`Delete notification "${notification.title}"`}
+                                  className="p-3 sm:p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
+                                  title="Delete"
+                                >
+                                  <Trash2 className="w-4 h-4" />
+                                </button>
+                              </div>
+                            </div>
+
+                            {notification.actionUrl && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleNotificationClick(notification);
+                                }}
+                                className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+                              >
+                                {notification.actionLabel || "View Details"}
+                                <ArrowRight className="w-4 h-4" />
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
               );
             })}
           </div>

--- a/client/src/services/notificationApi.js
+++ b/client/src/services/notificationApi.js
@@ -5,6 +5,12 @@ export const notificationApi = {
   getUnreadCount: () => apiClient.get("/api/notifications/unread-count"),
   markAsRead: (id) => apiClient.patch(`/api/notifications/${id}/read`),
   markAllAsRead: () => apiClient.patch("/api/notifications/mark-all-read"),
+  markGroupAsRead: (ids) =>
+    apiClient.patch("/api/notifications/mark-group-read", { ids }),
+  muteMeeting: (meetingId) =>
+    apiClient.post(`/api/notifications/mute-meeting/${meetingId}`),
+  unmuteMeeting: (meetingId) =>
+    apiClient.delete(`/api/notifications/mute-meeting/${meetingId}`),
   deleteNotification: (id) => apiClient.delete(`/api/notifications/${id}`),
   getPreferences: () => apiClient.get("/api/notifications/preferences"),
   updatePreferences: (data) =>

--- a/client/src/utils/__tests__/groupNotifications.test.js
+++ b/client/src/utils/__tests__/groupNotifications.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { groupNotifications, notificationId } from "../groupNotifications.js";
+
+describe("groupNotifications (#2064)", () => {
+  const sample = [
+    {
+      id: "1",
+      category: "meetings",
+      createdAt: "2026-08-20T10:00:00Z",
+      metadata: { meetingId: "m1", meetingTitle: "Sprint Planning" },
+      isRead: false,
+    },
+    {
+      id: "2",
+      category: "tasks",
+      createdAt: "2026-08-20T12:00:00Z",
+      metadata: { meetingId: "m1", meetingTitle: "Sprint Planning" },
+      isRead: true,
+    },
+    {
+      id: "3",
+      category: "meetings",
+      createdAt: "2026-08-21T09:00:00Z",
+      metadata: { meetingId: "m2" },
+      isRead: false,
+    },
+  ];
+
+  it("groups by day", () => {
+    const groups = groupNotifications(sample, "day");
+    expect(groups.length).toBe(2);
+    expect(groups.every((g) => g.key.startsWith("day:"))).toBe(true);
+  });
+
+  it("groups by meeting", () => {
+    const groups = groupNotifications(sample, "meeting");
+    expect(groups).toHaveLength(2);
+    const sprint = groups.find((g) => g.key === "meeting:m1");
+    expect(sprint.label).toBe("Sprint Planning");
+    expect(sprint.items).toHaveLength(2);
+  });
+
+  it("groups by type", () => {
+    const groups = groupNotifications(sample, "type");
+    expect(groups.map((g) => g.key).sort()).toEqual([
+      "type:meetings",
+      "type:tasks",
+    ]);
+  });
+
+  it("supports flat none grouping", () => {
+    const groups = groupNotifications(sample, "none");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items).toHaveLength(3);
+  });
+
+  it("resolves notification ids from id or _id", () => {
+    expect(notificationId({ id: "abc" })).toBe("abc");
+    expect(notificationId({ _id: "xyz" })).toBe("xyz");
+  });
+});

--- a/client/src/utils/groupNotifications.js
+++ b/client/src/utils/groupNotifications.js
@@ -1,0 +1,82 @@
+/**
+ * Group notification list for the Notifications page (Issue #2064).
+ *
+ * @param {Array<object>} notifications
+ * @param {"none"|"day"|"meeting"|"type"} groupBy
+ * @returns {Array<{ key: string, label: string, items: object[] }>}
+ */
+export function groupNotifications(notifications, groupBy = "day") {
+  if (!Array.isArray(notifications) || notifications.length === 0) {
+    return [];
+  }
+
+  if (groupBy === "none") {
+    return [
+      {
+        key: "all",
+        label: "All notifications",
+        items: notifications,
+      },
+    ];
+  }
+
+  const groups = new Map();
+
+  for (const notification of notifications) {
+    const { key, label } = resolveGroup(notification, groupBy);
+    if (!groups.has(key)) {
+      groups.set(key, { key, label, items: [] });
+    }
+    groups.get(key).items.push(notification);
+  }
+
+  return Array.from(groups.values());
+}
+
+function resolveGroup(notification, groupBy) {
+  if (groupBy === "type") {
+    const category = notification.category || "system";
+    return {
+      key: `type:${category}`,
+      label: category,
+    };
+  }
+
+  if (groupBy === "meeting") {
+    const meetingId =
+      notification.metadata?.meetingId ||
+      notification.metadata?.meeting ||
+      null;
+    if (meetingId) {
+      return {
+        key: `meeting:${String(meetingId)}`,
+        label: notification.metadata?.meetingTitle
+          ? String(notification.metadata.meetingTitle)
+          : `Meeting ${String(meetingId).slice(-6)}`,
+      };
+    }
+    return { key: "meeting:none", label: "No meeting" };
+  }
+
+  // day (default)
+  const created = notification.createdAt
+    ? new Date(notification.createdAt)
+    : new Date();
+  const dayKey = Number.isNaN(created.getTime())
+    ? "unknown"
+    : created.toISOString().slice(0, 10);
+  const label =
+    dayKey === "unknown"
+      ? "Unknown date"
+      : created.toLocaleDateString(undefined, {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        });
+  return { key: `day:${dayKey}`, label };
+}
+
+export function notificationId(notification) {
+  return String(notification?.id || notification?._id || "");
+}

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -1,4 +1,5 @@
 // server/controllers/notificationController.js
+import mongoose from "mongoose";
 import notificationModel from "../models/notificationModel.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 import NotificationPreference from "../models/notificationPreferenceModel.js";
@@ -228,6 +229,7 @@ export const updatePreferences = async (req, res) => {
       "emailMeetingReminders",
       "emailTaskAssignments",
       "emailWeeklyDigest",
+      "emailDailyDigest",
       "pushMeetingReminders",
       "pushTaskAssignments",
       "pushAiProcessingComplete",
@@ -256,6 +258,106 @@ export const updatePreferences = async (req, res) => {
     sendSuccess(res, { preferences }, "Preferences updated successfully");
   } catch (error) {
     console.error("Error in updatePreferences:", error);
+    sendError(res, 500, "Server error");
+  }
+};
+
+// @desc    Mark a group of notifications as read (Issue #2064)
+// @route   PATCH /api/notifications/mark-group-read
+// @access  Private
+export const markGroupAsRead = async (req, res) => {
+  try {
+    if (!req.user || !req.user.id) {
+      return sendError(res, 401, "Authentication error, user ID not found.");
+    }
+
+    const ids = Array.isArray(req.body?.ids) ? req.body.ids : [];
+    const cleanIds = ids
+      .filter((id) => typeof id === "string" && mongoose.isValidObjectId(id))
+      .map((id) => id);
+
+    if (cleanIds.length === 0) {
+      return sendError(res, 400, "Provide at least one valid notification id.");
+    }
+
+    const result = await notificationModel.updateMany(
+      {
+        _id: { $in: cleanIds },
+        user: req.user.id,
+        isRead: false,
+      },
+      { isRead: true },
+    );
+
+    sendSuccess(
+      res,
+      { modifiedCount: result.modifiedCount },
+      "Group marked as read",
+    );
+  } catch (error) {
+    console.error("Error in markGroupAsRead:", error);
+    sendError(res, 500, "Server error");
+  }
+};
+
+// @desc    Mute in-app notifications for a meeting (Issue #2064)
+// @route   POST /api/notifications/mute-meeting/:meetingId
+// @access  Private
+export const muteMeeting = async (req, res) => {
+  try {
+    if (!req.user || !req.user.id) {
+      return sendError(res, 401, "Authentication error, user ID not found.");
+    }
+
+    const { meetingId } = req.params;
+    if (!mongoose.isValidObjectId(meetingId)) {
+      return sendError(res, 400, "Invalid meeting id");
+    }
+
+    const preferences = await NotificationPreference.findOneAndUpdate(
+      { user: req.user.id },
+      { $addToSet: { mutedMeetingIds: meetingId } },
+      { new: true, upsert: true },
+    );
+
+    sendSuccess(
+      res,
+      { preferences, muted: true, meetingId },
+      "Meeting notifications muted",
+    );
+  } catch (error) {
+    console.error("Error in muteMeeting:", error);
+    sendError(res, 500, "Server error");
+  }
+};
+
+// @desc    Unmute in-app notifications for a meeting (Issue #2064)
+// @route   DELETE /api/notifications/mute-meeting/:meetingId
+// @access  Private
+export const unmuteMeeting = async (req, res) => {
+  try {
+    if (!req.user || !req.user.id) {
+      return sendError(res, 401, "Authentication error, user ID not found.");
+    }
+
+    const { meetingId } = req.params;
+    if (!mongoose.isValidObjectId(meetingId)) {
+      return sendError(res, 400, "Invalid meeting id");
+    }
+
+    const preferences = await NotificationPreference.findOneAndUpdate(
+      { user: req.user.id },
+      { $pull: { mutedMeetingIds: meetingId } },
+      { new: true, upsert: true },
+    );
+
+    sendSuccess(
+      res,
+      { preferences, muted: false, meetingId },
+      "Meeting notifications unmuted",
+    );
+  } catch (error) {
+    console.error("Error in unmuteMeeting:", error);
     sendError(res, 500, "Server error");
   }
 };

--- a/server/models/notificationPreferenceModel.js
+++ b/server/models/notificationPreferenceModel.js
@@ -74,6 +74,25 @@ const notificationPreferenceSchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
+
+    // ── Mute per meeting (Issue #2064) ───────────────────────────────────
+    // Meeting ids whose in-app notifications should be suppressed.
+    mutedMeetingIds: {
+      type: [
+        {
+          type: mongoose.Schema.Types.ObjectId,
+          ref: "Meeting",
+        },
+      ],
+      default: [],
+    },
+
+    // Optional daily notification digest email toggle (Issue #2064).
+    // Preference is persisted here; digest delivery job may consume it later.
+    emailDailyDigest: {
+      type: Boolean,
+      default: false,
+    },
   },
   { timestamps: true },
 );

--- a/server/routes/notificationRoutes.js
+++ b/server/routes/notificationRoutes.js
@@ -7,10 +7,13 @@ import {
   getNotifications,
   markAsRead,
   markAllAsRead,
+  markGroupAsRead,
   deleteNotification,
   getUnreadCount,
   getPreferences,
   updatePreferences,
+  muteMeeting,
+  unmuteMeeting,
 } from "../controllers/notificationController.js";
 
 const notificationRouter = express.Router();
@@ -32,6 +35,24 @@ notificationRouter.patch(
   writeLimiter,
   requirePermission("notifications", "self_manage"),
   markAllAsRead,
+);
+notificationRouter.patch(
+  "/mark-group-read",
+  writeLimiter,
+  requirePermission("notifications", "self_manage"),
+  markGroupAsRead,
+);
+notificationRouter.post(
+  "/mute-meeting/:meetingId",
+  writeLimiter,
+  requirePermission("notifications", "self_manage"),
+  muteMeeting,
+);
+notificationRouter.delete(
+  "/mute-meeting/:meetingId",
+  writeLimiter,
+  requirePermission("notifications", "self_manage"),
+  unmuteMeeting,
 );
 notificationRouter.patch(
   "/:id/read",

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -98,6 +98,21 @@ export const isSuppressed = (prefs, category) => {
 };
 
 /**
+ * True when the user has muted in-app notifications for this meeting (Issue #2064).
+ *
+ * @param {object|undefined} prefs
+ * @param {object} [metadata]
+ * @returns {boolean}
+ */
+export const isMeetingMuted = (prefs, metadata = {}) => {
+  if (!prefs?.mutedMeetingIds?.length) return false;
+  const meetingId = metadata?.meetingId;
+  if (!meetingId) return false;
+  const target = String(meetingId);
+  return prefs.mutedMeetingIds.some((id) => String(id) === target);
+};
+
+/**
  * Formats a notification document for API/socket responses.
  *
  * @param {object} notification
@@ -165,14 +180,17 @@ export const createNotifications = async (recipients, payload) => {
   try {
     const prefsByUser = await loadPreferences(uniqueIds);
 
-    const deliverTo = uniqueIds.filter(
-      (userId) => !isSuppressed(prefsByUser.get(userId), category),
-    );
+    const deliverTo = uniqueIds.filter((userId) => {
+      const prefs = prefsByUser.get(userId);
+      if (isSuppressed(prefs, category)) return false;
+      if (isMeetingMuted(prefs, metadata)) return false;
+      return true;
+    });
 
     const suppressedCount = uniqueIds.length - deliverTo.length;
     if (suppressedCount > 0) {
       console.log(
-        `🔇 ${suppressedCount} notification(s) suppressed — category "${category}" disabled in preferences`,
+        `🔇 ${suppressedCount} notification(s) suppressed — category "${category}" disabled or meeting muted`,
       );
     }
 

--- a/server/tests/isMeetingMuted.test.js
+++ b/server/tests/isMeetingMuted.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { isMeetingMuted } from "../services/notificationService.js";
+
+describe("isMeetingMuted (#2064)", () => {
+  it("returns true when meeting id is in mutedMeetingIds", () => {
+    expect(
+      isMeetingMuted(
+        { mutedMeetingIds: ["507f1f77bcf86cd799439011"] },
+        { meetingId: "507f1f77bcf86cd799439011" },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when meeting is not muted or metadata missing", () => {
+    expect(
+      isMeetingMuted(
+        { mutedMeetingIds: ["507f1f77bcf86cd799439011"] },
+        { meetingId: "507f1f77bcf86cd799439012" },
+      ),
+    ).toBe(false);
+    expect(isMeetingMuted({ mutedMeetingIds: [] }, { meetingId: "x" })).toBe(
+      false,
+    );
+    expect(isMeetingMuted(undefined, { meetingId: "x" })).toBe(false);
+    expect(
+      isMeetingMuted({ mutedMeetingIds: ["507f1f77bcf86cd799439011"] }, {}),
+    ).toBe(false);
+  });
+});

--- a/server/tests/notificationPipeline.test.js
+++ b/server/tests/notificationPipeline.test.js
@@ -27,6 +27,7 @@ const {
   createNotification,
   createNotifications,
   isSuppressed,
+  isMeetingMuted,
 } = await import("../services/notificationService.js");
 const { initListeners, _resetListenerRegistration } =
   await import("../events/listeners.js");
@@ -120,6 +121,24 @@ describe("category → preference mapping", () => {
     expect(isSuppressed({}, "meetings")).toBe(false);
     expect(isSuppressed(undefined, "meetings")).toBe(false);
   });
+
+  it("detects muted meetings from preference list (#2064)", () => {
+    const meetingId = objectId();
+    expect(
+      isMeetingMuted(
+        { mutedMeetingIds: [meetingId] },
+        { meetingId: String(meetingId) },
+      ),
+    ).toBe(true);
+    expect(
+      isMeetingMuted(
+        { mutedMeetingIds: [meetingId] },
+        { meetingId: objectId() },
+      ),
+    ).toBe(false);
+    expect(isMeetingMuted({ mutedMeetingIds: [] }, { meetingId })).toBe(false);
+    expect(isMeetingMuted(undefined, { meetingId })).toBe(false);
+  });
 });
 
 describe("createNotifications — bulk fan-out", () => {
@@ -189,6 +208,27 @@ describe("createNotifications — bulk fan-out", () => {
 
     expect(created).toHaveLength(1);
     expect(String(created[0].user)).toBe(String(optedIn));
+  });
+
+  it("skips recipients who muted the meeting (#2064)", async () => {
+    const unmuted = objectId();
+    const muted = objectId();
+    const meetingId = objectId();
+
+    await NotificationPreference.create({
+      user: muted,
+      mutedMeetingIds: [meetingId],
+    });
+
+    const created = await createNotifications([unmuted, muted], {
+      title: "Meeting update",
+      description: "Something changed",
+      category: "meetings",
+      metadata: { meetingId },
+    });
+
+    expect(created).toHaveLength(1);
+    expect(String(created[0].user)).toBe(String(unmuted));
   });
 
   it("honours the tasks toggle independently of the meetings toggle", async () => {


### PR DESCRIPTION
## Summary
- Closes #2064
- Group notifications by day, meeting, or type with mark-group-as-read
- Mute/unmute meeting notifications from Meeting Details (enforced on create)
- Optional daily notification digest preference toggle
## Test plan
- [ ] `npm run lint:changed --prefix client && npm run format:check:changed --prefix client`
- [ ] `npm run lint:changed --prefix server && npm run format:check:changed --prefix server`
- [ ] `cd client && npx vitest run src/utils/__tests__/groupNotifications.test.js`
- [ ] `cd server && npx vitest run tests/isMeetingMuted.test.js`
- [ ] Open Notifications: switch Group by day/meeting/type; mark a group as read
- [ ] Toggle Daily notification digest
- [ ] On a meeting details page, Mute then confirm no new in-app alerts for that meeting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls to mute or unmute notifications for individual meetings.
  * Added notification grouping by day, meeting, type, or an ungrouped list.
  * Added group-level “mark as read” actions and notification counts.
  * Added an optional daily email digest preference.
  * Added clearer notification filtering, labels, and accessibility states.
  * Muted meetings no longer generate in-app notifications.

* **Bug Fixes**
  * Improved notification identity handling for consistent marking, deleting, and opening actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->