### PR TITLE
feat: gamification badges gallery and progress UI

### DIFF
--- a/client/src/components/gamification/BadgeNotification.jsx
+++ b/client/src/components/gamification/BadgeNotification.jsx
@@ -24,6 +24,11 @@ const BadgeNotification = () => {
           draggable: true,
           progress: undefined,
           theme: "colored",
+          onClick: () => {
+            window.location.assign(
+              badge._id ? `/badges#badge-${badge._id}` : "/badges",
+            );
+          },
         });
       });
     });

--- a/client/src/pages/Badges.jsx
+++ b/client/src/pages/Badges.jsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { toast } from "react-toastify";
+import apiClient from "../services/apiClient";
+import Navbar from "../components/Navbar.jsx";
+
+const TIER_STYLES = {
+  Bronze:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200",
+  Silver: "bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-200",
+  Gold: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200",
+  Platinum:
+    "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-200",
+};
+
+const BadgeCard = ({ badge }) => {
+  const tierClass = TIER_STYLES[badge.tier] || TIER_STYLES.Bronze;
+  const percent = badge.progress?.percent ?? (badge.earned ? 100 : 0);
+  const showProgress = !badge.earned && badge.progress?.target != null;
+
+  return (
+    <article
+      id={`badge-${badge.id}`}
+      className={`rounded-lg border p-4 transition ${
+        badge.earned
+          ? "border-yellow-200 bg-white dark:border-yellow-800/50 dark:bg-gray-800"
+          : "border-gray-200 bg-gray-50 opacity-90 dark:border-gray-700 dark:bg-gray-800/60"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+            {badge.iconUrl ? (
+              <img
+                src={badge.iconUrl}
+                alt=""
+                className="mr-2 inline h-5 w-5 align-text-bottom"
+              />
+            ) : (
+              <span className="mr-1" aria-hidden="true">
+                {badge.earned ? "🏅" : "🔒"}
+              </span>
+            )}
+            {badge.name}
+          </h3>
+          <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            {badge.description}
+          </p>
+        </div>
+        <span
+          className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${tierClass}`}
+        >
+          {badge.tier}
+        </span>
+      </div>
+
+      {badge.earned ? (
+        <p className="mt-3 text-xs font-medium text-green-700 dark:text-green-400">
+          Earned
+          {badge.unlockedAt
+            ? ` · ${new Date(badge.unlockedAt).toLocaleDateString()}`
+            : ""}
+        </p>
+      ) : showProgress ? (
+        <div className="mt-3">
+          <div className="mb-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+            <span>Progress</span>
+            <span>
+              {badge.progress.current} / {badge.progress.target} pts
+            </span>
+          </div>
+          <div
+            className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`Progress toward ${badge.name}`}
+          >
+            <div
+              className="h-full rounded-full bg-blue-600 transition-all"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">Locked</p>
+      )}
+    </article>
+  );
+};
+
+const Badges = () => {
+  const location = useLocation();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchBadges = async () => {
+      try {
+        const response = await apiClient.get("/api/gamification/badges");
+        if (response.data.success) {
+          setData(response.data.data);
+        }
+      } catch (error) {
+        console.error("Failed to load badges", error);
+        toast.error("Failed to load badges gallery.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchBadges();
+  }, []);
+
+  useEffect(() => {
+    if (!data || !location.hash) return;
+    const el = document.querySelector(location.hash);
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [data, location.hash]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50 text-gray-900 transition-colors dark:bg-gray-900 dark:text-gray-100">
+      <Navbar />
+      <div className="mx-auto w-full max-w-4xl px-4 pb-20 pt-24 sm:px-6">
+        <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              Badges gallery
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Browse earned and locked badges, and track progress toward the
+              next unlock.
+            </p>
+          </div>
+          <Link
+            to="/leaderboard"
+            className="text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400"
+          >
+            View leaderboard
+          </Link>
+        </div>
+
+        {loading ? (
+          <p className="text-center text-lg font-medium">Loading badges...</p>
+        ) : !data ? (
+          <div className="rounded-lg border border-gray-100 bg-white p-6 text-center shadow-md dark:border-gray-700 dark:bg-gray-800">
+            No badge data available.
+          </div>
+        ) : (
+          <>
+            <div className="mb-8 flex flex-wrap gap-3 text-sm">
+              <span className="rounded-lg bg-blue-50 px-3 py-1.5 font-semibold text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                {data.totalPoints} pts
+              </span>
+              <span className="rounded-lg bg-white px-3 py-1.5 text-gray-700 ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700">
+                {data.summary.earnedCount} earned
+              </span>
+              <span className="rounded-lg bg-white px-3 py-1.5 text-gray-700 ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700">
+                {data.summary.lockedCount} locked
+              </span>
+            </div>
+
+            {data.inProgress?.length > 0 && (
+              <section className="mb-10">
+                <h2 className="mb-4 text-xl font-semibold text-gray-800 dark:text-gray-200">
+                  In progress
+                </h2>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {data.inProgress.map((badge) => (
+                    <BadgeCard key={badge.id} badge={badge} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            <section className="mb-10">
+              <h2 className="mb-4 text-xl font-semibold text-gray-800 dark:text-gray-200">
+                Earned
+              </h2>
+              {data.earned.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  No badges earned yet. Keep improving meeting hygiene.
+                </p>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {data.earned.map((badge) => (
+                    <BadgeCard key={badge.id} badge={badge} />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-xl font-semibold text-gray-800 dark:text-gray-200">
+                Locked
+              </h2>
+              {data.locked.filter(
+                (b) => !(b.progress?.target != null && b.progress.percent > 0),
+              ).length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {data.locked.length === 0
+                    ? "You have unlocked every badge."
+                    : "All remaining badges are in progress above."}
+                </p>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {data.locked
+                    .filter(
+                      (b) =>
+                        !(b.progress?.target != null && b.progress.percent > 0),
+                    )
+                    .map((badge) => (
+                      <BadgeCard key={badge.id} badge={badge} />
+                    ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Badges;

--- a/client/src/pages/Leaderboard.jsx
+++ b/client/src/pages/Leaderboard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { toast } from "react-toastify";
 import apiClient from "../services/apiClient";
 import Navbar from "../components/Navbar.jsx";
@@ -45,6 +46,12 @@ const Leaderboard = () => {
           <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border border-gray-100 dark:border-gray-700 w-full text-center text-gray-900 dark:text-gray-100">
             No leaderboard data available.
           </div>
+          <Link
+            to="/badges"
+            className="mt-4 text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400"
+          >
+            Browse badges gallery
+          </Link>
         </div>
       </div>
     );
@@ -55,9 +62,17 @@ const Leaderboard = () => {
       <Navbar />
       <div className="max-w-4xl mx-auto w-full pt-24 pb-20 px-4 sm:px-6">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border border-gray-100 dark:border-gray-700">
-          <h1 className="text-3xl font-bold mb-6 text-gray-900 dark:text-white text-center">
-            🏆 Meeting Hygiene Leaderboard
-          </h1>
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white text-center sm:text-left">
+              🏆 Meeting Hygiene Leaderboard
+            </h1>
+            <Link
+              to="/badges"
+              className="text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400"
+            >
+              Browse badges gallery
+            </Link>
+          </div>
 
           <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-6">
             <h2 className="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-200">
@@ -86,8 +101,16 @@ const Leaderboard = () => {
                       {score.user.name}
                     </span>
                   </div>
-                  <div className="text-xl font-bold text-blue-600 dark:text-blue-400">
-                    {score.totalPoints} pts
+                  <div className="flex flex-col items-end gap-1">
+                    <div className="text-xl font-bold text-blue-600 dark:text-blue-400">
+                      {score.totalPoints} pts
+                    </div>
+                    <Link
+                      to="/badges"
+                      className="text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      View badges
+                    </Link>
                   </div>
                 </li>
               ))}

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import axios from "axios";
 import Navbar from "../components/Navbar.jsx";
@@ -302,28 +303,58 @@ const Profile = () => {
                 </p>
               </div>
 
-              {/* Gamification section */}
+              {/* Gamification section — top badge showcase (#2066) */}
               {gamificationData && (
                 <div className="pt-6 border-t border-slate-100 dark:border-slate-800 space-y-4">
-                  <div className="text-[11px] text-slate-400 dark:text-slate-500 font-bold uppercase tracking-wider">
-                    {t("profile.trophyCase")}
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-[11px] text-slate-400 dark:text-slate-500 font-bold uppercase tracking-wider">
+                      {t("profile.trophyCase")}
+                    </div>
+                    <Link
+                      to="/badges"
+                      className="text-xs font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400"
+                    >
+                      View all badges
+                    </Link>
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-4 py-2 rounded-lg font-bold">
                       {gamificationData.totalPoints} {t("profile.points")}
                     </div>
                   </div>
-                  {gamificationData.unlockedBadges?.length > 0 && (
+                  {gamificationData.unlockedBadges?.length > 0 ? (
                     <div className="flex flex-wrap gap-2 mt-2">
-                      {gamificationData.unlockedBadges.map((ub, idx) => (
-                        <div
-                          key={idx}
-                          className="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs px-3 py-1 rounded-full font-medium flex items-center gap-1 border border-yellow-200 dark:border-yellow-700/50"
-                        >
-                          🏅 {ub.badge?.name || t("profile.badge")}
-                        </div>
-                      ))}
+                      {[...gamificationData.unlockedBadges]
+                        .sort(
+                          (a, b) =>
+                            new Date(b.unlockedAt || 0) -
+                            new Date(a.unlockedAt || 0),
+                        )
+                        .slice(0, 3)
+                        .map((ub, idx) => (
+                          <Link
+                            key={ub.badge?._id || idx}
+                            to={
+                              ub.badge?._id
+                                ? `/badges#badge-${ub.badge._id}`
+                                : "/badges"
+                            }
+                            className="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 text-xs px-3 py-1 rounded-full font-medium flex items-center gap-1 border border-yellow-200 dark:border-yellow-700/50 hover:ring-2 hover:ring-yellow-300/60"
+                          >
+                            🏅 {ub.badge?.name || t("profile.badge")}
+                          </Link>
+                        ))}
                     </div>
+                  ) : (
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      No badges yet —{" "}
+                      <Link
+                        to="/badges"
+                        className="text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        browse the gallery
+                      </Link>
+                    </p>
                   )}
                 </div>
               )}

--- a/client/src/pages/__tests__/Badges.test.jsx
+++ b/client/src/pages/__tests__/Badges.test.jsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import Badges from "../Badges.jsx";
+import apiClient from "../../services/apiClient";
+
+vi.mock("../../services/apiClient", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar">Navbar</div>,
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe("Badges gallery page (#2066)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders earned and locked badges with progress", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          totalPoints: 40,
+          summary: { total: 2, earnedCount: 1, lockedCount: 1 },
+          inProgress: [
+            {
+              id: "b2",
+              name: "Action Assassin",
+              description: "Reach 100 pts",
+              tier: "Gold",
+              earned: false,
+              progress: { current: 40, target: 100, percent: 40 },
+            },
+          ],
+          earned: [
+            {
+              id: "b1",
+              name: "First Steps",
+              description: "Join an org",
+              tier: "Bronze",
+              earned: true,
+              unlockedAt: "2026-01-01",
+              progress: { current: 40, target: 10, percent: 100 },
+            },
+          ],
+          locked: [
+            {
+              id: "b2",
+              name: "Action Assassin",
+              description: "Reach 100 pts",
+              tier: "Gold",
+              earned: false,
+              progress: { current: 40, target: 100, percent: 40 },
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <Badges />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/api/gamification/badges");
+      expect(screen.getByText("First Steps")).toBeInTheDocument();
+      expect(screen.getByText("Action Assassin")).toBeInTheDocument();
+      expect(screen.getByText("40 / 100 pts")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /view leaderboard/i }),
+      ).toHaveAttribute("href", "/leaderboard");
+    });
+  });
+});

--- a/client/src/pages/__tests__/Leaderboard.test.jsx
+++ b/client/src/pages/__tests__/Leaderboard.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import Leaderboard from "../Leaderboard.jsx";
 import apiClient from "../../services/apiClient";
@@ -20,11 +21,18 @@ vi.mock("react-toastify", () => ({
   },
 }));
 
+const renderLeaderboard = () =>
+  render(
+    <MemoryRouter>
+      <Leaderboard />
+    </MemoryRouter>,
+  );
+
 describe("Leaderboard Page (#1799)", () => {
   it("renders Navbar and loading indicator with dark mode classes initially", async () => {
     apiClient.get.mockReturnValue(new Promise(() => {})); // Never resolves
 
-    render(<Leaderboard />);
+    renderLeaderboard();
 
     expect(screen.getByTestId("mock-navbar")).toBeInTheDocument();
 
@@ -53,7 +61,7 @@ describe("Leaderboard Page (#1799)", () => {
 
     apiClient.get.mockResolvedValue({ data: mockData });
 
-    render(<Leaderboard />);
+    renderLeaderboard();
 
     await waitFor(() => {
       expect(apiClient.get).toHaveBeenCalledWith(
@@ -61,18 +69,24 @@ describe("Leaderboard Page (#1799)", () => {
       );
       expect(screen.getByText("Alice")).toBeInTheDocument();
       expect(screen.getByText("120 pts")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /browse badges gallery/i }),
+      ).toHaveAttribute("href", "/badges");
     });
   });
 
   it("handles empty/missing leaderboard data gracefully", async () => {
     apiClient.get.mockResolvedValue({ data: { success: true, data: null } });
 
-    render(<Leaderboard />);
+    renderLeaderboard();
 
     await waitFor(() => {
       expect(
         screen.getByText("No leaderboard data available."),
       ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /browse badges gallery/i }),
+      ).toHaveAttribute("href", "/badges");
     });
   });
 });

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -67,6 +67,7 @@ import ConflictResolution from "../pages/ConflictResolution.jsx";
 import SpeakingTimeTrends from "../pages/SpeakingTimeTrends.jsx";
 import SpeakingTimeCompare from "../pages/SpeakingTimeCompare.jsx";
 import Leaderboard from "../pages/Leaderboard.jsx";
+import Badges from "../pages/Badges.jsx";
 import ParticipantEngagement from "../pages/ParticipantEngagement.jsx";
 import ActionItemAnalytics from "../pages/ActionItemAnalytics.jsx";
 import ActionItemsDashboard from "../pages/ActionItemsDashboard.jsx";
@@ -692,6 +693,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute>
           <Leaderboard />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/badges"
+      element={
+        <ProtectedRoute>
+          <Badges />
         </ProtectedRoute>
       }
     />

--- a/server/controllers/gamificationController.js
+++ b/server/controllers/gamificationController.js
@@ -1,6 +1,10 @@
 import GamificationScore from "../models/gamificationScoreModel.js";
+import Badge from "../models/badgeModel.js";
 import { getRedisClient } from "../services/redisService.js";
 import { calculateLeaderboards } from "../jobs/leaderboardAggregationJob.js";
+import { buildBadgeCatalogEntry } from "../utils/badgeCatalog.js";
+
+export { buildBadgeCatalogEntry };
 
 export const getLeaderboard = async (req, res) => {
   try {
@@ -59,6 +63,59 @@ export const getUserScore = async (req, res) => {
     });
   } catch (error) {
     console.error("Error fetching user score:", error);
+    res.status(500).json({ success: false, error: "Server Error" });
+  }
+};
+
+/**
+ * Badge catalog with earned/locked status and progress (Issue #2066).
+ */
+export const getBadgesGallery = async (req, res) => {
+  try {
+    const userId = req.user.id || req.user._id;
+    const orgId = req.user.organization;
+
+    if (!orgId) {
+      return res.status(400).json({
+        success: false,
+        error: "User is not part of an organization.",
+      });
+    }
+
+    const [allBadges, score] = await Promise.all([
+      Badge.find({}).sort({ tier: 1, name: 1 }).lean(),
+      GamificationScore.findOne({
+        user: userId,
+        organization: orgId,
+      }).lean(),
+    ]);
+
+    const badges = allBadges.map((badge) =>
+      buildBadgeCatalogEntry(badge, score),
+    );
+    const earned = badges.filter((b) => b.earned);
+    const locked = badges.filter((b) => !b.earned);
+    const inProgress = locked.filter(
+      (b) => b.progress.target != null && b.progress.percent > 0,
+    );
+
+    res.status(200).json({
+      success: true,
+      data: {
+        totalPoints: score?.totalPoints || 0,
+        badges,
+        earned,
+        locked,
+        inProgress,
+        summary: {
+          total: badges.length,
+          earnedCount: earned.length,
+          lockedCount: locked.length,
+        },
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching badges gallery:", error);
     res.status(500).json({ success: false, error: "Server Error" });
   }
 };

--- a/server/routes/gamificationRoutes.js
+++ b/server/routes/gamificationRoutes.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   getLeaderboard,
   getUserScore,
+  getBadgesGallery,
 } from "../controllers/gamificationController.js";
 import userAuth from "../middleware/userAuth.js";
 
@@ -11,5 +12,6 @@ router.use(userAuth);
 
 router.get("/leaderboard", getLeaderboard);
 router.get("/score", getUserScore);
+router.get("/badges", getBadgesGallery);
 
 export default router;

--- a/server/tests/badgesGalleryProgress.test.js
+++ b/server/tests/badgesGalleryProgress.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { buildBadgeCatalogEntry } from "../utils/badgeCatalog.js";
+
+describe("buildBadgeCatalogEntry (Issue #2066)", () => {
+  const badge = {
+    _id: "b1",
+    name: "Punctual Pro",
+    description: "Earn 100 points",
+    iconUrl: "",
+    tier: "Silver",
+    criteria: { type: "points", threshold: 100 },
+  };
+
+  it("marks badge earned with full progress", () => {
+    const entry = buildBadgeCatalogEntry(badge, {
+      totalPoints: 150,
+      unlockedBadges: [{ badge: "b1", unlockedAt: "2026-01-01" }],
+    });
+    expect(entry.earned).toBe(true);
+    expect(entry.progress.percent).toBe(100);
+  });
+
+  it("computes in-progress percent for locked points badges", () => {
+    const entry = buildBadgeCatalogEntry(badge, {
+      totalPoints: 40,
+      unlockedBadges: [],
+    });
+    expect(entry.earned).toBe(false);
+    expect(entry.progress).toEqual({
+      current: 40,
+      target: 100,
+      percent: 40,
+    });
+  });
+
+  it("caps progress at 100 when points exceed threshold but not unlocked yet", () => {
+    const entry = buildBadgeCatalogEntry(badge, {
+      totalPoints: 250,
+      unlockedBadges: [],
+    });
+    expect(entry.progress.percent).toBe(100);
+    expect(entry.earned).toBe(false);
+  });
+});

--- a/server/utils/badgeCatalog.js
+++ b/server/utils/badgeCatalog.js
@@ -1,0 +1,39 @@
+/**
+ * Build earned/locked + progress for one badge (Issue #2066).
+ */
+export const buildBadgeCatalogEntry = (badge, scoreDoc) => {
+  const unlockedEntry = scoreDoc?.unlockedBadges?.find(
+    (ub) => String(ub.badge?._id || ub.badge) === String(badge._id),
+  );
+  const earned = Boolean(unlockedEntry);
+  const totalPoints = scoreDoc?.totalPoints || 0;
+
+  let progress = { current: 0, target: null, percent: earned ? 100 : 0 };
+
+  if (badge.criteria?.type === "points" && badge.criteria.threshold != null) {
+    const target = Number(badge.criteria.threshold) || 0;
+    const percent =
+      target > 0
+        ? Math.min(100, Math.round((totalPoints / target) * 100))
+        : earned
+          ? 100
+          : 0;
+    progress = {
+      current: totalPoints,
+      target,
+      percent: earned ? 100 : percent,
+    };
+  }
+
+  return {
+    id: badge._id,
+    name: badge.name,
+    description: badge.description,
+    iconUrl: badge.iconUrl || "",
+    tier: badge.tier || "Bronze",
+    criteria: badge.criteria || {},
+    earned,
+    unlockedAt: unlockedEntry?.unlockedAt || null,
+    progress,
+  };
+};


### PR DESCRIPTION
## Summary
- Badges gallery with earned, locked, and in-progress progress bars
- Profile showcases top badges with links into the gallery
- Leaderboard links to the badges gallery

## Test plan
- [ ] Open `/badges` and see earned vs locked badges
- [ ] In-progress points badges show a progress bar
- [ ] Profile trophy case links to `/badges` (and badge hash when available)
- [ ] Leaderboard “Browse badges gallery” / “View badges” go to `/badges`
- [ ] `cd server && npx vitest run tests/badgesGalleryProgress.test.js`
- [ ] `cd client && npx vitest run src/pages/__tests__/Badges.test.jsx src/pages/__tests__/Leaderboard.test.jsx`

Closes #2066