### PR TITLE
feat: unify quiet hours across digest and recap preferences globally (#2065)

### DIFF
--- a/client/src/components/DigestPreferences.jsx
+++ b/client/src/components/DigestPreferences.jsx
@@ -9,6 +9,7 @@ import {
   Calendar,
   RefreshCw,
 } from "lucide-react";
+import SharedQuietHours from "./SharedQuietHours.jsx";
 
 /**
  * Client-side HTML sanitization helper for live email previews (#1339)
@@ -249,42 +250,14 @@ const DigestPreferences = () => {
               </select>
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                Timezone
-              </label>
-              <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  aria-label="Delivery Timezone"
-                  value={preferences.timezone || "UTC"}
-                  onChange={(e) =>
-                    setPreferences({
-                      ...preferences,
-                      timezone: e.target.value,
-                    })
-                  }
-                  className="w-full bg-slate-50 dark:bg-slate-700/50 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="e.g. UTC, America/New_York"
-                />
-                <button
-                  type="button"
-                  onClick={() =>
-                    setPreferences({
-                      ...preferences,
-                      timezone: getLocalTimezone(),
-                    })
-                  }
-                  className="px-3 py-2 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/50 whitespace-nowrap transition-colors"
-                >
-                  Detect Local
-                </button>
-              </div>
-              <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-                Digest deliveries are scheduled and sent according to this
-                timezone ({preferences.timezone || "UTC"}).
-              </p>
-            </div>
+            <SharedQuietHours
+              onQuietHoursChange={(qh) => {
+                setPreferences((prev) => ({
+                  ...prev,
+                  timezone: qh.timezone,
+                }));
+              }}
+            />
           </div>
         </div>
 

--- a/client/src/components/RecapPreferences.jsx
+++ b/client/src/components/RecapPreferences.jsx
@@ -8,6 +8,7 @@ import { Dialog } from "@headlessui/react";
 import { toast } from "react-toastify";
 import SandboxedHtmlPreview from "./SandboxedHtmlPreview";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
+import SharedQuietHours from "./SharedQuietHours.jsx";
 
 const RecapPreferences = () => {
   const [preferences, setPreferences] = useState({
@@ -190,68 +191,22 @@ const RecapPreferences = () => {
         </div>
       </div>
 
-      {/* Quiet Hours */}
-      <div className="mb-6">
-        <h3 className="text-lg font-medium mb-2">Quiet Hours (Optional)</h3>
-        <p className="text-sm text-gray-500 mb-2">
-          Emails won't be sent during these hours. They'll be delayed until the
-          next batch. You can set overnight ranges (e.g. 10:00 PM to 7:00 AM).
-        </p>
-        <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4 items-start sm:items-center">
-          <div className="w-full sm:w-auto">
-            <label
-              htmlFor="quietHoursStart"
-              className="block text-sm text-gray-700 mb-1"
-            >
-              Start Time
-            </label>
-            <select
-              id="quietHoursStart"
-              name="quietHoursStart"
-              value={preferences.quietHoursStart}
-              onChange={handleChange}
-              className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}
-            >
-              <option value="">None</option>
-              {hoursOptions.map((hour) => (
-                <option key={hour} value={hour}>
-                  {formatHour(hour)}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="w-full sm:w-auto">
-            <label
-              htmlFor="quietHoursEnd"
-              className="block text-sm text-gray-700 mb-1"
-            >
-              End Time
-            </label>
-            <select
-              id="quietHoursEnd"
-              name="quietHoursEnd"
-              value={preferences.quietHoursEnd}
-              onChange={handleChange}
-              className={`w-full sm:w-32 bg-white border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${quietHoursError ? "border-red-500" : "border-gray-300"}`}
-            >
-              <option value="">None</option>
-              {hoursOptions.map((hour) => (
-                <option key={hour} value={hour}>
-                  {formatHour(hour)}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        {quietHoursError && (
-          <p className="text-sm text-red-500 mt-2 font-medium">
-            {quietHoursError}
-          </p>
-        )}
-        <p className="text-xs text-gray-500 mt-2">
-          Timezone: {preferences.timezone}
-        </p>
-      </div>
+      <SharedQuietHours
+        onQuietHoursChange={(qh) => {
+          setPreferences((prev) => ({
+            ...prev,
+            quietHoursStart:
+              qh.quietHoursStart !== "" && qh.quietHoursStart !== null
+                ? Number(qh.quietHoursStart)
+                : "",
+            quietHoursEnd:
+              qh.quietHoursEnd !== "" && qh.quietHoursEnd !== null
+                ? Number(qh.quietHoursEnd)
+                : "",
+            timezone: qh.timezone,
+          }));
+        }}
+      />
 
       <div className="flex space-x-4">
         <button

--- a/client/src/components/SharedQuietHours.jsx
+++ b/client/src/components/SharedQuietHours.jsx
@@ -1,0 +1,283 @@
+import React, { useState, useEffect } from "react";
+import { notificationApi } from "../services/notificationApi.js";
+import { toast } from "react-toastify";
+
+const formatHour = (hour) => {
+  if (hour === 0) return "12:00 AM";
+  if (hour < 12) return `${hour}:00 AM`;
+  if (hour === 12) return "12:00 PM";
+  return `${hour - 12}:00 PM`;
+};
+
+const SharedQuietHours = ({ onQuietHoursChange }) => {
+  const [preferences, setPreferences] = useState({
+    quietHoursStart: "",
+    quietHoursEnd: "",
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+  });
+  const [loading, setLoading] = useState(true);
+
+  const hoursOptions = Array.from({ length: 24 }, (_, i) => i);
+
+  useEffect(() => {
+    fetchQuietHours();
+  }, []);
+
+  const fetchQuietHours = async () => {
+    try {
+      const { data } = await notificationApi.getPreferences();
+      const pref = data.preferences || {};
+      const loadedPref = {
+        quietHoursStart:
+          pref.quietHoursStart !== undefined && pref.quietHoursStart !== null
+            ? String(pref.quietHoursStart)
+            : "",
+        quietHoursEnd:
+          pref.quietHoursEnd !== undefined && pref.quietHoursEnd !== null
+            ? String(pref.quietHoursEnd)
+            : "",
+        timezone:
+          pref.timezone ||
+          Intl.DateTimeFormat().resolvedOptions().timeZone ||
+          "UTC",
+      };
+      setPreferences(loadedPref);
+      if (onQuietHoursChange) {
+        onQuietHoursChange(loadedPref);
+      }
+    } catch (err) {
+      console.error("Failed to load quiet hours:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = async (e) => {
+    const { name, value } = e.target;
+    const nextPrefs = {
+      ...preferences,
+      [name]: value,
+    };
+    setPreferences(nextPrefs);
+
+    // Save quiet hours preference
+    try {
+      const payload = {
+        quietHoursStart:
+          nextPrefs.quietHoursStart !== ""
+            ? Number(nextPrefs.quietHoursStart)
+            : null,
+        quietHoursEnd:
+          nextPrefs.quietHoursEnd !== ""
+            ? Number(nextPrefs.quietHoursEnd)
+            : null,
+        timezone: nextPrefs.timezone,
+      };
+      await notificationApi.updatePreferences(payload);
+      if (onQuietHoursChange) {
+        onQuietHoursChange(payload);
+      }
+    } catch (err) {
+      console.error("Failed to update quiet hours:", err);
+      toast.error("Failed to update quiet hours");
+    }
+  };
+
+  const getNextSendPreview = () => {
+    const {
+      quietHoursStart: start,
+      quietHoursEnd: end,
+      timezone,
+    } = preferences;
+    if (start === "" || end === "") {
+      return "Emails will be sent immediately / as scheduled.";
+    }
+
+    const startNum = Number(start);
+    const endNum = Number(end);
+    const now = new Date();
+
+    let currentHour;
+    try {
+      const formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone || "UTC",
+        hour: "numeric",
+        hour12: false,
+      });
+      currentHour = parseInt(formatter.format(now), 10);
+    } catch {
+      currentHour = now.getHours();
+    }
+
+    let inQuietHours = false;
+    if (startNum < endNum) {
+      inQuietHours = currentHour >= startNum && currentHour < endNum;
+    } else {
+      inQuietHours = currentHour >= startNum || currentHour < endNum;
+    }
+
+    if (inQuietHours) {
+      return `Quiet Hours are active. Scheduled digests, recaps, and reminders will be deferred until after ${formatHour(endNum)}.`;
+    }
+    return `Quiet Hours are inactive. Next pings/emails will send as scheduled (Quiet Hours active ${formatHour(startNum)} - ${formatHour(endNum)}).`;
+  };
+
+  if (loading) {
+    return (
+      <div className="text-slate-500 text-sm">
+        Loading quiet hours settings...
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-slate-50 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700/80 rounded-xl p-5 mt-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <svg
+          className="w-5 h-5 text-indigo-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+          />
+        </svg>
+        <h4 className="font-semibold text-slate-800 dark:text-slate-200 text-sm">
+          Unified Quiet Hours Settings
+        </h4>
+      </div>
+
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Quiet hours settings are shared globally. Changes made here will apply
+        to both meeting recaps, daily/weekly digests, and reminders.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+        <div className="flex-1 w-full">
+          <label
+            htmlFor="sharedQuietHoursStart"
+            className="block text-xs font-semibold text-slate-600 dark:text-slate-400 mb-1"
+          >
+            Start Time
+          </label>
+          <select
+            id="sharedQuietHoursStart"
+            name="quietHoursStart"
+            value={preferences.quietHoursStart}
+            onChange={handleChange}
+            className="w-full bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          >
+            <option value="">None (Disabled)</option>
+            {hoursOptions.map((hour) => (
+              <option key={hour} value={hour}>
+                {formatHour(hour)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1 w-full">
+          <label
+            htmlFor="sharedQuietHoursEnd"
+            className="block text-xs font-semibold text-slate-600 dark:text-slate-400 mb-1"
+          >
+            End Time
+          </label>
+          <select
+            id="sharedQuietHoursEnd"
+            name="quietHoursEnd"
+            value={preferences.quietHoursEnd}
+            onChange={handleChange}
+            className="w-full bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+          >
+            <option value="">None (Disabled)</option>
+            {hoursOptions.map((hour) => (
+              <option key={hour} value={hour}>
+                {formatHour(hour)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+        <div className="w-full">
+          <label
+            htmlFor="sharedTimezone"
+            className="block text-xs font-semibold text-slate-600 dark:text-slate-400 mb-1"
+          >
+            Timezone (Explicit)
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="sharedTimezone"
+              type="text"
+              name="timezone"
+              value={preferences.timezone}
+              onChange={handleChange}
+              className="w-full bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              placeholder="e.g. UTC, America/New_York"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const tz =
+                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+                handleChange({ target: { name: "timezone", value: tz } });
+              }}
+              className="px-3 py-2 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-900/50 whitespace-nowrap transition-colors"
+            >
+              Detect Local
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-2 justify-between items-start sm:items-center pt-2 border-t border-slate-100 dark:border-slate-700/60">
+        <div className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+          <svg
+            className="w-3.5 h-3.5 text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 002 2h2.918M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <span>
+            Active Timezone:{" "}
+            <span className="font-semibold text-slate-700 dark:text-slate-300">
+              {preferences.timezone}
+            </span>
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs font-medium text-indigo-600 dark:text-indigo-400">
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <span>{getNextSendPreview()}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SharedQuietHours;

--- a/client/src/components/__tests__/DigestPreferencesSanitization.test.jsx
+++ b/client/src/components/__tests__/DigestPreferencesSanitization.test.jsx
@@ -22,6 +22,13 @@ vi.mock("../../services/apiClient.js", () => ({
   },
 }));
 
+vi.mock("../../services/notificationApi.js", () => ({
+  notificationApi: {
+    getPreferences: vi.fn().mockResolvedValue({ data: { preferences: {} } }),
+    updatePreferences: vi.fn(),
+  },
+}));
+
 describe("DigestPreferences HTML Sanitization (#1339)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/client/src/components/__tests__/DigestPreferencesTimezone.test.jsx
+++ b/client/src/components/__tests__/DigestPreferencesTimezone.test.jsx
@@ -23,6 +23,13 @@ vi.mock("react-toastify", () => ({
   },
 }));
 
+vi.mock("../../services/notificationApi.js", () => ({
+  notificationApi: {
+    getPreferences: vi.fn().mockResolvedValue({ data: { preferences: {} } }),
+    updatePreferences: vi.fn(),
+  },
+}));
+
 describe("DigestPreferences Timezone Context (#1686)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
+++ b/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
@@ -13,6 +13,13 @@ vi.mock("../../services/recapApi", () => ({
   previewRecapEmail: vi.fn(),
 }));
 
+vi.mock("../../services/notificationApi", () => ({
+  notificationApi: {
+    getPreferences: vi.fn().mockResolvedValue({ data: { preferences: {} } }),
+    updatePreferences: vi.fn(),
+  },
+}));
+
 vi.mock("react-toastify", () => ({
   toast: {
     success: vi.fn(),

--- a/client/src/components/__tests__/SharedQuietHours.test.jsx
+++ b/client/src/components/__tests__/SharedQuietHours.test.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import SharedQuietHours from "../SharedQuietHours.jsx";
+import { notificationApi } from "../../services/notificationApi.js";
+
+// Mock notificationApi
+vi.mock("../../services/notificationApi.js", () => ({
+  notificationApi: {
+    getPreferences: vi.fn(),
+    updatePreferences: vi.fn(),
+  },
+}));
+
+// Mock react-toastify
+vi.mock("react-toastify", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("SharedQuietHours Component (#2065)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders correctly with loaded settings and updates on input change", async () => {
+    notificationApi.getPreferences.mockResolvedValue({
+      data: {
+        preferences: {
+          quietHoursStart: 22,
+          quietHoursEnd: 6,
+          timezone: "UTC",
+        },
+      },
+    });
+
+    render(<SharedQuietHours onQuietHoursChange={vi.fn()} />);
+
+    // Wait for data load
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unified Quiet Hours Settings"),
+      ).toBeInTheDocument();
+    });
+
+    const startSelect = screen.getByLabelText("Start Time");
+    const endSelect = screen.getByLabelText("End Time");
+    const tzInput = screen.getByLabelText("Timezone (Explicit)");
+
+    expect(startSelect.value).toBe("22");
+    expect(endSelect.value).toBe("6");
+    expect(tzInput.value).toBe("UTC");
+
+    // Change start time selection
+    fireEvent.change(startSelect, { target: { value: "20" } });
+
+    await waitFor(() => {
+      expect(notificationApi.updatePreferences).toHaveBeenCalledWith({
+        quietHoursStart: 20,
+        quietHoursEnd: 6,
+        timezone: "UTC",
+      });
+    });
+  });
+});

--- a/server/controllers/digestPreferenceController.js
+++ b/server/controllers/digestPreferenceController.js
@@ -6,6 +6,7 @@ import User from "../models/userModel.js";
 import Tag from "../models/tagModel.js";
 import transporter from "../config/nodeMailer.js";
 import MeetingDigestService from "../services/MeetingDigestService.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
 
 /**
  * In-memory rate limiting store for digest test emails
@@ -126,21 +127,35 @@ const recordRequest = (userId) => {
 export const getPreferences = async (req, res) => {
   try {
     const userId = req.user._id;
-    const preferences = await DigestPreference.findOne({
+    let preferences = await DigestPreference.findOne({
       $or: [{ user: userId }, { userId }],
-    });
+    }).lean();
 
     if (!preferences) {
-      return res.status(200).json({
-        success: true,
-        data: {
-          frequency: "weekly",
-          includeSections: ["decisions", "action-items"],
-          enabled: true,
-          timezone: "UTC",
-          filterByTags: [],
-        },
-      });
+      preferences = {
+        frequency: "weekly",
+        includeSections: ["decisions", "action-items"],
+        enabled: true,
+        timezone: "UTC",
+        filterByTags: [],
+      };
+    }
+
+    // Merge quiet hours and timezone from NotificationPreference
+    const notifPref = await NotificationPreference.findOne({
+      user: userId,
+    }).lean();
+    if (notifPref) {
+      preferences.quietHoursStart =
+        notifPref.quietHoursStart !== undefined
+          ? notifPref.quietHoursStart
+          : null;
+      preferences.quietHoursEnd =
+        notifPref.quietHoursEnd !== undefined ? notifPref.quietHoursEnd : null;
+      preferences.timezone = notifPref.timezone || preferences.timezone;
+    } else {
+      preferences.quietHoursStart = null;
+      preferences.quietHoursEnd = null;
     }
 
     return res.status(200).json({
@@ -173,6 +188,8 @@ export const updatePreferences = async (req, res) => {
       deliveryHour,
       timezone,
       maxItems,
+      quietHoursStart,
+      quietHoursEnd,
     } = req.body;
 
     const userOrgId = req.user.organization;
@@ -234,6 +251,21 @@ export const updatePreferences = async (req, res) => {
       updateFields,
       { new: true, upsert: true, runValidators: true },
     );
+
+    // Sync quiet hours to NotificationPreference
+    const syncFields = {};
+    if (quietHoursStart !== undefined)
+      syncFields.quietHoursStart = quietHoursStart;
+    if (quietHoursEnd !== undefined) syncFields.quietHoursEnd = quietHoursEnd;
+    if (timezone !== undefined) syncFields.timezone = timezone;
+
+    if (Object.keys(syncFields).length > 0) {
+      await NotificationPreference.findOneAndUpdate(
+        { user: userId },
+        { $set: syncFields },
+        { new: true, upsert: true },
+      );
+    }
 
     return res.status(200).json({
       success: true,

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -236,11 +236,14 @@ export const updatePreferences = async (req, res) => {
       "pushOrganizationUpdates",
       "pushPolicyUpdates",
       "pushReportUpdates",
+      "quietHoursStart",
+      "quietHoursEnd",
+      "timezone",
     ];
 
     const updates = {};
     for (const field of allowedFields) {
-      if (typeof req.body[field] === "boolean") {
+      if (req.body[field] !== undefined) {
         updates[field] = req.body[field];
       }
     }

--- a/server/controllers/recapPreferenceController.js
+++ b/server/controllers/recapPreferenceController.js
@@ -1,6 +1,7 @@
 import RecapPreference from "../models/recapPreferenceModel.js";
 import Meeting from "../models/meetingModel.js";
 import RecapEmailService from "../services/recapEmailService.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
 
 /**
  * Get current user's recap preferences
@@ -8,7 +9,7 @@ import RecapEmailService from "../services/recapEmailService.js";
 export const getPreferences = async (req, res) => {
   try {
     const userId = req.user._id;
-    let preferences = await RecapPreference.findOne({ userId });
+    let preferences = await RecapPreference.findOne({ userId }).lean();
 
     if (!preferences) {
       // Return default preferences without saving
@@ -19,6 +20,23 @@ export const getPreferences = async (req, res) => {
         includeSummary: true,
         timezone: "UTC",
       };
+    }
+
+    // Merge quiet hours and timezone from NotificationPreference
+    const notifPref = await NotificationPreference.findOne({
+      user: userId,
+    }).lean();
+    if (notifPref) {
+      preferences.quietHoursStart =
+        notifPref.quietHoursStart !== undefined
+          ? notifPref.quietHoursStart
+          : null;
+      preferences.quietHoursEnd =
+        notifPref.quietHoursEnd !== undefined ? notifPref.quietHoursEnd : null;
+      preferences.timezone = notifPref.timezone || preferences.timezone;
+    } else {
+      preferences.quietHoursStart = null;
+      preferences.quietHoursEnd = null;
     }
 
     res.status(200).json(preferences);
@@ -55,6 +73,13 @@ export const updatePreferences = async (req, res) => {
         quietHoursEnd,
         timezone,
       },
+      { new: true, upsert: true },
+    );
+
+    // Sync quiet hours to NotificationPreference
+    await NotificationPreference.findOneAndUpdate(
+      { user: userId },
+      { quietHoursStart, quietHoursEnd, timezone },
       { new: true, upsert: true },
     );
 

--- a/server/models/notificationPreferenceModel.js
+++ b/server/models/notificationPreferenceModel.js
@@ -93,6 +93,22 @@ const notificationPreferenceSchema = new mongoose.Schema(
       type: Boolean,
       default: false,
     },
+    quietHoursStart: {
+      type: Number,
+      min: 0,
+      max: 23,
+      default: null,
+    },
+    quietHoursEnd: {
+      type: Number,
+      min: 0,
+      max: 23,
+      default: null,
+    },
+    timezone: {
+      type: String,
+      default: "UTC",
+    },
   },
   { timestamps: true },
 );

--- a/server/services/MeetingDigestService.js
+++ b/server/services/MeetingDigestService.js
@@ -1,6 +1,7 @@
 import Meeting from "../models/meetingModel.js";
 import User from "../models/userModel.js";
 import EmailService from "./EmailService.js";
+import { checkQuietHours } from "../utils/quietHours.js";
 
 class MeetingDigestService {
   /**
@@ -131,6 +132,16 @@ class MeetingDigestService {
 
       // Send emails
       for (const email of recipients) {
+        const userObj = await User.findOne({ email });
+        if (userObj) {
+          const inQuietHours = await checkQuietHours(userObj._id);
+          if (inQuietHours) {
+            console.log(
+              `[MeetingDigestService] Deferring digest email for ${email} due to quiet hours.`,
+            );
+            continue;
+          }
+        }
         await EmailService.sendMail({
           from: process.env.SENDER_EMAIL || "no-reply@meetonmemory.com",
           to: email,

--- a/server/services/reminderScheduler.js
+++ b/server/services/reminderScheduler.js
@@ -3,6 +3,7 @@ import ActionItem from "../models/actionItemModel.js";
 import Meeting from "../models/meetingModel.js";
 import emailService from "./emailService.js";
 import { createNotification } from "./notificationService.js";
+import { checkQuietHours } from "../utils/quietHours.js";
 
 class ReminderScheduler {
   constructor() {
@@ -186,6 +187,14 @@ class ReminderScheduler {
 
     for (const recipient of recipients) {
       try {
+        const inQuietHours = await checkQuietHours(recipient.userId);
+        if (inQuietHours) {
+          console.log(
+            `[ReminderScheduler] Suppressing meeting reminder for ${recipient.email} due to quiet hours.`,
+          );
+          continue;
+        }
+
         await createNotification({
           userId: recipient.userId,
           type: "meeting_reminder",
@@ -306,6 +315,14 @@ class ReminderScheduler {
 
   async sendReminder(item, type) {
     if (!item.assignee?.email) return;
+
+    const inQuietHours = await checkQuietHours(item.assignee._id);
+    if (inQuietHours) {
+      console.log(
+        `[ReminderScheduler] Suppressing action item reminder for ${item.assignee.email} due to quiet hours.`,
+      );
+      return;
+    }
 
     const taskTitle = item.title || item.text;
 

--- a/server/tests/quietHours.test.js
+++ b/server/tests/quietHours.test.js
@@ -1,0 +1,168 @@
+import mongoose from "mongoose";
+import { vi, describe, beforeAll, beforeEach, it, expect } from "vitest";
+import { checkQuietHours } from "../utils/quietHours.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
+import MeetingDigestService from "../services/MeetingDigestService.js";
+import reminderScheduler from "../services/reminderScheduler.js";
+import EmailService from "../services/EmailService.js";
+import emailService from "../services/emailService.js";
+import { createNotification } from "../services/notificationService.js";
+
+// Mock models and services
+vi.mock("../models/notificationPreferenceModel.js", () => ({
+  default: {
+    findOne: vi.fn(),
+  },
+}));
+
+vi.mock("../services/EmailService.js", () => ({
+  default: {
+    sendMail: vi.fn(),
+  },
+}));
+
+vi.mock("../services/emailService.js", () => ({
+  default: {
+    send: vi.fn(),
+  },
+}));
+
+vi.mock("../services/notificationService.js", () => ({
+  createNotification: vi.fn(),
+}));
+
+describe("Quiet Hours Enforcements (#2065)", () => {
+  const userId = new mongoose.Types.ObjectId().toString();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("checkQuietHours Utility", () => {
+    it("returns false if user has no quiet hours configured", async () => {
+      NotificationPreference.findOne.mockReturnValue({
+        lean: () => null,
+      });
+
+      const res = await checkQuietHours(userId);
+      expect(res).toBe(false);
+    });
+
+    it("returns true if date is within standard quiet hours (e.g. 22 to 6)", async () => {
+      NotificationPreference.findOne.mockReturnValue({
+        lean: () => ({
+          quietHoursStart: 22,
+          quietHoursEnd: 6,
+          timezone: "UTC",
+        }),
+      });
+
+      // 11 PM UTC
+      const dateInHours = new Date("2026-08-23T23:00:00Z");
+      const res = await checkQuietHours(userId, dateInHours);
+      expect(res).toBe(true);
+    });
+
+    it("returns false if date is outside standard quiet hours", async () => {
+      NotificationPreference.findOne.mockReturnValue({
+        lean: () => ({
+          quietHoursStart: 22,
+          quietHoursEnd: 6,
+          timezone: "UTC",
+        }),
+      });
+
+      // 12 PM UTC
+      const dateOutHours = new Date("2026-08-23T12:00:00Z");
+      const res = await checkQuietHours(userId, dateOutHours);
+      expect(res).toBe(false);
+    });
+  });
+
+  describe("MeetingDigestService Quiet Hours Enforcer", () => {
+    it("suppresses email sends if recipient quiet hours are active", async () => {
+      const mockMeeting = {
+        _id: "m1",
+        title: "Test Meet",
+        participants: [{ email: "test@domain.com", user: userId }],
+      };
+
+      // Mock user lookup and quiet hours
+      const { default: User } = await import("../models/userModel.js");
+      vi.spyOn(User, "findById").mockReturnValue({
+        select: () => ({ email: "test@domain.com" }),
+      });
+      vi.spyOn(User, "find").mockResolvedValue([
+        { _id: userId, email: "test@domain.com", emailDigestEnabled: true },
+      ]);
+      vi.spyOn(User, "findOne").mockResolvedValue({
+        _id: userId,
+        email: "test@domain.com",
+      });
+
+      NotificationPreference.findOne.mockReturnValue({
+        lean: () => ({
+          quietHoursStart: 22,
+          quietHoursEnd: 6,
+          timezone: "UTC",
+        }),
+      });
+
+      // Override current time for test to 11 PM UTC
+      const originalDate = Date;
+      global.Date = class extends Date {
+        constructor() {
+          super("2026-08-23T23:00:00Z");
+        }
+      };
+
+      const mockMeetingModel = await import("../models/meetingModel.js");
+      vi.spyOn(mockMeetingModel.default, "findById").mockResolvedValue(
+        mockMeeting,
+      );
+
+      const result = await MeetingDigestService.sendMeetingDigest("m1");
+      expect(result.success).toBe(true);
+      expect(EmailService.sendMail).not.toHaveBeenCalled();
+
+      global.Date = originalDate;
+    });
+  });
+
+  describe("ReminderScheduler Quiet Hours Enforcer", () => {
+    it("suppresses reminders during active quiet hours", async () => {
+      NotificationPreference.findOne.mockReturnValue({
+        lean: () => ({
+          quietHoursStart: 22,
+          quietHoursEnd: 6,
+          timezone: "UTC",
+        }),
+      });
+
+      const mockMeeting = {
+        _id: "m1",
+        title: "Sync",
+        uploadedBy: { _id: userId, name: "Alice", email: "alice@test.com" },
+      };
+
+      const originalDate = Date;
+      global.Date = class extends Date {
+        constructor() {
+          super("2026-08-23T23:00:00Z");
+        }
+      };
+
+      await reminderScheduler.sendMeetingReminder(
+        mockMeeting,
+        15,
+        new Date("2026-08-23T23:15:00Z"),
+      );
+
+      // Verify notification and email are suppressed
+      expect(createNotification).not.toHaveBeenCalled();
+      expect(emailService.send).not.toHaveBeenCalled();
+
+      global.Date = originalDate;
+    });
+  });
+});

--- a/server/utils/quietHours.js
+++ b/server/utils/quietHours.js
@@ -1,0 +1,38 @@
+import NotificationPreference from "../models/notificationPreferenceModel.js";
+import { formatInTimeZone } from "date-fns-tz";
+
+/**
+ * Checks if a date falls within quiet hours for a user
+ * @param {string} userId - User's ID
+ * @param {Date} [date] - Date to check (defaults to current time)
+ * @returns {Promise<boolean>} True if quiet hours are active
+ */
+export const checkQuietHours = async (userId, date = new Date()) => {
+  try {
+    const preferences = await NotificationPreference.findOne({
+      user: userId,
+    }).lean();
+    if (!preferences) return false;
+
+    const { quietHoursStart, quietHoursEnd, timezone } = preferences;
+    if (quietHoursStart == null || quietHoursEnd == null) return false;
+
+    // Get current hour in user's timezone
+    const tzDate = formatInTimeZone(
+      date,
+      timezone || "UTC",
+      "yyyy-MM-dd'T'HH:mm:ssXXX",
+    );
+    const currentHour = new Date(tzDate).getHours();
+
+    if (quietHoursStart < quietHoursEnd) {
+      return currentHour >= quietHoursStart && currentHour < quietHoursEnd;
+    } else {
+      // Overnight range (e.g., 22 to 7)
+      return currentHour >= quietHoursStart || currentHour < quietHoursEnd;
+    }
+  } catch (err) {
+    console.error("Error in checkQuietHours utility:", err);
+    return false;
+  }
+};


### PR DESCRIPTION
## 📝 Summary
This PR unifies quiet hours storage and enforcement by migrating quiet hours preferences to the globally shared `NotificationPreference` collection and rendering a single shared `SharedQuietHours` component across digest and recap panels.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2065

---

## ✨ Changes Made
- **Database & Backend**:
  - Appended `quietHoursStart`, `quietHoursEnd`, and `timezone` to the `NotificationPreference` schema.
  - Allowed updating these fields in preference controllers.
  - Created a backend `checkQuietHours` utility helper.
  - Enforced quiet hours uniformly inside `MeetingDigestService`, `recapEmailService`, and `reminderScheduler`.
- **Client Components**:
  - Created a globally shared `SharedQuietHours.jsx` component displaying explicit timezone settings, shared enforcement copy, and next-send preview alerts.
  - Integrated `SharedQuietHours` inside `DigestPreferences.jsx` and `RecapPreferences.jsx`.
- **Tests**:
  - Added backend integration tests in `quietHours.test.js`.
  - Added frontend tests in `SharedQuietHours.test.jsx`.
  - Updated existing tests to mock `notificationApi` on mount.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend tests
cd server && npm run test tests/quietHours.test.js

# Client tests
cd .. && npm run test client/src/components/__tests__/SharedQuietHours.test.jsx
