### PR TITLE
fix: sanitize recap HTML preview

### DIFF
--- a/client/src/components/RecapPreferences.jsx
+++ b/client/src/components/RecapPreferences.jsx
@@ -6,6 +6,8 @@ import {
 } from "../services/recapApi";
 import { Dialog } from "@headlessui/react";
 import { toast } from "react-toastify";
+import SandboxedHtmlPreview from "./SandboxedHtmlPreview";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 
 const RecapPreferences = () => {
   const [preferences, setPreferences] = useState({
@@ -115,7 +117,7 @@ const RecapPreferences = () => {
             : null,
       };
       const html = await previewRecapEmail(payload);
-      setPreviewHtml(html);
+      setPreviewHtml(sanitizeHtml(html));
       setIsPreviewOpen(true);
     } catch {
       toast.error("Failed to generate preview");
@@ -291,8 +293,11 @@ const RecapPreferences = () => {
                   Email Preview
                 </Dialog.Title>
                 <div className="mt-2 w-full border rounded p-4 max-h-[60vh] overflow-y-auto bg-gray-50">
-                  {/* Dangerously set HTML since we generate it in backend */}
-                  <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
+                  <SandboxedHtmlPreview
+                    htmlContent={previewHtml}
+                    title="Email Preview"
+                    className="min-h-[240px]"
+                  />
                 </div>
               </div>
             </div>

--- a/client/src/components/SandboxedHtmlPreview.jsx
+++ b/client/src/components/SandboxedHtmlPreview.jsx
@@ -1,19 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 
 /**
  * SandboxedHtmlPreview
  * Securely renders raw HTML (such as email digests or generated previews)
- * by isolating it within an iframe using a restrictive sandbox policy.
- * This prevents XSS attacks by disallowing scripts, same-origin access,
- * top navigation, and form submissions.
+ * by sanitizing first, then isolating the result in an iframe with a
+ * restrictive sandbox policy. Scripts, same-origin access, top navigation,
+ * and form submissions are all disallowed.
  */
 const SandboxedHtmlPreview = ({
   htmlContent,
   className = "",
   title = "Digest Preview",
 }) => {
-  if (!htmlContent) return null;
+  const sanitizedHtml = sanitizeHtml(htmlContent);
+  if (!sanitizedHtml) return null;
 
   return (
     <div
@@ -21,7 +23,7 @@ const SandboxedHtmlPreview = ({
     >
       <iframe
         title={title}
-        srcDoc={htmlContent}
+        srcDoc={sanitizedHtml}
         className="w-full h-full min-h-[400px] border-none"
         // Maximum restriction sandbox:
         // - No 'allow-scripts': prevents JS execution
@@ -30,6 +32,7 @@ const SandboxedHtmlPreview = ({
         // - No 'allow-popups': prevents opening new windows
         // - No 'allow-forms': prevents form submissions
         sandbox=""
+        referrerPolicy="no-referrer"
       />
     </div>
   );

--- a/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
+++ b/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import RecapPreferences from "../RecapPreferences.jsx";
+import {
+  getRecapPreferences,
+  previewRecapEmail,
+} from "../../services/recapApi";
+
+vi.mock("../../services/recapApi", () => ({
+  getRecapPreferences: vi.fn(),
+  updateRecapPreferences: vi.fn(),
+  previewRecapEmail: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const defaultPreferences = {
+  deliveryTiming: "immediate",
+  includeSummary: true,
+  includeActionItems: true,
+  includeTranscript: true,
+  quietHoursStart: "",
+  quietHoursEnd: "",
+  timezone: "UTC",
+};
+
+const openPreview = async (html) => {
+  previewRecapEmail.mockResolvedValueOnce(html);
+  render(<RecapPreferences />);
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: /preview email/i }),
+    ).toBeEnabled();
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /preview email/i }));
+
+  await waitFor(() => {
+    expect(screen.getByTitle("Email Preview")).toBeInTheDocument();
+  });
+
+  return screen.getByTitle("Email Preview");
+};
+
+describe("RecapPreferences HTML preview sanitization (#1391)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRecapPreferences.mockResolvedValue(defaultPreferences);
+  });
+
+  it("renders API HTML through a sandboxed iframe", async () => {
+    const iframe = await openPreview(
+      `<div><h2>Meeting Recap: Project Alpha Kickoff</h2><p>We discussed the roadmap.</p></div>`,
+    );
+
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(iframe.getAttribute("srcdoc")).toContain(
+      "Meeting Recap: Project Alpha Kickoff",
+    );
+    expect(iframe.getAttribute("srcdoc")).toContain(
+      "We discussed the roadmap.",
+    );
+  });
+
+  it("does not inject script tags from the API HTML into the preview", async () => {
+    const iframe = await openPreview(
+      `<p>Safe recap</p><script>alert("xss")</script>`,
+    );
+
+    const srcDoc = iframe.getAttribute("srcdoc") || "";
+    expect(srcDoc).toContain("Safe recap");
+    expect(srcDoc).not.toMatch(/<script/i);
+    expect(srcDoc).not.toContain("alert(");
+    expect(document.body.innerHTML).not.toMatch(/<script>alert/i);
+  });
+
+  it("strips event handlers from the API HTML", async () => {
+    const iframe = await openPreview(
+      `<img src="x" onerror="alert(1)" /><div onclick="alert(2)">Summary</div>`,
+    );
+
+    const srcDoc = iframe.getAttribute("srcdoc") || "";
+    expect(srcDoc).toContain("Summary");
+    expect(srcDoc).not.toMatch(/onerror/i);
+    expect(srcDoc).not.toMatch(/onclick/i);
+  });
+
+  it("blocks javascript: URLs from the API HTML", async () => {
+    const iframe = await openPreview(
+      `<a href="javascript:alert(1)">Open recap</a>`,
+    );
+
+    const srcDoc = iframe.getAttribute("srcdoc") || "";
+    expect(srcDoc).toContain("Open recap");
+    expect(srcDoc).not.toMatch(/javascript:/i);
+  });
+});

--- a/client/src/components/__tests__/SandboxedHtmlPreview.test.jsx
+++ b/client/src/components/__tests__/SandboxedHtmlPreview.test.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import SandboxedHtmlPreview from "../SandboxedHtmlPreview.jsx";
+
+const iframeSrcDoc = (title) =>
+  screen.getByTitle(title).getAttribute("srcdoc") || "";
+
+describe("SandboxedHtmlPreview (#1391)", () => {
+  it("renders sanitized HTML inside a maximally restricted iframe", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Meeting Recap</p>"
+        title="Email Preview"
+      />,
+    );
+
+    const iframe = screen.getByTitle("Email Preview");
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(iframeSrcDoc("Email Preview")).toContain("Meeting Recap");
+  });
+
+  it("strips script tags before assigning srcDoc", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent={`<p>Safe recap</p><script>alert("xss")</script>`}
+        title="Email Preview"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("Safe recap");
+    expect(srcDoc).not.toMatch(/<script/i);
+    expect(srcDoc).not.toContain("alert(");
+  });
+
+  it("strips event handlers before assigning srcDoc", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent={`<img src="x" onerror="alert(1)" /><p onclick="steal()">Summary</p>`}
+        title="Email Preview"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("Summary");
+    expect(srcDoc).not.toMatch(/onerror/i);
+    expect(srcDoc).not.toMatch(/onclick/i);
+    expect(srcDoc).not.toContain("alert(");
+    expect(srcDoc).not.toContain("steal(");
+  });
+
+  it("blocks javascript: URLs before assigning srcDoc", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent={`<a href="javascript:alert(1)">Open recap</a>`}
+        title="Email Preview"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("Open recap");
+    expect(srcDoc).not.toMatch(/javascript:/i);
+  });
+
+  it("preserves legitimate recap markup", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent={`
+          <div style="font-family: sans-serif;">
+            <h2>Meeting Recap: Project Alpha Kickoff</h2>
+            <p>Date: 1/15/2026</p>
+          </div>
+        `}
+        title="Email Preview"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("Meeting Recap: Project Alpha Kickoff");
+    expect(srcDoc).toContain("Date: 1/15/2026");
+    expect(srcDoc).toMatch(/<h2/i);
+  });
+
+  it("renders nothing when HTML is empty after sanitization", () => {
+    const { container } = render(
+      <SandboxedHtmlPreview htmlContent="" title="Email Preview" />,
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTitle("Email Preview")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/utils/__tests__/sanitizeHtml.test.js
+++ b/client/src/utils/__tests__/sanitizeHtml.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeHtml } from "../sanitizeHtml.js";
+
+const LEGITIMATE_RECAP_HTML = `
+<div style="font-family: sans-serif; max-width: 600px; margin: auto; padding: 20px; color: #333; border: 1px solid #eee; border-radius: 10px;">
+  <h2 style="color: #2563eb;">Meeting Recap: Project Alpha Kickoff</h2>
+  <p style="color: #666;">Date: 1/15/2026</p>
+  <hr />
+  <h3 style="color: #1e40af;">Summary</h3>
+  <p style="white-space: pre-wrap;">We discussed the roadmap for Project Alpha.</p>
+  <h3 style="color: #1e40af;">Action Items</h3>
+  <ul>
+    <li><strong>Jane:</strong> Draft the Q3 plan <em>(Due: 2/1/2026)</em></li>
+  </ul>
+</div>
+`;
+
+describe("sanitizeHtml (#1391)", () => {
+  it("strips script tags and their contents", () => {
+    const sanitized = sanitizeHtml(
+      `<p>Safe</p><script>alert("xss")</script><p>Also safe</p>`,
+    );
+
+    expect(sanitized).toContain("Safe");
+    expect(sanitized).toContain("Also safe");
+    expect(sanitized).not.toMatch(/<script/i);
+    expect(sanitized).not.toContain("alert(");
+  });
+
+  it("removes inline event-handler attributes", () => {
+    const sanitized = sanitizeHtml(
+      `<img src="x" onerror="alert(1)" /><div onclick="alert(2)">Recap</div>`,
+    );
+
+    expect(sanitized).not.toMatch(/onerror/i);
+    expect(sanitized).not.toMatch(/onclick/i);
+    expect(sanitized).not.toContain("alert(");
+    expect(sanitized).toContain("Recap");
+  });
+
+  it("blocks javascript: URLs", () => {
+    const sanitized = sanitizeHtml(
+      `<a href="javascript:alert(1)">Open recap</a>`,
+    );
+
+    expect(sanitized).not.toMatch(/javascript:/i);
+    expect(sanitized).not.toContain("alert(");
+    expect(sanitized).toContain("Open recap");
+  });
+
+  it("preserves legitimate recap/email preview markup", () => {
+    const sanitized = sanitizeHtml(LEGITIMATE_RECAP_HTML);
+
+    expect(sanitized).toContain("Meeting Recap: Project Alpha Kickoff");
+    expect(sanitized).toContain("We discussed the roadmap for Project Alpha.");
+    expect(sanitized).toContain("Jane:");
+    expect(sanitized).toMatch(/<h2/i);
+    expect(sanitized).toMatch(/<h3/i);
+    expect(sanitized).toMatch(/<ul/i);
+    expect(sanitized).toMatch(/<strong/i);
+    expect(sanitized).toMatch(/<em/i);
+    expect(sanitized).toMatch(/style=/i);
+  });
+
+  it("returns an empty string for non-string input", () => {
+    expect(sanitizeHtml(null)).toBe("");
+    expect(sanitizeHtml(undefined)).toBe("");
+    expect(sanitizeHtml("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Description

Fixes #1391.

Secures the Recap Preferences HTML preview by sanitizing API-provided HTML before rendering it inside an isolated sandboxed iframe.

## What Changed

- Sanitized recap HTML using the existing `sanitizeHtml`/DOMPurify pipeline.
- Replaced direct HTML rendering in `RecapPreferences` with `SandboxedHtmlPreview`.
- Added a second sanitization boundary inside `SandboxedHtmlPreview` before assigning `srcDoc`.
- Preserved legitimate recap/email formatting and inline styles.
- Added an empty iframe `sandbox` to prevent script execution and parent application access.
- Added `referrerPolicy="no-referrer"` to the preview iframe.

## Security

The preview now blocks:

- `<script>` elements
- Inline event handlers such as `onclick` and `onerror`
- Dangerous `javascript:` URLs
- Script execution inside the preview
- Access from the preview to the parent application

The iframe does not grant unnecessary capabilities such as scripts, same-origin access, forms, popups, or navigation.

## Tests

Added regression coverage for:

- Script injection
- Event-handler XSS
- `javascript:` URLs
- Legitimate recap HTML rendering
- Sandboxed iframe configuration
- Recap Preferences preview integration

## Files Changed

- `client/src/components/RecapPreferences.jsx`
- `client/src/components/SandboxedHtmlPreview.jsx`
- `client/src/components/__tests__/RecapPreferencesPreview.test.jsx`
- `client/src/components/__tests__/SandboxedHtmlPreview.test.jsx`
- `client/src/utils/__tests__/sanitizeHtml.test.js`

## Related Issue

Closes #1391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved recap email previews by sanitizing HTML content before display.
  * Blocked scripts, inline event handlers, and unsafe `javascript:` links.
  * Added additional iframe privacy restrictions for preview content.

* **Bug Fixes**
  * Empty or invalid preview content no longer displays a blank preview frame.

* **Tests**
  * Added coverage for HTML sanitization, safe markup preservation, and sandboxed preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->