### PR TITLE
feat(analytics): build organization sentiment trends page and aggregation API

### DIFF
--- a/client/src/pages/OrganizationSentimentTrends.jsx
+++ b/client/src/pages/OrganizationSentimentTrends.jsx
@@ -1,0 +1,324 @@
+import React, { useState, useEffect, useContext, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Navbar from "../components/Navbar.jsx";
+import AppContent from "../context/AppContent.js";
+import apiClient from "../services/apiClient.js";
+import {
+  TrendingUp,
+  Smile,
+  Frown,
+  Meh,
+  Calendar,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Clock,
+  Sparkles,
+} from "lucide-react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+const OrganizationSentimentTrends = () => {
+  const { userData } = useContext(AppContent) || {};
+  const navigate = useNavigate();
+  const orgId = userData?.organization?._id || userData?.organization;
+
+  const [range, setRange] = useState("30d");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [stats, setStats] = useState({
+    totalMeetings: 0,
+    analyzedMeetings: 0,
+    overallAverageScore: 0,
+    trends: [],
+  });
+
+  const fetchTrends = useCallback(async () => {
+    if (!orgId) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.get(
+        `/api/sentiment-timeline/organization/${orgId}/trends?range=${range}`,
+      );
+      if (res.data?.success && res.data?.data) {
+        setStats(res.data.data);
+      } else {
+        setError(res.data?.message || "Failed to load sentiment trends");
+      }
+    } catch (err) {
+      console.error("Error loading sentiment trends:", err);
+      setError(
+        "Failed to load organization sentiment trends. Please try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, range]);
+
+  useEffect(() => {
+    fetchTrends();
+  }, [fetchTrends]);
+
+  const chartData = (stats.trends || [])
+    .filter((t) => t.hasSentiment)
+    .map((t) => ({
+      name: t.title?.length > 20 ? `${t.title.slice(0, 20)}...` : t.title,
+      score: t.averageScore,
+      date: t.date ? new Date(t.date).toLocaleDateString() : "",
+      meetingId: t.meetingId,
+    }));
+
+  const getSentimentBadge = (score) => {
+    if (score === null || score === undefined) {
+      return (
+        <span className="px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">
+          Unanalyzed
+        </span>
+      );
+    }
+    if (score >= 0.6) {
+      return (
+        <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300">
+          <Smile className="w-3.5 h-3.5" />
+          Positive ({(score * 100).toFixed(0)}%)
+        </span>
+      );
+    }
+    if (score >= 0.4) {
+      return (
+        <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
+          <Meh className="w-3.5 h-3.5" />
+          Neutral ({(score * 100).toFixed(0)}%)
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300">
+        <Frown className="w-3.5 h-3.5" />
+        Needs Attention ({(score * 100).toFixed(0)}%)
+      </span>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200">
+      <Navbar />
+
+      <div className="pt-28 pb-16 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto space-y-6">
+        <div
+          role="region"
+          aria-label="Organization Sentiment Header"
+          className="flex items-start justify-between gap-4 flex-wrap pb-2 border-b border-slate-200 dark:border-slate-800"
+        >
+          <div>
+            <h1 className="text-3xl font-extrabold text-slate-900 dark:text-white flex items-center gap-3">
+              <TrendingUp className="w-7 h-7 text-indigo-600 dark:text-indigo-400" />
+              Organization Sentiment Trends
+            </h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+              Track overall mood, tone, and meeting engagement trajectories
+              across your organization over time.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <select
+              aria-label="Time Range Filter"
+              value={range}
+              onChange={(e) => setRange(e.target.value)}
+              className="px-3.5 py-2 rounded-xl text-xs font-semibold border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300"
+            >
+              <option value="7d">Last 7 Days</option>
+              <option value="30d">Last 30 Days</option>
+              <option value="90d">Last 90 Days</option>
+              <option value="all">Past Year</option>
+            </select>
+            <button
+              onClick={fetchTrends}
+              className="p-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 cursor-pointer"
+              aria-label="Refresh Sentiment Data"
+            >
+              <RefreshCw className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Overview KPI Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-xs">
+            <span className="text-xs font-bold uppercase text-slate-400">
+              Overall Sentiment Score
+            </span>
+            <div className="flex items-center gap-3 mt-2">
+              <p className="text-3xl font-black text-indigo-600 dark:text-indigo-400">
+                {(stats.overallAverageScore * 100).toFixed(0)}%
+              </p>
+              {getSentimentBadge(stats.overallAverageScore)}
+            </div>
+          </div>
+
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-xs">
+            <span className="text-xs font-bold uppercase text-slate-400">
+              Analyzed Meetings
+            </span>
+            <p className="text-3xl font-black text-slate-900 dark:text-white mt-2">
+              {stats.analyzedMeetings} / {stats.totalMeetings}
+            </p>
+          </div>
+
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-xs">
+            <span className="text-xs font-bold uppercase text-slate-400">
+              Sentiment Coverage
+            </span>
+            <p className="text-3xl font-black text-emerald-600 dark:text-emerald-400 mt-2">
+              {stats.totalMeetings
+                ? `${((stats.analyzedMeetings / stats.totalMeetings) * 100).toFixed(0)}%`
+                : "100%"}
+            </p>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="p-12 text-center text-slate-500">
+            <Loader2 className="w-8 h-8 animate-spin mx-auto text-indigo-600 mb-2" />
+            Aggregating organization sentiment trends...
+          </div>
+        ) : error ? (
+          <div
+            data-testid="sentiment-error-card"
+            className="p-8 text-center bg-white dark:bg-slate-900 rounded-2xl border border-red-200 dark:border-red-800 max-w-md mx-auto space-y-4"
+          >
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            <button
+              onClick={fetchTrends}
+              className="px-4 py-2 bg-indigo-600 text-white rounded-xl text-xs font-semibold cursor-pointer"
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {/* Trend Chart */}
+            <div
+              role="region"
+              aria-label="Sentiment Trajectory Chart"
+              className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-xs space-y-4"
+            >
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+                Sentiment Trajectory Over Range
+              </h2>
+              {chartData.length > 0 ? (
+                <div className="h-72 w-full">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart
+                      data={chartData}
+                      margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
+                    >
+                      <defs>
+                        <linearGradient
+                          id="sentimentGrad"
+                          x1="0"
+                          y1="0"
+                          x2="0"
+                          y2="1"
+                        >
+                          <stop
+                            offset="5%"
+                            stopColor="#6366f1"
+                            stopOpacity={0.4}
+                          />
+                          <stop
+                            offset="95%"
+                            stopColor="#6366f1"
+                            stopOpacity={0}
+                          />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
+                      <XAxis dataKey="date" />
+                      <YAxis domain={[0, 1]} />
+                      <Tooltip />
+                      <Area
+                        type="monotone"
+                        dataKey="score"
+                        stroke="#6366f1"
+                        fillOpacity={1}
+                        fill="url(#sentimentGrad)"
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              ) : (
+                <div className="text-center py-12 text-sm text-slate-400 dark:text-slate-500">
+                  No meeting sentiment timelines found for this timeframe.
+                </div>
+              )}
+            </div>
+
+            {/* Meetings Breakdown Drill-down Table */}
+            <div
+              role="region"
+              aria-label="Meeting Sentiment Breakdown"
+              className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 shadow-xs space-y-4"
+            >
+              <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+                Meeting Sentiment Breakdown ({stats.trends?.length || 0})
+              </h2>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-100 dark:border-slate-800 text-xs uppercase text-slate-400">
+                      <th className="pb-3">Meeting</th>
+                      <th className="pb-3">Date</th>
+                      <th className="pb-3">Sentiment Score</th>
+                      <th className="pb-3 text-right">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                    {(stats.trends || []).map((m) => (
+                      <tr key={m.meetingId}>
+                        <td className="py-3 font-semibold text-slate-900 dark:text-white">
+                          {m.title || "Untitled Meeting"}
+                        </td>
+                        <td className="py-3 text-slate-500 dark:text-slate-400 text-xs">
+                          {m.date ? new Date(m.date).toLocaleDateString() : "—"}
+                        </td>
+                        <td className="py-3">
+                          {getSentimentBadge(m.averageScore)}
+                        </td>
+                        <td className="py-3 text-right">
+                          <button
+                            onClick={() => navigate(`/meetings/${m.meetingId}`)}
+                            className="inline-flex items-center gap-1 text-xs text-indigo-600 dark:text-indigo-400 hover:underline cursor-pointer font-medium"
+                          >
+                            <span>Details</span>
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OrganizationSentimentTrends;

--- a/client/src/pages/__tests__/OrganizationSentimentTrends.test.jsx
+++ b/client/src/pages/__tests__/OrganizationSentimentTrends.test.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import OrganizationSentimentTrends from "../OrganizationSentimentTrends.jsx";
+import apiClient from "../../services/apiClient.js";
+import AppContent from "../../context/AppContent.js";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <nav data-testid="shared-navbar">Shared Navbar</nav>,
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("OrganizationSentimentTrends Page (#2039)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockUserContext = {
+    userData: {
+      _id: "u_1",
+      organization: "org_123",
+    },
+  };
+
+  it("renders sentiment trends overview KPIs and breakdown table", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          organizationId: "org_123",
+          range: "30d",
+          totalMeetings: 2,
+          analyzedMeetings: 2,
+          overallAverageScore: 0.85,
+          trends: [
+            {
+              meetingId: "m_1",
+              title: "Product Strategy Sync",
+              date: "2026-08-20",
+              averageScore: 0.85,
+              hasSentiment: true,
+              dataPointsCount: 5,
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <AppContent.Provider value={mockUserContext}>
+          <OrganizationSentimentTrends />
+        </AppContent.Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shared-navbar")).toBeInTheDocument();
+      expect(
+        screen.getByText("Organization Sentiment Trends"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("85%")).toBeInTheDocument();
+      expect(screen.getByText("Product Strategy Sync")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Organization Sentiment Header" }),
+    ).toBeInTheDocument();
+  });
+
+  it("displays error card on fetch error and retries", async () => {
+    apiClient.get.mockRejectedValueOnce(new Error("Network Error"));
+
+    render(
+      <BrowserRouter>
+        <AppContent.Provider value={mockUserContext}>
+          <OrganizationSentimentTrends />
+        </AppContent.Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sentiment-error-card")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Failed to load organization sentiment trends. Please try again.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -77,6 +77,7 @@ import FollowUpDashboard from "../pages/FollowUpDashboard.jsx";
 import EscalationDashboard from "../pages/EscalationDashboard.jsx";
 import Glossary from "../pages/Glossary.jsx";
 import StandupReports from "../pages/StandupReports.jsx";
+import OrganizationSentimentTrends from "../pages/OrganizationSentimentTrends.jsx";
 
 const ProtectedRoutes = (
   <React.Fragment>
@@ -680,6 +681,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="reports" action="view">
           <StandupReports />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/sentiment-trends"
+      element={
+        <ProtectedRoute resource="reports" action="view">
+          <OrganizationSentimentTrends />
         </ProtectedRoute>
       }
     />

--- a/server/controllers/__tests__/orgSentimentTrends.test.js
+++ b/server/controllers/__tests__/orgSentimentTrends.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { getOrgSentimentTrends } from "../sentimentTimelineController.js";
+import Meeting from "../../models/meetingModel.js";
+import SentimentTimeline from "../../models/sentimentTimelineModel.js";
+
+vi.mock("../../models/meetingModel.js");
+vi.mock("../../models/sentimentTimelineModel.js");
+vi.mock("../../services/sentimentTimelineService.js");
+
+describe("Organization Sentiment Trends Controller (#2039)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const validOrgId = new mongoose.Types.ObjectId().toString();
+  const mockUser = {
+    _id: new mongoose.Types.ObjectId(),
+    organization: validOrgId,
+    role: "member",
+  };
+
+  const createMockRes = () => {
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  };
+
+  it("returns 400 when orgId format is invalid", async () => {
+    const req = { params: { orgId: "invalid-id" }, query: {}, user: mockUser };
+    const res = createMockRes();
+
+    await getOrgSentimentTrends(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Invalid organization ID format",
+      }),
+    );
+  });
+
+  it("returns 403 when user belongs to a different organization and is not admin", async () => {
+    const diffOrgId = new mongoose.Types.ObjectId().toString();
+    const req = { params: { orgId: diffOrgId }, query: {}, user: mockUser };
+    const res = createMockRes();
+
+    await getOrgSentimentTrends(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message:
+          "Forbidden: You don't have access to this organization's sentiment trends",
+      }),
+    );
+  });
+
+  it("successfully aggregates organization sentiment trends", async () => {
+    const mId1 = new mongoose.Types.ObjectId();
+    const mId2 = new mongoose.Types.ObjectId();
+
+    Meeting.find.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          { _id: mId1, title: "Sprint Planning", createdAt: new Date() },
+          { _id: mId2, title: "Product Retro", createdAt: new Date() },
+        ]),
+      }),
+    });
+
+    SentimentTimeline.find.mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            meeting: mId1,
+            averageScore: 0.85,
+            dataPoints: [{ sentimentScore: 0.85 }],
+          },
+        ]),
+    });
+
+    const req = {
+      params: { orgId: validOrgId },
+      query: { range: "30d" },
+      user: mockUser,
+    };
+    const res = createMockRes();
+
+    await getOrgSentimentTrends(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          totalMeetings: 2,
+          analyzedMeetings: 1,
+          overallAverageScore: 0.85,
+        }),
+      }),
+    );
+  });
+});

--- a/server/controllers/sentimentTimelineController.js
+++ b/server/controllers/sentimentTimelineController.js
@@ -85,3 +85,106 @@ export const generateTimeline = async (req, res) => {
     });
   }
 };
+
+// Aggregate organization-wide sentiment trends (#2039)
+export const getOrgSentimentTrends = async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const { range = "30d" } = req.query;
+
+    const userOrg = (
+      req.user?.organization?._id || req.user?.organization
+    )?.toString();
+    if (!orgId || !mongoose.Types.ObjectId.isValid(orgId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid organization ID format" });
+    }
+
+    if (
+      userOrg !== orgId &&
+      req.user?.role !== "admin" &&
+      req.user?.role !== "owner"
+    ) {
+      return res.status(403).json({
+        success: false,
+        message:
+          "Forbidden: You don't have access to this organization's sentiment trends",
+      });
+    }
+
+    const now = new Date();
+    let days = 30;
+    if (range === "7d") days = 7;
+    else if (range === "90d") days = 90;
+    else if (range === "all") days = 365;
+
+    const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const meetings = await Meeting.find({
+      organization: orgId,
+      createdAt: { $gte: cutoff },
+    })
+      .select("_id title createdAt uploadedBy")
+      .lean();
+
+    const meetingIds = meetings.map((m) => m._id);
+
+    const timelines = await SentimentTimeline.find({
+      meeting: { $in: meetingIds },
+    }).lean();
+
+    const timelineMap = new Map();
+    timelines.forEach((t) => {
+      timelineMap.set(t.meeting.toString(), t);
+    });
+
+    const meetingTrends = meetings.map((m) => {
+      const tl = timelineMap.get(m._id.toString());
+      const averageScore =
+        tl?.averageScore ??
+        (tl?.dataPoints?.length
+          ? tl.dataPoints.reduce((acc, p) => acc + (p.sentimentScore || 0), 0) /
+            tl.dataPoints.length
+          : null);
+      return {
+        meetingId: m._id,
+        title: m.title,
+        date: m.createdAt,
+        averageScore:
+          averageScore !== null ? Number(averageScore.toFixed(2)) : null,
+        hasSentiment: averageScore !== null,
+        dataPointsCount: tl?.dataPoints?.length || 0,
+      };
+    });
+
+    const meetingsWithSentiment = meetingTrends.filter((m) => m.hasSentiment);
+    const overallAvgScore = meetingsWithSentiment.length
+      ? Number(
+          (
+            meetingsWithSentiment.reduce((acc, m) => acc + m.averageScore, 0) /
+            meetingsWithSentiment.length
+          ).toFixed(2),
+        )
+      : 0;
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        organizationId: orgId,
+        range,
+        totalMeetings: meetings.length,
+        analyzedMeetings: meetingsWithSentiment.length,
+        overallAverageScore: overallAvgScore,
+        trends: meetingTrends,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching org sentiment trends:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch organization sentiment trends",
+      error: error.message,
+    });
+  }
+};

--- a/server/routes/sentimentTimelineRoutes.js
+++ b/server/routes/sentimentTimelineRoutes.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   getTimeline,
   generateTimeline,
+  getOrgSentimentTrends,
 } from "../controllers/sentimentTimelineController.js";
 import userAuth from "../middleware/userAuth.js";
 import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
@@ -11,6 +12,7 @@ const router = express.Router();
 router.use(userAuth);
 router.use(requireOrgMembership);
 
+router.get("/organization/:orgId/trends", getOrgSentimentTrends);
 router.get("/:meetingId", requirePermission("meetings", "view"), getTimeline);
 router.post(
   "/:meetingId/generate",


### PR DESCRIPTION
Fixes #2039

## Description
This PR introduces organization-wide sentiment trend aggregation (GET /api/sentiment-timeline/organization/:orgId/trends) and adds a dedicated /sentiment-trends page with trajectory charts, timeframe selectors (7d/30d/90d/1y), sentiment coverage KPIs, and meeting drill-downs.

## Proposed Changes
- **Aggregation Controller & Route**: Added getOrgSentimentTrends with timeframe filtering, role authorization, and multi-meeting timeline aggregation.
- **Sentiment Trends Page**: Built OrganizationSentimentTrends.jsx featuring AreaChart trajectories, breakdown tables, sentiment badge scores, and Navbar chrome.
- **Route Registration**: Registered /sentiment-trends in ProtectedRoutes.jsx.
- **Unit Test Coverage**: Added backend test suite server/controllers/__tests__/orgSentimentTrends.test.js and frontend test suite client/src/pages/__tests__/OrganizationSentimentTrends.test.jsx.

## Checklist
- [x] Related Issue is linked (Fixes #2039).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.