### PR TITLE
Add hybrid search advanced filters, history, and URL state.

### DIFF
--- a/client/src/components/ai-search/SearchEmptyState.jsx
+++ b/client/src/components/ai-search/SearchEmptyState.jsx
@@ -1,30 +1,60 @@
 import React from "react";
 
-const SearchEmptyState = ({ hasSearched }) => {
-  if (hasSearched) {
+const SearchEmptyState = ({ hasSearched, error, onClearFilters }) => {
+  if (error) {
     return (
-      <div className="text-center py-16">
-        <div className="text-6xl mb-4">🔍</div>
-        <h3 className="text-xl font-semibold text-gray-700 mb-2">
-          No results found
+      <div className="text-center py-16 px-4">
+        <div className="text-5xl mb-4" aria-hidden="true">
+          ⚠️
+        </div>
+        <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">
+          Search failed
         </h3>
-        <p className="text-gray-500 max-w-md mx-auto">
-          We couldn't find any matches for your search. Try different keywords
-          or adjust your filters.
+        <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto text-sm">
+          {error}
         </p>
       </div>
     );
   }
 
+  if (hasSearched) {
+    return (
+      <div className="text-center py-16 px-4">
+        <div className="text-5xl mb-4" aria-hidden="true">
+          🔍
+        </div>
+        <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">
+          No results found
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto text-sm">
+          We couldn&apos;t find any matches. Try different keywords or clear
+          advanced filters.
+        </p>
+        {onClearFilters ? (
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="mt-4 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+          >
+            Clear filters
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
-    <div className="text-center py-16">
-      <div className="text-6xl mb-4">💬</div>
-      <h3 className="text-xl font-semibold text-gray-700 mb-2">
+    <div className="text-center py-16 px-4">
+      <div className="text-5xl mb-4" aria-hidden="true">
+        💬
+      </div>
+      <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">
         Start searching
       </h3>
-      <p className="text-gray-500 max-w-md mx-auto">
-        Type your question above to explore your meetings, policies, and AI
-        summaries using natural language.
+      <p className="text-gray-500 dark:text-gray-400 max-w-md mx-auto text-sm">
+        Type your question above to explore meetings, decisions, and action
+        items. Hybrid mode supports date, meeting type, speaker, and tag
+        filters. Recent searches appear below once you run a query.
       </p>
     </div>
   );

--- a/client/src/components/ai-search/SearchFilters.jsx
+++ b/client/src/components/ai-search/SearchFilters.jsx
@@ -1,62 +1,129 @@
 import React from "react";
 
-const SearchFilters = ({ filters, setFilters, resultCount }) => {
+const SearchFilters = ({
+  filters,
+  setFilters,
+  resultCount,
+  advanced = false,
+}) => {
   const handleFilterChange = (key, value) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
   };
 
   return (
-    <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100 mb-6">
+    <div className="bg-white dark:bg-gray-800 p-4 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 mb-6 w-full text-left">
       <div className="flex flex-wrap gap-4 items-center">
-        <div className="flex items-center gap-2">
-          <label className="text-sm font-medium text-gray-700">Type:</label>
-          <select
-            value={filters.resultType}
-            onChange={(e) => handleFilterChange("resultType", e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
-          >
-            <option value="all">All Types</option>
-            <option value="meeting">Meetings</option>
-            <option value="policy">Policies</option>
-            <option value="summary">AI Summaries</option>
-          </select>
-        </div>
+        {!advanced && (
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Type:
+            </label>
+            <select
+              value={filters.resultType || "all"}
+              onChange={(e) => handleFilterChange("resultType", e.target.value)}
+              className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none"
+            >
+              <option value="all">All Types</option>
+              <option value="meeting">Meetings</option>
+              <option value="policy">Policies</option>
+              <option value="summary">AI Summaries</option>
+            </select>
+          </div>
+        )}
+
+        {advanced && (
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Meeting type:
+            </label>
+            <select
+              value={filters.meetingType || ""}
+              onChange={(e) =>
+                handleFilterChange("meetingType", e.target.value)
+              }
+              className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none"
+            >
+              <option value="">Any</option>
+              <option value="conference">Conference</option>
+              <option value="policy">Policy</option>
+              <option value="event">Event</option>
+              <option value="internal">Internal</option>
+            </select>
+          </div>
+        )}
 
         <div className="flex items-center gap-2">
-          <label className="text-sm font-medium text-gray-700">From:</label>
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            From:
+          </label>
           <input
             type="date"
             value={filters.dateFrom || ""}
             onChange={(e) => handleFilterChange("dateFrom", e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+            className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none"
           />
         </div>
 
         <div className="flex items-center gap-2">
-          <label className="text-sm font-medium text-gray-700">To:</label>
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            To:
+          </label>
           <input
             type="date"
             value={filters.dateTo || ""}
             onChange={(e) => handleFilterChange("dateTo", e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+            className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none"
           />
         </div>
 
-        <div className="flex items-center gap-2">
-          <label className="text-sm font-medium text-gray-700">Sort:</label>
-          <select
-            value={filters.sortBy}
-            onChange={(e) => handleFilterChange("sortBy", e.target.value)}
-            className="px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
-          >
-            <option value="relevance">Relevance</option>
-            <option value="date-desc">Newest First</option>
-            <option value="date-asc">Oldest First</option>
-          </select>
-        </div>
+        {advanced && (
+          <>
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Speaker:
+              </label>
+              <input
+                type="text"
+                value={filters.speaker || ""}
+                onChange={(e) => handleFilterChange("speaker", e.target.value)}
+                placeholder="Name or email"
+                className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none w-36"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tag:
+              </label>
+              <input
+                type="text"
+                value={filters.tag || ""}
+                onChange={(e) => handleFilterChange("tag", e.target.value)}
+                placeholder="e.g. finance"
+                className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none w-32"
+              />
+            </div>
+          </>
+        )}
 
-        {resultCount > 0 && (
-          <div className="ml-auto text-sm text-gray-500">
+        {!advanced && (
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Sort:
+            </label>
+            <select
+              value={filters.sortBy || "relevance"}
+              onChange={(e) => handleFilterChange("sortBy", e.target.value)}
+              className="px-3 py-2 text-sm border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 outline-none"
+            >
+              <option value="relevance">Relevance</option>
+              <option value="date-desc">Newest First</option>
+              <option value="date-asc">Oldest First</option>
+            </select>
+          </div>
+        )}
+
+        {typeof resultCount === "number" && resultCount > 0 && (
+          <div className="ml-auto text-sm text-gray-500 dark:text-gray-400">
             {resultCount} result{resultCount !== 1 ? "s" : ""}
           </div>
         )}

--- a/client/src/pages/AiSearch.jsx
+++ b/client/src/pages/AiSearch.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState, useRef, useId } from "react";
+import React, { useCallback, useEffect, useRef, useState, useId } from "react";
 import { useTranslation } from "react-i18next";
-import { X } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
+import { History, X } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import SearchBar from "../components/ai-search/SearchBar.jsx";
 import SearchFilters from "../components/ai-search/SearchFilters.jsx";
@@ -11,12 +12,28 @@ import SearchSkeleton from "../components/ai-search/SearchSkeleton.jsx";
 import SearchEmptyState from "../components/ai-search/SearchEmptyState.jsx";
 import { apiClient } from "../services";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
+import {
+  clearSearchHistory,
+  loadSearchHistory,
+  paramsToSearchState,
+  saveSearchHistoryEntry,
+  searchStateToParams,
+} from "../utils/searchHistory.js";
 import { toast } from "react-toastify";
 
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-// Modal Component for showing full details
+const DEFAULT_FILTERS = {
+  resultType: "all",
+  dateFrom: "",
+  dateTo: "",
+  sortBy: "relevance",
+  meetingType: "",
+  speaker: "",
+  tag: "",
+};
+
 const ResultModal = ({ result, onClose }) => {
   const { t } = useTranslation();
   const titleId = useId();
@@ -176,92 +193,164 @@ const ResultModal = ({ result, onClose }) => {
 
 const AiSearch = () => {
   const { t } = useTranslation();
-  const [query, setQuery] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const bootstrapped = useRef(false);
+
+  const initial = paramsToSearchState(searchParams);
+
+  const [query, setQuery] = useState(initial.query);
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [selectedResult, setSelectedResult] = useState(null);
   const [hasSearched, setHasSearched] = useState(false);
   const [filters, setFilters] = useState({
-    resultType: "all",
-    dateFrom: "",
-    dateTo: "",
-    sortBy: "relevance",
+    ...DEFAULT_FILTERS,
+    ...initial.filters,
   });
-  const [searchMode, setSearchMode] = useState("standard"); // "standard" | "hybrid"
-  const [hybridWeights, setHybridWeights] = useState({
-    semanticWeight: 0.7,
-    graphWeight: 0.3,
-  });
+  const [searchMode, setSearchMode] = useState(initial.mode);
+  const [hybridWeights, setHybridWeights] = useState(initial.weights);
+  const [history, setHistory] = useState(() => loadSearchHistory());
 
-  const handleSearch = async () => {
-    if (!query.trim()) {
-      setError(t("aiSearch.enterQuery"));
-      return;
-    }
+  const syncUrl = useCallback(
+    (next) => {
+      const params = searchStateToParams(next);
+      setSearchParams(params, { replace: true });
+    },
+    [setSearchParams],
+  );
 
-    setLoading(true);
-    setError("");
-    setResults([]);
-    setHasSearched(true);
+  const runSearch = useCallback(
+    async ({
+      nextQuery = query,
+      nextMode = searchMode,
+      nextFilters = filters,
+      nextWeights = hybridWeights,
+      persistHistory = true,
+    } = {}) => {
+      if (!nextQuery.trim()) {
+        setError(t("aiSearch.enterQuery"));
+        return;
+      }
 
-    try {
-      if (searchMode === "hybrid") {
-        const res = await apiClient.post("/api/search/hybrid", {
-          query,
-          ...hybridWeights,
-        });
-        setResults(res.data.results || []);
-      } else {
-        const res = await apiClient.post("/api/ai", { query, filters });
-        const data = res.data;
+      setLoading(true);
+      setError("");
+      setResults([]);
+      setHasSearched(true);
+      syncUrl({
+        query: nextQuery,
+        mode: nextMode,
+        filters: nextFilters,
+        weights: nextWeights,
+      });
 
-        let sortedResults = data.results || [];
+      try {
+        if (nextMode === "hybrid") {
+          const res = await apiClient.post("/api/search/hybrid", {
+            query: nextQuery,
+            ...nextWeights,
+            dateFrom: nextFilters.dateFrom || undefined,
+            dateTo: nextFilters.dateTo || undefined,
+            meetingType: nextFilters.meetingType || undefined,
+            speaker: nextFilters.speaker || undefined,
+            tag: nextFilters.tag || undefined,
+          });
+          setResults(res.data.results || []);
+        } else {
+          const res = await apiClient.post("/api/ai", {
+            query: nextQuery,
+            filters: nextFilters,
+          });
+          let sortedResults = res.data.results || [];
 
-        if (filters.sortBy === "date-desc") {
-          sortedResults.sort(
-            (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
-          );
-        } else if (filters.sortBy === "date-asc") {
-          sortedResults.sort(
-            (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
-          );
+          if (nextFilters.sortBy === "date-desc") {
+            sortedResults = [...sortedResults].sort(
+              (a, b) => new Date(b.createdAt) - new Date(a.createdAt),
+            );
+          } else if (nextFilters.sortBy === "date-asc") {
+            sortedResults = [...sortedResults].sort(
+              (a, b) => new Date(a.createdAt) - new Date(b.createdAt),
+            );
+          }
+
+          setResults(sortedResults);
         }
 
-        setResults(sortedResults);
-      }
-    } catch (err) {
-      console.error("❌ Search error:", err);
+        if (persistHistory) {
+          setHistory(
+            saveSearchHistoryEntry({
+              query: nextQuery,
+              mode: nextMode,
+              filters: nextFilters,
+              weights: nextWeights,
+            }),
+          );
+        }
+      } catch (err) {
+        console.error("❌ Search error:", err);
+        const message =
+          err?.response?.data?.message ||
+          err?.message ||
+          t("aiSearch.fetchFailed");
 
-      if (err.message === "Failed to fetch") {
-        setError(t("aiSearch.unableToConnect"));
-      } else if (err.message.includes("500")) {
-        setError(t("aiSearch.serverError"));
-      } else if (err.message.includes("404")) {
-        setError(t("aiSearch.serviceNotFound"));
-      } else {
-        setError(err.message || t("aiSearch.fetchFailed"));
+        if (message === "Failed to fetch" || err?.code === "ERR_NETWORK") {
+          setError(t("aiSearch.unableToConnect"));
+        } else {
+          setError(message);
+        }
+        setResults([]);
+      } finally {
+        setLoading(false);
       }
-    } finally {
-      setLoading(false);
+    },
+    [query, searchMode, filters, hybridWeights, syncUrl, t],
+  );
+
+  useEffect(() => {
+    if (bootstrapped.current) return;
+    bootstrapped.current = true;
+    if (initial.query.trim().length >= 3) {
+      runSearch({ persistHistory: false });
     }
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bootstrap once from URL
+  }, []);
+
+  const handleSearch = () => runSearch();
 
   const handleClear = () => {
     setQuery("");
     setResults([]);
     setError("");
     setHasSearched(false);
+    setFilters({ ...DEFAULT_FILTERS });
+    setSearchParams({}, { replace: true });
   };
 
-  const handleViewDetails = (result) => {
-    setSelectedResult(result);
+  const handleClearFilters = () => {
+    const cleared = { ...DEFAULT_FILTERS };
+    setFilters(cleared);
+    if (query.trim()) {
+      runSearch({ nextFilters: cleared });
+    }
   };
 
+  const handleRerunHistory = (entry) => {
+    setQuery(entry.query);
+    setSearchMode(entry.mode);
+    setFilters({ ...DEFAULT_FILTERS, ...(entry.filters || {}) });
+    if (entry.weights) setHybridWeights(entry.weights);
+    runSearch({
+      nextQuery: entry.query,
+      nextMode: entry.mode,
+      nextFilters: { ...DEFAULT_FILTERS, ...(entry.filters || {}) },
+      nextWeights: entry.weights || hybridWeights,
+    });
+  };
+
+  const handleViewDetails = (result) => setSelectedResult(result);
   const handleOpenMeeting = (result) => {
     window.open(`/meeting/${result.meetingId}`, "_blank");
   };
-
   const handleOpenMeetingById = (meetingId) => {
     if (meetingId) window.open(`/meeting/${meetingId}`, "_blank");
   };
@@ -283,7 +372,6 @@ const AiSearch = () => {
       <Navbar />
 
       <div className="max-w-4xl mx-auto pt-28 px-6 flex flex-col items-center text-center">
-        {/* Header */}
         <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-gray-100 mb-3 tracking-tight">
           {t("aiSearch.title")}
         </h1>
@@ -294,7 +382,6 @@ const AiSearch = () => {
           }}
         />
 
-        {/* Search Input */}
         <SearchBar
           query={query}
           setQuery={setQuery}
@@ -310,7 +397,48 @@ const AiSearch = () => {
           setWeights={setHybridWeights}
         />
 
-        {/* Error Message */}
+        <div className="mt-4 w-full">
+          <SearchFilters
+            filters={filters}
+            setFilters={setFilters}
+            resultCount={results.length}
+            advanced={searchMode === "hybrid"}
+          />
+        </div>
+
+        {history.length > 0 && (
+          <div className="w-full text-left mb-2">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 flex items-center gap-1.5">
+                <History className="w-3.5 h-3.5" /> Recent searches
+              </p>
+              <button
+                type="button"
+                onClick={() => setHistory(clearSearchHistory())}
+                className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
+              >
+                Clear history
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {history.slice(0, 6).map((entry) => (
+                <button
+                  key={`${entry.at}-${entry.query}-${entry.mode}`}
+                  type="button"
+                  onClick={() => handleRerunHistory(entry)}
+                  className="text-xs px-3 py-1.5 rounded-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:border-blue-400 cursor-pointer"
+                  title={entry.mode}
+                >
+                  {entry.query.length > 40
+                    ? `${entry.query.slice(0, 37)}…`
+                    : entry.query}
+                  {entry.mode === "hybrid" ? " · hybrid" : ""}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
         {error && (
           <div className="mt-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm text-left w-full">
             <span className="font-semibold">
@@ -324,48 +452,40 @@ const AiSearch = () => {
           </div>
         )}
 
-        {/* Search Results Section */}
         <div className="mt-10 w-full text-left">
           {loading && <SearchSkeleton />}
 
           {!loading && results.length > 0 && (
-            <>
-              {searchMode === "standard" && (
-                <SearchFilters
-                  filters={filters}
-                  setFilters={setFilters}
-                  resultCount={results.length}
-                />
-              )}
-              <div className="space-y-5">
-                {searchMode === "hybrid"
-                  ? results.map((result, index) => (
-                      <HybridResultCard
-                        key={result.key || index}
-                        result={result}
-                        onOpenMeeting={handleOpenMeetingById}
-                      />
-                    ))
-                  : results.map((result, index) => (
-                      <SearchResultCard
-                        key={result.meetingId || index}
-                        result={result}
-                        onViewDetails={handleViewDetails}
-                        onOpenMeeting={handleOpenMeeting}
-                        onCopySummary={handleCopySummary}
-                      />
-                    ))}
-              </div>
-            </>
+            <div className="space-y-5">
+              {searchMode === "hybrid"
+                ? results.map((result, index) => (
+                    <HybridResultCard
+                      key={result.key || index}
+                      result={result}
+                      onOpenMeeting={handleOpenMeetingById}
+                    />
+                  ))
+                : results.map((result, index) => (
+                    <SearchResultCard
+                      key={result.meetingId || index}
+                      result={result}
+                      onViewDetails={handleViewDetails}
+                      onOpenMeeting={handleOpenMeeting}
+                      onCopySummary={handleCopySummary}
+                    />
+                  ))}
+            </div>
           )}
 
-          {!loading && results.length === 0 && (
-            <SearchEmptyState hasSearched={hasSearched} />
+          {!loading && results.length === 0 && !error && (
+            <SearchEmptyState
+              hasSearched={hasSearched}
+              onClearFilters={handleClearFilters}
+            />
           )}
         </div>
       </div>
 
-      {/* Result Modal */}
       {selectedResult && (
         <ResultModal
           result={selectedResult}

--- a/client/src/pages/__tests__/AiSearch.test.jsx
+++ b/client/src/pages/__tests__/AiSearch.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import AiSearch from "../AiSearch";
 
@@ -27,16 +28,32 @@ vi.mock("../../services", () => ({
   },
 }));
 
+const renderAiSearch = (initialEntry = "/ai-search") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <AiSearch />
+    </MemoryRouter>,
+  );
+
+const getQueryInput = () => screen.getByPlaceholderText(/ask e\.g\./i);
+
 describe("AiSearch meeting navigation (#615)", () => {
   let openSpy;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    const store = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    });
     openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
   });
 
   afterEach(() => {
-    openSpy.mockRestore();
+    openSpy?.mockRestore();
   });
 
   it("opens the singular /meeting/:id route from a standard search result", async () => {
@@ -54,9 +71,9 @@ describe("AiSearch meeting navigation (#615)", () => {
       },
     });
 
-    render(<AiSearch />);
+    renderAiSearch();
 
-    fireEvent.change(screen.getByRole("textbox"), {
+    fireEvent.change(getQueryInput(), {
       target: { value: "sprint planning" },
     });
     fireEvent.click(screen.getByRole("button", { name: /^search$/i }));
@@ -96,10 +113,10 @@ describe("AiSearch meeting navigation (#615)", () => {
       },
     });
 
-    render(<AiSearch />);
+    renderAiSearch();
 
     fireEvent.click(screen.getByRole("button", { name: /hybrid/i }));
-    fireEvent.change(screen.getByRole("textbox"), {
+    fireEvent.change(getQueryInput(), {
       target: { value: "ship v2" },
     });
     fireEvent.click(screen.getByRole("button", { name: /^search$/i }));
@@ -111,5 +128,34 @@ describe("AiSearch meeting navigation (#615)", () => {
     fireEvent.click(screen.getByRole("button", { name: /open meeting/i }));
 
     expect(openSpy).toHaveBeenCalledWith("/meeting/mtg-456", "_blank");
+  });
+
+  it("passes advanced filters to hybrid search and stores history (#2085)", async () => {
+    apiPost.mockResolvedValue({ data: { results: [] } });
+
+    renderAiSearch();
+
+    fireEvent.click(screen.getByRole("button", { name: /hybrid/i }));
+    fireEvent.change(getQueryInput(), {
+      target: { value: "budget review" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. finance/i), {
+      target: { value: "finance" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith(
+        "/api/search/hybrid",
+        expect.objectContaining({
+          query: "budget review",
+          tag: "finance",
+        }),
+      );
+    });
+
+    expect(
+      screen.getByRole("button", { name: /budget review/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/utils/__tests__/searchHistory.test.js
+++ b/client/src/utils/__tests__/searchHistory.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  clearSearchHistory,
+  loadSearchHistory,
+  paramsToSearchState,
+  saveSearchHistoryEntry,
+  searchStateToParams,
+} from "../searchHistory.js";
+
+describe("searchHistory utils (Issue #2085)", () => {
+  beforeEach(() => {
+    const store = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  it("saves and dedupes recent searches", () => {
+    saveSearchHistoryEntry({
+      query: "alpha",
+      mode: "hybrid",
+      filters: { tag: "x" },
+    });
+    saveSearchHistoryEntry({
+      query: "beta",
+      mode: "standard",
+      filters: {},
+    });
+    saveSearchHistoryEntry({
+      query: "alpha",
+      mode: "hybrid",
+      filters: { tag: "x" },
+    });
+
+    const history = loadSearchHistory();
+    expect(history).toHaveLength(2);
+    expect(history[0].query).toBe("alpha");
+    expect(history[1].query).toBe("beta");
+  });
+
+  it("round-trips query state through URL params", () => {
+    const params = searchStateToParams({
+      query: "roadmap",
+      mode: "hybrid",
+      filters: {
+        dateFrom: "2026-01-01",
+        dateTo: "2026-01-31",
+        meetingType: "internal",
+        speaker: "Ada",
+        tag: "ops",
+      },
+      weights: { semanticWeight: 0.6, graphWeight: 0.4 },
+    });
+
+    const state = paramsToSearchState(params);
+    expect(state.query).toBe("roadmap");
+    expect(state.mode).toBe("hybrid");
+    expect(state.filters.meetingType).toBe("internal");
+    expect(state.filters.speaker).toBe("Ada");
+    expect(state.filters.tag).toBe("ops");
+    expect(state.weights.semanticWeight).toBeCloseTo(0.6);
+  });
+
+  it("clears history", () => {
+    saveSearchHistoryEntry({ query: "keep" });
+    expect(loadSearchHistory()).toHaveLength(1);
+    clearSearchHistory();
+    expect(loadSearchHistory()).toHaveLength(0);
+  });
+});

--- a/client/src/utils/searchHistory.js
+++ b/client/src/utils/searchHistory.js
@@ -1,0 +1,100 @@
+const STORAGE_KEY = "meetonmemory.searchHistory.v1";
+const MAX_ENTRIES = 10;
+
+export function loadSearchHistory() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.slice(0, MAX_ENTRIES) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveSearchHistoryEntry(entry) {
+  const query = String(entry?.query || "").trim();
+  if (!query) return loadSearchHistory();
+
+  const nextEntry = {
+    query,
+    mode: entry.mode === "hybrid" ? "hybrid" : "standard",
+    filters: entry.filters || {},
+    weights: entry.weights || null,
+    at: new Date().toISOString(),
+  };
+
+  const prev = loadSearchHistory().filter(
+    (item) =>
+      !(
+        item.query === nextEntry.query &&
+        item.mode === nextEntry.mode &&
+        JSON.stringify(item.filters || {}) ===
+          JSON.stringify(nextEntry.filters || {})
+      ),
+  );
+
+  const next = [nextEntry, ...prev].slice(0, MAX_ENTRIES);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    /* ignore quota */
+  }
+  return next;
+}
+
+export function clearSearchHistory() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+export function searchStateToParams({ query, mode, filters, weights }) {
+  const params = new URLSearchParams();
+  if (query?.trim()) params.set("q", query.trim());
+  if (mode === "hybrid") params.set("mode", "hybrid");
+  if (filters?.dateFrom) params.set("from", filters.dateFrom);
+  if (filters?.dateTo) params.set("to", filters.dateTo);
+  if (filters?.meetingType) params.set("meetingType", filters.meetingType);
+  if (filters?.speaker) params.set("speaker", filters.speaker);
+  if (filters?.tag) params.set("tag", filters.tag);
+  if (filters?.resultType && filters.resultType !== "all") {
+    params.set("resultType", filters.resultType);
+  }
+  if (filters?.sortBy && filters.sortBy !== "relevance") {
+    params.set("sort", filters.sortBy);
+  }
+  if (mode === "hybrid" && typeof weights?.semanticWeight === "number") {
+    params.set("sw", String(Math.round(weights.semanticWeight * 100)));
+  }
+  return params;
+}
+
+export function paramsToSearchState(params) {
+  const q = params.get("q") || "";
+  const mode = params.get("mode") === "hybrid" ? "hybrid" : "standard";
+  const sw = Number.parseInt(params.get("sw") || "", 10);
+  const semanticWeight =
+    Number.isFinite(sw) && sw >= 0 && sw <= 100 ? sw / 100 : 0.7;
+
+  return {
+    query: q,
+    mode,
+    filters: {
+      resultType: params.get("resultType") || "all",
+      dateFrom: params.get("from") || "",
+      dateTo: params.get("to") || "",
+      sortBy: params.get("sort") || "relevance",
+      meetingType: params.get("meetingType") || "",
+      speaker: params.get("speaker") || "",
+      tag: params.get("tag") || "",
+    },
+    weights: {
+      semanticWeight,
+      graphWeight: 1 - semanticWeight,
+    },
+  };
+}

--- a/server/controllers/hybridSearchController.js
+++ b/server/controllers/hybridSearchController.js
@@ -29,7 +29,12 @@ import {
  *    maxHops?: number,              // graph traversal depth, default 2
  *    decay?: number,                // per-hop score decay (0-1), default 0.6
  *    minEdgeWeight?: number,        // ignore weak relatesTo edges (0-100)
- *    includeTypes?: ("meeting"|"decision"|"actionItem")[]
+ *    includeTypes?: ("meeting"|"decision"|"actionItem")[],
+ *    dateFrom?: string,             // YYYY-MM-DD
+ *    dateTo?: string,               // YYYY-MM-DD
+ *    meetingType?: string,          // conference|policy|event|internal
+ *    speaker?: string,              // participant name/email substring
+ *    tag?: string                   // exact tag match (case-insensitive)
  *  }
  */
 export const hybridSearch = async (req, res) => {

--- a/server/services/hybridRetrievalService.js
+++ b/server/services/hybridRetrievalService.js
@@ -28,6 +28,10 @@ import {
   stripClientTenantFields,
 } from "../utils/resolveSearchTenant.js";
 import {
+  applyHybridAdvancedFilters,
+  parseHybridFilterOptions,
+} from "../utils/hybridAdvancedFilters.js";
+import {
   buildGraph,
   expandFromSeeds,
   nodeKey,
@@ -128,6 +132,7 @@ export function resolveOptions(rawOptions = {}) {
     includeTypes: includeTypes.length
       ? includeTypes
       : DEFAULT_OPTIONS.includeTypes,
+    ...parseHybridFilterOptions(sanitized),
   };
 }
 
@@ -315,7 +320,7 @@ async function enrichWithMeetingContext(rankedResults, graph, organization) {
       ? new mongoose.Types.ObjectId(expectedOrg)
       : expectedOrg,
   })
-    .select("title createdAt organization")
+    .select("title createdAt date meetingType tags participants organization")
     .lean();
   const meetingById = new Map(meetings.map((m) => [m._id.toString(), m]));
 
@@ -328,6 +333,10 @@ async function enrichWithMeetingContext(rankedResults, graph, organization) {
             ...result,
             title: result.title || meeting.title,
             createdAt: meeting.createdAt,
+            date: meeting.date || meeting.createdAt,
+            meetingType: meeting.meetingType || null,
+            tags: meeting.tags || [],
+            participants: meeting.participants || [],
             organization: meeting.organization?.toString() || expectedOrg,
           };
         }
@@ -348,6 +357,10 @@ async function enrichWithMeetingContext(rankedResults, graph, organization) {
               id: meeting._id.toString(),
               title: meeting.title,
               createdAt: meeting.createdAt,
+              date: meeting.date || meeting.createdAt,
+              meetingType: meeting.meetingType || null,
+              tags: meeting.tags || [],
+              participants: meeting.participants || [],
               organization: meeting.organization?.toString() || expectedOrg,
             },
           }
@@ -441,9 +454,13 @@ export async function hybridRetrieve(query, organization, rawOptions = {}) {
       : [];
 
   const fused = fuseResults(semanticResults, graphExpansions, options);
-  const topResults = fused.slice(0, options.topK);
+  const topResults = fused.slice(0, Math.max(options.topK * 3, options.topK));
   const enriched = await enrichWithMeetingContext(topResults, graph, tenantOrg);
-  const explained = attachExplanations(enriched, graph, tenantOrg);
+  const filtered = applyHybridAdvancedFilters(enriched, options).slice(
+    0,
+    options.topK,
+  );
+  const explained = attachExplanations(filtered, graph, tenantOrg);
   const results = filterHybridResultsByTenant(
     explained,
     graph.nodes,
@@ -459,6 +476,7 @@ export async function hybridRetrieve(query, organization, rawOptions = {}) {
       semanticHitCount: semanticResults.length,
       graphExpansionCount: graphExpansions.length,
       fusedCount: fused.length,
+      filteredCount: results.length,
     },
   };
 }

--- a/server/tests/hybridAdvancedFilters.test.js
+++ b/server/tests/hybridAdvancedFilters.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyHybridAdvancedFilters,
+  parseHybridFilterOptions,
+} from "../utils/hybridAdvancedFilters.js";
+
+describe("hybridAdvancedFilters (Issue #2085)", () => {
+  it("parses advanced filter fields", () => {
+    const opts = parseHybridFilterOptions({
+      dateFrom: "2026-01-01",
+      dateTo: "2026-02-01",
+      meetingType: "internal",
+      speaker: " Ada ",
+      tag: "finance",
+    });
+    expect(opts.dateFrom).toBe("2026-01-01");
+    expect(opts.meetingType).toBe("internal");
+    expect(opts.speaker).toBe("Ada");
+    expect(opts.tag).toBe("finance");
+  });
+
+  it("filters by tag and speaker", () => {
+    const sample = [
+      {
+        type: "meeting",
+        title: "A",
+        date: "2026-01-10T12:00:00.000Z",
+        meetingType: "internal",
+        tags: ["finance"],
+        participants: [{ name: "Ada Lovelace", email: "ada@ex.com" }],
+      },
+      {
+        type: "decision",
+        title: "B",
+        sourceMeeting: {
+          date: "2026-03-01T12:00:00.000Z",
+          meetingType: "conference",
+          tags: ["ops"],
+          participants: [{ name: "Bob" }],
+        },
+      },
+    ];
+
+    const byTag = applyHybridAdvancedFilters(sample, { tag: "finance" });
+    expect(byTag).toHaveLength(1);
+    expect(byTag[0].title).toBe("A");
+
+    const bySpeaker = applyHybridAdvancedFilters(sample, { speaker: "ada" });
+    expect(bySpeaker).toHaveLength(1);
+    expect(bySpeaker[0].title).toBe("A");
+  });
+
+  it("filters by date range and meeting type", () => {
+    const sample = [
+      {
+        type: "meeting",
+        title: "A",
+        date: "2026-01-10T12:00:00.000Z",
+        meetingType: "internal",
+        tags: [],
+        participants: [],
+      },
+      {
+        type: "decision",
+        title: "B",
+        sourceMeeting: {
+          date: "2026-03-01T12:00:00.000Z",
+          meetingType: "conference",
+          tags: [],
+          participants: [],
+        },
+      },
+    ];
+
+    const ranged = applyHybridAdvancedFilters(sample, {
+      dateFrom: "2026-02-01",
+      dateTo: "2026-03-31",
+      meetingType: "conference",
+    });
+    expect(ranged).toHaveLength(1);
+    expect(ranged[0].title).toBe("B");
+  });
+});

--- a/server/utils/hybridAdvancedFilters.js
+++ b/server/utils/hybridAdvancedFilters.js
@@ -1,0 +1,94 @@
+/**
+ * Advanced hybrid-search filters (Issue #2085).
+ * Pure helpers — no Redis/Pinecone/Mongo required.
+ */
+
+const MEETING_TYPES = Object.freeze([
+  "conference",
+  "policy",
+  "event",
+  "internal",
+]);
+
+export function parseHybridFilterOptions(sanitized = {}) {
+  const meetingType =
+    typeof sanitized.meetingType === "string" &&
+    MEETING_TYPES.includes(sanitized.meetingType)
+      ? sanitized.meetingType
+      : "";
+
+  const dateFrom =
+    typeof sanitized.dateFrom === "string" && sanitized.dateFrom
+      ? sanitized.dateFrom.slice(0, 10)
+      : "";
+  const dateTo =
+    typeof sanitized.dateTo === "string" && sanitized.dateTo
+      ? sanitized.dateTo.slice(0, 10)
+      : "";
+  const speaker =
+    typeof sanitized.speaker === "string" ? sanitized.speaker.trim() : "";
+  const tag = typeof sanitized.tag === "string" ? sanitized.tag.trim() : "";
+
+  return { dateFrom, dateTo, meetingType, speaker, tag };
+}
+
+/**
+ * Applies advanced meeting filters to hybrid results.
+ * Uses meeting / sourceMeeting metadata attached during enrichment.
+ */
+export function applyHybridAdvancedFilters(results, options = {}) {
+  if (!Array.isArray(results) || !results.length) return results || [];
+
+  const dateFrom = options.dateFrom
+    ? new Date(`${options.dateFrom}T00:00:00.000Z`)
+    : null;
+  const dateTo = options.dateTo
+    ? new Date(`${options.dateTo}T23:59:59.999Z`)
+    : null;
+  const meetingType = options.meetingType || "";
+  const speaker = (options.speaker || "").toLowerCase();
+  const tag = (options.tag || "").toLowerCase();
+
+  if (!dateFrom && !dateTo && !meetingType && !speaker && !tag) {
+    return results;
+  }
+
+  return results.filter((result) => {
+    const meetingMeta =
+      result.type === "meeting" ? result : result.sourceMeeting || {};
+
+    const rawDate =
+      meetingMeta.date || meetingMeta.createdAt || result.createdAt || null;
+    if (dateFrom || dateTo) {
+      if (!rawDate) return false;
+      const when = new Date(rawDate);
+      if (Number.isNaN(when.getTime())) return false;
+      if (dateFrom && when < dateFrom) return false;
+      if (dateTo && when > dateTo) return false;
+    }
+
+    if (meetingType) {
+      const type = meetingMeta.meetingType || result.meetingType || "";
+      if (type !== meetingType) return false;
+    }
+
+    if (speaker) {
+      const participants =
+        meetingMeta.participants || result.participants || [];
+      const hit = participants.some((p) => {
+        const name = String(p?.name || "").toLowerCase();
+        const email = String(p?.email || "").toLowerCase();
+        return name.includes(speaker) || email.includes(speaker);
+      });
+      if (!hit) return false;
+    }
+
+    if (tag) {
+      const tags = meetingMeta.tags || result.tags || [];
+      const hit = tags.some((t) => String(t).toLowerCase() === tag);
+      if (!hit) return false;
+    }
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- Advanced hybrid filters (date range, meeting type, speaker, tag) applied server-side
- Local recent-search history with one-click re-run
- Shareable URL sync for query, mode, filters, and hybrid weights
- Clearer empty/error empty-states
Closes #2085
## Test plan
- [ ] Run a hybrid search, confirm URL updates (`q`, `mode`, filters)
- [ ] Open the URL in a new tab and confirm state restores / search re-runs
- [ ] Apply tag/speaker/date filters and confirm result set changes
- [ ] Re-run a chip from Recent searches
- [ ] `cd client && npx vitest run src/utils/__tests__/searchHistory.test.js src/pages/__tests__/AiSearch.test.jsx`
- [ ] `cd server && npx vitest run tests/hybridAdvancedFilters.test.js`
