### PR TITLE
fix(a11y): remove global select-none from Settings container

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -416,7 +416,7 @@ const Settings = () => {
   };
 
   return (
-    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 flex flex-col font-sans select-none">
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 flex flex-col font-sans">
       <Navbar />
 
       <div className="flex-1 w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-28 pb-16">

--- a/client/src/pages/__tests__/SettingsSelectableText.test.jsx
+++ b/client/src/pages/__tests__/SettingsSelectableText.test.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import Settings from "../Settings.jsx";
+import AppContent from "../../context/AppContent.js";
+import { ThemeProvider } from "../../context/ThemeContext.jsx";
+import { PreferencesProvider } from "../../context/PreferencesContext.jsx";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar">Navbar</div>,
+}));
+
+vi.mock("../../components/ClerkUserControls.jsx", () => ({
+  ClerkManageAccountButton: ({ children }) => <button>{children}</button>,
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+    post: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+    put: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+    delete: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+    request: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+  },
+  DEFAULT_TIMEOUT_MS: 30000,
+}));
+
+describe("Settings Page Selectable Text (#1796)", () => {
+  const mockUserData = {
+    name: "Jane Smith",
+    email: "jane.smith@example.com",
+    role: "admin",
+    organization: "Acme Corp",
+    timezone: "UTC",
+    isAccountVerified: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not apply select-none to the main container", () => {
+    const { container } = render(
+      <BrowserRouter>
+        <ThemeProvider>
+          <PreferencesProvider>
+            <AppContent.Provider
+              value={{
+                userData: mockUserData,
+                setUserData: vi.fn(),
+                backendUrl: "http://localhost:5000",
+                isLoggedin: true,
+              }}
+            >
+              <Settings />
+            </AppContent.Provider>
+          </PreferencesProvider>
+        </ThemeProvider>
+      </BrowserRouter>,
+    );
+
+    const root = container.firstChild;
+    expect(root.className).not.toMatch(/\bselect-none\b/);
+  });
+});


### PR DESCRIPTION
### Description
Fixes an accessibility and usability issue on the Settings page where the main container had the CSS class `select-none` applied, preventing users from selecting or copying text, webhook URLs, notification endpoints, email addresses, and configuration IDs.

### Changes Made
- Updated `client/src/pages/Settings.jsx`:
  - Removed `select-none` from the main settings wrapper element.
  - Restored default user text selection capability across all settings tabs and panels.
- Added unit test in `client/src/pages/__tests__/SettingsSelectableText.test.jsx` verifying that `select-none` is absent from the container.

### Issue Reference
Closes #1796

### Checklist
- [x] Code passes ESLint and Prettier checks
- [x] Unit test verified (`vitest src/pages/__tests__/SettingsSelectableText.test.jsx`)
- [x] User text selection enabled on settings tabs and configuration values
