### PR TITLE
feat: implement ICS download and add-to-calendar deep links on meeting details (#2057)

### DIFF
--- a/client/src/components/meeting-details/MeetingActions.jsx
+++ b/client/src/components/meeting-details/MeetingActions.jsx
@@ -7,6 +7,11 @@ import { toast } from "react-toastify";
 import apiClient from "../../services/apiClient";
 import ConfirmModal from "../ConfirmModal.jsx";
 import { usePolling } from "../../hooks/usePolling.js";
+import {
+  generateICS,
+  getGoogleCalendarUrl,
+  getOutlookCalendarUrl,
+} from "../../utils/calendarExport.js";
 
 /**
  * Deadline for the post-recording transcription poll (Issue #1455).
@@ -22,6 +27,7 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
   const [showRenameModal, setShowRenameModal] = useState(false);
   const [newTitle, setNewTitle] = useState("");
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showCalendarMenu, setShowCalendarMenu] = useState(false);
   const { exportMeeting, isExporting } = useExport();
 
   // Recording state
@@ -410,6 +416,59 @@ const MeetingActions = ({ meeting, onDelete, onRename }) => {
                 >
                   Export as Markdown
                 </button>
+              </div>
+            )}
+          </div>
+
+          <div className="relative">
+            <button
+              onClick={() => setShowCalendarMenu(!showCalendarMenu)}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors text-sm font-medium"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              Add to Calendar
+            </button>
+            {showCalendarMenu && (
+              <div className="absolute top-full left-0 mt-2 w-full bg-white border border-gray-200 rounded-lg shadow-lg z-10 overflow-hidden">
+                <button
+                  onClick={() => {
+                    setShowCalendarMenu(false);
+                    generateICS(meeting);
+                  }}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                >
+                  Download ICS
+                </button>
+                <a
+                  href={getGoogleCalendarUrl(meeting)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setShowCalendarMenu(false)}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                >
+                  Google Calendar
+                </a>
+                <a
+                  href={getOutlookCalendarUrl(meeting)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setShowCalendarMenu(false)}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                >
+                  Outlook Web
+                </a>
               </div>
             )}
           </div>

--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -15,6 +15,11 @@ import { toast } from "react-toastify";
 import { toggleBookmarkAPI, getBookmarkStatusAPI } from "../../api/bookmarkApi";
 import { askAssistantAbout } from "../../utils/askAssistant.js";
 import { notificationApi } from "../../services/notificationApi.js";
+import {
+  generateICS,
+  getGoogleCalendarUrl,
+  getOutlookCalendarUrl,
+} from "../../utils/calendarExport.js";
 
 const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
   const navigate = useNavigate();
@@ -22,6 +27,7 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
   const [isLoadingBookmark, setIsLoadingBookmark] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const [muteLoading, setMuteLoading] = useState(false);
+  const [showCalendarMenu, setShowCalendarMenu] = useState(false);
 
   useEffect(() => {
     if (meeting?._id) {
@@ -249,6 +255,58 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
           >
             <Share2 className="w-4 h-4" /> Share
           </button>
+          <div className="relative">
+            <button
+              onClick={() => setShowCalendarMenu(!showCalendarMenu)}
+              className="flex items-center gap-2 px-3 py-1.5 bg-gray-50 text-gray-700 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 rounded-lg text-sm font-medium transition-colors"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              Add to Calendar
+            </button>
+            {showCalendarMenu && (
+              <div className="absolute right-0 top-full mt-2 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-10 overflow-hidden">
+                <button
+                  onClick={() => {
+                    setShowCalendarMenu(false);
+                    generateICS(meeting);
+                  }}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                >
+                  Download ICS
+                </button>
+                <a
+                  href={getGoogleCalendarUrl(meeting)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setShowCalendarMenu(false)}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                >
+                  Google Calendar
+                </a>
+                <a
+                  href={getOutlookCalendarUrl(meeting)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setShowCalendarMenu(false)}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                >
+                  Outlook Web
+                </a>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/client/src/components/meeting-details/__tests__/CalendarButtons.test.jsx
+++ b/client/src/components/meeting-details/__tests__/CalendarButtons.test.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import MeetingHeader from "../MeetingHeader.jsx";
+import MeetingActions from "../MeetingActions.jsx";
+import * as calendarExport from "../../../utils/calendarExport.js";
+
+// Mock calendarExport utilities
+vi.spyOn(calendarExport, "generateICS").mockImplementation(() => {});
+
+// Mock askAssistantAbout utility
+vi.mock("../../../utils/askAssistant.js", () => ({
+  askAssistantAbout: vi.fn(),
+}));
+
+// Mock useExport hook
+vi.mock("../../../hooks/useExport.js", () => ({
+  default: () => ({ exportMeeting: vi.fn(), isExporting: false }),
+}));
+
+describe("Add to Calendar buttons on Meeting Details (#2057)", () => {
+  const mockMeeting = {
+    _id: "m123",
+    title: "Quarterly Review Meeting",
+    description: "Discussing quarterly highlights and objectives.",
+    location: "Zoom",
+    venue: "https://zoom.us/j/123456789",
+    date: "2026-08-30T10:00:00.000Z",
+    duration: 90,
+    agendaItems: [
+      { text: "Agenda item 1", description: "First part details" },
+      { text: "Agenda item 2", description: "Second part details" },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders Add to Calendar button in MeetingHeader and displays options on click", () => {
+    render(
+      <MemoryRouter>
+        <MeetingHeader
+          meeting={mockMeeting}
+          onShare={vi.fn()}
+          onShareInvite={vi.fn()}
+          onPresent={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const calendarBtn = screen.getByText("Add to Calendar");
+    expect(calendarBtn).toBeInTheDocument();
+
+    // Click to open dropdown
+    fireEvent.click(calendarBtn);
+
+    // Verify calendar options are visible
+    expect(screen.getByText("Download ICS")).toBeInTheDocument();
+    expect(screen.getByText("Google Calendar")).toBeInTheDocument();
+    expect(screen.getByText("Outlook Web")).toBeInTheDocument();
+
+    // Click Download ICS option
+    fireEvent.click(screen.getByText("Download ICS"));
+    expect(calendarExport.generateICS).toHaveBeenCalledWith(mockMeeting);
+  });
+
+  it("renders Add to Calendar button in MeetingActions and displays options on click", () => {
+    render(
+      <MemoryRouter>
+        <MeetingActions
+          meeting={mockMeeting}
+          onDelete={vi.fn()}
+          onRename={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    // Get calendar button in actions grid
+    const calendarBtn = screen.getByText("Add to Calendar");
+    expect(calendarBtn).toBeInTheDocument();
+
+    // Click to open dropdown
+    fireEvent.click(calendarBtn);
+
+    // Verify calendar options
+    expect(screen.getByText("Download ICS")).toBeInTheDocument();
+    expect(screen.getByText("Google Calendar")).toBeInTheDocument();
+    expect(screen.getByText("Outlook Web")).toBeInTheDocument();
+
+    // Click Download ICS
+    fireEvent.click(screen.getByText("Download ICS"));
+    expect(calendarExport.generateICS).toHaveBeenCalledWith(mockMeeting);
+  });
+});

--- a/client/src/utils/calendarExport.js
+++ b/client/src/utils/calendarExport.js
@@ -1,0 +1,116 @@
+export const formatICSDate = (date) => {
+  return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+};
+
+export const generateICS = (meeting) => {
+  const title = meeting.title || "Untitled Meeting";
+  const description = meeting.description || "";
+  const location = meeting.venue || meeting.location || "";
+
+  let agendaString = "";
+  if (meeting.agendaItems && meeting.agendaItems.length > 0) {
+    agendaString =
+      "\n\nAgenda:\n" +
+      meeting.agendaItems
+        .map(
+          (item, idx) =>
+            `${idx + 1}. ${item.text}${item.description ? ` - ${item.description}` : ""}`,
+        )
+        .join("\n");
+  }
+
+  const appUrl = `${window.location.origin}/meeting/${meeting._id}`;
+  const fullDescription = `${description}${agendaString}\n\nView details in MeetOnMemory: ${appUrl}`;
+
+  const startDate = new Date(meeting.date);
+  const durationMins = meeting.duration || 60;
+  const endDate = new Date(startDate.getTime() + durationMins * 60 * 1000);
+
+  const icsContent = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//MeetOnMemory//NONSGML v1.0//EN",
+    "BEGIN:VEVENT",
+    `UID:${meeting._id || Math.random().toString(36).substring(2, 11)}@meetonmemory.com`,
+    `DTSTAMP:${formatICSDate(new Date())}`,
+    `DTSTART:${formatICSDate(startDate)}`,
+    `DTEND:${formatICSDate(endDate)}`,
+    `SUMMARY:${title}`,
+    `DESCRIPTION:${fullDescription.replace(/\n/g, "\\n")}`,
+    `LOCATION:${location}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const blob = new Blob([icsContent], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, "_")}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
+export const getGoogleCalendarUrl = (meeting) => {
+  const title = encodeURIComponent(meeting.title || "Untitled Meeting");
+  const description = meeting.description || "";
+  const location = encodeURIComponent(meeting.venue || meeting.location || "");
+
+  let agendaString = "";
+  if (meeting.agendaItems && meeting.agendaItems.length > 0) {
+    agendaString =
+      "\n\nAgenda:\n" +
+      meeting.agendaItems
+        .map(
+          (item, idx) =>
+            `${idx + 1}. ${item.text}${item.description ? ` - ${item.description}` : ""}`,
+        )
+        .join("\n");
+  }
+
+  const appUrl = `${window.location.origin}/meeting/${meeting._id}`;
+  const fullDescription = encodeURIComponent(
+    `${description}${agendaString}\n\nView details in MeetOnMemory: ${appUrl}`,
+  );
+
+  const startDate = new Date(meeting.date);
+  const durationMins = meeting.duration || 60;
+  const endDate = new Date(startDate.getTime() + durationMins * 60 * 1000);
+
+  const dates = `${formatICSDate(startDate)}/${formatICSDate(endDate)}`;
+  return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${dates}&details=${fullDescription}&location=${location}`;
+};
+
+export const getOutlookCalendarUrl = (meeting) => {
+  const title = encodeURIComponent(meeting.title || "Untitled Meeting");
+  const description = meeting.description || "";
+  const location = encodeURIComponent(meeting.venue || meeting.location || "");
+
+  let agendaString = "";
+  if (meeting.agendaItems && meeting.agendaItems.length > 0) {
+    agendaString =
+      "\n\nAgenda:\n" +
+      meeting.agendaItems
+        .map(
+          (item, idx) =>
+            `${idx + 1}. ${item.text}${item.description ? ` - ${item.description}` : ""}`,
+        )
+        .join("\n");
+  }
+
+  const appUrl = `${window.location.origin}/meeting/${meeting._id}`;
+  const fullDescription = encodeURIComponent(
+    `${description}${agendaString}\n\nView details in MeetOnMemory: ${appUrl}`,
+  );
+
+  const startDate = new Date(meeting.date);
+  const durationMins = meeting.duration || 60;
+  const endDate = new Date(startDate.getTime() + durationMins * 60 * 1000);
+
+  const startdt = encodeURIComponent(startDate.toISOString());
+  const enddt = encodeURIComponent(endDate.toISOString());
+
+  return `https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=${title}&startdt=${startdt}&enddt=${enddt}&body=${fullDescription}&location=${location}`;
+};


### PR DESCRIPTION
## 📝 Summary
This PR implements client-side calendar integration support on the Meeting Details page. Meeting viewers can now click the "Add to Calendar" dropdown in either the header or actions section to:
1. Download a custom `.ics` (text/calendar) file.
2. Compose pre-filled meeting events in Google Calendar.
3. Compose pre-filled meeting events in Outlook Web Calendar.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2057

---

## ✨ Changes Made
- **Client Utilities**:
  - Created `calendarExport.js` with client-side `.ics` generator and deep link builders for Google Calendar and Outlook Web Calendar. Prefilled fields include meeting title, dates, descriptions, agenda list, locations, and the MeetOnMemory details URL.
- **UI Components Integration**:
  - Mounted the "Add to Calendar" dropdown in `MeetingHeader.jsx`.
  - Mounted the "Add to Calendar" dropdown in `MeetingActions.jsx`.
- **Automated Tests**:
  - Created `CalendarButtons.test.jsx` verifying that dropdown button renders on both components and functions as expected.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run client unit tests:
```bash
npm run test client/src/components/meeting-details/__tests__/CalendarButtons.test.jsx
