### PR TITLE
feat(client): connect RecurrenceSelector to meeting series creation API (#2004)

### DIFF
--- a/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.series.test.jsx
+++ b/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.series.test.jsx
@@ -1,0 +1,174 @@
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AppContent from "../../../../context/AppContent";
+import { useScheduleMeeting } from "../useScheduleMeeting";
+import { meetingApi, meetingSeriesApi } from "../../../../services";
+import { toast } from "react-toastify";
+
+vi.mock("../../../../services", () => ({
+  meetingApi: {
+    scheduleMeeting: vi.fn(),
+  },
+  meetingSeriesApi: {
+    createSeries: vi.fn(),
+  },
+  meetingTemplateApi: {
+    getTemplates: vi
+      .fn()
+      .mockResolvedValue({ data: { success: true, templates: [] } }),
+  },
+  aiSummaryTemplateApi: {
+    getTemplates: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useScheduleMeeting Series Wiring (#2004)", () => {
+  const mockUserData = {
+    _id: "user-123",
+    organization: { _id: "org-456" },
+  };
+
+  const wrapper = ({ children }) => (
+    <AppContent.Provider value={{ userData: mockUserData }}>
+      {children}
+    </AppContent.Provider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("submits single non-recurring meeting to meetingApi.scheduleMeeting", async () => {
+    meetingApi.scheduleMeeting.mockResolvedValue({
+      data: { success: true, meeting: { _id: "m-1" } },
+    });
+
+    const { result } = renderHook(() => useScheduleMeeting(), { wrapper });
+
+    act(() => {
+      result.current.setScheduleData((prev) => ({
+        ...prev,
+        title: "Single Sync",
+        date: "2026-09-01",
+        time: "10:00",
+        recurrencePattern: "none",
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleScheduleSubmit({ preventDefault: vi.fn() });
+    });
+
+    expect(meetingApi.scheduleMeeting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Single Sync",
+        date: "2026-09-01",
+        time: "10:00",
+        recurrencePattern: "none",
+      }),
+    );
+    expect(meetingSeriesApi.createSeries).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining("Meeting scheduled"),
+    );
+  });
+
+  it("submits recurring schedule to meetingSeriesApi.createSeries when recurrencePattern is set", async () => {
+    meetingSeriesApi.createSeries.mockResolvedValue({
+      data: {
+        success: true,
+        meetingsCreated: 4,
+        series: { _id: "series-101" },
+      },
+    });
+
+    const { result } = renderHook(() => useScheduleMeeting(), { wrapper });
+
+    act(() => {
+      result.current.setScheduleData((prev) => ({
+        ...prev,
+        title: "Weekly Standup",
+        date: "2026-09-01",
+        endDate: "2026-09-30",
+        time: "09:30",
+        recurrencePattern: "weekly",
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleScheduleSubmit({ preventDefault: vi.fn() });
+    });
+
+    expect(meetingSeriesApi.createSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Weekly Standup",
+        startDate: "2026-09-01",
+        endDate: "2026-09-30",
+        recurrencePattern: "weekly",
+      }),
+    );
+    expect(meetingApi.scheduleMeeting).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Meeting series created successfully with 4 occurrence(s)!",
+      ),
+    );
+  });
+
+  it("blocks recurring schedule if endDate is missing", async () => {
+    const { result } = renderHook(() => useScheduleMeeting(), { wrapper });
+
+    act(() => {
+      result.current.setScheduleData((prev) => ({
+        ...prev,
+        title: "Weekly Standup",
+        date: "2026-09-01",
+        time: "09:30",
+        recurrencePattern: "weekly",
+        endDate: "",
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleScheduleSubmit({ preventDefault: vi.fn() });
+    });
+
+    expect(meetingSeriesApi.createSeries).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "End date is required for recurring meetings",
+    );
+  });
+
+  it("blocks recurring schedule if startDate is after endDate", async () => {
+    const { result } = renderHook(() => useScheduleMeeting(), { wrapper });
+
+    act(() => {
+      result.current.setScheduleData((prev) => ({
+        ...prev,
+        title: "Weekly Standup",
+        date: "2026-10-01",
+        endDate: "2026-09-01",
+        time: "09:30",
+        recurrencePattern: "weekly",
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleScheduleSubmit({ preventDefault: vi.fn() });
+    });
+
+    expect(meetingSeriesApi.createSeries).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Start date must be before or equal to end date",
+    );
+  });
+});

--- a/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.series.test.jsx
+++ b/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.series.test.jsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppContent from "../../../../context/AppContent";
 import { useScheduleMeeting } from "../useScheduleMeeting";
 import { meetingApi, meetingSeriesApi } from "../../../../services";

--- a/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
+++ b/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
@@ -1,6 +1,7 @@
 import { toast } from "react-toastify";
 import {
   meetingApi,
+  meetingSeriesApi,
   meetingTemplateApi,
   aiSummaryTemplateApi,
 } from "../../../services";
@@ -29,6 +30,10 @@ export const buildDuplicateScheduleState = (duplicateData = {}) => ({
     syncToCalendar: true,
     reminderEnabled: duplicateData.reminderEnabled || false,
     reminderMinutesBefore: duplicateData.reminderMinutesBefore || 30,
+    recurrencePattern: duplicateData.recurrencePattern || "none",
+    endDate: duplicateData.endDate || "",
+    dayOfWeek: duplicateData.dayOfWeek || "",
+    dayOfMonth: duplicateData.dayOfMonth || "",
   },
   participants: (duplicateData.participants || []).map(
     (participant, index) => ({
@@ -65,6 +70,10 @@ export const useScheduleMeeting = ({
     syncToCalendar: true,
     reminderEnabled: false,
     reminderMinutesBefore: 30,
+    recurrencePattern: "none",
+    endDate: "",
+    dayOfWeek: "",
+    dayOfMonth: "",
   });
   const [participants, setParticipants] = useState([]);
   const [newParticipant, setNewParticipant] = useState({ name: "", email: "" });
@@ -141,6 +150,36 @@ export const useScheduleMeeting = ({
     serverUpdatedAt,
     onRestore: restoreDraftValues,
   });
+
+  const resetFormState = useCallback(() => {
+    setScheduleData({
+      title: "",
+      description: "",
+      meetingType: "conference",
+      date: "",
+      time: "",
+      duration: "",
+      location: "",
+      venue: "",
+      syncToCalendar: true,
+      reminderEnabled: false,
+      reminderMinutesBefore: 30,
+      recurrencePattern: "none",
+      endDate: "",
+      dayOfWeek: "",
+      dayOfMonth: "",
+    });
+    setParticipants([]);
+    setAgendaItems([]);
+    setAttachments([]);
+    setDuplicateMetadata({
+      tags: [],
+      policyDetails: null,
+      recordingType: "upload",
+    });
+    setSelectedTemplateId("");
+    clearDraft();
+  }, [clearDraft]);
 
   useEffect(() => {
     let cancelled = false;
@@ -271,70 +310,119 @@ export const useScheduleMeeting = ({
       return;
     }
 
+    const isRecurring =
+      Boolean(scheduleData.recurrencePattern) &&
+      scheduleData.recurrencePattern !== "none";
+
+    if (isRecurring) {
+      if (!scheduleData.endDate) {
+        toast.error("End date is required for recurring meetings");
+        return;
+      }
+      if (new Date(scheduleData.date) > new Date(scheduleData.endDate)) {
+        toast.error("Start date must be before or equal to end date");
+        return;
+      }
+      const validPatterns = ["daily", "weekly", "biweekly", "monthly"];
+      if (!validPatterns.includes(scheduleData.recurrencePattern)) {
+        toast.error("Invalid recurrence pattern selected");
+        return;
+      }
+    }
+
     setLoading(true);
     try {
-      const payload = {
-        ...scheduleData,
-        participants,
-        tags: duplicateMetadata.tags,
-        policyDetails: duplicateMetadata.policyDetails,
-        recordingType: duplicateMetadata.recordingType,
-        agendaItems: normalizeAgendaItems(agendaItems),
-      };
+      if (isRecurring) {
+        const seriesPayload = {
+          title: scheduleData.title.trim(),
+          description: scheduleData.description || "",
+          meetingType: scheduleData.meetingType || "conference",
+          recurrencePattern: scheduleData.recurrencePattern,
+          dayOfWeek:
+            scheduleData.dayOfWeek !== "" &&
+            scheduleData.dayOfWeek !== undefined &&
+            scheduleData.dayOfWeek !== null
+              ? Number(scheduleData.dayOfWeek)
+              : undefined,
+          dayOfMonth:
+            scheduleData.dayOfMonth !== "" &&
+            scheduleData.dayOfMonth !== undefined &&
+            scheduleData.dayOfMonth !== null
+              ? Number(scheduleData.dayOfMonth)
+              : undefined,
+          startDate: scheduleData.date,
+          endDate: scheduleData.endDate,
+          time: scheduleData.time,
+          duration: scheduleData.duration ? Number(scheduleData.duration) : 60,
+          location: scheduleData.location || "",
+          venue: scheduleData.venue || "",
+          participants: participants.map((p) => ({
+            name: p.name,
+            email: p.email,
+            role: p.role,
+          })),
+          agendaItems: normalizeAgendaItems(agendaItems).map((a) => ({
+            text: a.text,
+            description: a.description,
+            duration: a.duration ? Number(a.duration) : undefined,
+          })),
+        };
 
-      const response = await meetingApi.scheduleMeeting(payload);
+        const response = await meetingSeriesApi.createSeries(seriesPayload);
 
-      if (response.data?.success) {
-        if (customFields.fields.length > 0 && userData?.organization) {
-          try {
-            await customFieldApi.setMeetingFields(
-              response.data.meeting._id,
-              userData.organization,
-              customFields.fields,
-            );
-          } catch (err) {
-            console.error("Failed to save custom fields", err);
-            toast.error("Meeting saved, but custom fields failed to save");
-          }
+        if (response.data?.success) {
+          const createdCount = response.data.meetingsCreated || 0;
+          toast.success(
+            `✅ Meeting series created successfully with ${createdCount} occurrence(s)!`,
+          );
+          resetFormState();
+        } else {
+          toast.error(
+            response.data?.message || "Failed to create meeting series",
+          );
         }
-        toast.success("✅ Meeting scheduled and synced to calendars!");
-
-        // Trigger calendar integration
-        if (response.data.calendarLinks) {
-          toast.info("📅 Calendar invites sent to all participants!");
-        }
-
-        // Reset form
-        setScheduleData({
-          title: "",
-          description: "",
-          meetingType: "conference",
-          date: "",
-          time: "",
-          duration: "",
-          location: "",
-          venue: "",
-          syncToCalendar: true,
-          reminderEnabled: false,
-          reminderMinutesBefore: 30,
-        });
-        setParticipants([]);
-        setAgendaItems([]);
-        setAttachments([]);
-        setDuplicateMetadata({
-          tags: [],
-          policyDetails: null,
-          recordingType: "upload",
-        });
-        setSelectedTemplateId("");
-        clearDraft();
       } else {
-        toast.error(response.data?.message || "Failed to schedule meeting");
+        const payload = {
+          ...scheduleData,
+          participants,
+          tags: duplicateMetadata.tags,
+          policyDetails: duplicateMetadata.policyDetails,
+          recordingType: duplicateMetadata.recordingType,
+          agendaItems: normalizeAgendaItems(agendaItems),
+        };
+
+        const response = await meetingApi.scheduleMeeting(payload);
+
+        if (response.data?.success) {
+          if (customFields.fields.length > 0 && userData?.organization) {
+            try {
+              await customFieldApi.setMeetingFields(
+                response.data.meeting._id,
+                userData.organization,
+                customFields.fields,
+              );
+            } catch (err) {
+              console.error("Failed to save custom fields", err);
+              toast.error("Meeting saved, but custom fields failed to save");
+            }
+          }
+          toast.success("✅ Meeting scheduled and synced to calendars!");
+
+          if (response.data.calendarLinks) {
+            toast.info("📅 Calendar invites sent to all participants!");
+          }
+
+          resetFormState();
+        } else {
+          toast.error(response.data?.message || "Failed to schedule meeting");
+        }
       }
     } catch (error) {
       console.error("Error scheduling meeting:", error);
       toast.error(
-        error.response?.data?.message || "Unable to schedule meeting",
+        error.response?.data?.message ||
+          error.response?.data?.errors?.[0]?.message ||
+          "Unable to schedule meeting",
       );
     } finally {
       setLoading(false);


### PR DESCRIPTION
### Summary
Connected `RecurrenceSelector.jsx` selection state in `useScheduleMeeting.js` to the `meetingSeriesApi.createSeries` backend endpoint so that choosing Daily, Weekly, Bi-weekly, or Monthly recurrence creates a real meeting series with linked occurrences instead of a single static meeting.

### Key Changes
1. **Recurrence Detection & Branching**: Updated [`useScheduleMeeting.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js) to inspect `recurrencePattern` (`"daily" | "weekly" | "biweekly" | "monthly"` vs `"none"`).
2. **Client Validation**: Added client-side validation requiring `endDate` for recurring schedules and checking that `startDate <= endDate` before submission.
3. **Series API Wiring**: When `recurrencePattern !== "none"`, `useScheduleMeeting.js` calls `meetingSeriesApi.createSeries` with `title`, `description`, `meetingType`, `recurrencePattern`, `dayOfWeek`, `dayOfMonth`, `startDate`, `endDate`, `time`, `duration`, `participants`, and `agendaItems`.
4. **Non-Recurring Path**: Preserved single-meeting scheduling via `meetingApi.scheduleMeeting` when `recurrencePattern` is `"none"`.
5. **Automated Unit Testing**: Created [`useScheduleMeeting.series.test.jsx`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.series.test.jsx) (4 tests) testing single meeting routing, recurring series creation, missing end date validation, and date order validation.

### Verification
- ✅ `useScheduleMeeting.series.test.jsx` (4 tests) passed cleanly in Vitest.
- ✅ `npm run format:check:changed` passed cleanly ("All matched files use Prettier code style!").
- ✅ Pushed to `origin/fix/2004-connect-recurrence-selector-meeting-series`.