### PR TITLE
feat: participant CSV import on schedule create

### DIFF
--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ParticipantsSection.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ParticipantsSection.jsx
@@ -1,4 +1,6 @@
-import { Users, UserPlus, X } from "lucide-react";
+import { useRef, useState } from "react";
+import { Users, UserPlus, X, Upload, FileSpreadsheet } from "lucide-react";
+import { parseParticipantCsv } from "../../utils/parseParticipantCsv.js";
 
 const ParticipantsSection = ({
   participants,
@@ -6,13 +8,51 @@ const ParticipantsSection = ({
   setNewParticipant,
   addParticipant,
   removeParticipant,
+  importParticipants,
 }) => {
+  const fileInputRef = useRef(null);
+  const [csvPreview, setCsvPreview] = useState(null);
+  const [csvError, setCsvError] = useState("");
+
+  const handleCsvFile = async (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    setCsvError("");
+    setCsvPreview(null);
+    if (!file) return;
+
+    if (!/\.csv$/i.test(file.name) && file.type && !file.type.includes("csv")) {
+      setCsvError("Please upload a .csv file.");
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const existingEmails = participants.map((p) => p.email);
+      const result = parseParticipantCsv(text, existingEmails);
+      if (result.valid.length === 0 && result.invalid.length === 0) {
+        setCsvError("CSV contained no participant rows.");
+        return;
+      }
+      setCsvPreview(result);
+    } catch (err) {
+      setCsvError(err.message || "Failed to parse CSV.");
+    }
+  };
+
+  const confirmImport = () => {
+    if (!csvPreview?.valid?.length || !importParticipants) return;
+    importParticipants(csvPreview.valid);
+    setCsvPreview(null);
+    setCsvError("");
+  };
+
   return (
     <div className="mb-6">
-      <label className="block mb-3 font-semibold text-gray-700 dark:text-gray-300 flex items-center gap-2">
+      <label className="mb-3 flex items-center gap-2 font-semibold text-gray-700 dark:text-gray-300">
         <Users size={18} /> Invite Participants
       </label>
-      <div className="grid md:grid-cols-2 gap-3 mb-3">
+      <div className="mb-3 grid gap-3 md:grid-cols-2">
         <input
           type="text"
           value={newParticipant.name}
@@ -23,7 +63,7 @@ const ParticipantsSection = ({
             })
           }
           placeholder="Full Name"
-          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+          className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none placeholder-gray-400 focus:ring-2 focus:ring-blue-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
         />
         <input
           type="email"
@@ -35,31 +75,129 @@ const ParticipantsSection = ({
             })
           }
           placeholder="Email Address"
-          className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+          className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 outline-none placeholder-gray-400 focus:ring-2 focus:ring-blue-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500"
         />
       </div>
-      <button
-        type="button"
-        onClick={addParticipant}
-        className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2 cursor-pointer"
-      >
-        <UserPlus size={16} /> Add Participant
-      </button>
+      <div className="mb-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={addParticipant}
+          className="flex cursor-pointer items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700"
+        >
+          <UserPlus size={16} /> Add Participant
+        </button>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex cursor-pointer items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          <Upload size={16} /> Import CSV
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv,text/csv"
+          className="hidden"
+          onChange={handleCsvFile}
+          aria-label="Import participants from CSV"
+        />
+      </div>
+      <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+        CSV headers: <code>email</code>, <code>name</code>, optional{" "}
+        <code>role</code>. Duplicates are skipped.
+      </p>
+
+      {csvError && (
+        <div
+          role="alert"
+          className="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+        >
+          {csvError}
+        </div>
+      )}
+
+      {csvPreview && (
+        <div className="mb-4 rounded-xl border border-blue-100 bg-blue-50/60 p-4 dark:border-blue-900/50 dark:bg-blue-950/30">
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-blue-900 dark:text-blue-300">
+            <FileSpreadsheet size={16} /> CSV preview
+          </div>
+          <p className="mb-2 text-xs text-blue-800 dark:text-blue-400">
+            {csvPreview.valid.length} valid
+            {csvPreview.skippedDuplicates > 0
+              ? ` · ${csvPreview.skippedDuplicates} duplicate(s) skipped`
+              : ""}
+            {csvPreview.invalid.length > 0
+              ? ` · ${csvPreview.invalid.length} invalid`
+              : ""}
+          </p>
+
+          {csvPreview.valid.length > 0 && (
+            <ul className="mb-3 max-h-32 space-y-1 overflow-y-auto text-xs text-gray-700 dark:text-gray-300">
+              {csvPreview.valid.map((row) => (
+                <li key={row.email}>
+                  <strong>{row.name}</strong> — {row.email}
+                  {row.role ? ` (${row.role})` : ""}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {csvPreview.invalid.length > 0 && (
+            <div
+              role="alert"
+              className="mb-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200"
+            >
+              <p className="mb-1 font-semibold">Invalid rows</p>
+              <ul className="max-h-28 space-y-1 overflow-y-auto">
+                {csvPreview.invalid.map((row) => (
+                  <li key={`${row.row}-${row.email}`}>
+                    Row {row.row}
+                    {row.email ? ` (${row.email})` : ""}: {row.reason}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={confirmImport}
+              disabled={csvPreview.valid.length === 0}
+              className="cursor-pointer rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Add {csvPreview.valid.length} to list
+            </button>
+            <button
+              type="button"
+              onClick={() => setCsvPreview(null)}
+              className="cursor-pointer rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-white dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {participants.length > 0 && (
         <div className="mt-4 space-y-2">
           {participants.map((p) => (
             <div
               key={p.id}
-              className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-4 py-2 rounded-lg text-gray-900 dark:text-gray-100"
+              className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             >
               <span className="text-sm">
                 <strong>{p.name}</strong> - {p.email}
+                {p.role ? (
+                  <span className="ml-1 text-gray-500 dark:text-gray-400">
+                    ({p.role})
+                  </span>
+                ) : null}
               </span>
               <button
                 type="button"
                 onClick={() => removeParticipant(p.id)}
-                className="text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 cursor-pointer"
+                className="cursor-pointer text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
               >
                 <X size={18} />
               </button>

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
@@ -26,6 +26,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
     handleScheduleChange,
     addParticipant,
     removeParticipant,
+    importParticipants,
     addAgendaItem,
     removeAgendaItem,
     reorderAgendaItem,
@@ -93,6 +94,7 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
           setNewParticipant={setNewParticipant}
           addParticipant={addParticipant}
           removeParticipant={removeParticipant}
+          importParticipants={importParticipants}
         />
 
         {templates && templates.length > 0 && (

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/__tests__/ParticipantsSection.test.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/__tests__/ParticipantsSection.test.jsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ParticipantsSection from "../ParticipantsSection.jsx";
+
+describe("ParticipantsSection CSV import (#2056)", () => {
+  const baseProps = {
+    participants: [],
+    newParticipant: { name: "", email: "" },
+    setNewParticipant: vi.fn(),
+    addParticipant: vi.fn(),
+    removeParticipant: vi.fn(),
+    importParticipants: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("previews valid and invalid CSV rows then merges on confirm", async () => {
+    const importParticipants = vi.fn();
+    render(
+      <ParticipantsSection
+        {...baseProps}
+        importParticipants={importParticipants}
+      />,
+    );
+
+    const file = new File(
+      [
+        `email,name,role
+good@example.com,Good Person,attendee
+bad-email,No Email,
+`,
+      ],
+      "participants.csv",
+      { type: "text/csv" },
+    );
+
+    const input = screen.getByLabelText(/import participants from csv/i);
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/CSV preview/i)).toBeInTheDocument();
+      expect(screen.getByText(/Good Person/)).toBeInTheDocument();
+      expect(screen.getByText(/Invalid rows/i)).toBeInTheDocument();
+      expect(screen.getByText(/Invalid email address/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add 1 to list/i }));
+    expect(importParticipants).toHaveBeenCalledWith([
+      {
+        name: "Good Person",
+        email: "good@example.com",
+        role: "attendee",
+      },
+    ]);
+  });
+
+  it("shows parse errors for missing headers", async () => {
+    render(<ParticipantsSection {...baseProps} />);
+
+    const file = new File([`role,message\nhost,hi`], "bad.csv", {
+      type: "text/csv",
+    });
+    fireEvent.change(screen.getByLabelText(/import participants from csv/i), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/email.*name/i);
+    });
+  });
+});

--- a/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
+++ b/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
@@ -297,6 +297,38 @@ export const useScheduleMeeting = ({
     setParticipants(participants.filter((p) => p.id !== id));
   };
 
+  const importParticipants = (rows) => {
+    if (!Array.isArray(rows) || rows.length === 0) return;
+    const existing = new Set(
+      participants.map((p) =>
+        String(p.email || "")
+          .trim()
+          .toLowerCase(),
+      ),
+    );
+    const toAdd = [];
+    for (const row of rows) {
+      const email = String(row.email || "").trim();
+      const key = email.toLowerCase();
+      if (!email || existing.has(key)) continue;
+      existing.add(key);
+      toAdd.push({
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        name: String(row.name || "").trim(),
+        email,
+        role: String(row.role || "").trim(),
+      });
+    }
+    if (toAdd.length === 0) {
+      toast.info("No new participants to import.");
+      return;
+    }
+    setParticipants((prev) => [...prev, ...toAdd]);
+    toast.success(
+      `Imported ${toAdd.length} participant${toAdd.length === 1 ? "" : "s"} from CSV`,
+    );
+  };
+
   const addAgendaItem = () => {
     if (newAgenda.trim()) {
       setAgendaItems((current) =>
@@ -562,6 +594,7 @@ export const useScheduleMeeting = ({
     handleScheduleChange,
     addParticipant,
     removeParticipant,
+    importParticipants,
     addAgendaItem,
     removeAgendaItem,
     reorderAgendaItem,

--- a/client/src/pages/CreateMeeting/utils/__tests__/parseParticipantCsv.test.js
+++ b/client/src/pages/CreateMeeting/utils/__tests__/parseParticipantCsv.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseParticipantCsv,
+  isValidParticipantEmail,
+} from "../parseParticipantCsv.js";
+
+describe("parseParticipantCsv (Issue #2056)", () => {
+  it("parses valid rows with optional role", () => {
+    const csv = `email,name,role
+ada@example.com,Ada Lovelace,host
+bob@example.com,Bob Builder,
+`;
+    const result = parseParticipantCsv(csv);
+    expect(result.valid).toEqual([
+      { name: "Ada Lovelace", email: "ada@example.com", role: "host" },
+      { name: "Bob Builder", email: "bob@example.com", role: "" },
+    ]);
+    expect(result.invalid).toHaveLength(0);
+  });
+
+  it("reports invalid emails and missing names", () => {
+    const csv = `email,name,role
+not-an-email,Broken,
+ok@example.com,,
+`;
+    const result = parseParticipantCsv(csv);
+    expect(result.valid).toHaveLength(0);
+    expect(result.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: "Invalid email address.",
+          email: "not-an-email",
+        }),
+        expect.objectContaining({ reason: "Name is required." }),
+      ]),
+    );
+  });
+
+  it("skips duplicates against existing and within CSV", () => {
+    const csv = `email,name
+ada@example.com,Ada
+ADA@example.com,Ada Again
+new@example.com,New Person
+`;
+    const result = parseParticipantCsv(csv, ["ada@example.com"]);
+    expect(result.valid).toEqual([
+      { name: "New Person", email: "new@example.com", role: "" },
+    ]);
+    expect(result.skippedDuplicates).toBe(2);
+  });
+
+  it("requires email and name headers", () => {
+    expect(() => parseParticipantCsv("email,role\na@b.com,host")).toThrow(
+      /email.*name/i,
+    );
+  });
+
+  it("validates emails", () => {
+    expect(isValidParticipantEmail("a@b.co")).toBe(true);
+    expect(isValidParticipantEmail("bad")).toBe(false);
+  });
+});

--- a/client/src/pages/CreateMeeting/utils/parseParticipantCsv.js
+++ b/client/src/pages/CreateMeeting/utils/parseParticipantCsv.js
@@ -1,0 +1,147 @@
+/**
+ * Parse participant CSV for schedule-create import (Issue #2056).
+ * Distinct from org Team Members invitation CSV.
+ *
+ * Expected headers: email, name (required); role (optional).
+ */
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
+export const splitCsvLine = (line) => {
+  const fields = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      fields.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (inQuotes) {
+    throw new Error("Malformed CSV: unmatched quote.");
+  }
+  fields.push(current);
+  return fields;
+};
+
+export const normalizeHeader = (value) =>
+  String(value ?? "")
+    .replace(/^\uFEFF/, "")
+    .trim()
+    .toLowerCase();
+
+export const isValidParticipantEmail = (email) =>
+  EMAIL_RE.test(String(email || "").trim());
+
+/**
+ * @param {string} input
+ * @param {string[]} [existingEmails]
+ * @returns {{
+ *   valid: Array<{ name: string, email: string, role: string }>,
+ *   invalid: Array<{ row: number, email: string, reason: string }>,
+ *   skippedDuplicates: number
+ * }}
+ */
+export const parseParticipantCsv = (input, existingEmails = []) => {
+  if (input == null || String(input).trim() === "") {
+    throw new Error("CSV content is required.");
+  }
+
+  let text = String(input).replace(/^\uFEFF/, "");
+  const lines = text
+    .split(/\r\n|\n|\r/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim() !== "");
+
+  if (lines.length === 0) {
+    throw new Error("CSV file is empty.");
+  }
+
+  const headerFields = splitCsvLine(lines[0]).map(normalizeHeader);
+  const emailIdx = headerFields.indexOf("email");
+  const nameIdx = headerFields.indexOf("name");
+  const roleIdx = headerFields.indexOf("role");
+
+  if (emailIdx === -1 || nameIdx === -1) {
+    throw new Error("CSV must include 'email' and 'name' headers.");
+  }
+
+  const seen = new Set(
+    existingEmails
+      .map((e) =>
+        String(e || "")
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  const valid = [];
+  const invalid = [];
+  let skippedDuplicates = 0;
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const rowNum = i + 1;
+    let fields;
+    try {
+      fields = splitCsvLine(lines[i]);
+    } catch (err) {
+      invalid.push({
+        row: rowNum,
+        email: "",
+        reason: err.message || "Malformed row.",
+      });
+      continue;
+    }
+
+    const email = String(fields[emailIdx] ?? "").trim();
+    const name = String(fields[nameIdx] ?? "").trim();
+    const role = roleIdx >= 0 ? String(fields[roleIdx] ?? "").trim() : "";
+
+    if (!email && !name) {
+      continue;
+    }
+    if (!name) {
+      invalid.push({ row: rowNum, email, reason: "Name is required." });
+      continue;
+    }
+    if (!email) {
+      invalid.push({ row: rowNum, email: "", reason: "Email is required." });
+      continue;
+    }
+    if (!isValidParticipantEmail(email)) {
+      invalid.push({ row: rowNum, email, reason: "Invalid email address." });
+      continue;
+    }
+
+    const key = email.toLowerCase();
+    if (seen.has(key)) {
+      skippedDuplicates += 1;
+      continue;
+    }
+    seen.add(key);
+    valid.push({ name, email, role });
+  }
+
+  return { valid, invalid, skippedDuplicates };
+};


### PR DESCRIPTION
## Summary
- Import participants from CSV while scheduling (email, name, optional role)
- Preview valid rows and report invalid ones; skip duplicates
- Merge confirmed rows into the participant list before submit

## Test plan
- [ ] On Schedule Meeting, use **Import CSV** with headers `email,name,role`
- [ ] Preview shows valid rows and invalid-row reasons
- [ ] **Add N to list** appends participants; duplicates are skipped
- [ ] Manual add still works; schedule submit includes imported participants
- [ ] `cd client && npx vitest run src/pages/CreateMeeting/utils/__tests__/parseParticipantCsv.test.js src/pages/CreateMeeting/components/ScheduleMeeting/__tests__/ParticipantsSection.test.jsx`

Closes #2056