### PR TITLE
Add admin Pinecone reindex UI and queued embedding jobs.

### DIFF
--- a/client/src/components/admin/EmbeddingReindexAdmin.jsx
+++ b/client/src/components/admin/EmbeddingReindexAdmin.jsx
@@ -1,0 +1,257 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  RefreshCw,
+  Loader2,
+  Database,
+  RotateCcw,
+  ExternalLink,
+  AlertTriangle,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { adminEmbeddingsApi } from "../../services/adminEmbeddingsApi.js";
+
+const statusClass = (status) => {
+  switch (status) {
+    case "succeeded":
+      return "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300";
+    case "failed":
+      return "bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300";
+    case "queued":
+    case "running":
+      return "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300";
+    default:
+      return "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300";
+  }
+};
+
+export default function EmbeddingReindexAdmin() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [meetings, setMeetings] = useState([]);
+  const [busyKey, setBusyKey] = useState(null);
+  const [lastJob, setLastJob] = useState(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const { data } = await adminEmbeddingsApi.listStatus({ limit: 25 });
+      setMeetings(data.meetings || []);
+    } catch (err) {
+      setError(
+        err?.response?.data?.message || "Failed to load embedding status",
+      );
+      setMeetings([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const refreshJob = async (jobId) => {
+    if (!jobId) return;
+    try {
+      const { data } = await adminEmbeddingsApi.getJobStatus(jobId);
+      setLastJob(data);
+    } catch {
+      /* ignore transient poll errors */
+    }
+  };
+
+  const handleOrgReindex = async () => {
+    if (
+      !window.confirm(
+        "Reindex all meetings with transcripts for this organization? This is queued and rate-limited.",
+      )
+    ) {
+      return;
+    }
+    setBusyKey("org");
+    try {
+      const { data } = await adminEmbeddingsApi.reindexOrg();
+      toast.success(`Org reindex queued (${data.meetingCount || 0} meetings)`);
+      setLastJob({
+        jobId: data.jobId,
+        state: data.status,
+        name: data.jobName,
+      });
+      await load();
+      await refreshJob(data.jobId);
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to enqueue org reindex",
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const handleMeetingReindex = async (meetingId, title) => {
+    if (!window.confirm(`Reindex vectors for “${title || "this meeting"}”?`)) {
+      return;
+    }
+    setBusyKey(meetingId);
+    try {
+      const { data } = await adminEmbeddingsApi.reindexMeeting(meetingId);
+      toast.success("Meeting reindex queued");
+      setLastJob({
+        jobId: data.jobId,
+        state: data.status,
+        name: data.jobName,
+      });
+      await load();
+      await refreshJob(data.jobId);
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to enqueue meeting reindex",
+      );
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  if (loading && meetings.length === 0 && !error) {
+    return (
+      <div className="flex items-center justify-center py-16 text-slate-500 gap-2">
+        <Loader2 className="w-5 h-5 animate-spin" />
+        Loading embedding index status…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-slate-500 dark:text-slate-400 max-w-xl">
+          Queue Pinecone reindex jobs for a meeting or the whole org. Progress
+          also appears under Admin → Jobs (
+          <code className="text-[11px]">embedding-reindex-queue</code>).
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => navigate("/admin-panel?module=jobs")}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 text-xs font-semibold cursor-pointer"
+          >
+            <ExternalLink className="w-3.5 h-3.5" /> Jobs dashboard
+          </button>
+          <button
+            type="button"
+            onClick={load}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 text-xs font-semibold cursor-pointer disabled:opacity-50"
+          >
+            <RefreshCw
+              className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleOrgReindex}
+            disabled={busyKey === "org"}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-teal-600 text-white text-xs font-semibold cursor-pointer disabled:opacity-50"
+          >
+            <Database className="w-3.5 h-3.5" />
+            Reindex organization
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/30 px-4 py-3 text-sm text-rose-700 dark:text-rose-200 flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          {error}
+        </div>
+      ) : null}
+
+      {lastJob?.jobId ? (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3 text-sm flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="font-semibold text-slate-900 dark:text-white">
+              Last job: {lastJob.name || "reindex"} #{lastJob.jobId}
+            </p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              State: {lastJob.state || "unknown"}
+              {lastJob.progress
+                ? ` · progress ${JSON.stringify(lastJob.progress)}`
+                : ""}
+              {lastJob.failedReason ? ` · ${lastJob.failedReason}` : ""}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refreshJob(lastJob.jobId)}
+            className="text-xs font-semibold text-teal-600 dark:text-teal-400 cursor-pointer"
+          >
+            Refresh job status
+          </button>
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 p-5 shadow-sm">
+        <h3 className="text-sm font-bold text-slate-900 dark:text-white mb-4">
+          Meetings · index status
+        </h3>
+        {meetings.length === 0 ? (
+          <p className="text-sm text-slate-400 text-center py-8">
+            No meetings found for this organization.
+          </p>
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {meetings.map((m) => {
+              const idx = m.embeddingIndex || {};
+              return (
+                <li
+                  key={m.id}
+                  className="py-3 flex flex-wrap items-start justify-between gap-3"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white truncate">
+                      {m.title || "Untitled"}
+                    </p>
+                    <p className="text-xs text-slate-500 mt-0.5">
+                      {m.date
+                        ? new Date(m.date).toLocaleDateString()
+                        : "No date"}
+                      {idx.lastIndexedAt
+                        ? ` · last indexed ${new Date(idx.lastIndexedAt).toLocaleString()}`
+                        : " · never indexed"}
+                      {idx.lastJobId ? ` · job ${idx.lastJobId}` : ""}
+                    </p>
+                    {idx.lastError ? (
+                      <p className="text-xs text-rose-500 mt-1 break-words">
+                        {idx.lastError}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`text-[10px] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full ${statusClass(idx.status)}`}
+                    >
+                      {idx.status || "idle"}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={!m.hasTranscript || busyKey === m.id}
+                      onClick={() => handleMeetingReindex(m.id, m.title)}
+                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 disabled:opacity-40 cursor-pointer"
+                    >
+                      <RotateCcw className="w-3 h-3" />
+                      Reindex
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AdminPanel.jsx
+++ b/client/src/pages/AdminPanel.jsx
@@ -27,11 +27,13 @@ import {
   Clock,
   RefreshCw,
   ListTodo,
+  Database,
 } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import TemplateBuilder from "../components/admin/TemplateBuilder.jsx";
 import TestimonialsModeration from "../components/admin/TestimonialsModeration.jsx";
 import JobsDashboard from "../components/admin/JobsDashboard.jsx";
+import EmbeddingReindexAdmin from "../components/admin/EmbeddingReindexAdmin.jsx";
 import MembershipRequests from "../components/organization/MembershipRequests.jsx";
 import AppContent from "../context/AppContent.js";
 import {
@@ -106,6 +108,14 @@ const MODULES = [
     icon: ListTodo,
     iconBg: "bg-teal-50 dark:bg-teal-900/30",
     iconColor: "text-teal-600 dark:text-teal-400",
+  },
+  {
+    id: "embeddings",
+    labelKey: "Embeddings",
+    descriptionKey: "Pinecone index health and reindex actions",
+    icon: Database,
+    iconBg: "bg-cyan-50 dark:bg-cyan-900/30",
+    iconColor: "text-cyan-600 dark:text-cyan-400",
   },
   {
     id: "policies",
@@ -275,6 +285,7 @@ const AdminPanel = () => {
       activeModule === "templates" ||
       activeModule === "testimonials" ||
       activeModule === "jobs" ||
+      activeModule === "embeddings" ||
       activeModule === "joinRequests"
     ) {
       return;
@@ -562,6 +573,8 @@ const AdminPanel = () => {
             <TestimonialsModeration />
           ) : activeModule === "jobs" ? (
             <JobsDashboard />
+          ) : activeModule === "embeddings" ? (
+            <EmbeddingReindexAdmin />
           ) : activeModule === "joinRequests" ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm">
               <MembershipRequests organizationId={orgId} />
@@ -670,18 +683,28 @@ const AdminPanel = () => {
             </div>
           ) : activeModule === "meetings" ? (
             <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm space-y-4">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
                 <h3 className="text-lg font-bold text-slate-900 dark:text-white">
                   Meeting Records
                 </h3>
-                <button
-                  type="button"
-                  onClick={() => navigate("/meetings")}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-900/50 cursor-pointer"
-                >
-                  <span>View All Meetings</span>
-                  <ExternalLink className="w-3.5 h-3.5" />
-                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => selectModule("embeddings")}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300 hover:bg-teal-100 dark:hover:bg-teal-900/50 cursor-pointer"
+                  >
+                    <Database className="w-3.5 h-3.5" />
+                    Embedding reindex
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => navigate("/meetings")}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-900/50 cursor-pointer"
+                  >
+                    <span>View All Meetings</span>
+                    <ExternalLink className="w-3.5 h-3.5" />
+                  </button>
+                </div>
               </div>
 
               {loadingModule ? (
@@ -704,7 +727,18 @@ const AdminPanel = () => {
                           {m.date
                             ? new Date(m.date).toLocaleDateString()
                             : "No date"}
+                          {m.embeddingIndex?.lastIndexedAt
+                            ? ` · indexed ${new Date(m.embeddingIndex.lastIndexedAt).toLocaleDateString()}`
+                            : ""}
+                          {m.embeddingIndex?.status
+                            ? ` · ${m.embeddingIndex.status}`
+                            : ""}
                         </p>
+                        {m.embeddingIndex?.lastError ? (
+                          <p className="text-xs text-rose-500 mt-1">
+                            {m.embeddingIndex.lastError}
+                          </p>
+                        ) : null}
                       </div>
                       <span className="text-xs font-semibold px-2.5 py-0.5 rounded-full bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300">
                         {m.status || "Recorded"}

--- a/client/src/services/adminEmbeddingsApi.js
+++ b/client/src/services/adminEmbeddingsApi.js
@@ -1,0 +1,12 @@
+import apiClient from "./apiClient";
+
+export const adminEmbeddingsApi = {
+  listStatus: (params) => apiClient.get("/api/admin/embeddings", { params }),
+  getJobStatus: (jobId) =>
+    apiClient.get(`/api/admin/embeddings/jobs/${encodeURIComponent(jobId)}`),
+  reindexMeeting: (meetingId) =>
+    apiClient.post(
+      `/api/admin/embeddings/reindex/meeting/${encodeURIComponent(meetingId)}`,
+    ),
+  reindexOrg: () => apiClient.post("/api/admin/embeddings/reindex/org"),
+};

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -28,6 +28,7 @@ export * from "./actionItemDependencyApi";
 export * from "./parkingLotApi";
 export * from "./statusApi";
 export * from "./adminJobsApi";
+export * from "./adminEmbeddingsApi";
 export { default as sentimentTimelineApi } from "./sentimentTimelineApi";
 export { default as carryForwardApi } from "./carryForwardApi";
 export { default as bulkMeetingApi } from "./bulkMeetingApi";

--- a/server/config/workers.js
+++ b/server/config/workers.js
@@ -10,6 +10,7 @@ import {
   initMemoryLifecycleWorker,
   initRecapDeliveryWorker,
   initPolicyComplianceRetryWorker,
+  initEmbeddingReindexWorker,
 } from "../services/queueService.js";
 import { initWebhookWorker } from "../services/webhookDispatcherService.js";
 import { describeRateLimitBacking } from "../middleware/rateLimitStore.js";
@@ -77,6 +78,9 @@ export async function startWorkers(app) {
   await safeInit("Recap Delivery Worker", () => initRecapDeliveryWorker());
   await safeInit("Policy Compliance Retry Worker", () =>
     initPolicyComplianceRetryWorker(),
+  );
+  await safeInit("Embedding Reindex Worker", () =>
+    initEmbeddingReindexWorker(),
   );
 
   // Pinecone pre-warm is best-effort and independent of the queue layer.

--- a/server/controllers/adminReindexController.js
+++ b/server/controllers/adminReindexController.js
@@ -1,0 +1,75 @@
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import {
+  enqueueMeetingReindex,
+  enqueueOrgReindex,
+  getReindexJobStatus,
+  listOrgEmbeddingStatus,
+} from "../services/adminReindexService.js";
+
+const orgIdFromReq = (req) =>
+  req.user?.organization?._id || req.user?.organization || null;
+
+export const getEmbeddingAdminStatus = async (req, res) => {
+  try {
+    const organizationId = orgIdFromReq(req);
+    if (!organizationId) {
+      return sendError(res, 400, "No organization associated with this user");
+    }
+
+    const payload = await listOrgEmbeddingStatus({
+      organizationId,
+      limit: req.query.limit,
+    });
+    return sendSuccess(res, payload);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in getEmbeddingAdminStatus:", error);
+    return sendError(res, 500, "Failed to load embedding status");
+  }
+};
+
+export const getEmbeddingJobStatus = async (req, res) => {
+  try {
+    const status = await getReindexJobStatus(req.params.jobId);
+    return sendSuccess(res, status);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in getEmbeddingJobStatus:", error);
+    return sendError(res, 500, "Failed to load job status");
+  }
+};
+
+export const postReindexMeeting = async (req, res) => {
+  try {
+    const organizationId = orgIdFromReq(req);
+    const result = await enqueueMeetingReindex({
+      organizationId,
+      meetingId: req.params.meetingId,
+    });
+    return sendSuccess(res, result, "Meeting reindex queued", 202);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in postReindexMeeting:", error);
+    return sendError(res, 500, "Failed to enqueue meeting reindex");
+  }
+};
+
+export const postReindexOrg = async (req, res) => {
+  try {
+    const organizationId = orgIdFromReq(req);
+    const result = await enqueueOrgReindex({ organizationId });
+    return sendSuccess(res, result, "Organization reindex queued", 202);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("Error in postReindexOrg:", error);
+    return sendError(res, 500, "Failed to enqueue organization reindex");
+  }
+};

--- a/server/jobs/embeddingReindexJob.js
+++ b/server/jobs/embeddingReindexJob.js
@@ -1,0 +1,121 @@
+import Meeting from "../models/meetingModel.js";
+import {
+  deleteMeetingFromPinecone,
+  indexMeeting,
+} from "../utils/embeddingUtils.js";
+
+/**
+ * BullMQ job processor for Pinecone reindex (Issue #2084).
+ * Job names: reindex-meeting | reindex-org
+ */
+export default async function embeddingReindexJob(job) {
+  const { organizationId, meetingId } = job.data || {};
+
+  if (job.name === "reindex-meeting") {
+    if (!meetingId) throw new Error("meetingId is required");
+    return reindexOneMeeting(meetingId, organizationId, job);
+  }
+
+  if (job.name === "reindex-org") {
+    if (!organizationId) throw new Error("organizationId is required");
+    return reindexOrgMeetings(organizationId, job);
+  }
+
+  throw new Error(`Unsupported embedding reindex job: ${job.name}`);
+}
+
+async function reindexOneMeeting(meetingId, organizationId, job) {
+  const filter = { _id: meetingId, deletedAt: null };
+  if (organizationId) filter.organization = organizationId;
+
+  const meeting = await Meeting.findOne(filter);
+  if (!meeting) throw new Error("Meeting not found");
+  if (!meeting.transcript) {
+    await Meeting.updateOne(
+      { _id: meeting._id },
+      {
+        $set: {
+          "embeddingIndex.status": "failed",
+          "embeddingIndex.lastError": "Meeting has no transcript to index",
+          "embeddingIndex.lastJobId": String(job.id),
+        },
+      },
+    );
+    return { skipped: true, reason: "no_transcript" };
+  }
+
+  await Meeting.updateOne(
+    { _id: meeting._id },
+    {
+      $set: {
+        "embeddingIndex.status": "running",
+        "embeddingIndex.lastError": null,
+        "embeddingIndex.lastJobId": String(job.id),
+      },
+    },
+  );
+
+  await deleteMeetingFromPinecone(meeting._id);
+  await indexMeeting(meeting);
+
+  return { meetingId: String(meeting._id), indexed: true };
+}
+
+async function reindexOrgMeetings(organizationId, job) {
+  const meetings = await Meeting.find({
+    organization: organizationId,
+    deletedAt: null,
+    transcript: { $exists: true, $ne: "" },
+  }).select("_id title transcript summary organization");
+
+  let indexed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < meetings.length; i += 1) {
+    const meeting = meetings[i];
+    try {
+      await Meeting.updateOne(
+        { _id: meeting._id },
+        {
+          $set: {
+            "embeddingIndex.status": "running",
+            "embeddingIndex.lastJobId": String(job.id),
+            "embeddingIndex.lastError": null,
+          },
+        },
+      );
+      await deleteMeetingFromPinecone(meeting._id);
+      await indexMeeting(meeting);
+      indexed += 1;
+    } catch (err) {
+      failed += 1;
+      await Meeting.updateOne(
+        { _id: meeting._id },
+        {
+          $set: {
+            "embeddingIndex.status": "failed",
+            "embeddingIndex.lastError": String(err?.message || err).slice(
+              0,
+              500,
+            ),
+            "embeddingIndex.lastJobId": String(job.id),
+          },
+        },
+      );
+    }
+
+    await job.updateProgress({
+      total: meetings.length,
+      completed: i + 1,
+      indexed,
+      failed,
+    });
+  }
+
+  return {
+    organizationId: String(organizationId),
+    total: meetings.length,
+    indexed,
+    failed,
+  };
+}

--- a/server/models/meetingModel.js
+++ b/server/models/meetingModel.js
@@ -265,6 +265,18 @@ const meetingSchema = new mongoose.Schema(
       enum: ["not_started", "in_progress", "completed"],
       default: "not_started",
     },
+
+    // Pinecone embedding index status (Issue #2084)
+    embeddingIndex: {
+      status: {
+        type: String,
+        enum: ["idle", "queued", "running", "succeeded", "failed"],
+        default: "idle",
+      },
+      lastIndexedAt: { type: Date, default: null },
+      lastError: { type: String, default: null, maxlength: 500 },
+      lastJobId: { type: String, default: null },
+    },
   },
   { timestamps: true },
 );

--- a/server/routes/adminReindexRoutes.js
+++ b/server/routes/adminReindexRoutes.js
@@ -1,0 +1,21 @@
+import express from "express";
+import userAuth from "../middleware/userAuth.js";
+import { apiLimiter, writeLimiter } from "../middleware/rateLimiter.js";
+import { requireAdminOrOwner } from "../middleware/rbac.js";
+import {
+  getEmbeddingAdminStatus,
+  getEmbeddingJobStatus,
+  postReindexMeeting,
+  postReindexOrg,
+} from "../controllers/adminReindexController.js";
+
+const router = express.Router();
+
+router.use(userAuth, apiLimiter, requireAdminOrOwner);
+
+router.get("/", getEmbeddingAdminStatus);
+router.get("/jobs/:jobId", getEmbeddingJobStatus);
+router.post("/reindex/meeting/:meetingId", writeLimiter, postReindexMeeting);
+router.post("/reindex/org", writeLimiter, postReindexOrg);
+
+export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -214,6 +214,8 @@ router.use("/api/testimonials", testimonialRoutes);
 router.use("/api/admin/testimonials", adminTestimonialRouter);
 import adminJobsRoutes from "./adminJobsRoutes.js";
 router.use("/api/admin/jobs", adminJobsRoutes);
+import adminReindexRoutes from "./adminReindexRoutes.js";
+router.use("/api/admin/embeddings", adminReindexRoutes);
 router.use("/api/alerts/keywords", keywordAlertRoutes);
 router.use("/api/integrations/notion", notionIntegrationRoutes);
 

--- a/server/services/adminReindexService.js
+++ b/server/services/adminReindexService.js
@@ -1,0 +1,253 @@
+import Meeting from "../models/meetingModel.js";
+import { embeddingReindexQueue, getQueueInstance } from "./queueService.js";
+
+const QUEUE_NAME = "embedding-reindex-queue";
+const ORG_REINDEX_CAP = 500;
+
+const assertOrg = (organizationId) => {
+  if (!organizationId) {
+    const err = new Error("Organization is required");
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+/**
+ * Enqueue a single-meeting Pinecone reindex (Issue #2084).
+ */
+export const enqueueMeetingReindex = async ({
+  organizationId,
+  meetingId,
+} = {}) => {
+  assertOrg(organizationId);
+  if (!meetingId) {
+    const err = new Error("meetingId is required");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const meeting = await Meeting.findOne({
+    _id: meetingId,
+    organization: organizationId,
+    deletedAt: null,
+  }).select("_id title embeddingIndex");
+
+  if (!meeting) {
+    const err = new Error("Meeting not found in this organization");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  if (!embeddingReindexQueue.isActive) {
+    const err = new Error("Reindex queue unavailable (Redis not configured)");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  let job;
+  try {
+    job = await embeddingReindexQueue.add(
+      "reindex-meeting",
+      {
+        organizationId: String(organizationId),
+        meetingId: String(meetingId),
+      },
+      {
+        jobId: `reindex-meeting-${meetingId}`,
+        removeOnComplete: { count: 50, age: 24 * 60 * 60 },
+      },
+    );
+  } catch (err) {
+    const conflict = new Error(
+      err?.message?.includes("Job")
+        ? "A reindex job for this meeting is already queued or active"
+        : err?.message || "Failed to enqueue reindex job",
+    );
+    conflict.statusCode = 409;
+    throw conflict;
+  }
+
+  if (!job) {
+    const err = new Error("Failed to enqueue reindex job");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  await Meeting.updateOne(
+    { _id: meeting._id },
+    {
+      $set: {
+        "embeddingIndex.status": "queued",
+        "embeddingIndex.lastError": null,
+        "embeddingIndex.lastJobId": String(job.id),
+      },
+    },
+  );
+
+  return {
+    queue: QUEUE_NAME,
+    jobId: String(job.id),
+    jobName: "reindex-meeting",
+    meetingId: String(meeting._id),
+    status: "queued",
+  };
+};
+
+/**
+ * Enqueue org-wide reindex (rate-limited to one active job per org).
+ */
+export const enqueueOrgReindex = async ({ organizationId } = {}) => {
+  assertOrg(organizationId);
+
+  if (!embeddingReindexQueue.isActive) {
+    const err = new Error("Reindex queue unavailable (Redis not configured)");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  const countable = await Meeting.countDocuments({
+    organization: organizationId,
+    deletedAt: null,
+    transcript: { $exists: true, $ne: "" },
+  });
+
+  if (countable === 0) {
+    const err = new Error("No indexable meetings found for this organization");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (countable > ORG_REINDEX_CAP) {
+    const err = new Error(
+      `Org reindex capped at ${ORG_REINDEX_CAP} meetings (found ${countable})`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  let job;
+  try {
+    job = await embeddingReindexQueue.add(
+      "reindex-org",
+      { organizationId: String(organizationId) },
+      {
+        jobId: `reindex-org-${organizationId}`,
+        removeOnComplete: { count: 20, age: 24 * 60 * 60 },
+      },
+    );
+  } catch (err) {
+    const conflict = new Error(
+      err?.message?.includes("Job")
+        ? "An org reindex job is already queued or active"
+        : err?.message || "Failed to enqueue org reindex job",
+    );
+    conflict.statusCode = 409;
+    throw conflict;
+  }
+
+  if (!job) {
+    const err = new Error("Failed to enqueue org reindex job");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  await Meeting.updateMany(
+    {
+      organization: organizationId,
+      deletedAt: null,
+      transcript: { $exists: true, $ne: "" },
+    },
+    {
+      $set: {
+        "embeddingIndex.status": "queued",
+        "embeddingIndex.lastJobId": String(job.id),
+        "embeddingIndex.lastError": null,
+      },
+    },
+  );
+
+  return {
+    queue: QUEUE_NAME,
+    jobId: String(job.id),
+    jobName: "reindex-org",
+    meetingCount: countable,
+    status: "queued",
+  };
+};
+
+/**
+ * Job progress for the Jobs dashboard / admin UI.
+ */
+export const getReindexJobStatus = async (jobId) => {
+  if (!jobId) {
+    const err = new Error("jobId is required");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const queue = getQueueInstance(QUEUE_NAME);
+  if (!queue) {
+    const err = new Error("Reindex queue unavailable (Redis not configured)");
+    err.statusCode = 503;
+    throw err;
+  }
+
+  const job = await queue.getJob(String(jobId));
+  if (!job) {
+    const err = new Error("Job not found");
+    err.statusCode = 404;
+    throw err;
+  }
+
+  const state = await job.getState();
+  return {
+    queue: QUEUE_NAME,
+    jobId: String(job.id),
+    name: job.name,
+    state,
+    progress: job.progress || null,
+    failedReason: job.failedReason || null,
+    finishedOn: job.finishedOn || null,
+    processedOn: job.processedOn || null,
+    data: {
+      organizationId: job.data?.organizationId || null,
+      meetingId: job.data?.meetingId || null,
+    },
+  };
+};
+
+/**
+ * Meetings with embedding index metadata for the admin view.
+ */
+export const listOrgEmbeddingStatus = async ({
+  organizationId,
+  limit = 25,
+} = {}) => {
+  assertOrg(organizationId);
+  const capped = Math.min(50, Math.max(1, Number(limit) || 25));
+
+  const meetings = await Meeting.find({
+    organization: organizationId,
+    deletedAt: null,
+  })
+    .select("title date embeddingIndex transcript")
+    .sort({ updatedAt: -1 })
+    .limit(capped)
+    .lean();
+
+  return {
+    queue: QUEUE_NAME,
+    meetings: meetings.map((m) => ({
+      id: String(m._id),
+      title: m.title,
+      date: m.date,
+      hasTranscript: Boolean(m.transcript && String(m.transcript).trim()),
+      embeddingIndex: m.embeddingIndex || {
+        status: "idle",
+        lastIndexedAt: null,
+        lastError: null,
+        lastJobId: null,
+      },
+    })),
+  };
+};

--- a/server/services/queueRegistry.js
+++ b/server/services/queueRegistry.js
@@ -94,6 +94,11 @@ export const QUEUE_DEFINITIONS = Object.freeze({
     jobOptions: { attempts: 3, backoff: { type: "exponential", delay: 10000 } },
     workerOptions: { concurrency: 2 },
   }),
+  "embedding-reindex-queue": Object.freeze({
+    // Reindex is CPU-heavy (local embeddings) and Pinecone-bound; keep serial.
+    jobOptions: { attempts: 2, backoff: { type: "exponential", delay: 10000 } },
+    workerOptions: { concurrency: 1 },
+  }),
   "webhook-dispatches": Object.freeze({
     // These values already existed inline in webhookDispatcherService.js; they
     // are recorded here so the webhook queue picks up the shared retention caps

--- a/server/services/queueService.js
+++ b/server/services/queueService.js
@@ -10,6 +10,7 @@ import recalculateImportanceJob from "../jobs/recalculateImportanceJob.js";
 import memoryLifecycleJob from "../jobs/memoryLifecycleJob.js";
 import policyComplianceReevaluationJob from "../jobs/policyComplianceReevaluationJob.js";
 import RecapEmailService from "./recapEmailService.js";
+import embeddingReindexJob from "../jobs/embeddingReindexJob.js";
 import queueRegistry, {
   readPositiveIntEnv,
   resolveJobOptions,
@@ -160,6 +161,9 @@ export const memoryLifecycleQueue = createQueueFacade("memory-lifecycle-queue");
 export const recapDeliveryQueue = createQueueFacade("recap-delivery-queue");
 export const policyComplianceRetryQueue = createQueueFacade(
   "policy-compliance-retry-queue",
+);
+export const embeddingReindexQueue = createQueueFacade(
+  "embedding-reindex-queue",
 );
 
 /**
@@ -368,6 +372,13 @@ export const initRecapDeliveryWorker = () =>
     },
   });
 
+export const initEmbeddingReindexWorker = () =>
+  createWorker({
+    name: "embedding-reindex-queue",
+    label: "Embedding Reindex Worker",
+    processor: embeddingReindexJob,
+  });
+
 /**
  * Drains every registered worker, then closes queues and shared Redis
  * connections. Safe to call more than once.
@@ -409,6 +420,7 @@ export const KNOWN_QUEUE_NAMES = Object.freeze([
   "recap-delivery-queue",
   "policy-compliance-retry-queue",
   "webhook-dispatches",
+  "embedding-reindex-queue",
 ]);
 
 /**

--- a/server/tests/adminReindexRoutes.test.js
+++ b/server/tests/adminReindexRoutes.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+
+vi.mock("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    req.user = req.headers["x-test-role"]
+      ? {
+          _id: "u1",
+          role: req.headers["x-test-role"],
+          organization: "org1",
+        }
+      : null;
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    next();
+  },
+}));
+
+vi.mock("../middleware/rateLimiter.js", () => ({
+  apiLimiter: (_req, _res, next) => next(),
+  writeLimiter: (_req, _res, next) => next(),
+}));
+
+vi.mock("../services/adminReindexService.js", () => ({
+  listOrgEmbeddingStatus: vi.fn(async () => ({
+    queue: "embedding-reindex-queue",
+    meetings: [],
+  })),
+  getReindexJobStatus: vi.fn(async () => ({
+    jobId: "j1",
+    state: "completed",
+  })),
+  enqueueMeetingReindex: vi.fn(async () => ({
+    jobId: "j1",
+    status: "queued",
+  })),
+  enqueueOrgReindex: vi.fn(async () => ({
+    jobId: "j2",
+    status: "queued",
+    meetingCount: 2,
+  })),
+}));
+
+import adminReindexRoutes from "../routes/adminReindexRoutes.js";
+
+describe("Admin embedding reindex routes authz (Issue #2084)", () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/admin/embeddings", adminReindexRoutes);
+  });
+
+  afterAll(() => {
+    vi.resetAllMocks();
+  });
+
+  it("denies unauthenticated access", async () => {
+    const res = await request(app).get("/api/admin/embeddings");
+    expect(res.status).toBe(401);
+  });
+
+  it("denies members", async () => {
+    const res = await request(app)
+      .get("/api/admin/embeddings")
+      .set("x-test-role", "member");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admins to list status", async () => {
+    const res = await request(app)
+      .get("/api/admin/embeddings")
+      .set("x-test-role", "admin");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it("allows owners to enqueue org reindex", async () => {
+    const res = await request(app)
+      .post("/api/admin/embeddings/reindex/org")
+      .set("x-test-role", "owner");
+    expect(res.status).toBe(202);
+  });
+});

--- a/server/tests/adminReindexService.test.js
+++ b/server/tests/adminReindexService.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { findOne, updateOne, updateMany, countDocuments, find, add } =
+  vi.hoisted(() => ({
+    findOne: vi.fn(),
+    updateOne: vi.fn(),
+    updateMany: vi.fn(),
+    countDocuments: vi.fn(),
+    find: vi.fn(),
+    add: vi.fn(),
+  }));
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findOne,
+    updateOne,
+    updateMany,
+    countDocuments,
+    find,
+  },
+}));
+
+vi.mock("../services/queueService.js", () => ({
+  embeddingReindexQueue: {
+    get isActive() {
+      return true;
+    },
+    add,
+  },
+  getQueueInstance: vi.fn(),
+}));
+
+import {
+  enqueueMeetingReindex,
+  enqueueOrgReindex,
+  listOrgEmbeddingStatus,
+} from "../services/adminReindexService.js";
+
+describe("adminReindexService (Issue #2084)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a meeting reindex and marks status queued", async () => {
+    findOne.mockReturnValue({
+      select: vi.fn().mockResolvedValue({ _id: "m1", title: "Standup" }),
+    });
+    add.mockResolvedValue({ id: "reindex-meeting-m1" });
+    updateOne.mockResolvedValue({});
+
+    const result = await enqueueMeetingReindex({
+      organizationId: "org1",
+      meetingId: "m1",
+    });
+
+    expect(add).toHaveBeenCalledWith(
+      "reindex-meeting",
+      { organizationId: "org1", meetingId: "m1" },
+      expect.objectContaining({ jobId: "reindex-meeting-m1" }),
+    );
+    expect(result.status).toBe("queued");
+    expect(updateOne).toHaveBeenCalled();
+  });
+
+  it("rejects meeting reindex without org", async () => {
+    await expect(
+      enqueueMeetingReindex({ meetingId: "m1" }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("enqueues org reindex when meetings exist", async () => {
+    countDocuments.mockResolvedValue(3);
+    add.mockResolvedValue({ id: "reindex-org-org1" });
+    updateMany.mockResolvedValue({});
+
+    const result = await enqueueOrgReindex({ organizationId: "org1" });
+    expect(result.meetingCount).toBe(3);
+    expect(result.jobName).toBe("reindex-org");
+    expect(updateMany).toHaveBeenCalled();
+  });
+
+  it("lists embedding status without leaking transcripts", async () => {
+    find.mockReturnValue({
+      select: () => ({
+        sort: () => ({
+          limit: () => ({
+            lean: async () => [
+              {
+                _id: "m1",
+                title: "A",
+                date: new Date("2026-01-01"),
+                transcript: "secret transcript text",
+                embeddingIndex: {
+                  status: "succeeded",
+                  lastIndexedAt: new Date("2026-01-02"),
+                  lastError: null,
+                  lastJobId: "j1",
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    });
+
+    const payload = await listOrgEmbeddingStatus({ organizationId: "org1" });
+    expect(payload.meetings).toHaveLength(1);
+    expect(payload.meetings[0].hasTranscript).toBe(true);
+    expect(payload.meetings[0].transcript).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("secret transcript");
+  });
+});

--- a/server/tests/routeRegistration.test.js
+++ b/server/tests/routeRegistration.test.js
@@ -78,6 +78,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/quality",
       "/api/testimonials",
       "/api/admin/jobs",
+      "/api/admin/embeddings",
     ];
 
     for (const prefix of standaloneRoutePrefixes) {
@@ -156,6 +157,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/testimonials",
       "/api/admin/testimonials",
       "/api/admin/jobs",
+      "/api/admin/embeddings",
     ];
 
     for (const routePath of expectedRoutes) {

--- a/server/utils/embeddingUtils.js
+++ b/server/utils/embeddingUtils.js
@@ -180,8 +180,35 @@ export const indexMeeting = async (meeting) => {
     console.log(
       `✅ Indexed meeting: ${title} (${transcriptChunks.length} chunks)`,
     );
+
+    if (meeting._id) {
+      await Meeting.updateOne(
+        { _id: meeting._id },
+        {
+          $set: {
+            "embeddingIndex.status": "succeeded",
+            "embeddingIndex.lastIndexedAt": new Date(),
+            "embeddingIndex.lastError": null,
+          },
+        },
+      ).catch(() => {});
+    }
   } catch (error) {
     console.error("❌ Failed to index meeting:", error);
+    if (meeting?._id) {
+      await Meeting.updateOne(
+        { _id: meeting._id },
+        {
+          $set: {
+            "embeddingIndex.status": "failed",
+            "embeddingIndex.lastError": String(error?.message || error).slice(
+              0,
+              500,
+            ),
+          },
+        },
+      ).catch(() => {});
+    }
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- Queued meeting/org Pinecone reindex via `embedding-reindex-queue`
- Meeting embedding status (last indexed / failures) in Admin Embeddings + Meetings
- Confirmations, write rate limits, and job status visible on Jobs dashboard
Closes #2084
## Test plan
- [ ] As admin/owner, open Admin → Embeddings and see meeting index statuses
- [ ] Reindex one meeting (confirm dialog) and watch status → Jobs dashboard
- [ ] Reindex organization and confirm progress updates
- [ ] As member, `/api/admin/embeddings` returns 403
- [ ] After job completes, semantic search reflects reindexed content
- [ ] `cd server && npx vitest run tests/adminReindexService.test.js tests/adminReindexRoutes.test.js`