### PR TITLE
feat: wire feedback form into meeting details

### DIFF
--- a/client/src/components/meeting-details/FeedbackForm.jsx
+++ b/client/src/components/meeting-details/FeedbackForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Star } from "lucide-react";
 import { toast } from "react-toastify";
 import { meetingFeedbackApi } from "../../services";
@@ -11,7 +11,7 @@ const PREDEFINED_TAGS = [
   "Inaccurate Speakers",
 ];
 
-const StarRating = ({ label, value, onChange }) => {
+const StarRating = ({ label, value, onChange, disabled }) => {
   return (
     <div className="flex items-center justify-between py-2">
       <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -22,8 +22,10 @@ const StarRating = ({ label, value, onChange }) => {
           <button
             key={star}
             type="button"
+            aria-label={`${label} ${star} of 5`}
+            disabled={disabled}
             onClick={() => onChange(star)}
-            className={`p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${
+            className={`p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:pointer-events-none ${
               star <= value
                 ? "text-yellow-400"
                 : "text-gray-300 dark:text-gray-600"
@@ -40,11 +42,13 @@ const StarRating = ({ label, value, onChange }) => {
   );
 };
 
-const FeedbackForm = ({ meetingId }) => {
+const FeedbackForm = ({ meetingId, organizationId }) => {
   const [feedback, setFeedback] = useState(null);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState(null);
+  const [forbidden, setForbidden] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
   const [formData, setFormData] = useState({
     overallRating: 0,
     summaryAccuracy: 0,
@@ -54,10 +58,16 @@ const FeedbackForm = ({ meetingId }) => {
   });
 
   useEffect(() => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+
     const fetchFeedback = async () => {
       try {
         setLoading(true);
         setFetchError(null);
+        setForbidden(false);
         const { data } =
           await meetingFeedbackApi.getUserFeedbackForMeeting(meetingId);
         if (data.success && data.feedback) {
@@ -72,7 +82,15 @@ const FeedbackForm = ({ meetingId }) => {
         }
       } catch (error) {
         console.error("Failed to fetch feedback", error);
-        setFetchError("Unable to check previous feedback submission.");
+        if (error.response?.status === 403) {
+          setForbidden(true);
+          setFetchError(
+            error.response?.data?.message ||
+              "You are not authorized to submit feedback for this meeting.",
+          );
+        } else {
+          setFetchError("Unable to check previous feedback submission.");
+        }
       } finally {
         setLoading(false);
       }
@@ -91,6 +109,8 @@ const FeedbackForm = ({ meetingId }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (forbidden || isSubmittingRef.current) return;
+
     if (
       !formData.overallRating ||
       !formData.summaryAccuracy ||
@@ -100,11 +120,16 @@ const FeedbackForm = ({ meetingId }) => {
       return;
     }
 
+    isSubmittingRef.current = true;
     setIsSubmitting(true);
     try {
       const { data } = await meetingFeedbackApi.submitFeedback({
         meetingId,
-        ...formData,
+        overallRating: formData.overallRating,
+        summaryAccuracy: formData.summaryAccuracy,
+        transcriptQuality: formData.transcriptQuality,
+        comment: formData.comment,
+        tags: formData.tags,
       });
 
       if (data.success) {
@@ -116,22 +141,63 @@ const FeedbackForm = ({ meetingId }) => {
         setFeedback(data.feedback);
       }
     } catch (error) {
+      if (error.response?.status === 403) {
+        setForbidden(true);
+        setFetchError(
+          error.response?.data?.message ||
+            "You are not authorized to submit feedback for this meeting.",
+        );
+      }
       toast.error(error.response?.data?.message || "Failed to submit feedback");
     } finally {
+      isSubmittingRef.current = false;
       setIsSubmitting(false);
     }
   };
 
   if (loading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6 flex justify-center items-center py-10">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400"></div>
+      <div
+        data-testid="meeting-feedback-form"
+        data-meeting-id={meetingId}
+        data-organization-id={organizationId || ""}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6 flex justify-center items-center py-10"
+      >
+        <div
+          role="status"
+          aria-label="Loading feedback form"
+          className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400"
+        />
+      </div>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <div
+        data-testid="meeting-feedback-forbidden"
+        data-meeting-id={meetingId}
+        data-organization-id={organizationId || ""}
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6"
+      >
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          Meeting Feedback
+        </h3>
+        <p role="status" className="text-sm text-gray-600 dark:text-gray-400">
+          {fetchError ||
+            "You are not authorized to submit feedback for this meeting."}
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6">
+    <div
+      data-testid="meeting-feedback-form"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mt-6"
+    >
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
         Meeting Feedback
       </h3>
@@ -153,16 +219,22 @@ const FeedbackForm = ({ meetingId }) => {
           </span>
         </div>
       )}
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form
+        onSubmit={handleSubmit}
+        aria-label="Meeting feedback"
+        className="space-y-4"
+      >
         <div className="space-y-2">
           <StarRating
             label="Overall Rating"
             value={formData.overallRating}
+            disabled={isSubmitting}
             onChange={(val) => setFormData({ ...formData, overallRating: val })}
           />
           <StarRating
             label="Summary Accuracy"
             value={formData.summaryAccuracy}
+            disabled={isSubmitting}
             onChange={(val) =>
               setFormData({ ...formData, summaryAccuracy: val })
             }
@@ -170,6 +242,7 @@ const FeedbackForm = ({ meetingId }) => {
           <StarRating
             label="Transcript Quality"
             value={formData.transcriptQuality}
+            disabled={isSubmitting}
             onChange={(val) =>
               setFormData({ ...formData, transcriptQuality: val })
             }
@@ -185,8 +258,9 @@ const FeedbackForm = ({ meetingId }) => {
               <button
                 key={tag}
                 type="button"
+                disabled={isSubmitting}
                 onClick={() => handleTagToggle(tag)}
-                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors border ${
+                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors border disabled:opacity-50 ${
                   formData.tags.includes(tag)
                     ? "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800"
                     : "bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700 dark:hover:bg-gray-700"
@@ -204,10 +278,11 @@ const FeedbackForm = ({ meetingId }) => {
           </label>
           <textarea
             value={formData.comment}
+            disabled={isSubmitting}
             onChange={(e) =>
               setFormData({ ...formData, comment: e.target.value })
             }
-            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
             rows={3}
             placeholder="Tell us what could be improved..."
           />

--- a/client/src/components/meeting-details/__tests__/FeedbackForm.test.jsx
+++ b/client/src/components/meeting-details/__tests__/FeedbackForm.test.jsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "react-toastify";
+import { meetingFeedbackApi } from "../../../services";
+import FeedbackForm from "../FeedbackForm.jsx";
+
+vi.mock("../../../services", () => ({
+  meetingFeedbackApi: {
+    getUserFeedbackForMeeting: vi.fn(),
+    submitFeedback: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const MEETING_ID = "meeting-123";
+const ORG_ID = "org-42";
+
+const fillRequiredRatings = () => {
+  fireEvent.click(
+    screen.getByRole("button", { name: /overall rating 4 of 5/i }),
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: /summary accuracy 5 of 5/i }),
+  );
+  fireEvent.click(
+    screen.getByRole("button", { name: /transcript quality 3 of 5/i }),
+  );
+};
+
+describe("FeedbackForm (#1983)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    meetingFeedbackApi.getUserFeedbackForMeeting.mockResolvedValue({
+      data: { success: true, feedback: null },
+    });
+  });
+
+  it("mounts with meeting and organization context after the previous-feedback check", async () => {
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    const form = await screen.findByTestId("meeting-feedback-form");
+    expect(form).toHaveAttribute("data-meeting-id", MEETING_ID);
+    expect(form).toHaveAttribute("data-organization-id", ORG_ID);
+    expect(meetingFeedbackApi.getUserFeedbackForMeeting).toHaveBeenCalledWith(
+      MEETING_ID,
+    );
+    expect(
+      screen.getByRole("heading", { name: /meeting feedback/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("lets an authorized participant submit ratings through the existing feedback API", async () => {
+    meetingFeedbackApi.submitFeedback.mockResolvedValue({
+      data: {
+        success: true,
+        feedback: {
+          meetingId: MEETING_ID,
+          overallRating: 4,
+          summaryAccuracy: 5,
+          transcriptQuality: 3,
+        },
+      },
+    });
+
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    await screen.findByRole("button", { name: /submit feedback/i });
+    fillRequiredRatings();
+    fireEvent.click(screen.getByRole("button", { name: /submit feedback/i }));
+
+    await waitFor(() => {
+      expect(meetingFeedbackApi.submitFeedback).toHaveBeenCalledTimes(1);
+    });
+
+    expect(meetingFeedbackApi.submitFeedback).toHaveBeenCalledWith({
+      meetingId: MEETING_ID,
+      overallRating: 4,
+      summaryAccuracy: 5,
+      transcriptQuality: 3,
+      comment: "",
+      tags: [],
+    });
+    const payload = meetingFeedbackApi.submitFeedback.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("organization");
+    expect(payload).not.toHaveProperty("organizationId");
+    expect(toast.success).toHaveBeenCalledWith(
+      "Feedback submitted successfully!",
+    );
+  });
+
+  it("shows a forbidden empty state and hides the form for unauthorized users", async () => {
+    meetingFeedbackApi.getUserFeedbackForMeeting.mockRejectedValue({
+      response: {
+        status: 403,
+        data: {
+          message: "Not authorized to access feedback for this meeting",
+        },
+      },
+    });
+
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    const forbidden = await screen.findByTestId("meeting-feedback-forbidden");
+    expect(forbidden).toHaveTextContent(
+      "Not authorized to access feedback for this meeting",
+    );
+    expect(
+      screen.queryByRole("button", { name: /submit feedback/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("form", { name: /meeting feedback/i }),
+    ).not.toBeInTheDocument();
+    expect(meetingFeedbackApi.submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when required ratings are missing", async () => {
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /submit feedback/i }),
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Please provide ratings for all dimensions",
+    );
+    expect(meetingFeedbackApi.submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("surfaces API failures with the existing toast error pattern", async () => {
+    meetingFeedbackApi.submitFeedback.mockRejectedValue({
+      response: {
+        status: 500,
+        data: { message: "Server Error" },
+      },
+    });
+
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    await screen.findByRole("button", { name: /submit feedback/i });
+    fillRequiredRatings();
+    fireEvent.click(screen.getByRole("button", { name: /submit feedback/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Server Error");
+    });
+    expect(
+      screen.getByRole("button", { name: /submit feedback/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("prevents double submission while a request is in flight", async () => {
+    let resolveSubmit;
+    meetingFeedbackApi.submitFeedback.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+
+    render(<FeedbackForm meetingId={MEETING_ID} organizationId={ORG_ID} />);
+
+    await screen.findByRole("button", { name: /submit feedback/i });
+    fillRequiredRatings();
+
+    const submitButton = screen.getByRole("button", {
+      name: /submit feedback/i,
+    });
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+    fireEvent.submit(submitButton.closest("form"));
+
+    await waitFor(() => {
+      expect(meetingFeedbackApi.submitFeedback).toHaveBeenCalledTimes(1);
+    });
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveTextContent("Submitting...");
+
+    resolveSubmit({
+      data: {
+        success: true,
+        feedback: {
+          meetingId: MEETING_ID,
+          overallRating: 4,
+          summaryAccuracy: 5,
+          transcriptQuality: 3,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Feedback submitted successfully!",
+      );
+    });
+  });
+});

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -18,6 +18,7 @@ import {
 import Navbar from "../components/Navbar.jsx";
 import TopContributorsWidget from "../components/organization/TopContributorsWidget";
 import DashboardMetricsWidget from "../components/dashboard/DashboardMetricsWidget.jsx";
+import FeedbackTrendChart from "../components/dashboard/FeedbackTrendChart.jsx";
 import OrganizationLogo from "../components/organization/OrganizationLogo.jsx";
 import OrganizationBanner from "../components/organization/OrganizationBanner.jsx";
 import PersonalNotesSidebar from "../components/PersonalNotesSidebar.jsx";
@@ -56,6 +57,8 @@ const Dashboard = () => {
 
   const organizationName =
     userData?.organization?.name?.toUpperCase() || "ORGANIZATION";
+  const organizationId =
+    userData?.organization?._id || userData?.organization || "";
   const organizationLogoUrl =
     userData?.organization?.logoUrl || userData?.organization?.logo || "";
   const organizationBannerUrl = userData?.organization?.bannerUrl || "";
@@ -316,6 +319,12 @@ const Dashboard = () => {
 
         {/* ── Operational Metrics ── */}
         <DashboardMetricsWidget />
+
+        {organizationId ? (
+          <div className="mb-8">
+            <FeedbackTrendChart orgId={organizationId} />
+          </div>
+        ) : null}
 
         {/* ── Feature Cards ── */}
         <section aria-label="Dashboard features">

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -36,6 +36,7 @@ import GuestAccessManager from "../components/meetings/GuestAccessManager";
 import MeetingReadiness from "../components/MeetingReadiness";
 import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
 import PollSection from "../components/meeting-details/PollSection";
+import FeedbackForm from "../components/meeting-details/FeedbackForm";
 import MeetingRisksPanel from "../components/meetings/MeetingRisksPanel";
 import { Award } from "lucide-react";
 
@@ -379,6 +380,15 @@ const MeetingDetails = () => {
 
           <div className="mt-6 mb-6">
             <PollSection meetingId={meeting._id} title="Polls" />
+          </div>
+
+          <div className="mt-6 mb-6">
+            <FeedbackForm
+              meetingId={meeting._id}
+              organizationId={
+                meeting.organization?._id || meeting.organization || undefined
+              }
+            />
           </div>
 
           <div className="mt-6 mb-6">

--- a/client/src/pages/__tests__/Dashboard.test.jsx
+++ b/client/src/pages/__tests__/Dashboard.test.jsx
@@ -14,6 +14,12 @@ vi.mock("../../components/organization/TopContributorsWidget", () => ({
   default: () => <div data-testid="top-contributors">Top Contributors</div>,
 }));
 
+vi.mock("../../components/dashboard/FeedbackTrendChart.jsx", () => ({
+  default: ({ orgId }) => (
+    <div data-testid="feedback-trend-chart">Trends for {orgId}</div>
+  ),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key) => key,
@@ -44,6 +50,9 @@ describe("Dashboard", () => {
     expect(screen.getByTestId("navbar")).toBeInTheDocument();
     expect(screen.getByLabelText("Dashboard hero")).toBeInTheDocument();
     expect(screen.getByTestId("feature-cards-grid")).toBeInTheDocument();
+    expect(screen.getByTestId("feedback-trend-chart")).toHaveTextContent(
+      "Trends for org-1",
+    );
   });
 
   it("renders all seven admin feature cards in a plain CSS grid (#712)", async () => {

--- a/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
@@ -111,6 +111,17 @@ vi.mock("../../components/meeting-details/PollSection", () => ({
     <div data-testid="poll-section">Polls for {meetingId}</div>
   ),
 }));
+vi.mock("../../components/meeting-details/FeedbackForm", () => ({
+  default: ({ meetingId, organizationId }) => (
+    <div
+      data-testid="meeting-feedback-form"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+    >
+      Feedback for {meetingId}
+    </div>
+  ),
+}));
 
 import { meetingApi } from "../../services";
 
@@ -142,6 +153,7 @@ describe("MeetingDetails Navbar Integration (#1637)", () => {
           title: "Quarterly Planning",
           uploadedBy: "db_123",
           participants: [],
+          organization: { _id: "org-42" },
         },
       },
     });
@@ -161,6 +173,10 @@ describe("MeetingDetails Navbar Integration (#1637)", () => {
     expect(screen.getByTestId("poll-section")).toHaveTextContent(
       "Polls for 123",
     );
+    const feedbackForm = screen.getByTestId("meeting-feedback-form");
+    expect(feedbackForm).toHaveTextContent("Feedback for 123");
+    expect(feedbackForm).toHaveAttribute("data-meeting-id", "123");
+    expect(feedbackForm).toHaveAttribute("data-organization-id", "org-42");
   });
 
   it("renders Navbar in error state", async () => {

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -40,6 +40,18 @@ vi.mock("../../components/meeting-details/PollSection.jsx", () => ({
   ),
 }));
 
+vi.mock("../../components/meeting-details/FeedbackForm.jsx", () => ({
+  default: ({ meetingId, organizationId }) => (
+    <div
+      data-testid="meeting-feedback-form"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+    >
+      Feedback for {meetingId}
+    </div>
+  ),
+}));
+
 vi.mock("../../services", () => ({
   meetingApi: {
     getMeetingById: vi.fn(),


### PR DESCRIPTION
## Description

Closes #1983.

Wires the existing FeedbackForm into Meeting Details and connects the Dashboard feedback trend chart to the current organization.

## What Changed

- Mounted `FeedbackForm` on Meeting Details with meeting and organization context.
- Added unauthorized/forbidden handling for users who cannot submit feedback.
- Added required-rating validation and API error handling.
- Prevented duplicate submissions while a request is in progress.
- Added success/error toast feedback.
- Passed the current organization ID to `FeedbackTrendChart` for aggregate feedback data.
- Preserved the existing backend feedback and authorization flow.

## Tests

Added coverage for:

- FeedbackForm mounting and context
- Authorized feedback submission
- Unauthorized users
- Required ratings
- API failures
- Double-submit prevention
- Meeting Details integration
- Dashboard organization context

## Verification

- Participants can submit feedback from Meeting Details.
- Unauthorized users see a clear forbidden state.
- Required fields prevent invalid submissions.
- Submit button is disabled during submission.
- Dashboard feedback trends use the current organization.
- Existing feedback API behavior remains unchanged.
