### PR TITLE
feat(meetings): add meeting bookmark and favorites endpoints

### DIFF
--- a/client/src/api/bookmarkApi.js
+++ b/client/src/api/bookmarkApi.js
@@ -37,6 +37,33 @@ export const deleteCollectionAPI = async (name) => {
 };
 
 export const getBookmarkStatusAPI = async (meetingId) => {
-  const response = await apiClient.get(`/api/bookmarks/status/${meetingId}`);
+  const response = await apiClient.get(`/api/meetings/${meetingId}/bookmark`);
+  return response.data;
+};
+
+export const addMeetingBookmarkAPI = async (
+  meetingId,
+  collectionName,
+  notes,
+  color,
+) => {
+  const response = await apiClient.post(`/api/meetings/${meetingId}/bookmark`, {
+    collectionName,
+    notes,
+    color,
+  });
+  return response.data;
+};
+
+export const removeMeetingBookmarkAPI = async (meetingId) => {
+  const response = await apiClient.delete(
+    `/api/meetings/${meetingId}/bookmark`,
+  );
+  return response.data;
+};
+
+export const getBookmarkedMeetingsAPI = async (collectionName) => {
+  const params = collectionName ? { collectionName } : {};
+  const response = await apiClient.get("/api/meetings/bookmarked", { params });
   return response.data;
 };

--- a/server/controllers/bookmarkController.js
+++ b/server/controllers/bookmarkController.js
@@ -185,3 +185,150 @@ export const deleteCollection = async (req, res) => {
     res.status(500).json({ message: "Server error deleting collection" });
   }
 };
+
+// @desc    Add meeting bookmark
+// @route   POST /api/meetings/:id/bookmark
+// @access  Private
+export const addMeetingBookmark = async (req, res) => {
+  try {
+    const meetingId = req.params.id;
+    const userId = req.user._id;
+    const { collectionName, notes, color } = req.body || {};
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meeting ID" });
+    }
+
+    const meeting =
+      await Meeting.findById(meetingId).select("organization _id");
+    if (!meeting) {
+      return res.status(404).json({ message: "Meeting not found" });
+    }
+
+    if (!isSameOrganization(req.user, meeting)) {
+      return res.status(403).json({
+        message: "Meeting does not belong to your organization",
+      });
+    }
+
+    let bookmark = await Bookmark.findOne({
+      user: userId,
+      meeting: meetingId,
+    });
+
+    if (!bookmark) {
+      bookmark = await Bookmark.create({
+        user: userId,
+        meeting: meetingId,
+        collectionName: collectionName || "Uncategorized",
+        notes: notes || "",
+        color: color || "#3b82f6",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Meeting bookmarked successfully",
+      bookmarked: true,
+      data: bookmark,
+    });
+  } catch (error) {
+    console.error("Error adding meeting bookmark:", error);
+    res.status(500).json({ message: "Server error bookmarking meeting" });
+  }
+};
+
+// @desc    Remove meeting bookmark
+// @route   DELETE /api/meetings/:id/bookmark
+// @access  Private
+export const removeMeetingBookmark = async (req, res) => {
+  try {
+    const meetingId = req.params.id;
+    const userId = req.user._id;
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meeting ID" });
+    }
+
+    await Bookmark.deleteOne({ user: userId, meeting: meetingId });
+
+    return res.status(200).json({
+      message: "Bookmark removed successfully",
+      bookmarked: false,
+    });
+  } catch (error) {
+    console.error("Error removing meeting bookmark:", error);
+    res.status(500).json({ message: "Server error removing bookmark" });
+  }
+};
+
+// @desc    Get bookmark status for a meeting
+// @route   GET /api/meetings/:id/bookmark
+// @access  Private
+export const getMeetingBookmarkStatus = async (req, res) => {
+  try {
+    const meetingId = req.params.id;
+    const userId = req.user._id;
+
+    if (!mongoose.Types.ObjectId.isValid(meetingId)) {
+      return res.status(400).json({ message: "Invalid meeting ID" });
+    }
+
+    const bookmark = await Bookmark.findOne({
+      user: userId,
+      meeting: meetingId,
+    });
+
+    return res.status(200).json({
+      bookmarked: Boolean(bookmark),
+      bookmark: bookmark || null,
+    });
+  } catch (error) {
+    console.error("Error getting meeting bookmark status:", error);
+    res.status(500).json({ message: "Server error checking bookmark status" });
+  }
+};
+
+// @desc    Get all bookmarked meetings for current user
+// @route   GET /api/meetings/bookmarked
+// @access  Private
+export const getBookmarkedMeetings = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { collectionName } = req.query;
+
+    const query = { user: userId };
+    if (collectionName) {
+      query.collectionName = String(collectionName);
+    }
+
+    const bookmarks = await Bookmark.find(query)
+      .sort({ createdAt: -1 })
+      .populate({
+        path: "meeting",
+        select:
+          "title date time duration meetingType status organization description _id",
+      });
+
+    // Filter out orphaned bookmarks where meeting was deleted
+    const validBookmarks = bookmarks.filter((b) => b.meeting !== null);
+    const meetings = validBookmarks.map((b) => ({
+      ...b.meeting.toObject(),
+      bookmarkId: b._id,
+      collectionName: b.collectionName,
+      bookmarkNotes: b.notes,
+      bookmarkColor: b.color,
+      bookmarkedAt: b.createdAt,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      count: meetings.length,
+      data: meetings,
+    });
+  } catch (error) {
+    console.error("Error fetching bookmarked meetings:", error);
+    res
+      .status(500)
+      .json({ message: "Server error fetching bookmarked meetings" });
+  }
+};

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -39,6 +39,12 @@ import {
   resolveMeetingInvite,
 } from "../controllers/meetingController.js";
 import {
+  addMeetingBookmark,
+  removeMeetingBookmark,
+  getMeetingBookmarkStatus,
+  getBookmarkedMeetings,
+} from "../controllers/bookmarkController.js";
+import {
   resendDigest,
   previewDigest,
 } from "../controllers/digestController.js";
@@ -239,6 +245,40 @@ router.get(
   requireOrgMembership,
   requirePermission("meetings", "view"),
   getAllMeetings,
+);
+
+// ✅ Fetch All Bookmarked Meetings for current user (#1827)
+router.get(
+  "/bookmarked",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getBookmarkedMeetings,
+);
+
+// ✅ Meeting bookmark operations (#1827)
+router.post(
+  "/:id/bookmark",
+  userAuth,
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  addMeetingBookmark,
+);
+router.delete(
+  "/:id/bookmark",
+  userAuth,
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  removeMeetingBookmark,
+);
+router.get(
+  "/:id/bookmark",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getMeetingBookmarkStatus,
 );
 
 // ✅ Resolve shareable meeting invite (must be before /:id)

--- a/server/tests/meetingBookmarkEndpoints.test.js
+++ b/server/tests/meetingBookmarkEndpoints.test.js
@@ -1,0 +1,196 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+
+const mockBookmarkFindOne = vi.fn();
+const mockBookmarkDeleteOne = vi.fn();
+const mockBookmarkCreate = vi.fn();
+const mockBookmarkFind = vi.fn();
+
+vi.mock("../models/bookmarkModel.js", () => ({
+  default: {
+    findOne: (...args) => mockBookmarkFindOne(...args),
+    deleteOne: (...args) => mockBookmarkDeleteOne(...args),
+    create: (...args) => mockBookmarkCreate(...args),
+    find: (...args) => mockBookmarkFind(...args),
+  },
+}));
+
+const mockMeetingFindById = vi.fn();
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findById: (...args) => mockMeetingFindById(...args),
+  },
+}));
+
+import {
+  addMeetingBookmark,
+  removeMeetingBookmark,
+  getMeetingBookmarkStatus,
+  getBookmarkedMeetings,
+} from "../controllers/bookmarkController.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: vi.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+describe("Meeting Bookmark Endpoints (#1827)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/meetings/:id/bookmark (addMeetingBookmark)", () => {
+    it("adds a bookmark for authorized user in same org", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const userId = new mongoose.Types.ObjectId();
+      const user = { _id: userId, organization: ORG_A };
+
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+      mockBookmarkFindOne.mockResolvedValue(null);
+      mockBookmarkCreate.mockResolvedValue({
+        _id: new mongoose.Types.ObjectId(),
+        user: userId,
+        meeting: meetingId,
+      });
+
+      const req = {
+        params: { id: meetingId.toString() },
+        body: { collectionName: "Project X" },
+        user,
+      };
+      const res = makeRes();
+
+      await addMeetingBookmark(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.bookmarked).toBe(true);
+      expect(mockBookmarkCreate).toHaveBeenCalled();
+    });
+
+    it("denies bookmark creation across organizations", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const user = { _id: new mongoose.Types.ObjectId(), organization: ORG_B };
+
+      mockMeetingFindById.mockReturnValue({
+        select: vi
+          .fn()
+          .mockResolvedValue({ _id: meetingId, organization: ORG_A }),
+      });
+
+      const req = {
+        params: { id: meetingId.toString() },
+        user,
+      };
+      const res = makeRes();
+
+      await addMeetingBookmark(req, res);
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("DELETE /api/meetings/:id/bookmark (removeMeetingBookmark)", () => {
+    it("removes bookmark", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const userId = new mongoose.Types.ObjectId();
+
+      mockBookmarkDeleteOne.mockResolvedValue({ deletedCount: 1 });
+
+      const req = {
+        params: { id: meetingId.toString() },
+        user: { _id: userId },
+      };
+      const res = makeRes();
+
+      await removeMeetingBookmark(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.bookmarked).toBe(false);
+      expect(mockBookmarkDeleteOne).toHaveBeenCalledWith({
+        user: userId,
+        meeting: meetingId.toString(),
+      });
+    });
+  });
+
+  describe("GET /api/meetings/:id/bookmark (getMeetingBookmarkStatus)", () => {
+    it("returns true when bookmarked", async () => {
+      const meetingId = new mongoose.Types.ObjectId();
+      const userId = new mongoose.Types.ObjectId();
+
+      mockBookmarkFindOne.mockResolvedValue({
+        _id: new mongoose.Types.ObjectId(),
+        user: userId,
+        meeting: meetingId,
+      });
+
+      const req = {
+        params: { id: meetingId.toString() },
+        user: { _id: userId },
+      };
+      const res = makeRes();
+
+      await getMeetingBookmarkStatus(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.bookmarked).toBe(true);
+    });
+  });
+
+  describe("GET /api/meetings/bookmarked (getBookmarkedMeetings)", () => {
+    it("returns list of bookmarked meetings", async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const meetingId = new mongoose.Types.ObjectId();
+
+      const mockQuery = {
+        sort: vi.fn().mockReturnThis(),
+        populate: vi.fn().mockResolvedValue([
+          {
+            _id: new mongoose.Types.ObjectId(),
+            collectionName: "Favorites",
+            notes: "Important",
+            color: "#3b82f6",
+            createdAt: new Date(),
+            meeting: {
+              _id: meetingId,
+              title: "Board Sync",
+              toObject: () => ({ _id: meetingId, title: "Board Sync" }),
+            },
+          },
+        ]),
+      };
+      mockBookmarkFind.mockReturnValue(mockQuery);
+
+      const req = {
+        query: {},
+        user: { _id: userId },
+      };
+      const res = makeRes();
+
+      await getBookmarkedMeetings(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.count).toBe(1);
+      expect(res.body.data[0].title).toBe("Board Sync");
+    });
+  });
+});


### PR DESCRIPTION
### Description
Adds dedicated backend endpoints and API client helpers for bookmarking and favoriting meetings, enabling users to organize important meetings into custom collections, add notes, set bookmark colors, and fetch all bookmarked meetings.

### Changes Made
- Updated `server/controllers/bookmarkController.js`:
  - Implemented `addMeetingBookmark` (`POST /api/meetings/:id/bookmark`) with organization boundary validation.
  - Implemented `removeMeetingBookmark` (`DELETE /api/meetings/:id/bookmark`).
  - Implemented `getMeetingBookmarkStatus` (`GET /api/meetings/:id/bookmark`).
  - Implemented `getBookmarkedMeetings` (`GET /api/meetings/bookmarked`) with collection filtering.
- Updated `server/routes/meetingRoutes.js`:
  - Registered `GET /bookmarked` (prior to `/:id` route parameters) protected by `userAuth`, `requireOrgMembership`, and `requirePermission("meetings", "view")`.
  - Registered `POST`, `DELETE`, and `GET` on `/:id/bookmark` protected by `userAuth` and `requireOrgMembership`.
- Updated `client/src/api/bookmarkApi.js`:
  - Exported `addMeetingBookmarkAPI`, `removeMeetingBookmarkAPI`, `getBookmarkStatusAPI`, and `getBookmarkedMeetingsAPI`.
- Added unit test suite in `server/tests/meetingBookmarkEndpoints.test.js` (5 passing tests).

### Issue Reference
Closes #1827

### Checklist
- [x] Code passes ESLint and Prettier checks
- [x] Backend unit tests passing (`npx vitest run tests/meetingBookmarkEndpoints.test.js`)
- [x] Cross-tenant bookmarking prevented
