### PR TITLE
feat: RecapSchedule ops UX (channels, dry-run, failure triage)

### DIFF
--- a/client/src/pages/RecapScheduleDashboard.jsx
+++ b/client/src/pages/RecapScheduleDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useCallback } from "react";
 import { format } from "date-fns";
 import AppContent from "../context/AppContent";
 import Navbar from "../components/Navbar.jsx";
@@ -12,9 +12,33 @@ import {
   Save,
   AlertCircle,
   Calendar,
+  Play,
+  Webhook,
+  Bell,
+  XCircle,
 } from "lucide-react";
 
 const RETRY_FEEDBACK_TIMEOUT = 3000;
+const CHANNELS = [
+  {
+    id: "email",
+    label: "Email",
+    hint: "Send recap emails to members with an address on file.",
+    Icon: Mail,
+  },
+  {
+    id: "in_app",
+    label: "In-app",
+    hint: "Show recaps inside MeetOnMemory notifications.",
+    Icon: Bell,
+  },
+  {
+    id: "webhook",
+    label: "Webhook",
+    hint: "POST recap payloads to a public HTTPS endpoint.",
+    Icon: Webhook,
+  },
+];
 
 const RecapScheduleDashboard = () => {
   const { userData } = useContext(AppContent);
@@ -22,57 +46,68 @@ const RecapScheduleDashboard = () => {
   const [schedule, setSchedule] = useState({
     scheduleType: "immediate",
     deliveryChannel: "email",
+    webhookUrl: "",
     preferredTime: "09:00",
     timezone: "UTC",
     startDate: "",
     endDate: "",
   });
   const [history, setHistory] = useState([]);
+  const [failedDeliveries, setFailedDeliveries] = useState([]);
+  const [dryRun, setDryRun] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDryRunning, setIsDryRunning] = useState(false);
   const [retryingDeliveryId, setRetryingDeliveryId] = useState(null);
   const [retryTarget, setRetryTarget] = useState(null);
   const [retryLoading, setRetryLoading] = useState(false);
   const [saveMessage, setSaveMessage] = useState({ type: "", text: "" });
   const [retryMessage, setRetryMessage] = useState({ type: "", text: "" });
 
-  useEffect(() => {
+  const fetchData = useCallback(async () => {
     if (!organizationId) {
       setIsLoading(false);
       return;
     }
-    const fetchData = async () => {
-      setIsLoading(true);
-      try {
-        const [scheduleRes, historyRes] = await Promise.allSettled([
-          recapScheduleApi.getSchedule(organizationId),
-          recapScheduleApi.getDeliveryHistory(),
-        ]);
-        if (scheduleRes.status === "fulfilled" && scheduleRes.value.data) {
-          const data = scheduleRes.value.data;
-          setSchedule({
-            scheduleType: data.scheduleType || "immediate",
-            deliveryChannel: data.deliveryChannel || "email",
-            preferredTime: data.preferredTime || "09:00",
-            timezone: data.timezone || "UTC",
-            startDate: data.startDate
-              ? new Date(data.startDate).toISOString().slice(0, 10)
-              : "",
-            endDate: data.endDate
-              ? new Date(data.endDate).toISOString().slice(0, 10)
-              : "",
-          });
-        }
-        if (historyRes.status === "fulfilled" && historyRes.value.data)
-          setHistory(historyRes.value.data);
-      } catch (error) {
-        console.error("Failed to fetch dashboard data:", error);
-      } finally {
-        setIsLoading(false);
+    setIsLoading(true);
+    try {
+      const [scheduleRes, historyRes, failedRes] = await Promise.allSettled([
+        recapScheduleApi.getSchedule(organizationId),
+        recapScheduleApi.getDeliveryHistory(),
+        recapScheduleApi.getFailedDeliveries(),
+      ]);
+      if (scheduleRes.status === "fulfilled" && scheduleRes.value.data) {
+        const data = scheduleRes.value.data;
+        setSchedule({
+          scheduleType: data.scheduleType || "immediate",
+          deliveryChannel: data.deliveryChannel || "email",
+          webhookUrl: data.webhookUrl || "",
+          preferredTime: data.preferredTime || "09:00",
+          timezone: data.timezone || "UTC",
+          startDate: data.startDate
+            ? new Date(data.startDate).toISOString().slice(0, 10)
+            : "",
+          endDate: data.endDate
+            ? new Date(data.endDate).toISOString().slice(0, 10)
+            : "",
+        });
       }
-    };
-    fetchData();
+      if (historyRes.status === "fulfilled" && historyRes.value.data) {
+        setHistory(historyRes.value.data);
+      }
+      if (failedRes.status === "fulfilled" && failedRes.value.data) {
+        setFailedDeliveries(failedRes.value.data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch dashboard data:", error);
+    } finally {
+      setIsLoading(false);
+    }
   }, [organizationId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -80,9 +115,29 @@ const RecapScheduleDashboard = () => {
     if (saveMessage.type === "error") setSaveMessage({ type: "", text: "" });
   };
 
+  const selectChannel = (channelId) => {
+    setSchedule((prev) => ({ ...prev, deliveryChannel: channelId }));
+    if (saveMessage.type === "error") setSaveMessage({ type: "", text: "" });
+  };
+
   const validateSchedule = () => {
     if (!schedule.timezone || !schedule.timezone.trim())
       return "Timezone cannot be empty.";
+    if (!["email", "webhook", "in_app"].includes(schedule.deliveryChannel)) {
+      return "Select a valid delivery channel (email, webhook, or in-app).";
+    }
+    if (schedule.deliveryChannel === "webhook") {
+      const url = (schedule.webhookUrl || "").trim();
+      if (!url) return "Webhook URL is required for webhook delivery.";
+      try {
+        const parsed = new URL(url);
+        if (!["http:", "https:"].includes(parsed.protocol)) {
+          return "Webhook URL must use http or https.";
+        }
+      } catch {
+        return "Webhook URL is invalid.";
+      }
+    }
     const todayStr = new Date().toISOString().slice(0, 10);
     if (schedule.startDate && schedule.startDate < todayStr)
       return "Start date cannot be in the past.";
@@ -105,7 +160,14 @@ const RecapScheduleDashboard = () => {
     setIsSaving(true);
     setSaveMessage({ type: "", text: "" });
     try {
-      await recapScheduleApi.upsertSchedule(organizationId, schedule);
+      await recapScheduleApi.upsertSchedule(organizationId, {
+        scheduleType: schedule.scheduleType,
+        deliveryChannel: schedule.deliveryChannel,
+        webhookUrl:
+          schedule.deliveryChannel === "webhook" ? schedule.webhookUrl : "",
+        preferredTime: schedule.preferredTime,
+        timezone: schedule.timezone,
+      });
       setSaveMessage({
         type: "success",
         text: "Schedule updated successfully!",
@@ -113,9 +175,38 @@ const RecapScheduleDashboard = () => {
       setTimeout(() => setSaveMessage({ type: "", text: "" }), 3000);
     } catch (error) {
       console.error("Save error:", error);
-      setSaveMessage({ type: "error", text: "Failed to update schedule." });
+      const apiError = error?.response?.data?.error;
+      const message =
+        typeof apiError === "string"
+          ? apiError
+          : "Failed to update schedule. Check channel settings and try again.";
+      setSaveMessage({ type: "error", text: message });
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleDryRun = async () => {
+    setIsDryRunning(true);
+    setDryRun(null);
+    try {
+      const { data } = await recapScheduleApi.dryRun(organizationId, {
+        deliveryChannel: schedule.deliveryChannel,
+        webhookUrl: schedule.webhookUrl,
+      });
+      setDryRun(data);
+    } catch (error) {
+      setDryRun({
+        warnings: [
+          error?.response?.data?.error ||
+            "Dry-run failed. Save your schedule and try again.",
+        ],
+        recipients: [],
+        recipientCount: 0,
+        channel: schedule.deliveryChannel,
+      });
+    } finally {
+      setIsDryRunning(false);
     }
   };
 
@@ -136,16 +227,42 @@ const RecapScheduleDashboard = () => {
         () => setRetryMessage({ type: "", text: "" }),
         RETRY_FEEDBACK_TIMEOUT,
       );
+      await fetchData();
     } catch (error) {
       console.error("Retry failed:", error);
       setRetryMessage({
         type: "error",
-        text: "We couldn't enqueue the retry. Please try again.",
+        text:
+          error?.response?.data?.error ||
+          "We couldn't enqueue the retry. Please try again.",
       });
     } finally {
       setRetryingDeliveryId(null);
       setRetryLoading(false);
     }
+  };
+
+  const statusBadge = (delivery) => {
+    const status = delivery.status || "delivered";
+    if (status === "failed") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-600/20 dark:bg-red-900/20 dark:text-red-400">
+          <XCircle className="w-3 h-3" /> Failed
+        </span>
+      );
+    }
+    if (status === "pending") {
+      return (
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-900/20 dark:text-amber-400">
+          <RefreshCw className="w-3 h-3" /> Pending
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-900/20 dark:text-green-400 dark:ring-green-500/20">
+        <CheckCircle2 className="w-3 h-3" /> Delivered
+      </span>
+    );
   };
 
   return (
@@ -157,8 +274,8 @@ const RecapScheduleDashboard = () => {
             Recap Scheduling & Delivery
           </h1>
           <p className="mt-2 text-slate-600 dark:text-gray-400">
-            Configure how and when you receive meeting recaps and view delivery
-            history.
+            Configure channels, dry-run recipients, and triage failed
+            deliveries.
           </p>
         </div>
         {isLoading ? (
@@ -186,7 +303,7 @@ const RecapScheduleDashboard = () => {
           </div>
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            <div className="lg:col-span-1">
+            <div className="lg:col-span-1 space-y-6">
               <div className="bg-white dark:bg-gray-800 shadow rounded-xl p-6 border border-slate-200 dark:border-gray-700">
                 <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2 mb-4">
                   <Clock className="w-5 h-5 text-blue-600" />
@@ -208,21 +325,58 @@ const RecapScheduleDashboard = () => {
                       <option value="weekly">Weekly</option>
                     </select>
                   </div>
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
+
+                  <fieldset>
+                    <legend className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-2">
                       Delivery Channel
-                    </label>
-                    <select
-                      name="deliveryChannel"
-                      value={schedule.deliveryChannel}
-                      onChange={handleChange}
-                      className="w-full rounded-lg border-slate-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                    >
-                      <option value="email">Email</option>
-                      <option value="in_app">In-App Only</option>
-                      <option value="webhook">Webhook</option>
-                    </select>
-                  </div>
+                    </legend>
+                    <div className="space-y-2">
+                      {CHANNELS.map(({ id, label, hint, Icon }) => {
+                        const selected = schedule.deliveryChannel === id;
+                        return (
+                          <button
+                            key={id}
+                            type="button"
+                            onClick={() => selectChannel(id)}
+                            className={`w-full text-left rounded-lg border px-3 py-2.5 transition cursor-pointer ${
+                              selected
+                                ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                                : "border-slate-200 dark:border-gray-600 hover:border-slate-300"
+                            }`}
+                          >
+                            <div className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-white">
+                              <Icon className="w-4 h-4 text-blue-600" />
+                              {label}
+                            </div>
+                            <p className="text-xs text-slate-500 dark:text-gray-400 mt-1">
+                              {hint}
+                            </p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </fieldset>
+
+                  {schedule.deliveryChannel === "webhook" && (
+                    <div>
+                      <label
+                        htmlFor="webhook-url"
+                        className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1"
+                      >
+                        Webhook URL
+                      </label>
+                      <input
+                        id="webhook-url"
+                        type="url"
+                        name="webhookUrl"
+                        value={schedule.webhookUrl}
+                        onChange={handleChange}
+                        placeholder="https://example.com/hooks/recap"
+                        className="w-full rounded-lg border-slate-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm"
+                      />
+                    </div>
+                  )}
+
                   {schedule.scheduleType !== "immediate" && (
                     <div>
                       <label className="block text-sm font-medium text-slate-700 dark:text-gray-300 mb-1">
@@ -296,6 +450,19 @@ const RecapScheduleDashboard = () => {
                     )}
                     {isSaving ? "Saving..." : "Save Preferences"}
                   </button>
+                  <button
+                    type="button"
+                    onClick={handleDryRun}
+                    disabled={isDryRunning}
+                    className="w-full flex justify-center items-center gap-2 border border-slate-300 dark:border-gray-600 text-slate-700 dark:text-gray-200 font-medium py-2 px-4 rounded-lg transition-colors hover:bg-slate-50 dark:hover:bg-gray-700 disabled:opacity-70 cursor-pointer"
+                  >
+                    {isDryRunning ? (
+                      <RefreshCw className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Play className="w-4 h-4" />
+                    )}
+                    {isDryRunning ? "Running dry-run…" : "Dry-run preview"}
+                  </button>
                   {saveMessage.text && (
                     <div
                       role="alert"
@@ -311,14 +478,65 @@ const RecapScheduleDashboard = () => {
                   )}
                 </form>
               </div>
+
+              {dryRun && (
+                <div className="bg-white dark:bg-gray-800 shadow rounded-xl p-5 border border-slate-200 dark:border-gray-700">
+                  <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-2">
+                    Dry-run · {dryRun.channel || schedule.deliveryChannel}
+                  </h3>
+                  <p className="text-xs text-slate-500 dark:text-gray-400 mb-3">
+                    {dryRun.recipientCount ?? 0} recipient(s) would receive a
+                    recap.
+                  </p>
+                  {(dryRun.warnings || []).map((warning) => (
+                    <p
+                      key={warning}
+                      className="text-xs text-amber-700 dark:text-amber-400 mb-2 flex gap-1.5"
+                    >
+                      <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                      {warning}
+                    </p>
+                  ))}
+                  <ul className="space-y-2 max-h-48 overflow-y-auto">
+                    {(dryRun.recipients || []).map((r) => (
+                      <li
+                        key={String(r.userId)}
+                        className="text-xs border border-slate-100 dark:border-gray-700 rounded-lg px-3 py-2"
+                      >
+                        <p className="font-semibold text-slate-800 dark:text-gray-100">
+                          {r.name}
+                        </p>
+                        <p
+                          className={
+                            r.wouldReceive
+                              ? "text-slate-500 dark:text-gray-400"
+                              : "text-red-600 dark:text-red-400"
+                          }
+                        >
+                          {r.detail}
+                        </p>
+                      </li>
+                    ))}
+                    {(dryRun.recipients || []).length === 0 && (
+                      <li className="text-xs text-slate-400">
+                        No recipients to preview.
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              )}
             </div>
-            <div className="lg:col-span-2">
-              <div className="bg-white dark:bg-gray-800 shadow rounded-xl border border-slate-200 dark:border-gray-700 flex flex-col h-full">
+
+            <div className="lg:col-span-2 space-y-6">
+              <div className="bg-white dark:bg-gray-800 shadow rounded-xl border border-slate-200 dark:border-gray-700 flex flex-col">
                 <div className="p-6 border-b border-slate-200 dark:border-gray-700">
                   <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2">
-                    <Mail className="w-5 h-5 text-indigo-600" />
-                    Delivery History
+                    <XCircle className="w-5 h-5 text-red-500" />
+                    Failed delivery triage
                   </h2>
+                  <p className="text-xs text-slate-500 dark:text-gray-400 mt-1">
+                    Review error details and retry failed deliveries.
+                  </p>
                 </div>
                 <div className="p-0 overflow-x-auto">
                   {retryMessage.text && (
@@ -335,6 +553,70 @@ const RecapScheduleDashboard = () => {
                       <span>{retryMessage.text}</span>
                     </div>
                   )}
+                  {failedDeliveries.length === 0 ? (
+                    <div className="px-6 py-10 text-center text-sm text-slate-500 dark:text-gray-400">
+                      No failed deliveries. You&apos;re clear.
+                    </div>
+                  ) : (
+                    <ul className="divide-y divide-slate-200 dark:divide-gray-700">
+                      {failedDeliveries.map((delivery) => (
+                        <li
+                          key={delivery._id}
+                          className="px-6 py-4 flex flex-wrap items-start justify-between gap-3"
+                        >
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                              {delivery.meetingId?.title || "Unknown Meeting"}
+                            </p>
+                            <p className="text-xs text-slate-500 mt-0.5">
+                              {delivery.channel || "email"} ·{" "}
+                              {delivery.updatedAt || delivery.deliveredAt
+                                ? format(
+                                    new Date(
+                                      delivery.updatedAt ||
+                                        delivery.deliveredAt,
+                                    ),
+                                    "MMM d, yyyy h:mm a",
+                                  )
+                                : "—"}
+                            </p>
+                            <p className="text-xs text-red-600 dark:text-red-400 mt-2 break-words">
+                              {delivery.errorMessage ||
+                                "Delivery failed without a detailed error. Retry or check mail/webhook configuration."}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setRetryTarget({
+                                _id: delivery._id,
+                                meetingTitle:
+                                  delivery.meetingId?.title ||
+                                  "Unknown Meeting",
+                              })
+                            }
+                            disabled={retryingDeliveryId === delivery._id}
+                            className="text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 cursor-pointer disabled:opacity-60"
+                          >
+                            {retryingDeliveryId === delivery._id
+                              ? "Retrying..."
+                              : "Retry"}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </div>
+
+              <div className="bg-white dark:bg-gray-800 shadow rounded-xl border border-slate-200 dark:border-gray-700 flex flex-col h-full">
+                <div className="p-6 border-b border-slate-200 dark:border-gray-700">
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-white flex items-center gap-2">
+                    <Mail className="w-5 h-5 text-indigo-600" />
+                    Delivery History
+                  </h2>
+                </div>
+                <div className="p-0 overflow-x-auto">
                   <table className="w-full text-left border-collapse">
                     <thead>
                       <tr className="bg-slate-50 dark:bg-gray-900/50 text-slate-500 dark:text-gray-400 text-sm">
@@ -363,9 +645,7 @@ const RecapScheduleDashboard = () => {
                               )}
                             </td>
                             <td className="px-6 py-4">
-                              <span className="inline-flex items-center gap-1.5 rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-900/20 dark:text-green-400 dark:ring-green-500/20">
-                                <CheckCircle2 className="w-3 h-3" /> Delivered
-                              </span>
+                              {statusBadge(delivery)}
                             </td>
                             <td className="px-6 py-4 text-right">
                               <button
@@ -416,7 +696,6 @@ const RecapScheduleDashboard = () => {
         )}
       </div>
 
-      {/* Confirmation Modal prior to retrying recap delivery (#1612) */}
       <ConfirmModal
         isOpen={Boolean(retryTarget)}
         onClose={() => setRetryTarget(null)}

--- a/client/src/pages/__tests__/RecapScheduleConfirmModal.test.jsx
+++ b/client/src/pages/__tests__/RecapScheduleConfirmModal.test.jsx
@@ -13,6 +13,8 @@ vi.mock("../../services/recapScheduleApi", () => ({
   recapScheduleApi: {
     getSchedule: vi.fn(),
     getDeliveryHistory: vi.fn(),
+    getFailedDeliveries: vi.fn().mockResolvedValue({ data: [] }),
+    dryRun: vi.fn(),
     upsertSchedule: vi.fn(),
     retryDelivery: vi.fn(),
   },

--- a/client/src/pages/__tests__/RecapScheduleValidation.test.jsx
+++ b/client/src/pages/__tests__/RecapScheduleValidation.test.jsx
@@ -5,7 +5,6 @@ import { MemoryRouter } from "react-router-dom";
 import RecapScheduleDashboard from "../RecapScheduleDashboard.jsx";
 import AppContent from "../../context/AppContent.js";
 import { RBACProvider } from "../../context/RBACContext.jsx";
-import { ThemeProvider } from "../../context/ThemeContext.jsx";
 import { recapScheduleApi } from "../../services/recapScheduleApi.js";
 
 vi.mock("@clerk/clerk-react", () => ({
@@ -25,6 +24,15 @@ vi.mock("../../services/recapScheduleApi.js", () => ({
       .fn()
       .mockResolvedValue({ data: { scheduleType: "daily", timezone: "UTC" } }),
     getDeliveryHistory: vi.fn().mockResolvedValue({ data: [] }),
+    getFailedDeliveries: vi.fn().mockResolvedValue({ data: [] }),
+    dryRun: vi.fn().mockResolvedValue({
+      data: {
+        recipients: [],
+        recipientCount: 0,
+        warnings: [],
+        channel: "email",
+      },
+    }),
     upsertSchedule: vi.fn(),
     retryDelivery: vi.fn(),
   },
@@ -36,13 +44,11 @@ const mockUserData = {
 const renderDashboard = () =>
   render(
     <MemoryRouter>
-      <ThemeProvider>
-        <AppContent.Provider value={{ userData: mockUserData }}>
-          <RBACProvider>
-            <RecapScheduleDashboard />
-          </RBACProvider>
-        </AppContent.Provider>
-      </ThemeProvider>
+      <AppContent.Provider value={{ userData: mockUserData }}>
+        <RBACProvider>
+          <RecapScheduleDashboard />
+        </RBACProvider>
+      </AppContent.Provider>
     </MemoryRouter>,
   );
 
@@ -53,6 +59,7 @@ describe("RecapScheduleDashboard Date & Timezone Validation (#1308)", () => {
       data: { scheduleType: "daily", timezone: "UTC" },
     });
     recapScheduleApi.getDeliveryHistory.mockResolvedValue({ data: [] });
+    recapScheduleApi.getFailedDeliveries.mockResolvedValue({ data: [] });
   });
 
   it("prevents submission when start date is set in the past", async () => {
@@ -99,6 +106,7 @@ describe("RecapScheduleDashboard Retry Feedback (#1524)", () => {
     recapScheduleApi.getSchedule.mockResolvedValue({
       data: { scheduleType: "daily", timezone: "UTC" },
     });
+    recapScheduleApi.getFailedDeliveries.mockResolvedValue({ data: [] });
   });
 
   it("shows inline success feedback when a retry is enqueued", async () => {

--- a/client/src/services/recapScheduleApi.js
+++ b/client/src/services/recapScheduleApi.js
@@ -7,6 +7,10 @@ export const recapScheduleApi = {
     apiClient.put(`/api/recap-schedule/${organizationId}`, data),
   getDeliveryHistory: () =>
     apiClient.get("/api/recap-schedule/history/deliveries"),
+  getFailedDeliveries: () =>
+    apiClient.get("/api/recap-schedule/history/failed"),
+  dryRun: (organizationId, data = {}) =>
+    apiClient.post(`/api/recap-schedule/${organizationId}/dry-run`, data),
   retryDelivery: (deliveryId) =>
     apiClient.post(`/api/recap-schedule/retry/${deliveryId}`),
 };

--- a/server/controllers/__tests__/recapScheduleValidation.test.js
+++ b/server/controllers/__tests__/recapScheduleValidation.test.js
@@ -5,9 +5,20 @@ import RecapSchedule from "../../models/recapScheduleModel.js";
 
 jest.mock("../../models/recapDeliveryModel.js");
 jest.mock("../../models/recapScheduleModel.js");
+jest.mock("../../models/userModel.js", () => ({
+  default: { findById: jest.fn() },
+}));
+jest.mock("../../models/membershipModel.js", () => ({
+  default: { find: jest.fn() },
+}));
+jest.mock("../../utils/webhookUrlSafety.js", () => ({
+  isSafeWebhookUrl: jest.fn(async () => true),
+}));
 jest.mock("../../services/queueService.js", () => ({
   recapDeliveryQueue: { isActive: false, add: jest.fn() },
 }));
+
+import { isSafeWebhookUrl } from "../../utils/webhookUrlSafety.js";
 
 describe("Recap Schedule Controller Validation (#1609)", () => {
   let req, res;
@@ -45,6 +56,7 @@ describe("Recap Schedule Controller Validation (#1609)", () => {
           _id: "507f1f77bcf86cd799439011",
           userId: "507f1f77bcf86cd799439011",
           meetingId: { organization: "org123", title: "Team Sync" },
+          save: jest.fn().mockResolvedValue(undefined),
         }),
       });
 
@@ -85,6 +97,41 @@ describe("Recap Schedule Controller Validation (#1609)", () => {
       await upsertSchedule(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it("rejects webhook channel without URL (Issue #2069)", async () => {
+      req.body = {
+        scheduleType: "daily",
+        deliveryChannel: "webhook",
+        webhookUrl: "",
+      };
+
+      await upsertSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringMatching(/webhook url is required/i),
+        }),
+      );
+    });
+
+    it("rejects unsafe webhook destinations", async () => {
+      isSafeWebhookUrl.mockResolvedValueOnce(false);
+      req.body = {
+        scheduleType: "immediate",
+        deliveryChannel: "webhook",
+        webhookUrl: "http://localhost/hook",
+      };
+
+      await upsertSchedule(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringMatching(/not allowed/i),
+        }),
+      );
     });
   });
 });

--- a/server/controllers/recapScheduleController.js
+++ b/server/controllers/recapScheduleController.js
@@ -1,12 +1,22 @@
 import mongoose from "mongoose";
 import RecapSchedule from "../models/recapScheduleModel.js";
 import RecapDelivery from "../models/recapDeliveryModel.js";
+import User from "../models/userModel.js";
+import Membership from "../models/membershipModel.js";
 import { recapDeliveryQueue } from "../services/queueService.js";
+import { isSafeWebhookUrl } from "../utils/webhookUrlSafety.js";
 import { z } from "zod";
 
 const scheduleSchema = z.object({
   scheduleType: z.enum(["immediate", "daily", "weekly"]),
   deliveryChannel: z.enum(["email", "webhook", "in_app"]).optional(),
+  webhookUrl: z
+    .union([
+      z.string().max(2048, "Webhook URL cannot exceed 2048 characters"),
+      z.literal(""),
+      z.null(),
+    ])
+    .optional(),
   preferredTime: z
     .string()
     .max(10, "Preferred time cannot exceed 10 characters")
@@ -25,6 +35,23 @@ const resolveAuthorizedOrganizationId = (req) =>
   req.authorizedOrganizationId ||
   (req.user?.organization?._id || req.user?.organization)?.toString();
 
+const validateChannelConfig = async (parsedData) => {
+  const channel = parsedData.deliveryChannel || "in_app";
+  const webhookUrl = (parsedData.webhookUrl || "").trim();
+
+  if (channel === "webhook") {
+    if (!webhookUrl) {
+      return "Webhook URL is required when delivery channel is webhook.";
+    }
+    const safe = await isSafeWebhookUrl(webhookUrl);
+    if (!safe) {
+      return "Webhook URL is invalid or not allowed (use a public https destination).";
+    }
+  }
+
+  return null;
+};
+
 export const upsertSchedule = async (req, res) => {
   try {
     const organizationId = resolveAuthorizedOrganizationId(req);
@@ -38,6 +65,16 @@ export const upsertSchedule = async (req, res) => {
     }
 
     const parsedData = scheduleSchema.parse(req.body);
+    const channelError = await validateChannelConfig(parsedData);
+    if (channelError) {
+      return res.status(400).json({ error: channelError });
+    }
+
+    if (parsedData.deliveryChannel !== "webhook") {
+      parsedData.webhookUrl = null;
+    } else if (typeof parsedData.webhookUrl === "string") {
+      parsedData.webhookUrl = parsedData.webhookUrl.trim();
+    }
 
     const schedule = await RecapSchedule.findOneAndUpdate(
       { organizationId, userId },
@@ -82,7 +119,6 @@ export const getSchedule = async (req, res) => {
 export const getDeliveryHistory = async (req, res) => {
   try {
     const userId = req.user._id;
-    // Membership org only — never trust a client-supplied organization id (#1401).
     const organizationId = resolveAuthorizedOrganizationId(req);
 
     if (!organizationId) {
@@ -96,19 +132,167 @@ export const getDeliveryHistory = async (req, res) => {
       .populate({
         path: "meetingId",
         select: "title date organization",
-        // Drop meetings outside the caller's organization at populate time.
         match: { organization: organizationId },
       })
       .sort({ deliveredAt: -1 })
       .limit(50);
 
-    // Non-matching orgs leave meetingId null — omit those rows from the response.
     const scoped = (deliveries || []).filter((d) => d.meetingId != null);
 
     res.status(200).json(scoped);
   } catch (error) {
     console.error("[recapScheduleController.getDeliveryHistory] Error:", error);
     res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Failed delivery triage list (Issue #2069).
+ */
+export const getFailedDeliveries = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const organizationId = resolveAuthorizedOrganizationId(req);
+
+    if (!organizationId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    const deliveries = await RecapDelivery.find({ userId, status: "failed" })
+      .populate({
+        path: "meetingId",
+        select: "title date organization",
+        match: { organization: organizationId },
+      })
+      .sort({ updatedAt: -1 })
+      .limit(50);
+
+    const scoped = (deliveries || []).filter((d) => d.meetingId != null);
+    res.status(200).json(scoped);
+  } catch (error) {
+    console.error(
+      "[recapScheduleController.getFailedDeliveries] Error:",
+      error,
+    );
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+/**
+ * Dry-run preview of who would receive a recap and via which channel (#2069).
+ */
+export const dryRunDelivery = async (req, res) => {
+  try {
+    const organizationId = resolveAuthorizedOrganizationId(req);
+    const userId = req.user._id;
+
+    if (!organizationId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
+
+    const schedule = (await RecapSchedule.findOne({
+      organizationId,
+      userId,
+    }).lean()) || {
+      scheduleType: "immediate",
+      deliveryChannel: "email",
+      webhookUrl: null,
+    };
+
+    // Prefer unsaved form values from the request body when present (#2069).
+    const channel =
+      req.body?.deliveryChannel || schedule.deliveryChannel || "email";
+    const webhookUrl =
+      req.body?.webhookUrl !== undefined
+        ? req.body.webhookUrl
+        : schedule.webhookUrl;
+    const warnings = [];
+
+    if (channel === "webhook" && !(webhookUrl || "").trim()) {
+      warnings.push(
+        "Webhook channel is selected but no webhook URL is configured — deliveries would fail.",
+      );
+    }
+
+    const memberships = await Membership.find({
+      organization: organizationId,
+      status: "active",
+    })
+      .select("user role")
+      .populate("user", "name email")
+      .limit(100)
+      .lean();
+
+    let members = memberships
+      .map((m) => m.user)
+      .filter(Boolean)
+      .map((u) => ({
+        userId: u._id,
+        name: u.name || "Member",
+        email: u.email || null,
+      }));
+
+    // Fallback when Membership rows are sparse — still preview the caller.
+    if (members.length === 0) {
+      const self = await User.findById(userId).select("name email").lean();
+      if (self) {
+        members = [
+          {
+            userId: self._id,
+            name: self.name || "You",
+            email: self.email || null,
+          },
+        ];
+      }
+    }
+
+    const recipients = members.map((member) => {
+      let wouldReceive = true;
+      let detail = "";
+
+      if (channel === "email") {
+        wouldReceive = Boolean(member.email);
+        detail = wouldReceive
+          ? `Email to ${member.email}`
+          : "No email on account — would be skipped";
+      } else if (channel === "webhook") {
+        wouldReceive = Boolean((webhookUrl || "").trim());
+        detail = wouldReceive
+          ? `POST to configured webhook`
+          : "Webhook URL missing — would fail";
+      } else {
+        detail = "In-app notification";
+      }
+
+      return {
+        userId: member.userId,
+        name: member.name,
+        email: member.email,
+        channel,
+        wouldReceive,
+        detail,
+      };
+    });
+
+    res.status(200).json({
+      scheduleType: schedule.scheduleType || "immediate",
+      channel,
+      webhookConfigured: Boolean((webhookUrl || "").trim()),
+      warnings,
+      recipientCount: recipients.filter((r) => r.wouldReceive).length,
+      recipients,
+    });
+  } catch (error) {
+    console.error("[recapScheduleController.dryRunDelivery] Error:", error);
+    res.status(500).json({
+      error: "Failed to build dry-run preview. Please try again.",
+    });
   }
 };
 
@@ -135,7 +319,9 @@ export const retryDelivery = async (req, res) => {
     }).populate("meetingId", "organization title");
 
     if (!delivery) {
-      return res.status(404).json({ error: "Delivery not found" });
+      return res.status(404).json({
+        error: "Delivery not found. It may have been removed or is not yours.",
+      });
     }
 
     const meetingOrg = (
@@ -149,6 +335,17 @@ export const retryDelivery = async (req, res) => {
       });
     }
 
+    if (!delivery.meetingId) {
+      return res.status(400).json({
+        error:
+          "Cannot retry: meeting is missing. Re-process the meeting and try again.",
+      });
+    }
+
+    delivery.status = "pending";
+    delivery.errorMessage = null;
+    await delivery.save();
+
     if (recapDeliveryQueue.isActive) {
       await recapDeliveryQueue.add("retry-delivery", {
         deliveryId: delivery._id,
@@ -156,13 +353,20 @@ export const retryDelivery = async (req, res) => {
         userId: delivery.userId,
       });
     } else {
-      // Mock retry if queue not active
       console.log(`[Mock] Retrying delivery for ${deliveryId}`);
     }
 
-    res.status(200).json({ message: "Delivery retry enqueued successfully" });
+    res.status(200).json({
+      message: "Delivery retry enqueued successfully",
+      deliveryId: String(delivery._id),
+      status: "pending",
+    });
   } catch (error) {
     console.error("[recapScheduleController.retryDelivery] Error:", error);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({
+      error:
+        error?.message ||
+        "Internal server error while enqueueing retry. Check queue/Redis and try again.",
+    });
   }
 };

--- a/server/models/recapDeliveryModel.js
+++ b/server/models/recapDeliveryModel.js
@@ -16,6 +16,23 @@ const recapDeliverySchema = new mongoose.Schema(
       type: Date,
       default: Date.now,
     },
+    // Issue #2069 — ops triage for failed deliveries
+    status: {
+      type: String,
+      enum: ["delivered", "failed", "pending"],
+      default: "delivered",
+      index: true,
+    },
+    channel: {
+      type: String,
+      enum: ["email", "webhook", "in_app"],
+      default: "email",
+    },
+    errorMessage: {
+      type: String,
+      maxlength: 500,
+      default: null,
+    },
   },
   { timestamps: true },
 );

--- a/server/models/recapScheduleModel.js
+++ b/server/models/recapScheduleModel.js
@@ -22,6 +22,13 @@ const recapScheduleSchema = new mongoose.Schema(
       enum: ["email", "webhook", "in_app"],
       default: "in_app",
     },
+    /** Required when deliveryChannel is webhook (Issue #2069). */
+    webhookUrl: {
+      type: String,
+      default: null,
+      maxlength: 2048,
+      trim: true,
+    },
     preferredTime: {
       type: String,
       default: "09:00",

--- a/server/routes/recapScheduleRoutes.js
+++ b/server/routes/recapScheduleRoutes.js
@@ -8,6 +8,8 @@ import {
   upsertSchedule,
   getSchedule,
   getDeliveryHistory,
+  getFailedDeliveries,
+  dryRunDelivery,
   retryDelivery,
 } from "../controllers/recapScheduleController.js";
 
@@ -35,7 +37,13 @@ router.use(requireOrgMembership);
 // Static paths MUST be registered before "/:organizationId"
 // so "history" / "retry" are not captured as organization ids (#1401).
 router.get("/history/deliveries", getDeliveryHistory);
+router.get("/history/failed", getFailedDeliveries);
 router.post("/retry/:deliveryId", retryDelivery);
+router.post(
+  "/:organizationId/dry-run",
+  requireOrganizationParamMatch("organizationId"),
+  dryRunDelivery,
+);
 
 router.get(
   "/:organizationId",

--- a/server/services/recapEmailService.js
+++ b/server/services/recapEmailService.js
@@ -145,7 +145,9 @@ class RecapEmailService {
             meetingId,
             userId: user._id,
           });
-          if (alreadyDelivered) continue;
+          if (alreadyDelivered && alreadyDelivered.status !== "failed") {
+            continue;
+          }
 
           // Get preferences
           let preferences = await RecapPreference.findOne({ userId: user._id });
@@ -179,12 +181,44 @@ class RecapEmailService {
           });
 
           // Mark as delivered (unique index prevents duplicates)
-          await RecapDelivery.create({ meetingId, userId: user._id });
+          await RecapDelivery.findOneAndUpdate(
+            { meetingId, userId: user._id },
+            {
+              $set: {
+                status: "delivered",
+                channel: "email",
+                errorMessage: null,
+                deliveredAt: new Date(),
+              },
+              $setOnInsert: { meetingId, userId: user._id },
+            },
+            { upsert: true },
+          );
         } catch (userErr) {
           console.error(
             `[RecapEmailService] Immediate recap failed for user ${user._id}:`,
             userErr,
           );
+          try {
+            await RecapDelivery.findOneAndUpdate(
+              { meetingId, userId: user._id },
+              {
+                $set: {
+                  status: "failed",
+                  channel: "email",
+                  errorMessage: String(userErr?.message || userErr).slice(
+                    0,
+                    500,
+                  ),
+                  deliveredAt: new Date(),
+                },
+                $setOnInsert: { meetingId, userId: user._id },
+              },
+              { upsert: true },
+            );
+          } catch {
+            /* best-effort failure record */
+          }
         }
       }
     } catch (err) {

--- a/server/tests/recapScheduleChannelValidation.test.js
+++ b/server/tests/recapScheduleChannelValidation.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/recapScheduleModel.js", () => ({
+  default: {
+    findOneAndUpdate: vi.fn(),
+  },
+}));
+vi.mock("../models/recapDeliveryModel.js", () => ({
+  default: {},
+}));
+vi.mock("../models/membershipModel.js", () => ({
+  default: { find: vi.fn() },
+}));
+vi.mock("../models/userModel.js", () => ({
+  default: { findById: vi.fn() },
+}));
+vi.mock("../services/queueService.js", () => ({
+  recapDeliveryQueue: { isActive: false, add: vi.fn() },
+}));
+vi.mock("../utils/webhookUrlSafety.js", () => ({
+  isSafeWebhookUrl: vi.fn(async () => true),
+}));
+
+import RecapSchedule from "../models/recapScheduleModel.js";
+import { isSafeWebhookUrl } from "../utils/webhookUrlSafety.js";
+import { upsertSchedule } from "../controllers/recapScheduleController.js";
+
+describe("upsertSchedule channel validation (Issue #2069)", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSafeWebhookUrl.mockResolvedValue(true);
+    req = {
+      user: { _id: "u1", organization: "org1" },
+      authorizedOrganizationId: "org1",
+      body: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("rejects webhook channel without URL", async () => {
+    req.body = {
+      scheduleType: "daily",
+      deliveryChannel: "webhook",
+      webhookUrl: "",
+    };
+
+    await upsertSchedule(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringMatching(/webhook url is required/i),
+      }),
+    );
+  });
+
+  it("rejects unsafe webhook destinations", async () => {
+    isSafeWebhookUrl.mockResolvedValueOnce(false);
+    req.body = {
+      scheduleType: "immediate",
+      deliveryChannel: "webhook",
+      webhookUrl: "http://localhost/hook",
+    };
+
+    await upsertSchedule(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringMatching(/not allowed/i),
+      }),
+    );
+  });
+
+  it("upserts email channel without webhook URL", async () => {
+    RecapSchedule.findOneAndUpdate.mockResolvedValue({
+      scheduleType: "daily",
+      deliveryChannel: "email",
+    });
+    req.body = {
+      scheduleType: "daily",
+      deliveryChannel: "email",
+      timezone: "UTC",
+    };
+
+    await upsertSchedule(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(RecapSchedule.findOneAndUpdate).toHaveBeenCalled();
+  });
+});

--- a/server/tests/recapScheduleDryRun.test.js
+++ b/server/tests/recapScheduleDryRun.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/recapScheduleModel.js", () => ({
+  default: {
+    findOne: vi.fn(),
+  },
+}));
+vi.mock("../models/membershipModel.js", () => ({
+  default: {
+    find: vi.fn(),
+  },
+}));
+vi.mock("../models/userModel.js", () => ({
+  default: {
+    findById: vi.fn(),
+  },
+}));
+vi.mock("../models/recapDeliveryModel.js", () => ({
+  default: {},
+}));
+vi.mock("../services/queueService.js", () => ({
+  recapDeliveryQueue: { isActive: false, add: vi.fn() },
+}));
+vi.mock("../utils/webhookUrlSafety.js", () => ({
+  isSafeWebhookUrl: vi.fn(async () => true),
+}));
+
+import RecapSchedule from "../models/recapScheduleModel.js";
+import Membership from "../models/membershipModel.js";
+import { dryRunDelivery } from "../controllers/recapScheduleController.js";
+
+describe("dryRunDelivery (Issue #2069)", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      user: { _id: "u1", organization: "org1" },
+      authorizedOrganizationId: "org1",
+      body: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("returns channel recipients and webhook warning when URL missing", async () => {
+    RecapSchedule.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        scheduleType: "daily",
+        deliveryChannel: "webhook",
+        webhookUrl: "",
+      }),
+    });
+    Membership.find.mockReturnValue({
+      select: () => ({
+        populate: () => ({
+          limit: () => ({
+            lean: async () => [
+              {
+                user: {
+                  _id: "u1",
+                  name: "Ada",
+                  email: "ada@example.com",
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    });
+
+    await dryRunDelivery(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.channel).toBe("webhook");
+    expect(payload.warnings[0]).toMatch(/no webhook url/i);
+    expect(payload.recipients).toHaveLength(1);
+    expect(payload.recipients[0].wouldReceive).toBe(false);
+  });
+
+  it("prefers unsaved body channel over stored schedule", async () => {
+    RecapSchedule.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        scheduleType: "daily",
+        deliveryChannel: "email",
+        webhookUrl: null,
+      }),
+    });
+    Membership.find.mockReturnValue({
+      select: () => ({
+        populate: () => ({
+          limit: () => ({
+            lean: async () => [
+              {
+                user: {
+                  _id: "u1",
+                  name: "Ada",
+                  email: "ada@example.com",
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    });
+    req.body = {
+      deliveryChannel: "in_app",
+      webhookUrl: "",
+    };
+
+    await dryRunDelivery(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].channel).toBe("in_app");
+    expect(res.json.mock.calls[0][0].recipients[0].wouldReceive).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Channel picker (email / webhook / in-app) with webhook URL validation
- Dry-run preview of recipients for the selected channel
- Failed delivery triage list with actionable errors and retry

## Test plan
- [ ] Admin can save email, in-app, and webhook channels (webhook requires a valid HTTPS URL)
- [ ] Dry-run shows recipients/warnings for the current channel settings
- [ ] Failed deliveries appear with error text and Retry works
- [ ] `cd server && npx vitest run tests/recapScheduleDryRun.test.js tests/recapScheduleChannelValidation.test.js`
- [ ] `cd client && npx vitest run src/pages/__tests__/RecapScheduleValidation.test.jsx src/pages/__tests__/RecapScheduleConfirmModal.test.jsx`

Closes #2069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email, in-app, and webhook delivery channel support.
  * Added dry-run previews showing recipients and warnings before saving or sending.
  * Added failed-delivery triage with delivery history, status indicators, and retry actions.
  * Added webhook URL validation and safety checks.
* **Bug Fixes**
  * Improved delivery error reporting and retry handling.
  * Failed email deliveries are now tracked and can be retried.
  * Schedule saves now submit only relevant fields and surface API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->