### PR TITLE
feat: calendar sync job status, history, and Sync now UI

### DIFF
--- a/client/src/components/CalendarIntegrations.jsx
+++ b/client/src/components/CalendarIntegrations.jsx
@@ -20,6 +20,7 @@ const CalendarIntegrations = () => {
   const [integrations, setIntegrations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [resyncing, setResyncing] = useState({});
+  const [lastSyncResult, setLastSyncResult] = useState({});
   const [providerToDisconnect, setProviderToDisconnect] = useState(null);
 
   const fetchIntegrations = useCallback(async () => {
@@ -91,12 +92,34 @@ const CalendarIntegrations = () => {
     try {
       const res = await apiClient.post(`/api/calendar/resync/${provider}`);
       if (res.data.success) {
-        toast.success(`Synced ${provider} calendar successfully`);
-        fetchIntegrations();
+        const conn = res.data.connection;
+        setLastSyncResult((prev) => ({
+          ...prev,
+          [provider]: conn?.lastResult || {
+            status: "success",
+            message: res.data.message,
+            at: conn?.lastSyncedAt || conn?.lastSyncAt || new Date(),
+          },
+        }));
+        toast.success(res.data.message || `Synced ${provider} successfully`);
+        await fetchIntegrations();
       }
     } catch (err) {
       console.error(`Failed to resync ${provider}`, err);
-      toast.error(`Failed to resync ${provider}`);
+      const message =
+        err?.response?.data?.message ||
+        `Failed to sync ${provider}. Check connection or reconnect.`;
+      const conn = err?.response?.data?.connection;
+      setLastSyncResult((prev) => ({
+        ...prev,
+        [provider]: conn?.lastResult || {
+          status: "error",
+          message,
+          at: new Date(),
+        },
+      }));
+      toast.error(message);
+      await fetchIntegrations();
     } finally {
       setResyncing((prev) => ({ ...prev, [provider]: false }));
     }
@@ -107,7 +130,9 @@ const CalendarIntegrations = () => {
       (i) =>
         (i.provider === provider ||
           (provider === "outlook" && i.provider === "microsoft")) &&
-        (i.syncEnabled || i.syncStatus === "connected"),
+        ["connected", "error", "needs_reauth", "syncing"].includes(
+          i.syncStatus || (i.syncEnabled ? "connected" : ""),
+        ),
     );
 
   const getIntegration = (provider) =>
@@ -126,6 +151,13 @@ const CalendarIntegrations = () => {
       return (
         <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 dark:text-emerald-400 px-2 py-0.5 rounded-md border border-emerald-200 dark:border-emerald-800">
           <CheckCircle2 className="w-3 h-3" /> Connected
+        </span>
+      );
+    }
+    if (status === "syncing") {
+      return (
+        <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-blue-700 bg-blue-50 dark:bg-blue-950/40 dark:text-blue-400 px-2 py-0.5 rounded-md border border-blue-200 dark:border-blue-800">
+          <RefreshCw className="w-3 h-3 animate-spin" /> Syncing
         </span>
       );
     }
@@ -170,8 +202,8 @@ const CalendarIntegrations = () => {
             Calendar Integrations
           </h2>
           <p className="text-xs text-slate-500 dark:text-slate-400">
-            Sync meetings, view external availability, and automatically
-            propagate calendar events
+            Sync meetings, view job history, and manually trigger Sync now when
+            a provider fails
           </p>
         </div>
       </div>
@@ -181,67 +213,130 @@ const CalendarIntegrations = () => {
           const connected = isConnected(p.key);
           const integration = getIntegration(p.key);
           const isSyncing = resyncing[p.key];
+          const needsReauth = integration?.syncStatus === "needs_reauth";
+          const result =
+            lastSyncResult[p.key] || integration?.lastResult || null;
+          const history = integration?.syncHistory || [];
 
           return (
             <div
               key={p.key}
-              className={`flex items-center justify-between py-3.5 ${
+              className={`py-3.5 ${
                 idx < providers.length - 1
                   ? "border-b border-slate-100 dark:border-slate-800"
                   : ""
               }`}
             >
-              <div>
-                <div className="flex items-center gap-2">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">
-                    {p.label}
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                      {p.label}
+                    </p>
+                    {renderStatusBadge(integration)}
+                  </div>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                    {connected
+                      ? `Last synced: ${
+                          integration?.lastSyncedAt
+                            ? new Date(
+                                integration.lastSyncedAt,
+                              ).toLocaleString()
+                            : "Never"
+                        }`
+                      : `Connect your ${p.label} to sync meetings`}
                   </p>
-                  {renderStatusBadge(integration)}
                 </div>
-                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                  {connected
-                    ? `Last synced: ${
-                        integration?.lastSyncedAt
-                          ? new Date(integration.lastSyncedAt).toLocaleString()
-                          : "Just now"
-                      }`
-                    : `Connect your ${p.label} to sync meetings`}
-                </p>
+
+                <div className="flex items-center gap-2 shrink-0">
+                  {connected && !needsReauth && (
+                    <button
+                      type="button"
+                      onClick={() => resyncProvider(p.key)}
+                      disabled={isSyncing}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg transition-colors cursor-pointer disabled:opacity-60"
+                    >
+                      <RefreshCw
+                        className={`w-3.5 h-3.5 ${isSyncing ? "animate-spin" : ""}`}
+                      />
+                      {isSyncing ? "Syncing…" : "Sync now"}
+                    </button>
+                  )}
+
+                  {needsReauth ? (
+                    <button
+                      type="button"
+                      onClick={() => connectProvider(p.connectKey)}
+                      className="px-3 py-1.5 text-xs font-semibold text-white bg-amber-600 hover:bg-amber-500 rounded-lg transition-colors cursor-pointer shadow-xs"
+                    >
+                      Reconnect
+                    </button>
+                  ) : connected ? (
+                    <button
+                      type="button"
+                      onClick={() => setProviderToDisconnect(p.key)}
+                      className="px-3 py-1.5 text-xs font-semibold text-red-600 bg-red-50 hover:bg-red-100 dark:bg-red-950/40 dark:hover:bg-red-900/60 dark:text-red-400 rounded-lg transition-colors cursor-pointer"
+                    >
+                      Disconnect
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => connectProvider(p.connectKey)}
+                      className="px-3 py-1.5 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-colors cursor-pointer shadow-xs"
+                    >
+                      Connect
+                    </button>
+                  )}
+                </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                {connected && (
-                  <button
-                    type="button"
-                    onClick={() => resyncProvider(p.key)}
-                    disabled={isSyncing}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded-lg transition-colors cursor-pointer"
-                  >
-                    <RefreshCw
-                      className={`w-3.5 h-3.5 ${isSyncing ? "animate-spin" : ""}`}
-                    />
-                    Resync
-                  </button>
-                )}
+              {connected && (result || integration?.syncError) && (
+                <div
+                  className={`mt-2 rounded-lg px-3 py-2 text-xs ${
+                    (result?.status || "error") === "success"
+                      ? "bg-emerald-50 text-emerald-800 border border-emerald-200 dark:bg-emerald-950/30 dark:text-emerald-300 dark:border-emerald-800"
+                      : "bg-red-50 text-red-800 border border-red-200 dark:bg-red-950/30 dark:text-red-300 dark:border-red-800"
+                  }`}
+                  role="status"
+                >
+                  <span className="font-semibold">Last result: </span>
+                  {result?.message || integration?.syncError}
+                </div>
+              )}
 
-                {connected ? (
-                  <button
-                    type="button"
-                    onClick={() => setProviderToDisconnect(p.key)}
-                    className="px-3 py-1.5 text-xs font-semibold text-red-600 bg-red-50 hover:bg-red-100 dark:bg-red-950/40 dark:hover:bg-red-900/60 dark:text-red-400 rounded-lg transition-colors cursor-pointer"
-                  >
-                    Disconnect
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => connectProvider(p.connectKey)}
-                    className="px-3 py-1.5 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-colors cursor-pointer shadow-xs"
-                  >
-                    Connect
-                  </button>
-                )}
-              </div>
+              {connected && history.length > 0 && (
+                <div className="mt-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">
+                    Recent sync attempts
+                  </p>
+                  <ul className="space-y-1 max-h-28 overflow-y-auto">
+                    {history.slice(0, 5).map((h, i) => (
+                      <li
+                        key={`${h.at}-${i}`}
+                        className="text-[11px] text-slate-600 dark:text-slate-400 flex gap-2"
+                      >
+                        <span
+                          className={
+                            h.status === "success"
+                              ? "text-emerald-600 dark:text-emerald-400"
+                              : "text-red-600 dark:text-red-400"
+                          }
+                        >
+                          {h.status === "success" ? "OK" : "Fail"}
+                        </span>
+                        <span className="shrink-0 text-slate-400">
+                          {h.at ? new Date(h.at).toLocaleString() : "—"}
+                        </span>
+                        <span className="truncate">
+                          {h.message ||
+                            (h.status === "success" ? "Synced" : "Sync failed")}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           );
         })}

--- a/client/src/components/__tests__/CalendarIntegrationsSyncStatus.test.jsx
+++ b/client/src/components/__tests__/CalendarIntegrationsSyncStatus.test.jsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import CalendarIntegrations from "../CalendarIntegrations.jsx";
+import apiClient from "../../services/apiClient.js";
+import { toast } from "react-toastify";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("CalendarIntegrations Sync now (#2053)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("triggers Sync now and shows success result + updated lastSyncedAt", async () => {
+    const syncedAt = "2026-08-23T10:00:00.000Z";
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          integrations: [
+            {
+              provider: "google",
+              syncEnabled: true,
+              syncStatus: "connected",
+              lastSyncedAt: "2026-08-01T12:00:00.000Z",
+              syncHistory: [],
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          integrations: [
+            {
+              provider: "google",
+              syncEnabled: true,
+              syncStatus: "connected",
+              lastSyncedAt: syncedAt,
+              lastResult: {
+                status: "success",
+                message: "Synced 2 event(s) successfully.",
+                at: syncedAt,
+              },
+              syncHistory: [
+                {
+                  status: "success",
+                  message: "Synced 2 event(s) successfully.",
+                  at: syncedAt,
+                  trigger: "manual",
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+    apiClient.post.mockResolvedValue({
+      data: {
+        success: true,
+        message: "Synced 2 event(s) successfully",
+        connection: {
+          lastSyncedAt: syncedAt,
+          lastResult: {
+            status: "success",
+            message: "Synced 2 event(s) successfully.",
+            at: syncedAt,
+          },
+        },
+      },
+    });
+
+    render(<CalendarIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Google Calendar")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /sync now/i }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/calendar/resync/google",
+      );
+      expect(toast.success).toHaveBeenCalled();
+      expect(
+        screen.getAllByText(/Synced 2 event\(s\) successfully/i).length,
+      ).toBeGreaterThan(0);
+      expect(screen.getByText(/Recent sync attempts/i)).toBeInTheDocument();
+      expect(screen.getByText(/Last synced:/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows actionable error and Reconnect when needs_reauth", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        integrations: [
+          {
+            provider: "google",
+            syncEnabled: true,
+            syncStatus: "needs_reauth",
+            lastSyncedAt: "2026-08-01T12:00:00.000Z",
+            syncError:
+              "Calendar access expired. Reconnect the provider and try Sync now again.",
+            lastResult: {
+              status: "error",
+              message:
+                "Calendar access expired. Reconnect the provider and try Sync now again.",
+            },
+            syncHistory: [
+              {
+                status: "error",
+                message:
+                  "Calendar access expired. Reconnect the provider and try Sync now again.",
+                at: "2026-08-02T12:00:00.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(<CalendarIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Needs Re-auth/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /reconnect/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByText(/Calendar access expired/i).length,
+      ).toBeGreaterThan(0);
+    });
+  });
+});

--- a/server/controllers/calendarController.js
+++ b/server/controllers/calendarController.js
@@ -32,6 +32,8 @@ const rejectOAuthState = (res, isGetRequest, redirectPath, error) => {
   });
 };
 
+const lastResultAt = (entry) => entry?.at || entry?.createdAt || null;
+
 /**
  * Get calendar connection status for a user
  */
@@ -48,13 +50,43 @@ export const getConnectionStatus = async (req, res) => {
         ) || null,
     };
 
-    const integrations = connections.map((c) => ({
-      provider: c.provider,
-      syncStatus: c.syncStatus,
-      syncEnabled: c.syncStatus === "connected",
-      lastSyncedAt: c.lastSyncAt || c.updatedAt,
-      externalCalendarId: c.providerData?.calendarId || "primary",
-    }));
+    const integrations = connections.map((c) => {
+      const history = Array.isArray(c.syncHistory) ? c.syncHistory : [];
+      const lastResult = history[0]
+        ? {
+            at: lastResultAt(history[0]),
+            status: history[0].status,
+            message: history[0].message,
+            syncedCount: history[0].syncedCount || 0,
+            trigger: history[0].trigger || "cron",
+          }
+        : c.syncError
+          ? {
+              at: c.updatedAt,
+              status: "error",
+              message: c.syncError,
+              syncedCount: 0,
+              trigger: "cron",
+            }
+          : null;
+
+      return {
+        provider: c.provider,
+        syncStatus: c.syncStatus,
+        syncEnabled: c.syncStatus === "connected",
+        lastSyncedAt: c.lastSyncAt || c.updatedAt,
+        syncError: c.syncError || null,
+        lastResult,
+        syncHistory: history.slice(0, 10).map((h) => ({
+          at: lastResultAt(h),
+          status: h.status,
+          message: h.message,
+          syncedCount: h.syncedCount || 0,
+          trigger: h.trigger || "cron",
+        })),
+        externalCalendarId: c.providerData?.calendarId || "primary",
+      };
+    });
 
     res.json({ success: true, status, integrations });
   } catch (error) {
@@ -384,24 +416,64 @@ export const resyncCalendar = async (req, res) => {
     await connection.save();
 
     const providerKey = provider === "google" ? "google" : "microsoft";
-    await triggerManualSync(userId, providerKey);
+    const result = await triggerManualSync(userId, providerKey);
 
-    connection.syncStatus = "connected";
-    connection.lastSyncAt = new Date();
-    await connection.save();
+    const refreshed = await CalendarConnection.findOne({
+      user: userId,
+      provider: { $in: providersToMatch },
+    });
 
     res.json({
       success: true,
-      message: `${provider.charAt(0).toUpperCase() + provider.slice(1)} Calendar synced successfully`,
+      message:
+        result?.syncedCount != null
+          ? `Synced ${result.syncedCount} event(s) successfully`
+          : `${provider} calendar synced successfully`,
       connection: {
-        provider: connection.provider,
-        syncStatus: connection.syncStatus,
-        lastSyncAt: connection.lastSyncAt,
+        provider: refreshed?.provider || connection.provider,
+        syncStatus: refreshed?.syncStatus || "connected",
+        lastSyncAt: refreshed?.lastSyncAt,
+        lastSyncedAt: refreshed?.lastSyncAt,
+        syncError: refreshed?.syncError || null,
+        lastResult: refreshed?.syncHistory?.[0]
+          ? {
+              at: lastResultAt(refreshed.syncHistory[0]),
+              status: refreshed.syncHistory[0].status,
+              message: refreshed.syncHistory[0].message,
+              syncedCount: refreshed.syncHistory[0].syncedCount || 0,
+              trigger: refreshed.syncHistory[0].trigger || "manual",
+            }
+          : null,
+        syncHistory: (refreshed?.syncHistory || []).slice(0, 10),
       },
     });
   } catch (error) {
     console.error("Error resyncing calendar:", error.message);
-    res.status(500).json({ success: false, message: error.message });
+    const providersToMatch =
+      req.params.provider === "google" ? ["google"] : ["microsoft", "outlook"];
+    const refreshed = await CalendarConnection.findOne({
+      user: req.user.id || req.user._id,
+      provider: { $in: providersToMatch },
+    }).catch(() => null);
+
+    res.status(500).json({
+      success: false,
+      message:
+        refreshed?.syncError ||
+        error.message ||
+        "Calendar sync failed. Try again or reconnect.",
+      connection: refreshed
+        ? {
+            provider: refreshed.provider,
+            syncStatus: refreshed.syncStatus,
+            lastSyncAt: refreshed.lastSyncAt,
+            lastSyncedAt: refreshed.lastSyncAt,
+            syncError: refreshed.syncError,
+            lastResult: refreshed.syncHistory?.[0] || null,
+            syncHistory: (refreshed.syncHistory || []).slice(0, 10),
+          }
+        : null,
+    });
   }
 };
 

--- a/server/jobs/calendarSyncJob.js
+++ b/server/jobs/calendarSyncJob.js
@@ -8,6 +8,11 @@ import {
   getMicrosoftClient, // eslint-disable-line no-unused-vars
 } from "../services/calendarService.js";
 import { google } from "googleapis"; // eslint-disable-line no-unused-vars
+import {
+  formatSyncFailureMessage,
+  isAuthSyncFailure,
+  pushSyncHistory,
+} from "../utils/calendarSyncHistory.js";
 
 /**
  * Background sync job for calendar reconciliation
@@ -22,7 +27,11 @@ let syncIntervalId = null;
 /**
  * Sync external calendar events for a specific user and provider
  */
-const syncUserCalendar = async (userId, provider) => {
+const syncUserCalendar = async (
+  userId,
+  provider,
+  { trigger = "cron" } = {},
+) => {
   try {
     const providersToMatch =
       provider === "google" ? ["google"] : ["microsoft", "outlook"];
@@ -30,12 +39,12 @@ const syncUserCalendar = async (userId, provider) => {
     const connection = await CalendarConnection.findOne({
       user: userId,
       provider: { $in: providersToMatch },
-      syncStatus: "connected",
+      syncStatus: { $in: ["connected", "error", "syncing"] },
     });
 
     if (!connection) {
       console.log(`No active ${provider} connection for user ${userId}`);
-      return;
+      return null;
     }
 
     // Calculate sync window (last 30 days to next 90 days)
@@ -56,7 +65,17 @@ const syncUserCalendar = async (userId, provider) => {
       console.log(
         `No external events found for ${provider} for user ${userId}`,
       );
-      return;
+      connection.lastSyncAt = new Date();
+      connection.syncError = null;
+      connection.syncStatus = "connected";
+      pushSyncHistory(connection, {
+        status: "success",
+        message: "Sync completed — no external events in window.",
+        syncedCount: 0,
+        trigger,
+      });
+      await connection.save();
+      return { syncedCount: 0, conflictCount: 0 };
     }
 
     const events = externalEvents[provider];
@@ -164,6 +183,13 @@ const syncUserCalendar = async (userId, provider) => {
     // Update connection sync status
     connection.lastSyncAt = new Date();
     connection.syncError = null;
+    connection.syncStatus = "connected";
+    pushSyncHistory(connection, {
+      status: "success",
+      message: `Synced ${syncedCount} event(s) successfully.`,
+      syncedCount,
+      trigger,
+    });
     await connection.save();
 
     console.log(
@@ -176,22 +202,36 @@ const syncUserCalendar = async (userId, provider) => {
       error.message,
     );
 
+    const message = formatSyncFailureMessage(error);
+
     // Update connection with error
     try {
+      const providersToMatch =
+        provider === "google" ? ["google"] : ["microsoft", "outlook"];
       const connection = await CalendarConnection.findOne({
         user: userId,
-        provider,
+        provider: { $in: providersToMatch },
       });
       if (connection) {
-        connection.syncStatus = "error";
-        connection.syncError = error.message;
+        connection.syncStatus = isAuthSyncFailure(error)
+          ? "needs_reauth"
+          : "error";
+        connection.syncError = message;
+        pushSyncHistory(connection, {
+          status: "error",
+          message,
+          syncedCount: 0,
+          trigger,
+        });
         await connection.save();
       }
     } catch (updateError) {
       console.error("Error updating connection status:", updateError.message);
     }
 
-    throw error;
+    const wrapped = new Error(message);
+    wrapped.cause = error;
+    throw wrapped;
   }
 };
 
@@ -215,7 +255,11 @@ const syncAllCalendars = async () => {
 
     for (const connection of connections) {
       try {
-        await syncUserCalendar(connection.user, connection.provider);
+        const providerKey =
+          connection.provider === "google" ? "google" : "microsoft";
+        await syncUserCalendar(connection.user, providerKey, {
+          trigger: "cron",
+        });
       } catch (error) {
         console.error(
           `Failed to sync ${connection.provider} for user ${connection.user}:`,
@@ -264,7 +308,7 @@ export const stopCalendarSyncJob = () => {
  */
 export const triggerManualSync = async (userId = null, provider = null) => {
   if (userId && provider) {
-    return await syncUserCalendar(userId, provider);
+    return await syncUserCalendar(userId, provider, { trigger: "manual" });
   } else {
     return await syncAllCalendars();
   }

--- a/server/models/calendarConnectionModel.js
+++ b/server/models/calendarConnectionModel.js
@@ -48,6 +48,27 @@ const calendarConnectionSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    // Recent sync attempts for ops UI (Issue #2053)
+    syncHistory: {
+      type: [
+        {
+          at: { type: Date, default: Date.now },
+          status: {
+            type: String,
+            enum: ["success", "error"],
+            required: true,
+          },
+          message: { type: String, default: "" },
+          syncedCount: { type: Number, default: 0 },
+          trigger: {
+            type: String,
+            enum: ["manual", "cron"],
+            default: "cron",
+          },
+        },
+      ],
+      default: [],
+    },
     // Webhook subscription ID (for push notifications)
     webhookSubscriptionId: {
       type: String,

--- a/server/tests/calendarSyncHistory.test.js
+++ b/server/tests/calendarSyncHistory.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatSyncFailureMessage,
+  isAuthSyncFailure,
+  pushSyncHistory,
+  MAX_SYNC_HISTORY,
+} from "../utils/calendarSyncHistory.js";
+
+describe("calendarSyncHistory (Issue #2053)", () => {
+  it("formats token expiry as reconnect guidance", () => {
+    expect(formatSyncFailureMessage(new Error("invalid_grant"))).toMatch(
+      /reconnect/i,
+    );
+    expect(isAuthSyncFailure(new Error("Token expired"))).toBe(true);
+  });
+
+  it("prepends history and caps length", () => {
+    const connection = { syncHistory: [] };
+    for (let i = 0; i < MAX_SYNC_HISTORY + 5; i += 1) {
+      pushSyncHistory(connection, {
+        status: i % 2 === 0 ? "success" : "error",
+        message: `attempt-${i}`,
+        syncedCount: i,
+        trigger: "manual",
+      });
+    }
+    expect(connection.syncHistory).toHaveLength(MAX_SYNC_HISTORY);
+    expect(connection.syncHistory[0].message).toBe(
+      `attempt-${MAX_SYNC_HISTORY + 4}`,
+    );
+  });
+});

--- a/server/utils/calendarSyncHistory.js
+++ b/server/utils/calendarSyncHistory.js
@@ -1,0 +1,42 @@
+/** Max sync history entries kept per calendar connection (Issue #2053). */
+export const MAX_SYNC_HISTORY = 20;
+
+/**
+ * Build an actionable sync failure message for the UI.
+ */
+export const formatSyncFailureMessage = (error) => {
+  const raw = String(error?.message || error || "Calendar sync failed.");
+  if (/invalid_grant|token.*expir|unauthorized|401|needs.?reauth/i.test(raw)) {
+    return "Calendar access expired. Reconnect the provider and try Sync now again.";
+  }
+  if (/rate.?limit|429|quota/i.test(raw)) {
+    return "Provider rate limit hit. Wait a few minutes, then try Sync now.";
+  }
+  if (/network|ECONN|ETIMEDOUT|ENOTFOUND/i.test(raw)) {
+    return "Could not reach the calendar provider. Check your connection and try again.";
+  }
+  return raw.slice(0, 300);
+};
+
+export const isAuthSyncFailure = (error) =>
+  /invalid_grant|token.*expir|unauthorized|401|needs.?reauth/i.test(
+    String(error?.message || error || ""),
+  );
+
+/**
+ * Prepend a sync attempt onto the connection's history (mutates doc).
+ */
+export const pushSyncHistory = (connection, entry) => {
+  const next = {
+    at: entry.at || new Date(),
+    status: entry.status,
+    message: String(entry.message || "").slice(0, 500),
+    syncedCount: entry.syncedCount || 0,
+    trigger: entry.trigger === "manual" ? "manual" : "cron",
+  };
+  const history = Array.isArray(connection.syncHistory)
+    ? connection.syncHistory
+    : [];
+  connection.syncHistory = [next, ...history].slice(0, MAX_SYNC_HISTORY);
+  return next;
+};


### PR DESCRIPTION
## Summary
- Sync now button with last success/error result
- Recent sync attempt history and per-provider status badges
- Reconnect CTA when calendar access expires; successful sync refreshes `lastSyncedAt`

## Test plan
- [ ] Settings → Calendar Integrations: connected provider shows **Sync now**
- [ ] Successful sync updates lassynced time and history
- [ ] Failed sync shows an actionable message
- [ ] `needs_reauth` shows **Reconnect**
- [ ] `cd server && npx vitest run tests/calendarSyncHistory.test.js tests/calendarSyncOrganization.test.js`
- [ ] `cd client && npx vitest run src/components/__tests__/CalendarIntegrationsConfirm.test.jsx src/components/__tests__/CalendarIntegrationsSyncStatus.test.jsx`

Closes #2053