### PR TITLE
Add admin Jobs dashboard for BullMQ queue status and retries.

### DIFF
--- a/client/src/components/admin/JobsDashboard.jsx
+++ b/client/src/components/admin/JobsDashboard.jsx
@@ -1,0 +1,273 @@
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  RefreshCw,
+  RotateCcw,
+  Trash2,
+  Loader2,
+  AlertTriangle,
+  Activity,
+} from "lucide-react";
+import AppContent from "../../context/AppContent.js";
+import { adminJobsApi } from "../../services/adminJobsApi.js";
+
+const countTone = (n) =>
+  n > 0
+    ? "text-slate-900 dark:text-white"
+    : "text-slate-400 dark:text-slate-500";
+
+export default function JobsDashboard() {
+  const { userData } = useContext(AppContent) || {};
+  const canMutate = userData?.role === "owner";
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [dashboard, setDashboard] = useState(null);
+  const [busyKey, setBusyKey] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const { data } = await adminJobsApi.getDashboard({ failedLimit: 15 });
+      if (data?.success === false) {
+        setError(data.message || "Failed to load jobs");
+        setDashboard(null);
+      } else {
+        setDashboard({
+          redisConfigured: Boolean(data.redisConfigured),
+          workers: data.workers || [],
+          shuttingDown: Boolean(data.shuttingDown),
+          queues: data.queues || [],
+        });
+      }
+    } catch (err) {
+      setError(
+        err?.response?.data?.message || "Failed to load background job status",
+      );
+      setDashboard(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleRetry = async (queueName, jobId) => {
+    const key = `retry:${queueName}:${jobId}`;
+    setBusyKey(key);
+    try {
+      await adminJobsApi.retryJob(queueName, jobId);
+      toast.success("Job queued for retry");
+      await load();
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Retry failed");
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleDiscard = async (queueName, jobId) => {
+    if (!window.confirm("Discard this failed job permanently?")) return;
+    const key = `discard:${queueName}:${jobId}`;
+    setBusyKey(key);
+    try {
+      await adminJobsApi.discardJob(queueName, jobId);
+      toast.success("Failed job discarded");
+      await load();
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Discard failed");
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  if (loading && !dashboard) {
+    return (
+      <div className="flex items-center justify-center py-16 text-slate-500 gap-2">
+        <Loader2 className="w-5 h-5 animate-spin" />
+        Loading job queues…
+      </div>
+    );
+  }
+
+  if (error && !dashboard) {
+    return (
+      <div className="rounded-2xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 p-8 text-center">
+        <AlertTriangle className="w-8 h-8 text-rose-500 mx-auto mb-3" />
+        <p className="text-sm font-semibold text-rose-800 dark:text-rose-200">
+          {error}
+        </p>
+        <button
+          type="button"
+          onClick={load}
+          className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 text-white text-xs font-semibold cursor-pointer"
+        >
+          <RefreshCw className="w-3.5 h-3.5" /> Retry
+        </button>
+      </div>
+    );
+  }
+
+  const queues = dashboard?.queues || [];
+  const failedFlat = queues.flatMap((q) =>
+    (q.recentFailed || []).map((job) => ({ ...job, queueName: q.name })),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Redis{" "}
+            {dashboard?.redisConfigured ? (
+              <span className="text-emerald-600 dark:text-emerald-400 font-semibold">
+                connected
+              </span>
+            ) : (
+              <span className="text-amber-600 dark:text-amber-400 font-semibold">
+                not configured
+              </span>
+            )}
+            {dashboard?.workers?.length
+              ? ` · ${dashboard.workers.length} worker(s)`
+              : ""}
+          </p>
+          {!canMutate ? (
+            <p className="text-xs text-slate-400 mt-1">
+              Read-only: retry/discard requires owner role.
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 text-xs font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer disabled:opacity-50"
+        >
+          <RefreshCw
+            className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+        {queues.map((queue) => (
+          <div
+            key={queue.name}
+            className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-2 mb-3">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-wide text-slate-400">
+                  Queue
+                </p>
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-white break-all">
+                  {queue.name}
+                </h3>
+              </div>
+              <Activity
+                className={`w-4 h-4 shrink-0 ${
+                  queue.available
+                    ? "text-emerald-500"
+                    : "text-slate-300 dark:text-slate-600"
+                }`}
+              />
+            </div>
+            <dl className="grid grid-cols-3 gap-2 text-center">
+              {[
+                ["waiting", queue.counts?.waiting],
+                ["active", queue.counts?.active],
+                ["failed", queue.counts?.failed],
+                ["delayed", queue.counts?.delayed],
+                ["completed", queue.counts?.completed],
+                ["paused", queue.counts?.paused],
+              ].map(([label, value]) => (
+                <div
+                  key={label}
+                  className="rounded-lg bg-slate-50 dark:bg-slate-800/60 px-2 py-2"
+                >
+                  <dt className="text-[10px] uppercase tracking-wide text-slate-400">
+                    {label}
+                  </dt>
+                  <dd className={`text-sm font-bold ${countTone(value || 0)}`}>
+                    {value ?? 0}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+            {queue.error ? (
+              <p className="mt-2 text-xs text-rose-500">{queue.error}</p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-sm">
+        <h3 className="text-sm font-bold text-slate-900 dark:text-white mb-4">
+          Recent failed jobs
+        </h3>
+        {failedFlat.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 dark:border-slate-700 px-4 py-10 text-center text-sm text-slate-400">
+            No recent failed jobs.
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {failedFlat.map((job) => {
+              const retryKey = `retry:${job.queueName}:${job.id}`;
+              const discardKey = `discard:${job.queueName}:${job.id}`;
+              return (
+                <li
+                  key={`${job.queueName}-${job.id}`}
+                  className="rounded-xl border border-slate-200 dark:border-slate-700 p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                        {job.name}{" "}
+                        <span className="text-xs font-normal text-slate-500">
+                          #{job.id}
+                        </span>
+                      </p>
+                      <p className="text-xs text-slate-500 mt-0.5">
+                        Queue: {job.queueName} · Attempts: {job.attemptsMade}
+                      </p>
+                      <p className="text-xs text-rose-600 dark:text-rose-400 mt-2 break-words">
+                        {job.failedReason || "Unknown failure"}
+                      </p>
+                    </div>
+                    {canMutate ? (
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          disabled={busyKey === retryKey}
+                          onClick={() => handleRetry(job.queueName, job.id)}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-emerald-600 text-white disabled:opacity-50 cursor-pointer"
+                        >
+                          <RotateCcw className="w-3.5 h-3.5" />
+                          Retry
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busyKey === discardKey}
+                          onClick={() => handleDiscard(job.queueName, job.id)}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-rose-600 text-white disabled:opacity-50 cursor-pointer"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                          Discard
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   LayoutDashboard,
   Building2,
@@ -26,10 +26,12 @@ import {
   Loader2,
   Clock,
   RefreshCw,
+  ListTodo,
 } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import TemplateBuilder from "../components/admin/TemplateBuilder.jsx";
 import TestimonialsModeration from "../components/admin/TestimonialsModeration.jsx";
+import JobsDashboard from "../components/admin/JobsDashboard.jsx";
 import MembershipRequests from "../components/organization/MembershipRequests.jsx";
 import AppContent from "../context/AppContent.js";
 import {
@@ -98,6 +100,14 @@ const MODULES = [
     iconColor: "text-sky-600 dark:text-sky-400",
   },
   {
+    id: "jobs",
+    labelKey: "Jobs",
+    descriptionKey: "Background queues, failures, and retries",
+    icon: ListTodo,
+    iconBg: "bg-teal-50 dark:bg-teal-900/30",
+    iconColor: "text-teal-600 dark:text-teal-400",
+  },
+  {
     id: "policies",
     labelKey: "adminPanel.policies",
     descriptionKey: "adminPanel.policiesDesc",
@@ -134,10 +144,17 @@ const MODULES = [
 const AdminPanel = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { userData } = useContext(AppContent) || {};
   const orgId = userData?.organization?._id || userData?.organization;
 
-  const [activeModule, setActiveModule] = useState("overview");
+  const initialModule = (() => {
+    const requested = searchParams.get("module");
+    if (requested && MODULES.some((m) => m.id === requested)) return requested;
+    return "overview";
+  })();
+
+  const [activeModule, setActiveModule] = useState(initialModule);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const sidebarRef = useRef(null);
 
@@ -257,6 +274,7 @@ const AdminPanel = () => {
       activeModule === "overview" ||
       activeModule === "templates" ||
       activeModule === "testimonials" ||
+      activeModule === "jobs" ||
       activeModule === "joinRequests"
     ) {
       return;
@@ -542,6 +560,8 @@ const AdminPanel = () => {
             <TemplateBuilder />
           ) : activeModule === "testimonials" ? (
             <TestimonialsModeration />
+          ) : activeModule === "jobs" ? (
+            <JobsDashboard />
           ) : activeModule === "joinRequests" ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm">
               <MembershipRequests organizationId={orgId} />

--- a/client/src/pages/Status.jsx
+++ b/client/src/pages/Status.jsx
@@ -672,7 +672,15 @@ const Status = () => {
               Status reflects live checks against{" "}
               <code className="text-[11px]">/api/status</code>, backed by the
               same dependency probes as{" "}
-              <code className="text-[11px]">/health</code>.
+              <code className="text-[11px]">/health</code>. Admins can inspect
+              background queues on the{" "}
+              <a
+                href="/admin-panel?module=jobs"
+                className="text-blue-600 dark:text-blue-400 font-semibold hover:underline"
+              >
+                Jobs dashboard
+              </a>
+              .
             </p>
           </div>
           <a

--- a/client/src/services/adminJobsApi.js
+++ b/client/src/services/adminJobsApi.js
@@ -1,0 +1,13 @@
+import apiClient from "./apiClient";
+
+export const adminJobsApi = {
+  getDashboard: (params) => apiClient.get("/api/admin/jobs", { params }),
+  retryJob: (queueName, jobId) =>
+    apiClient.post(
+      `/api/admin/jobs/${encodeURIComponent(queueName)}/${encodeURIComponent(jobId)}/retry`,
+    ),
+  discardJob: (queueName, jobId) =>
+    apiClient.delete(
+      `/api/admin/jobs/${encodeURIComponent(queueName)}/${encodeURIComponent(jobId)}`,
+    ),
+};

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -27,6 +27,7 @@ export { default as meetingGoalApi } from "./meetingGoalApi";
 export * from "./actionItemDependencyApi";
 export * from "./parkingLotApi";
 export * from "./statusApi";
+export * from "./adminJobsApi";
 export { default as sentimentTimelineApi } from "./sentimentTimelineApi";
 export { default as carryForwardApi } from "./carryForwardApi";
 export { default as bulkMeetingApi } from "./bulkMeetingApi";

--- a/server/controllers/adminJobsController.js
+++ b/server/controllers/adminJobsController.js
@@ -1,0 +1,56 @@
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import {
+  getAdminJobsDashboard,
+  retryFailedJob,
+  discardFailedJob,
+} from "../services/adminJobsService.js";
+
+/**
+ * GET /api/admin/jobs
+ * Queue depths + recent failed jobs for the admin Jobs board (Issue #2080).
+ */
+export const getAdminJobs = async (req, res) => {
+  try {
+    const dashboard = await getAdminJobsDashboard({
+      failedLimit: req.query.failedLimit,
+    });
+    return sendSuccess(res, dashboard);
+  } catch (error) {
+    console.error("Error in getAdminJobs:", error);
+    return sendError(res, 500, "Failed to load job dashboard");
+  }
+};
+
+/**
+ * POST /api/admin/jobs/:queueName/:jobId/retry
+ */
+export const retryAdminJob = async (req, res) => {
+  try {
+    const { queueName, jobId } = req.params;
+    const result = await retryFailedJob(queueName, jobId);
+    return sendSuccess(res, result, "Job queued for retry");
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in retryAdminJob:", error);
+    return sendError(res, 500, "Failed to retry job");
+  }
+};
+
+/**
+ * DELETE /api/admin/jobs/:queueName/:jobId
+ */
+export const discardAdminJob = async (req, res) => {
+  try {
+    const { queueName, jobId } = req.params;
+    const result = await discardFailedJob(queueName, jobId);
+    return sendSuccess(res, result, "Failed job discarded");
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in discardAdminJob:", error);
+    return sendError(res, 500, "Failed to discard job");
+  }
+};

--- a/server/routes/adminJobsRoutes.js
+++ b/server/routes/adminJobsRoutes.js
@@ -1,0 +1,32 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import { apiLimiter, writeLimiter } from "../middleware/rateLimiter.js";
+import { requireAdminOrOwner, requireRole } from "../middleware/rbac.js";
+import {
+  getAdminJobs,
+  retryAdminJob,
+  discardAdminJob,
+} from "../controllers/adminJobsController.js";
+
+const router = express.Router();
+
+router.use(userAuth, apiLimiter);
+
+// Admins and owners can view queue status (Issue #2080).
+router.get("/", requireAdminOrOwner, getAdminJobs);
+
+// Mutating actions restricted to owners (read-only for non-super-admins).
+router.post(
+  "/:queueName/:jobId/retry",
+  writeLimiter,
+  requireRole(["owner"]),
+  retryAdminJob,
+);
+router.delete(
+  "/:queueName/:jobId",
+  writeLimiter,
+  requireRole(["owner"]),
+  discardAdminJob,
+);
+
+export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -212,6 +212,8 @@ router.use("/api/sentiment-timeline", sentimentTimelineRoutes);
 router.use("/api/rsvps", meetingRsvpRoutes);
 router.use("/api/testimonials", testimonialRoutes);
 router.use("/api/admin/testimonials", adminTestimonialRouter);
+import adminJobsRoutes from "./adminJobsRoutes.js";
+router.use("/api/admin/jobs", adminJobsRoutes);
 router.use("/api/alerts/keywords", keywordAlertRoutes);
 router.use("/api/integrations/notion", notionIntegrationRoutes);
 

--- a/server/services/adminJobsService.js
+++ b/server/services/adminJobsService.js
@@ -1,0 +1,193 @@
+import {
+  getQueueInstance,
+  getQueueStatus,
+  KNOWN_QUEUE_NAMES,
+} from "./queueService.js";
+
+const serializeFailedJob = (job) => ({
+  id: String(job.id),
+  name: job.name,
+  queueName: job.queueName,
+  failedReason: job.failedReason || null,
+  attemptsMade: job.attemptsMade ?? 0,
+  timestamp: job.timestamp || null,
+  finishedOn: job.finishedOn || null,
+  processedOn: job.processedOn || null,
+  data:
+    job.data && typeof job.data === "object" ? summarizeJobData(job.data) : {},
+});
+
+/**
+ * Keep failed-job payloads small for the admin UI (avoid dumping transcripts).
+ */
+const summarizeJobData = (data) => {
+  const summary = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value == null) {
+      summary[key] = value;
+      continue;
+    }
+    if (typeof value === "string") {
+      summary[key] = value.length > 120 ? `${value.slice(0, 117)}...` : value;
+      continue;
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      summary[key] = value;
+      continue;
+    }
+    if (typeof value === "object") {
+      summary[key] = Array.isArray(value)
+        ? `[array:${value.length}]`
+        : "[object]";
+    }
+  }
+  return summary;
+};
+
+/**
+ * Builds the admin Jobs dashboard payload (Issue #2080).
+ *
+ * @param {{ failedLimit?: number }} [options]
+ */
+export const getAdminJobsDashboard = async ({ failedLimit = 20 } = {}) => {
+  const limit = Math.min(50, Math.max(1, Number(failedLimit) || 20));
+  const status = getQueueStatus();
+
+  const queues = [];
+  for (const name of KNOWN_QUEUE_NAMES) {
+    const queue = getQueueInstance(name);
+    if (!queue) {
+      queues.push({
+        name,
+        available: false,
+        counts: {
+          waiting: 0,
+          active: 0,
+          completed: 0,
+          failed: 0,
+          delayed: 0,
+          paused: 0,
+        },
+        recentFailed: [],
+      });
+      continue;
+    }
+
+    try {
+      const counts = await queue.getJobCounts(
+        "waiting",
+        "active",
+        "completed",
+        "failed",
+        "delayed",
+        "paused",
+      );
+      const failedJobs = await queue.getJobs(["failed"], 0, limit - 1);
+      queues.push({
+        name,
+        available: true,
+        counts: {
+          waiting: counts.waiting || 0,
+          active: counts.active || 0,
+          completed: counts.completed || 0,
+          failed: counts.failed || 0,
+          delayed: counts.delayed || 0,
+          paused: counts.paused || 0,
+        },
+        recentFailed: failedJobs.map(serializeFailedJob),
+      });
+    } catch (error) {
+      queues.push({
+        name,
+        available: false,
+        error: error?.message || "Failed to read queue",
+        counts: {
+          waiting: 0,
+          active: 0,
+          completed: 0,
+          failed: 0,
+          delayed: 0,
+          paused: 0,
+        },
+        recentFailed: [],
+      });
+    }
+  }
+
+  return {
+    redisConfigured: status.redisConfigured,
+    workers: status.workers,
+    shuttingDown: status.shuttingDown,
+    queues,
+  };
+};
+
+const assertKnownQueue = (queueName) => {
+  if (!KNOWN_QUEUE_NAMES.includes(queueName)) {
+    const err = new Error("Unknown queue");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+/**
+ * Retries a failed BullMQ job.
+ */
+export const retryFailedJob = async (queueName, jobId) => {
+  assertKnownQueue(queueName);
+  const queue = getQueueInstance(queueName);
+  if (!queue) {
+    const err = new Error("Queue unavailable (Redis not configured)");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  const job = await queue.getJob(String(jobId));
+  if (!job) {
+    const err = new Error("Job not found");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const state = await job.getState();
+  if (state !== "failed") {
+    const err = new Error(`Job is not failed (state: ${state})`);
+    err.statusCode = 400;
+    throw err;
+  }
+
+  await job.retry();
+  return { queueName, jobId: String(job.id), state: "waiting" };
+};
+
+/**
+ * Discards (removes) a failed BullMQ job.
+ */
+export const discardFailedJob = async (queueName, jobId) => {
+  assertKnownQueue(queueName);
+  const queue = getQueueInstance(queueName);
+  if (!queue) {
+    const err = new Error("Queue unavailable (Redis not configured)");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  const job = await queue.getJob(String(jobId));
+  if (!job) {
+    const err = new Error("Job not found");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const state = await job.getState();
+  if (state !== "failed") {
+    const err = new Error(
+      `Only failed jobs can be discarded (state: ${state})`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  await job.remove();
+  return { queueName, jobId: String(jobId), discarded: true };
+};

--- a/server/services/queueService.js
+++ b/server/services/queueService.js
@@ -392,3 +392,33 @@ export const getQueueStatus = () => ({
   workers: queueRegistry.listWorkers(),
   shuttingDown: queueRegistry.isClosing(),
 });
+
+/**
+ * Known BullMQ queue names used by this app (Issue #2080 admin jobs board).
+ * Includes queues defined in queueRegistry even if not yet lazy-instantiated.
+ */
+export const KNOWN_QUEUE_NAMES = Object.freeze([
+  "ai-mom-generation",
+  "ai-mom-results",
+  "data-export-queue",
+  "export-cleanup-queue",
+  "conflict-scan-queue",
+  "sentiment-analysis-queue",
+  "recalculate-importance-queue",
+  "memory-lifecycle-queue",
+  "recap-delivery-queue",
+  "policy-compliance-retry-queue",
+  "webhook-dispatches",
+]);
+
+/**
+ * Returns a live BullMQ Queue instance (creating it if needed), or null when
+ * Redis is not configured.
+ *
+ * @param {string} name
+ * @returns {import("bullmq").Queue|null}
+ */
+export const getQueueInstance = (name) => {
+  if (typeof name !== "string" || !name) return null;
+  return getQueue(name);
+};

--- a/server/tests/adminJobsRoutes.test.js
+++ b/server/tests/adminJobsRoutes.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    req.user = req.headers["x-test-role"]
+      ? { _id: "u1", role: req.headers["x-test-role"] }
+      : null;
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    next();
+  },
+}));
+
+vi.mock("../middleware/rateLimiter.js", () => ({
+  apiLimiter: (_req, _res, next) => next(),
+  writeLimiter: (_req, _res, next) => next(),
+}));
+
+vi.mock("../services/adminJobsService.js", () => ({
+  getAdminJobsDashboard: vi.fn(async () => ({
+    redisConfigured: false,
+    workers: [],
+    shuttingDown: false,
+    queues: [],
+  })),
+  retryFailedJob: vi.fn(async () => ({
+    queueName: "data-export-queue",
+    jobId: "1",
+    state: "waiting",
+  })),
+  discardFailedJob: vi.fn(async () => ({
+    queueName: "data-export-queue",
+    jobId: "1",
+    discarded: true,
+  })),
+}));
+
+import adminJobsRoutes from "../routes/adminJobsRoutes.js";
+
+describe("Admin jobs routes authz (Issue #2080)", () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/admin/jobs", adminJobsRoutes);
+  });
+
+  afterAll(() => {
+    vi.resetAllMocks();
+  });
+
+  it("denies unauthenticated access", async () => {
+    const res = await request(app).get("/api/admin/jobs");
+    expect(res.status).toBe(401);
+  });
+
+  it("denies members from viewing jobs", async () => {
+    const res = await request(app)
+      .get("/api/admin/jobs")
+      .set("x-test-role", "member");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admins to view jobs (read-only)", async () => {
+    const res = await request(app)
+      .get("/api/admin/jobs")
+      .set("x-test-role", "admin");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("denies admins from retrying jobs", async () => {
+    const res = await request(app)
+      .post("/api/admin/jobs/data-export-queue/1/retry")
+      .set("x-test-role", "admin");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows owners to retry jobs", async () => {
+    const res = await request(app)
+      .post("/api/admin/jobs/data-export-queue/1/retry")
+      .set("x-test-role", "owner");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/server/tests/adminJobsService.test.js
+++ b/server/tests/adminJobsService.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/queueService.js", () => ({
+  KNOWN_QUEUE_NAMES: ["test-queue", "other-queue"],
+  getQueueStatus: vi.fn(() => ({
+    redisConfigured: true,
+    workers: ["test-queue"],
+    shuttingDown: false,
+  })),
+  getQueueInstance: vi.fn(),
+}));
+
+import { getQueueInstance } from "../services/queueService.js";
+import {
+  getAdminJobsDashboard,
+  retryFailedJob,
+  discardFailedJob,
+} from "../services/adminJobsService.js";
+
+describe("adminJobsService (Issue #2080)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns queue depths and recent failed jobs", async () => {
+    const failedJob = {
+      id: "42",
+      name: "export",
+      queueName: "test-queue",
+      failedReason: "boom",
+      attemptsMade: 3,
+      timestamp: 1,
+      finishedOn: 2,
+      processedOn: 1,
+      data: { meetingId: "m1", transcript: "x".repeat(200) },
+    };
+
+    getQueueInstance.mockImplementation((name) => {
+      if (name !== "test-queue") return null;
+      return {
+        getJobCounts: vi.fn().mockResolvedValue({
+          waiting: 1,
+          active: 0,
+          completed: 5,
+          failed: 1,
+          delayed: 0,
+          paused: 0,
+        }),
+        getJobs: vi.fn().mockResolvedValue([failedJob]),
+      };
+    });
+
+    const dashboard = await getAdminJobsDashboard({ failedLimit: 10 });
+    expect(dashboard.redisConfigured).toBe(true);
+    expect(dashboard.queues).toHaveLength(2);
+
+    const testQueue = dashboard.queues.find((q) => q.name === "test-queue");
+    expect(testQueue.available).toBe(true);
+    expect(testQueue.counts.waiting).toBe(1);
+    expect(testQueue.counts.failed).toBe(1);
+    expect(testQueue.recentFailed).toHaveLength(1);
+    expect(testQueue.recentFailed[0].failedReason).toBe("boom");
+    expect(testQueue.recentFailed[0].data.transcript.endsWith("...")).toBe(
+      true,
+    );
+  });
+
+  it("retries a failed job", async () => {
+    const retry = vi.fn().mockResolvedValue(undefined);
+    getQueueInstance.mockReturnValue({
+      getJob: vi.fn().mockResolvedValue({
+        id: "9",
+        getState: vi.fn().mockResolvedValue("failed"),
+        retry,
+      }),
+    });
+
+    const result = await retryFailedJob("test-queue", "9");
+    expect(retry).toHaveBeenCalled();
+    expect(result).toEqual({
+      queueName: "test-queue",
+      jobId: "9",
+      state: "waiting",
+    });
+  });
+
+  it("rejects retry for unknown queue", async () => {
+    await expect(retryFailedJob("nope", "1")).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("discards a failed job", async () => {
+    const remove = vi.fn().mockResolvedValue(undefined);
+    getQueueInstance.mockReturnValue({
+      getJob: vi.fn().mockResolvedValue({
+        id: "9",
+        getState: vi.fn().mockResolvedValue("failed"),
+        remove,
+      }),
+    });
+
+    const result = await discardFailedJob("test-queue", "9");
+    expect(remove).toHaveBeenCalled();
+    expect(result.discarded).toBe(true);
+  });
+
+  it("rejects discard when job is not failed", async () => {
+    getQueueInstance.mockReturnValue({
+      getJob: vi.fn().mockResolvedValue({
+        id: "9",
+        getState: vi.fn().mockResolvedValue("active"),
+        remove: vi.fn(),
+      }),
+    });
+
+    await expect(discardFailedJob("test-queue", "9")).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+});

--- a/server/tests/routeRegistration.test.js
+++ b/server/tests/routeRegistration.test.js
@@ -77,6 +77,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/topics",
       "/api/quality",
       "/api/testimonials",
+      "/api/admin/jobs",
     ];
 
     for (const prefix of standaloneRoutePrefixes) {
@@ -154,6 +155,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/quality",
       "/api/testimonials",
       "/api/admin/testimonials",
+      "/api/admin/jobs",
     ];
 
     for (const routePath of expectedRoutes) {


### PR DESCRIPTION
## Summary
- Admin Jobs board: queue depths, worker status, and recent failed jobs
- Owner-only retry/discard; admins can view (read-only); unauthorized access denied
- Link from Status (health/deps) page to `/admin-panel?module=jobs`
Closes #2080
## Test plan
- [ ] As admin/owner, open Admin Panel → Jobs and see queue counts
- [ ] As non-admin, `/api/admin/jobs` returns 403
- [ ] As admin, retry/discard buttons are hidden and API returns 403
- [ ] As owner, retry a failed job and confirm it leaves failed state
- [ ] Status page shows Jobs dashboard link
- [ ] `cd server && npx vitest run tests/adminJobsService.test.js tests/adminJobsRoutes.test.js`
