### PR TITLE
Add admin AI cost and embedding usage metrics.

### DIFF
--- a/client/src/components/admin/AiUsageMetrics.jsx
+++ b/client/src/components/admin/AiUsageMetrics.jsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, RefreshCw, AlertTriangle, Cpu } from "lucide-react";
+import { adminAiUsageApi } from "../../services/adminAiUsageApi.js";
+
+const defaultRange = () => {
+  const to = new Date();
+  const from = new Date();
+  from.setUTCDate(from.getUTCDate() - 13);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+  };
+};
+
+const fmtUsd = (n) =>
+  `$${(Number(n) || 0).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}`;
+
+export default function AiUsageMetrics() {
+  const [range, setRange] = useState(defaultRange);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [metrics, setMetrics] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const { data } = await adminAiUsageApi.getMetrics(range);
+      if (data?.success === false) {
+        setError(data.message || "Failed to load AI usage");
+        setMetrics(null);
+      } else {
+        setMetrics(data);
+      }
+    } catch (err) {
+      setError(err?.response?.data?.message || "Failed to load AI usage");
+      setMetrics(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const maxRequests = useMemo(() => {
+    const series = metrics?.series || [];
+    return Math.max(1, ...series.map((d) => d.requests || 0));
+  }, [metrics]);
+
+  if (loading && !metrics) {
+    return (
+      <div className="flex items-center justify-center py-16 text-slate-500 gap-2">
+        <Loader2 className="w-5 h-5 animate-spin" />
+        Loading AI usage…
+      </div>
+    );
+  }
+
+  if (error && !metrics) {
+    return (
+      <div className="rounded-2xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 p-8 text-center">
+        <AlertTriangle className="w-8 h-8 text-rose-500 mx-auto mb-3" />
+        <p className="text-sm font-semibold text-rose-800 dark:text-rose-200">
+          {error}
+        </p>
+        <button
+          type="button"
+          onClick={load}
+          className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-rose-600 text-white text-xs font-semibold cursor-pointer"
+        >
+          <RefreshCw className="w-3.5 h-3.5" /> Retry
+        </button>
+      </div>
+    );
+  }
+
+  const totals = metrics?.totals || {};
+  const series = metrics?.series || [];
+  const budget = metrics?.budgetAlert;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-wrap gap-3">
+          <label className="text-xs font-semibold text-slate-500">
+            From
+            <input
+              type="date"
+              value={range.from}
+              onChange={(e) =>
+                setRange((r) => ({ ...r, from: e.target.value }))
+              }
+              className="mt-1 block rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label className="text-xs font-semibold text-slate-500">
+            To
+            <input
+              type="date"
+              value={range.to}
+              onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
+              className="mt-1 block rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm"
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 text-xs font-semibold cursor-pointer disabled:opacity-50"
+        >
+          <RefreshCw
+            className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {budget?.enabled && budget.exceeded ? (
+        <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+          Daily AI budget of {fmtUsd(budget.dailyBudgetUsd)} exceeded (today{" "}
+          {fmtUsd(budget.todayCostUsd)}).
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {[
+          ["Requests", totals.requests ?? 0],
+          ["Tokens", totals.tokens ?? 0],
+          ["Est. cost", fmtUsd(totals.estimatedCostUsd)],
+          ["Errors", totals.errors ?? 0],
+        ].map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-4 shadow-sm"
+          >
+            <p className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+              {label}
+            </p>
+            <p className="text-xl font-extrabold text-slate-900 dark:text-white mt-1">
+              {value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-sm">
+        <div className="flex items-center gap-2 mb-4">
+          <Cpu className="w-4 h-4 text-indigo-500" />
+          <h3 className="text-sm font-bold text-slate-900 dark:text-white">
+            Daily requests
+          </h3>
+        </div>
+        {series.length === 0 ? (
+          <p className="text-sm text-slate-400 text-center py-8">
+            No instrumented AI usage in this range yet.
+          </p>
+        ) : (
+          <div className="flex items-end gap-1.5 h-40">
+            {series.map((day) => (
+              <div
+                key={day.date}
+                className="flex-1 min-w-0 flex flex-col items-center gap-1 h-full justify-end"
+                title={`${day.date}: ${day.requests} req, ${day.tokens} tok, ${fmtUsd(day.estimatedCostUsd)}`}
+              >
+                <div
+                  className="w-full max-w-[28px] rounded-t-md bg-indigo-500/80 dark:bg-indigo-400/70"
+                  style={{
+                    height: `${Math.max(4, (day.requests / maxRequests) * 100)}%`,
+                  }}
+                />
+                <span className="text-[9px] text-slate-400 truncate w-full text-center">
+                  {day.date.slice(5)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+        <p className="mt-4 text-xs text-slate-400">
+          Gemini requests: {totals.geminiRequests ?? 0} · Embeddings:{" "}
+          {totals.embeddingRequests ?? 0} · Embedding chars:{" "}
+          {totals.embeddingChars ?? 0}. Metrics exclude prompt contents.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -30,6 +30,7 @@ import {
   Database,
   ShieldCheck,
   BrainCircuit,
+  Cpu,
 } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import TemplateBuilder from "../components/admin/TemplateBuilder.jsx";
@@ -38,6 +39,7 @@ import JobsDashboard from "../components/admin/JobsDashboard.jsx";
 import EmbeddingReindexAdmin from "../components/admin/EmbeddingReindexAdmin.jsx";
 import RbacPermissionExplorer from "../components/admin/RbacPermissionExplorer.jsx";
 import ImportanceRecalculationAdmin from "../components/admin/ImportanceRecalculationAdmin.jsx";
+import AiUsageMetrics from "../components/admin/AiUsageMetrics.jsx";
 import MembershipRequests from "../components/organization/MembershipRequests.jsx";
 
 import AppContent from "../context/AppContent.js";
@@ -130,6 +132,14 @@ const MODULES = [
     icon: BrainCircuit,
     iconBg: "bg-indigo-50 dark:bg-indigo-900/30",
     iconColor: "text-indigo-600 dark:text-indigo-400",
+  },
+  {
+    id: "aiUsage",
+    labelKey: "AI Usage",
+    descriptionKey: "Gemini and embedding cost/usage over time",
+    icon: Cpu,
+    iconBg: "bg-violet-50 dark:bg-violet-900/30",
+    iconColor: "text-violet-600 dark:text-violet-400",
   },
   {
     id: "policies",
@@ -341,6 +351,7 @@ const AdminPanel = () => {
       activeModule === "jobs" ||
       activeModule === "embeddings" ||
       activeModule === "importance" ||
+      activeModule === "aiUsage" ||
       activeModule === "joinRequests"
     ) {
       return;
@@ -660,6 +671,8 @@ const AdminPanel = () => {
             <RbacPermissionExplorer />
           ) : activeModule === "importance" ? (
             <ImportanceRecalculationAdmin />
+          ) : activeModule === "aiUsage" ? (
+            <AiUsageMetrics />
           ) : activeModule === "joinRequests" ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm">
               <MembershipRequests organizationId={orgId} />

--- a/client/src/services/adminAiUsageApi.js
+++ b/client/src/services/adminAiUsageApi.js
@@ -1,0 +1,5 @@
+import apiClient from "./apiClient";
+
+export const adminAiUsageApi = {
+  getMetrics: (params) => apiClient.get("/api/admin/ai-usage", { params }),
+};

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -29,6 +29,7 @@ export * from "./parkingLotApi";
 export * from "./statusApi";
 export * from "./adminJobsApi";
 export * from "./adminEmbeddingsApi";
+export * from "./adminAiUsageApi";
 export { default as sentimentTimelineApi } from "./sentimentTimelineApi";
 export { default as carryForwardApi } from "./carryForwardApi";
 export { default as bulkMeetingApi } from "./bulkMeetingApi";

--- a/server/controllers/adminAiUsageController.js
+++ b/server/controllers/adminAiUsageController.js
@@ -1,0 +1,30 @@
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import { getOrgAiUsageMetrics } from "../services/aiUsageMetricsService.js";
+
+/**
+ * GET /api/admin/ai-usage
+ * Org AI cost/usage meter for admins (Issue #2083).
+ */
+export const getAdminAiUsage = async (req, res) => {
+  try {
+    const organizationId =
+      req.user?.organization?._id || req.user?.organization || null;
+    if (!organizationId) {
+      return sendError(res, 400, "No organization associated with this user");
+    }
+
+    const metrics = await getOrgAiUsageMetrics({
+      organizationId,
+      from: req.query.from,
+      to: req.query.to,
+    });
+
+    return sendSuccess(res, metrics);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in getAdminAiUsage:", error);
+    return sendError(res, 500, "Failed to load AI usage metrics");
+  }
+};

--- a/server/middleware/userAuth.js
+++ b/server/middleware/userAuth.js
@@ -8,6 +8,7 @@ import {
   verifyClerkSessionToken,
 } from "../utils/authUtils.js";
 import logger from "../utils/logger.js";
+import { runWithAiUsageContext } from "../services/aiUsageMetricsService.js";
 
 const DIAG = "[SYNC-CLERK-DIAG]";
 
@@ -182,7 +183,8 @@ const userAuth = async (req, res, next) => {
       });
     }
 
-    next();
+    const organizationId = user.organization?._id || user.organization || null;
+    return runWithAiUsageContext({ organizationId }, () => next());
   } catch (error) {
     if (error instanceof AccountMergeError) {
       console.error(`${DIAG} userAuth ACCOUNT MERGE CONFLICT`);

--- a/server/models/aiUsageDailyModel.js
+++ b/server/models/aiUsageDailyModel.js
@@ -1,0 +1,39 @@
+import mongoose from "mongoose";
+
+/**
+ * Per-org daily AI usage aggregates (Issue #2083).
+ * Stores counters only — never prompt/transcript contents.
+ */
+const aiUsageDailySchema = new mongoose.Schema(
+  {
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      required: true,
+      index: true,
+    },
+    /** UTC calendar day as YYYY-MM-DD */
+    date: {
+      type: String,
+      required: true,
+      match: /^\d{4}-\d{2}-\d{2}$/,
+    },
+    geminiRequests: { type: Number, default: 0, min: 0 },
+    geminiErrors: { type: Number, default: 0, min: 0 },
+    promptTokens: { type: Number, default: 0, min: 0 },
+    completionTokens: { type: Number, default: 0, min: 0 },
+    totalTokens: { type: Number, default: 0, min: 0 },
+    embeddingRequests: { type: Number, default: 0, min: 0 },
+    embeddingErrors: { type: Number, default: 0, min: 0 },
+    /** Character volume embedded (local MiniLM); not prompt text. */
+    embeddingChars: { type: Number, default: 0, min: 0 },
+    estimatedCostUsd: { type: Number, default: 0, min: 0 },
+  },
+  { timestamps: true },
+);
+
+aiUsageDailySchema.index({ organization: 1, date: 1 }, { unique: true });
+
+const AiUsageDaily = mongoose.model("AiUsageDaily", aiUsageDailySchema);
+
+export default AiUsageDaily;

--- a/server/routes/adminAiUsageRoutes.js
+++ b/server/routes/adminAiUsageRoutes.js
@@ -1,0 +1,11 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import { apiLimiter } from "../middleware/rateLimiter.js";
+import { requireAdminOrOwner } from "../middleware/rbac.js";
+import { getAdminAiUsage } from "../controllers/adminAiUsageController.js";
+
+const router = express.Router();
+
+router.get("/", userAuth, apiLimiter, requireAdminOrOwner, getAdminAiUsage);
+
+export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -208,6 +208,8 @@ import adminHealthRoutes from "./adminHealthRoutes.js";
 router.use("/api/admin/health", adminHealthRoutes);
 import adminRbacRoutes from "./adminRbacRoutes.js";
 router.use("/api/admin/rbac", adminRbacRoutes);
+import adminAiUsageRoutes from "./adminAiUsageRoutes.js";
+router.use("/api/admin/ai-usage", adminAiUsageRoutes);
 router.use("/api/alerts/keywords", keywordAlertRoutes);
 router.use("/api/integrations/notion", notionIntegrationRoutes);
 

--- a/server/services/GenerativeAIService.js
+++ b/server/services/GenerativeAIService.js
@@ -5,6 +5,7 @@ import {
   callWithResilience,
   createCircuitBreaker,
 } from "../utils/aiResilience.js";
+import { recordAiUsageSafe } from "./aiUsageMetricsService.js";
 
 const HUGGINGFACE_API_KEY = process.env.HUGGINGFACE_API_KEY; // eslint-disable-line no-unused-vars
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
@@ -93,31 +94,44 @@ export const resetGeminiClient = () => {
  * @returns {Promise<string>} raw model output text
  */
 export const generateText = async (prompt, label) => {
-  const result = await callWithResilience(
-    async (signal) => {
-      const model = getGenerativeModel();
-      // The SDK forwards requestOptions to fetch, so a well-behaved version
-      // cancels the in-flight request on abort. withTimeout rejects regardless,
-      // so an SDK that ignores the signal still cannot hang us.
-      return await model.generateContent(prompt, { signal });
-    },
-    {
-      label,
-      timeoutMs: GEMINI_TIMEOUT_MS(),
-      retries: GEMINI_MAX_RETRIES(),
-      baseDelayMs: GEMINI_RETRY_BASE_MS(),
-      maxDelayMs: GEMINI_RETRY_MAX_MS(),
-      breaker: geminiBreaker,
-      onRetry: ({ attempt, delayMs, classification }) =>
-        console.warn(
-          `↻ ${label}: attempt ${attempt} failed (${classification.kind}` +
-            `${classification.status ? ` ${classification.status}` : ""}), ` +
-            `retrying in ${delayMs}ms`,
-        ),
-    },
-  );
+  try {
+    const result = await callWithResilience(
+      async (signal) => {
+        const model = getGenerativeModel();
+        // The SDK forwards requestOptions to fetch, so a well-behaved version
+        // cancels the in-flight request on abort. withTimeout rejects regardless,
+        // so an SDK that ignores the signal still cannot hang us.
+        return await model.generateContent(prompt, { signal });
+      },
+      {
+        label,
+        timeoutMs: GEMINI_TIMEOUT_MS(),
+        retries: GEMINI_MAX_RETRIES(),
+        baseDelayMs: GEMINI_RETRY_BASE_MS(),
+        maxDelayMs: GEMINI_RETRY_MAX_MS(),
+        breaker: geminiBreaker,
+        onRetry: ({ attempt, delayMs, classification }) =>
+          console.warn(
+            `↻ ${label}: attempt ${attempt} failed (${classification.kind}` +
+              `${classification.status ? ` ${classification.status}` : ""}), ` +
+              `retrying in ${delayMs}ms`,
+          ),
+      },
+    );
 
-  return result.response.text();
+    const usage = result?.response?.usageMetadata || {};
+    recordAiUsageSafe({
+      kind: "gemini",
+      promptTokens: usage.promptTokenCount,
+      completionTokens: usage.candidatesTokenCount,
+      totalTokens: usage.totalTokenCount,
+    });
+
+    return result.response.text();
+  } catch (err) {
+    recordAiUsageSafe({ kind: "gemini", error: true });
+    throw err;
+  }
 };
 
 /**

--- a/server/services/aiUsageMetricsService.js
+++ b/server/services/aiUsageMetricsService.js
@@ -1,0 +1,207 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import AiUsageDaily from "../models/aiUsageDailyModel.js";
+
+const usageContext = new AsyncLocalStorage();
+
+/** Gemini Flash-class list prices (USD / 1M tokens) — approximate for admin meters. */
+const GEMINI_INPUT_USD_PER_M = Number.parseFloat(
+  process.env.AI_COST_GEMINI_INPUT_PER_M || "0.10",
+);
+const GEMINI_OUTPUT_USD_PER_M = Number.parseFloat(
+  process.env.AI_COST_GEMINI_OUTPUT_PER_M || "0.40",
+);
+
+export const runWithAiUsageContext = (store, fn) =>
+  usageContext.run(store || {}, fn);
+
+export const getAiUsageOrganizationId = () => {
+  const store = usageContext.getStore();
+  return store?.organizationId || null;
+};
+
+export const utcDayKey = (date = new Date()) => {
+  const d = date instanceof Date ? date : new Date(date);
+  return d.toISOString().slice(0, 10);
+};
+
+export const estimateGeminiCostUsd = ({
+  promptTokens = 0,
+  completionTokens = 0,
+} = {}) => {
+  const input = (Number(promptTokens) || 0) / 1_000_000;
+  const output = (Number(completionTokens) || 0) / 1_000_000;
+  return Number(
+    (input * GEMINI_INPUT_USD_PER_M + output * GEMINI_OUTPUT_USD_PER_M).toFixed(
+      6,
+    ),
+  );
+};
+
+/**
+ * Fire-and-forget daily counter upsert. Never stores prompt contents.
+ *
+ * @param {object} event
+ * @param {"gemini"|"embedding"} event.kind
+ * @param {string|import("mongoose").Types.ObjectId} [event.organizationId]
+ * @param {boolean} [event.error]
+ * @param {number} [event.promptTokens]
+ * @param {number} [event.completionTokens]
+ * @param {number} [event.totalTokens]
+ * @param {number} [event.embeddingChars]
+ */
+export const recordAiUsage = async (event = {}) => {
+  const organizationId =
+    event.organizationId || getAiUsageOrganizationId() || null;
+  if (!organizationId) return null;
+
+  const kind = event.kind === "embedding" ? "embedding" : "gemini";
+  const date = utcDayKey();
+  const promptTokens = Math.max(0, Number(event.promptTokens) || 0);
+  const completionTokens = Math.max(0, Number(event.completionTokens) || 0);
+  const totalTokens = Math.max(
+    0,
+    Number(event.totalTokens) || promptTokens + completionTokens,
+  );
+  const embeddingChars = Math.max(0, Number(event.embeddingChars) || 0);
+  const isError = Boolean(event.error);
+
+  const $inc = {
+    estimatedCostUsd:
+      kind === "gemini" && !isError
+        ? estimateGeminiCostUsd({ promptTokens, completionTokens })
+        : 0,
+  };
+
+  if (kind === "gemini") {
+    $inc.geminiRequests = 1;
+    if (isError) $inc.geminiErrors = 1;
+    else {
+      $inc.promptTokens = promptTokens;
+      $inc.completionTokens = completionTokens;
+      $inc.totalTokens = totalTokens;
+    }
+  } else {
+    $inc.embeddingRequests = 1;
+    if (isError) $inc.embeddingErrors = 1;
+    else $inc.embeddingChars = embeddingChars;
+  }
+
+  try {
+    return await AiUsageDaily.findOneAndUpdate(
+      { organization: organizationId, date },
+      { $inc, $setOnInsert: { organization: organizationId, date } },
+      { upsert: true, new: true },
+    );
+  } catch (err) {
+    console.warn("⚠️ AI usage metric write failed:", err?.message || err);
+    return null;
+  }
+};
+
+/** Non-blocking wrapper for call sites. */
+export const recordAiUsageSafe = (event) => {
+  Promise.resolve()
+    .then(() => recordAiUsage(event))
+    .catch(() => {});
+};
+
+const parseDay = (value, fallback) => {
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  return utcDayKey(fallback);
+};
+
+/**
+ * Admin dashboard payload for an org over a date range.
+ */
+export const getOrgAiUsageMetrics = async ({
+  organizationId,
+  from,
+  to,
+} = {}) => {
+  if (!organizationId) {
+    const err = new Error("Organization is required");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const end = parseDay(to, new Date());
+  const startDefault = new Date();
+  startDefault.setUTCDate(startDefault.getUTCDate() - 29);
+  const start = parseDay(from, startDefault);
+
+  const rows = await AiUsageDaily.find({
+    organization: organizationId,
+    date: { $gte: start, $lte: end },
+  })
+    .sort({ date: 1 })
+    .lean();
+
+  const series = rows.map((row) => ({
+    date: row.date,
+    requests: (row.geminiRequests || 0) + (row.embeddingRequests || 0),
+    geminiRequests: row.geminiRequests || 0,
+    embeddingRequests: row.embeddingRequests || 0,
+    tokens: row.totalTokens || 0,
+    promptTokens: row.promptTokens || 0,
+    completionTokens: row.completionTokens || 0,
+    errors: (row.geminiErrors || 0) + (row.embeddingErrors || 0),
+    embeddingChars: row.embeddingChars || 0,
+    estimatedCostUsd: Number(row.estimatedCostUsd || 0),
+  }));
+
+  const totals = series.reduce(
+    (acc, day) => {
+      acc.requests += day.requests;
+      acc.geminiRequests += day.geminiRequests;
+      acc.embeddingRequests += day.embeddingRequests;
+      acc.tokens += day.tokens;
+      acc.promptTokens += day.promptTokens;
+      acc.completionTokens += day.completionTokens;
+      acc.errors += day.errors;
+      acc.embeddingChars += day.embeddingChars;
+      acc.estimatedCostUsd += day.estimatedCostUsd;
+      return acc;
+    },
+    {
+      requests: 0,
+      geminiRequests: 0,
+      embeddingRequests: 0,
+      tokens: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+      errors: 0,
+      embeddingChars: 0,
+      estimatedCostUsd: 0,
+    },
+  );
+  totals.estimatedCostUsd = Number(totals.estimatedCostUsd.toFixed(6));
+
+  const budgetUsd = Number.parseFloat(
+    process.env.AI_USAGE_DAILY_BUDGET_USD || "",
+  );
+  const today = series.find((d) => d.date === utcDayKey());
+  const budgetAlert =
+    Number.isFinite(budgetUsd) && budgetUsd > 0
+      ? {
+          enabled: true,
+          dailyBudgetUsd: budgetUsd,
+          todayCostUsd: today?.estimatedCostUsd || 0,
+          exceeded: (today?.estimatedCostUsd || 0) >= budgetUsd,
+        }
+      : {
+          enabled: false,
+          dailyBudgetUsd: null,
+          todayCostUsd: null,
+          exceeded: false,
+        };
+
+  return {
+    from: start,
+    to: end,
+    series,
+    totals,
+    budgetAlert,
+  };
+};

--- a/server/tests/adminAiUsageRoutes.test.js
+++ b/server/tests/adminAiUsageRoutes.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    req.user = req.headers["x-test-role"]
+      ? {
+          _id: "u1",
+          role: req.headers["x-test-role"],
+          organization: "org1",
+        }
+      : null;
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    next();
+  },
+}));
+
+vi.mock("../middleware/rateLimiter.js", () => ({
+  apiLimiter: (_req, _res, next) => next(),
+}));
+
+vi.mock("../services/aiUsageMetricsService.js", () => ({
+  getOrgAiUsageMetrics: vi.fn(async () => ({
+    from: "2026-08-01",
+    to: "2026-08-07",
+    series: [],
+    totals: {
+      requests: 0,
+      tokens: 0,
+      errors: 0,
+      estimatedCostUsd: 0,
+    },
+    budgetAlert: { enabled: false },
+  })),
+}));
+
+import adminAiUsageRoutes from "../routes/adminAiUsageRoutes.js";
+
+describe("Admin AI usage routes authz (Issue #2083)", () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use("/api/admin/ai-usage", adminAiUsageRoutes);
+  });
+
+  afterAll(() => {
+    vi.resetAllMocks();
+  });
+
+  it("denies unauthenticated access", async () => {
+    const res = await request(app).get("/api/admin/ai-usage");
+    expect(res.status).toBe(401);
+  });
+
+  it("denies members", async () => {
+    const res = await request(app)
+      .get("/api/admin/ai-usage")
+      .set("x-test-role", "member");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admins", async () => {
+    const res = await request(app)
+      .get("/api/admin/ai-usage")
+      .set("x-test-role", "admin");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/server/tests/aiUsageMetricsService.test.js
+++ b/server/tests/aiUsageMetricsService.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { findOneAndUpdate, find } = vi.hoisted(() => ({
+  findOneAndUpdate: vi.fn(),
+  find: vi.fn(),
+}));
+
+vi.mock("../models/aiUsageDailyModel.js", () => ({
+  default: {
+    findOneAndUpdate,
+    find: (...args) => find(...args),
+  },
+}));
+
+import {
+  estimateGeminiCostUsd,
+  recordAiUsage,
+  getOrgAiUsageMetrics,
+  runWithAiUsageContext,
+  utcDayKey,
+} from "../services/aiUsageMetricsService.js";
+
+describe("aiUsageMetricsService (Issue #2083)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AI_USAGE_DAILY_BUDGET_USD;
+  });
+
+  it("estimates gemini cost from token counts", () => {
+    process.env.AI_COST_GEMINI_INPUT_PER_M = "0.10";
+    process.env.AI_COST_GEMINI_OUTPUT_PER_M = "0.40";
+    const cost = estimateGeminiCostUsd({
+      promptTokens: 1_000_000,
+      completionTokens: 1_000_000,
+    });
+    expect(cost).toBe(0.5);
+  });
+
+  it("records gemini counters without prompt fields", async () => {
+    findOneAndUpdate.mockResolvedValue({ date: utcDayKey() });
+
+    await runWithAiUsageContext({ organizationId: "org1" }, async () => {
+      await recordAiUsage({
+        kind: "gemini",
+        promptTokens: 100,
+        completionTokens: 20,
+        totalTokens: 120,
+      });
+    });
+
+    expect(findOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update] = findOneAndUpdate.mock.calls[0];
+    expect(filter.organization).toBe("org1");
+    expect(update.$inc.geminiRequests).toBe(1);
+    expect(update.$inc.promptTokens).toBe(100);
+    expect(JSON.stringify(update)).not.toMatch(/transcript|content/i);
+  });
+
+  it("skips writes when no organization context", async () => {
+    await recordAiUsage({ kind: "embedding", embeddingChars: 50 });
+    expect(findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("aggregates org usage over a date range", async () => {
+    find.mockReturnValue({
+      sort: () => ({
+        lean: async () => [
+          {
+            date: "2026-08-01",
+            geminiRequests: 2,
+            embeddingRequests: 1,
+            totalTokens: 300,
+            promptTokens: 200,
+            completionTokens: 100,
+            geminiErrors: 1,
+            embeddingErrors: 0,
+            embeddingChars: 40,
+            estimatedCostUsd: 0.01,
+          },
+          {
+            date: "2026-08-02",
+            geminiRequests: 1,
+            embeddingRequests: 0,
+            totalTokens: 50,
+            promptTokens: 40,
+            completionTokens: 10,
+            geminiErrors: 0,
+            embeddingErrors: 0,
+            embeddingChars: 0,
+            estimatedCostUsd: 0.002,
+          },
+        ],
+      }),
+    });
+
+    const metrics = await getOrgAiUsageMetrics({
+      organizationId: "org1",
+      from: "2026-08-01",
+      to: "2026-08-02",
+    });
+
+    expect(metrics.series).toHaveLength(2);
+    expect(metrics.totals.requests).toBe(4);
+    expect(metrics.totals.tokens).toBe(350);
+    expect(metrics.totals.errors).toBe(1);
+    expect(metrics.totals.estimatedCostUsd).toBe(0.012);
+    expect(metrics.budgetAlert.enabled).toBe(false);
+  });
+
+  it("flags budget alert when today exceeds threshold", async () => {
+    process.env.AI_USAGE_DAILY_BUDGET_USD = "0.005";
+    const today = utcDayKey();
+    find.mockReturnValue({
+      sort: () => ({
+        lean: async () => [
+          {
+            date: today,
+            geminiRequests: 1,
+            embeddingRequests: 0,
+            totalTokens: 10,
+            promptTokens: 8,
+            completionTokens: 2,
+            geminiErrors: 0,
+            embeddingErrors: 0,
+            embeddingChars: 0,
+            estimatedCostUsd: 0.01,
+          },
+        ],
+      }),
+    });
+
+    const metrics = await getOrgAiUsageMetrics({
+      organizationId: "org1",
+      from: today,
+      to: today,
+    });
+
+    expect(metrics.budgetAlert.enabled).toBe(true);
+    expect(metrics.budgetAlert.exceeded).toBe(true);
+  });
+});

--- a/server/utils/embeddingUtils.js
+++ b/server/utils/embeddingUtils.js
@@ -5,6 +5,7 @@
 
 import dotenv from "dotenv";
 import Meeting from "../models/meetingModel.js";
+import { recordAiUsageSafe } from "../services/aiUsageMetricsService.js";
 
 dotenv.config();
 
@@ -97,8 +98,15 @@ export const embedText = async (text) => {
       arr = padded;
     }
 
+    // Counters only — never store prompt/transcript text (Issue #2083).
+    recordAiUsageSafe({
+      kind: "embedding",
+      embeddingChars: text.length,
+    });
+
     return arr;
   } catch (error) {
+    recordAiUsageSafe({ kind: "embedding", error: true });
     console.error("❌ Local embedding creation failed:", error);
     throw new Error("Embedding creation failed");
   }


### PR DESCRIPTION
## Summary
- Per-org daily AI usage counters (Gemini tokens/cost + embedding volume); no prompt contents stored
- Admin Panel → AI Usage with date range, totals, request chart, optional daily budget alert
- Non-admins denied on `/api/admin/ai-usage`
Closes #2083
## Test plan
- [ ] As admin/owner, open Admin Panel → AI Usage and pick a date range
- [ ] Trigger a Gemini or embedding action, refresh, confirm counters move
- [ ] As member, `/api/admin/ai-usage` returns 403
- [ ] Optional: set `AI_USAGE_DAILY_BUDGET_USD` and confirm alert when exceeded
- [ ] `cd server && npx vitest run tests/aiUsageMetricsService.test.js tests/adminAiUsageRoutes.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only AI Usage dashboard with date-range selection and refresh controls.
  * View daily Gemini and embedding activity, request and error totals, token usage, estimated costs, and budget alerts.
  * Added daily usage tracking for AI generation and text embedding operations.
  * Added loading, error, and retry states for usage data.
* **Tests**
  * Added coverage for usage reporting, cost estimation, budget alerts, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->