### PR TITLE
fix(client): align collaborative notes socket URL with shared getBackendUrl() config (#2002)

### DIFF
--- a/client/src/hooks/__tests__/useCollaborativeNote.test.js
+++ b/client/src/hooks/__tests__/useCollaborativeNote.test.js
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useCollaborativeNote } from "../useCollaborativeNote.js";
+import { io } from "socket.io-client";
+import { toast } from "react-toastify";
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    userId: "user-123",
+    getToken: vi.fn().mockResolvedValue("test-clerk-token"),
+    isSignedIn: true,
+  }),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("socket.io-client", () => {
+  const listeners = {};
+  const mockSocket = {
+    on: vi.fn((event, callback) => {
+      listeners[event] = callback;
+    }),
+    emit: vi.fn((event, data, cb) => {
+      if (event === "join-meeting" && cb) {
+        cb({ success: true, userColor: "#ff0000", activeUsers: [] });
+      }
+    }),
+    disconnect: vi.fn(),
+    __trigger: (event, payload) => {
+      if (listeners[event]) listeners[event](payload);
+    },
+  };
+  return {
+    io: vi.fn(() => mockSocket),
+  };
+});
+
+describe("useCollaborativeNote socket URL & backend config alignment (#2002)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("connects to ${getBackendUrl()}/notes using shared Clerk socket options", async () => {
+    renderHook(() => useCollaborativeNote("meeting-123"));
+
+    await waitFor(() => {
+      expect(io).toHaveBeenCalledWith(
+        expect.stringMatching(/^http:\/\/.*\/notes$/),
+        expect.objectContaining({
+          transports: expect.arrayContaining(["websocket"]),
+        }),
+      );
+    });
+  });
+
+  it("handles connect_error, updates error state, and triggers toast error", async () => {
+    const { result } = renderHook(() => useCollaborativeNote("meeting-123"));
+
+    await waitFor(() => {
+      expect(io).toHaveBeenCalled();
+    });
+
+    const mockSocket = io.mock.results[0].value;
+    act(() => {
+      mockSocket.__trigger("connect_error", new Error("Authentication failed"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Authentication failed");
+      expect(result.current.isConnected).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining("Authentication failed"),
+      );
+    });
+  });
+});

--- a/client/src/hooks/useCollaborativeNote.js
+++ b/client/src/hooks/useCollaborativeNote.js
@@ -2,6 +2,12 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@clerk/clerk-react";
 import { io } from "socket.io-client";
 import * as Y from "yjs";
+import { toast } from "react-toastify";
+import {
+  createClerkSocketOptions,
+  getClerkBearerToken,
+} from "../services/apiClient.js";
+import { getBackendUrl } from "../config/backendConfig.js";
 
 /**
  * @desc Custom hook to manage the WebSocket connection, Yjs document state,
@@ -32,32 +38,67 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
     const initializeSocket = async () => {
       const token = await getToken();
 
-      if (!isActive || !token) {
+      if (!isActive) {
         setIsLoading(false);
         return;
       }
 
-      // Initialize Socket.io connection to the /notes namespace
-      const socket = io(`${import.meta.env.VITE_API_URL}/notes`, {
-        auth: { token },
-        transports: ["websocket"],
+      // Initialize Socket.io connection using shared Clerk options & backend URL config
+      const opts = await createClerkSocketOptions({
+        transports: ["websocket", "polling"],
       });
+      if (!isActive) return;
+
+      if (token && (!opts.auth || !opts.auth.token)) {
+        opts.auth = { token };
+      }
+
+      const backendUrl = getBackendUrl();
+      const socket = io(`${backendUrl}/notes`, opts);
       socketRef.current = socket;
+
+      socket.on("connect_error", (err) => {
+        console.error("[CollabNote] Socket connection error:", err);
+        const errorMsg =
+          err?.message || "Failed to connect to collaborative notes server";
+        setError(errorMsg);
+        setIsConnected(false);
+        setIsLoading(false);
+        toast.error(`Collaborative notes connection error: ${errorMsg}`);
+      });
+
+      socket.on("reconnect_attempt", async () => {
+        try {
+          const freshToken =
+            (await getClerkBearerToken()) || (await getToken());
+          if (socket.auth) {
+            socket.auth.token = freshToken;
+          } else {
+            socket.auth = { token: freshToken };
+          }
+        } catch (err) {
+          console.warn(
+            "[CollabNote] Failed to refresh token for reconnect",
+            err,
+          );
+        }
+      });
 
       socket.on("connect", () => {
         console.log("[CollabNote] Socket connected");
         setIsConnected(true);
+        setError(null);
 
         // Join the meeting room and fetch initial state
         socket.emit("join-meeting", { meetingId }, async (response) => {
-          if (response.success) {
+          if (!isActive) return;
+          if (response?.success) {
             userColorRef.current = response.userColor;
             setActiveUsers(response.activeUsers || []);
-
-            // Server can send a state vector for future sync logic, but the
-            // current flow relies on the server to provide the full state on join.
           } else {
-            setError(response.error || "Failed to join meeting");
+            const errorMsg = response?.error || "Failed to join meeting";
+            setError(errorMsg);
+            toast.error(errorMsg);
           }
           setIsLoading(false);
         });
@@ -122,13 +163,11 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
       });
 
       socket.on("snapshot-created", (snapshot) => {
-        // Could trigger a toast notification here
         console.log("[CollabNote] New snapshot created:", snapshot);
       });
 
       // Observe local Yjs document changes to broadcast to server
       const updateHandler = (update, origin) => {
-        // Only broadcast if the change originated locally (not from 'remote-update')
         if (origin !== "remote" && !isReadOnly) {
           socket.emit("sync-update", {
             meetingId,


### PR DESCRIPTION
### Summary
Aligned `useCollaborativeNote.js` WebSocket connection logic to use `getBackendUrl()` and `createClerkSocketOptions`. Previously, the socket hardcoded `import.meta.env.VITE_API_URL`, causing collaborative notes to fail in environments configured with `VITE_BACKEND_URL`.

### Key Changes
1. **Centralized Socket URL Resolution**: Updated [`useCollaborativeNote.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/client/src/hooks/useCollaborativeNote.js) to connect using `${getBackendUrl()}/notes` instead of hardcoding `import.meta.env.VITE_API_URL`.
2. **Clerk Socket Auth Alignment**: Used `createClerkSocketOptions` for initial connection setup and added token refresh logic on `reconnect_attempt` via `getClerkBearerToken()`.
3. **UI Failure Notification**: Added a `connect_error` listener that updates hook `error` state, sets `isConnected = false`, and surfaces connection failures in the UI via `toast.error`.
4. **Automated Unit Testing**: Created [`useCollaborativeNote.test.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/client/src/hooks/__tests__/useCollaborativeNote.test.js) (2 tests) testing backend URL resolution, Clerk socket options, and error toast emission.

### Verification
- ✅ `useCollaborativeNote.test.js` (2 tests) passed cleanly in Vitest.
- ✅ `npm run format:check:changed` passed cleanly ("All matched files use Prettier code style!").
- ✅ Pushed to `origin/fix/2002-collaborative-notes-socket-url`.