### PR TITLE
feat: meeting series list and manage page

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -406,6 +406,9 @@ const Navbar = () => {
         currentPath === "/policies"
       );
     }
+    if (tabPath === "/meeting-series") {
+      return currentPath.startsWith("/meeting-series");
+    }
     if (tabPath === "/organizations") {
       return (
         currentPath === "/organizations" ||
@@ -427,6 +430,12 @@ const Navbar = () => {
       label: t("navbar.meetings"),
       href: "/meetings",
       icon: Calendar,
+      permission: { resource: "meetings", action: "view" },
+    },
+    {
+      label: "Meeting Series",
+      href: "/meeting-series",
+      icon: CalendarDays,
       permission: { resource: "meetings", action: "view" },
     },
     {

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import {
   Users,
   Trophy,
   ArrowRight,
+  CalendarRange,
 } from "lucide-react";
 import Navbar from "../components/Navbar.jsx";
 import TopContributorsWidget from "../components/organization/TopContributorsWidget";
@@ -46,6 +47,7 @@ const ROUTE_MAP = {
   "attendance-analytics": "/attendance-analytics",
   "meeting-cost-analytics": "/meeting-cost-analytics",
   leaderboard: "/leaderboard",
+  "meeting-series": "/meeting-series",
 };
 
 /* ─── Dashboard ───────────────────────────────────────────────────────────── */
@@ -99,6 +101,19 @@ const Dashboard = () => {
       accentRing:
         "group-hover:ring-emerald-100 dark:group-hover:ring-emerald-900/40",
       requiresCreateMeeting: true,
+    },
+    {
+      id: "meeting-series",
+      icon: CalendarRange,
+      title: "Meeting Series",
+      description:
+        "Browse recurring programs, open retrospectives, and pause or cancel series.",
+      iconBg: "bg-teal-50 dark:bg-teal-900/30",
+      iconColor: "text-teal-600 dark:text-teal-400",
+      tag: "Recurring",
+      tagColor:
+        "bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300 border-teal-100 dark:border-teal-800",
+      accentRing: "group-hover:ring-teal-100 dark:group-hover:ring-teal-900/40",
     },
     {
       id: "summaries",

--- a/client/src/pages/MeetingSeriesList.jsx
+++ b/client/src/pages/MeetingSeriesList.jsx
@@ -1,0 +1,362 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { format } from "date-fns";
+import { toast } from "react-toastify";
+import {
+  CalendarRange,
+  Loader2,
+  RefreshCw,
+  ChevronDown,
+  ChevronUp,
+  Ban,
+  Pause,
+  Play,
+} from "lucide-react";
+import Navbar from "../components/Navbar.jsx";
+import ConfirmModal from "../components/ConfirmModal.jsx";
+import { meetingSeriesApi } from "../services/meetingSeriesApi.js";
+import { useRBAC } from "../hooks/useRBAC.js";
+
+const CADENCE_LABELS = {
+  daily: "Daily",
+  weekly: "Weekly",
+  biweekly: "Biweekly",
+  monthly: "Monthly",
+};
+
+const MeetingSeriesList = () => {
+  const { hasPermission } = useRBAC();
+  const canEdit = hasPermission("meetings", "edit");
+  const [series, setSeries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState(null);
+  const [occurrences, setOccurrences] = useState({});
+  const [loadingOccurrences, setLoadingOccurrences] = useState({});
+  const [confirmAction, setConfirmAction] = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  const fetchSeries = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await meetingSeriesApi.listSeries();
+      if (data?.success) {
+        setSeries(data.series || []);
+      }
+    } catch (err) {
+      console.error("Failed to load meeting series", err);
+      toast.error(
+        err?.response?.data?.message || "Failed to load meeting series.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSeries();
+  }, [fetchSeries]);
+
+  const toggleOccurrences = async (seriesId) => {
+    if (expandedId === seriesId) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(seriesId);
+    if (occurrences[seriesId]) return;
+
+    setLoadingOccurrences((prev) => ({ ...prev, [seriesId]: true }));
+    try {
+      const { data } = await meetingSeriesApi.getSeriesMeetings(
+        seriesId,
+        1,
+        50,
+      );
+      setOccurrences((prev) => ({
+        ...prev,
+        [seriesId]: data?.meetings || [],
+      }));
+    } catch (err) {
+      console.error("Failed to load occurrences", err);
+      toast.error("Failed to load series occurrences.");
+    } finally {
+      setLoadingOccurrences((prev) => ({ ...prev, [seriesId]: false }));
+    }
+  };
+
+  const runConfirmAction = async () => {
+    if (!confirmAction) return;
+    setActionLoading(true);
+    try {
+      const { type, seriesId } = confirmAction;
+      if (type === "cancel") {
+        await meetingSeriesApi.cancelSeries(seriesId);
+        toast.success("Series cancelled. Future unstarted meetings removed.");
+      } else if (type === "pause") {
+        await meetingSeriesApi.pauseSeries(seriesId);
+        toast.success("Series paused.");
+      } else if (type === "resume") {
+        await meetingSeriesApi.resumeSeries(seriesId);
+        toast.success("Series resumed.");
+      }
+      setConfirmAction(null);
+      await fetchSeries();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Could not update the series.",
+      );
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const confirmCopy = {
+    cancel: {
+      title: "Cancel meeting series",
+      message:
+        "Cancel this series? Future unstarted occurrences will be deleted. Past meetings stay in history.",
+      confirmText: "Cancel series",
+      variant: "danger",
+    },
+    pause: {
+      title: "Pause meeting series",
+      message:
+        "Pause this series? Existing occurrences stay on the calendar; mark it inactive until you resume.",
+      confirmText: "Pause series",
+      variant: "warning",
+    },
+    resume: {
+      title: "Resume meeting series",
+      message: "Resume this series and mark it active again?",
+      confirmText: "Resume series",
+      variant: "warning",
+    },
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-gray-900">
+      <Navbar />
+      <div className="mx-auto max-w-5xl px-4 pb-20 pt-28 sm:px-6">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">
+              Meeting series
+            </h1>
+            <p className="mt-1 text-sm text-slate-600 dark:text-gray-400">
+              Browse recurring programs, open retrospectives, and pause or
+              cancel series.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={fetchSeries}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          >
+            <RefreshCw className="h-3.5 w-3.5" /> Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-20">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+          </div>
+        ) : series.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white px-6 py-16 text-center shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-900/20">
+              <CalendarRange className="h-7 w-7 text-blue-600 dark:text-blue-400" />
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+              No meeting series yet
+            </h2>
+            <p className="mx-auto mt-2 max-w-md text-sm text-slate-600 dark:text-gray-400">
+              Recurring schedules you create from Schedule Meeting will appear
+              here.
+            </p>
+            <Link
+              to="/create-meeting"
+              className="mt-6 inline-flex rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+            >
+              Schedule a meeting
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {series.map((item) => {
+              const active = item.isActive !== false;
+              const expanded = expandedId === item._id;
+              return (
+                <li
+                  key={item._id}
+                  className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+                          {item.title}
+                        </h2>
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                            active
+                              ? "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300"
+                              : "bg-amber-50 text-amber-800 ring-1 ring-amber-200 dark:bg-amber-900/30 dark:text-amber-300"
+                          }`}
+                        >
+                          {active ? "Active" : "Paused"}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-sm text-slate-600 dark:text-gray-400">
+                        {CADENCE_LABELS[item.recurrencePattern] ||
+                          item.recurrencePattern}
+                        {item.time ? ` · ${item.time}` : ""}
+                        {item.occurrenceCount != null
+                          ? ` · ${item.occurrenceCount} occurrence(s)`
+                          : ""}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500 dark:text-gray-500">
+                        Next:{" "}
+                        {item.nextOccurrence?.date
+                          ? format(
+                              new Date(item.nextOccurrence.date),
+                              "MMM d, yyyy",
+                            ) +
+                            (item.nextOccurrence.time
+                              ? ` ${item.nextOccurrence.time}`
+                              : "")
+                          : "None scheduled"}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <Link
+                        to={`/meeting-series/${item._id}/retrospective`}
+                        className="rounded-lg bg-indigo-50 px-3 py-1.5 text-xs font-semibold text-indigo-700 hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-300"
+                      >
+                        Retrospective
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => toggleOccurrences(item._id)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                      >
+                        Occurrences
+                        {expanded ? (
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                      {canEdit &&
+                        (active ? (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setConfirmAction({
+                                  type: "pause",
+                                  seriesId: item._id,
+                                })
+                              }
+                              className="inline-flex items-center gap-1 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                            >
+                              <Pause className="h-3.5 w-3.5" /> Pause
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setConfirmAction({
+                                  type: "cancel",
+                                  seriesId: item._id,
+                                })
+                              }
+                              className="inline-flex items-center gap-1 rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300"
+                            >
+                              <Ban className="h-3.5 w-3.5" /> Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setConfirmAction({
+                                type: "resume",
+                                seriesId: item._id,
+                              })
+                            }
+                            className="inline-flex items-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-800 hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300"
+                          >
+                            <Play className="h-3.5 w-3.5" /> Resume
+                          </button>
+                        ))}
+                    </div>
+                  </div>
+
+                  {expanded && (
+                    <div className="mt-4 border-t border-slate-100 pt-3 dark:border-gray-700">
+                      {loadingOccurrences[item._id] ? (
+                        <div className="flex justify-center py-4">
+                          <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                        </div>
+                      ) : (occurrences[item._id] || []).length === 0 ? (
+                        <p className="text-sm text-slate-500">
+                          No occurrences found.
+                        </p>
+                      ) : (
+                        <ul className="max-h-56 space-y-2 overflow-y-auto text-sm">
+                          {(occurrences[item._id] || []).map((m) => (
+                            <li
+                              key={m._id}
+                              className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-slate-50 px-3 py-2 dark:bg-gray-900/50"
+                            >
+                              <span className="font-medium text-slate-800 dark:text-gray-100">
+                                #{m.seriesOccurrence || "—"} {m.title}
+                              </span>
+                              <span className="text-xs text-slate-500">
+                                {m.date
+                                  ? format(new Date(m.date), "MMM d, yyyy")
+                                  : "—"}
+                                {m.time ? ` · ${m.time}` : ""}
+                              </span>
+                              {m._id && (
+                                <Link
+                                  to={`/meeting/${m._id}`}
+                                  className="text-xs font-semibold text-blue-600 hover:underline dark:text-blue-400"
+                                >
+                                  Open
+                                </Link>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={Boolean(confirmAction)}
+        onClose={() => setConfirmAction(null)}
+        onConfirm={runConfirmAction}
+        title={
+          confirmAction ? confirmCopy[confirmAction.type].title : "Confirm"
+        }
+        message={confirmAction ? confirmCopy[confirmAction.type].message : ""}
+        confirmText={
+          confirmAction
+            ? confirmCopy[confirmAction.type].confirmText
+            : "Confirm"
+        }
+        variant={
+          confirmAction ? confirmCopy[confirmAction.type].variant : "danger"
+        }
+        isLoading={actionLoading}
+      />
+    </div>
+  );
+};
+
+export default MeetingSeriesList;

--- a/client/src/pages/__tests__/MeetingSeriesList.test.jsx
+++ b/client/src/pages/__tests__/MeetingSeriesList.test.jsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MeetingSeriesList from "../MeetingSeriesList.jsx";
+import { meetingSeriesApi } from "../../services/meetingSeriesApi.js";
+
+vi.mock("../../services/meetingSeriesApi.js", () => ({
+  meetingSeriesApi: {
+    listSeries: vi.fn(),
+    getSeriesMeetings: vi.fn(),
+    cancelSeries: vi.fn(),
+    pauseSeries: vi.fn(),
+    resumeSeries: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({ hasPermission: () => true }),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("MeetingSeriesList (#2036)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows empty state when no series exist", async () => {
+    meetingSeriesApi.listSeries.mockResolvedValue({
+      data: { success: true, series: [] },
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingSeriesList />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No meeting series yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("lists series and opens cancel confirmation", async () => {
+    meetingSeriesApi.listSeries.mockResolvedValue({
+      data: {
+        success: true,
+        series: [
+          {
+            _id: "s1",
+            title: "Weekly Sync",
+            recurrencePattern: "weekly",
+            isActive: true,
+            time: "10:00",
+            occurrenceCount: 4,
+            nextOccurrence: {
+              date: "2026-09-01T10:00:00.000Z",
+              time: "10:00",
+            },
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingSeriesList />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly Sync")).toBeInTheDocument();
+      expect(screen.getByText(/Active/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /retrospective/i }),
+      ).toHaveAttribute("href", "/meeting-series/s1/retrospective");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/Cancel meeting series/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -76,6 +76,7 @@ import MyDelegations from "../pages/MyDelegations.jsx";
 import MeetingPatterns from "../pages/MeetingPatterns.jsx";
 import FocusTime from "../pages/FocusTime.jsx";
 import SeriesRetrospective from "../pages/SeriesRetrospective.jsx";
+import MeetingSeriesList from "../pages/MeetingSeriesList.jsx";
 import DataRetentionSettings from "../pages/DataRetentionSettings.jsx";
 import FollowUpDashboard from "../pages/FollowUpDashboard.jsx";
 import EscalationDashboard from "../pages/EscalationDashboard.jsx";
@@ -107,6 +108,14 @@ const ProtectedRoutes = (
       element={
         <ProtectedRoute resource="meetings" action="view">
           <CompareMeetings />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/meeting-series"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <MeetingSeriesList />
         </ProtectedRoute>
       }
     />

--- a/client/src/services/__tests__/apiPrefix.test.js
+++ b/client/src/services/__tests__/apiPrefix.test.js
@@ -41,6 +41,11 @@ describe("API Services Endpoint Prefix (#803)", () => {
       });
     });
 
+    it("should call /api/meeting-series for listSeries", async () => {
+      meetingSeriesApi.listSeries();
+      expect(api.get).toHaveBeenCalledWith("/api/meeting-series");
+    });
+
     it("should call /api/meeting-series/:id for getSeriesById", async () => {
       meetingSeriesApi.getSeriesById("s1");
       expect(api.get).toHaveBeenCalledWith("/api/meeting-series/s1");

--- a/client/src/services/meetingSeriesApi.js
+++ b/client/src/services/meetingSeriesApi.js
@@ -1,9 +1,12 @@
 import api from "./apiClient";
 
 export const meetingSeriesApi = {
+  listSeries: () => api.get("/api/meeting-series"),
   createSeries: (data) => api.post("/api/meeting-series", data),
   getSeriesById: (id) => api.get(`/api/meeting-series/${id}`),
   getSeriesMeetings: (id, page = 1, limit = 20) =>
     api.get(`/api/meeting-series/${id}/meetings?page=${page}&limit=${limit}`),
   cancelSeries: (id) => api.patch(`/api/meeting-series/${id}/cancel`),
+  pauseSeries: (id) => api.patch(`/api/meeting-series/${id}/pause`),
+  resumeSeries: (id) => api.patch(`/api/meeting-series/${id}/resume`),
 };

--- a/server/controllers/meetingSeriesController.js
+++ b/server/controllers/meetingSeriesController.js
@@ -222,6 +222,136 @@ export const getSeriesById = async (req, res) => {
   }
 };
 
+/**
+ * List org meeting series for the manage page (Issue #2036).
+ */
+export const listSeries = async (req, res) => {
+  try {
+    const orgId = req.user?.organization || req.user?.organizationId;
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Organization membership required",
+      });
+    }
+
+    const seriesList = await MeetingSeries.find({ organization: orgId })
+      .sort({ updatedAt: -1 })
+      .lean();
+
+    const now = new Date();
+    const enriched = await Promise.all(
+      seriesList.map(async (series) => {
+        const [nextMeeting, occurrenceCount] = await Promise.all([
+          Meeting.findOne({
+            series: series._id,
+            organization: orgId,
+            date: { $gte: now },
+          })
+            .sort({ date: 1 })
+            .select("date time title seriesOccurrence")
+            .lean(),
+          Meeting.countDocuments({ series: series._id, organization: orgId }),
+        ]);
+
+        return {
+          ...series,
+          status: series.isActive ? "active" : "paused",
+          occurrenceCount,
+          nextOccurrence: nextMeeting
+            ? {
+                date: nextMeeting.date,
+                time: nextMeeting.time,
+                title: nextMeeting.title,
+                seriesOccurrence: nextMeeting.seriesOccurrence,
+              }
+            : null,
+        };
+      }),
+    );
+
+    res.json({ success: true, series: enriched });
+  } catch (error) {
+    console.error("Error listing meeting series:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error listing meeting series",
+    });
+  }
+};
+
+/**
+ * Pause a series without deleting future meetings (Issue #2036).
+ */
+export const pauseSeries = async (req, res) => {
+  try {
+    const series = await MeetingSeries.findOneAndUpdate(
+      {
+        _id: req.params.id,
+        organization: req.user.organization,
+        isActive: true,
+      },
+      { isActive: false },
+      { new: true },
+    );
+
+    if (!series) {
+      return res.status(404).json({
+        success: false,
+        message: "Active series not found",
+      });
+    }
+
+    res.json({
+      success: true,
+      message: "Series paused successfully",
+      series,
+    });
+  } catch (error) {
+    console.error("Error pausing meeting series:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error pausing meeting series",
+    });
+  }
+};
+
+/**
+ * Resume a paused series (Issue #2036).
+ */
+export const resumeSeries = async (req, res) => {
+  try {
+    const series = await MeetingSeries.findOneAndUpdate(
+      {
+        _id: req.params.id,
+        organization: req.user.organization,
+        isActive: false,
+      },
+      { isActive: true },
+      { new: true },
+    );
+
+    if (!series) {
+      return res.status(404).json({
+        success: false,
+        message: "Paused series not found",
+      });
+    }
+
+    res.json({
+      success: true,
+      message: "Series resumed successfully",
+      series,
+    });
+  } catch (error) {
+    console.error("Error resuming meeting series:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error resuming meeting series",
+    });
+  }
+};
+
 export const getSeriesMeetings = async (req, res) => {
   try {
     // `limit=0` / `limit=all` is the deliberate "give me the whole series"

--- a/server/routes/meetingSeriesRoutes.js
+++ b/server/routes/meetingSeriesRoutes.js
@@ -6,6 +6,9 @@ import {
   getSeriesById,
   getSeriesMeetings,
   cancelSeries,
+  listSeries,
+  pauseSeries,
+  resumeSeries,
 } from "../controllers/meetingSeriesController.js";
 import seriesRetrospectiveRoutes from "./seriesRetrospectiveRoutes.js";
 import {
@@ -23,6 +26,9 @@ router.use(requireOrgMembership);
 
 router.post("/", requirePermission("meetings", "create"), createSeries);
 
+// Static collection route must precede "/:id" (Issue #2036).
+router.get("/", requirePermission("meetings", "view"), listSeries);
+
 router.get("/:id", requirePermission("meetings", "view"), getSeriesById);
 
 router.get(
@@ -35,6 +41,14 @@ router.patch(
   "/:id/cancel",
   requirePermission("meetings", "edit"),
   cancelSeries,
+);
+
+router.patch("/:id/pause", requirePermission("meetings", "edit"), pauseSeries);
+
+router.patch(
+  "/:id/resume",
+  requirePermission("meetings", "edit"),
+  resumeSeries,
 );
 
 router.use(

--- a/server/tests/meetingSeriesList.test.js
+++ b/server/tests/meetingSeriesList.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/meetingSeriesModel.js", () => ({
+  default: {
+    find: vi.fn(),
+    findOneAndUpdate: vi.fn(),
+  },
+}));
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findOne: vi.fn(),
+    countDocuments: vi.fn(),
+  },
+}));
+
+import MeetingSeries from "../models/meetingSeriesModel.js";
+import Meeting from "../models/meetingModel.js";
+import {
+  listSeries,
+  pauseSeries,
+} from "../controllers/meetingSeriesController.js";
+
+describe("meetingSeries list/pause (Issue #2036)", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      user: { _id: "u1", organization: "org1" },
+      params: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+  });
+
+  it("lists org series with next occurrence and status", async () => {
+    MeetingSeries.find.mockReturnValue({
+      sort: () => ({
+        lean: async () => [
+          {
+            _id: "s1",
+            title: "Weekly Sync",
+            recurrencePattern: "weekly",
+            isActive: true,
+            time: "10:00",
+          },
+        ],
+      }),
+    });
+    Meeting.findOne.mockReturnValue({
+      sort: () => ({
+        select: () => ({
+          lean: async () => ({
+            date: "2026-09-01T10:00:00.000Z",
+            time: "10:00",
+            title: "Weekly Sync",
+            seriesOccurrence: 3,
+          }),
+        }),
+      }),
+    });
+    Meeting.countDocuments.mockResolvedValue(5);
+
+    await listSeries(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        series: [
+          expect.objectContaining({
+            title: "Weekly Sync",
+            status: "active",
+            occurrenceCount: 5,
+            nextOccurrence: expect.objectContaining({ time: "10:00" }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("pauses an active series", async () => {
+    req.params.id = "s1";
+    MeetingSeries.findOneAndUpdate.mockResolvedValue({
+      _id: "s1",
+      isActive: false,
+      title: "Weekly Sync",
+    });
+
+    await pauseSeries(req, res);
+
+    expect(MeetingSeries.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ isActive: true }),
+      { isActive: false },
+      { new: true },
+    );
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Org-scoped meeting series list with cadence, next occurrence, and status
- Manage actions: view occurrences, open retrospective, pause/resume/cancel with confirmation
- Navbar and Dashboard entry (RBAC: meetings view/edit)

## Test plan
- [ ] Open `/meeting-series` and see org series (or empty state)
- [ ] Expand Occurrences; open Retrospective
- [ ] Pause / Resume / Cancel with confirmation modal
- [ ] Navbar **Meeting Series** and Dashboard card navigate correctly
- [ ] `cd server && npx vitest run tests/meetingSeriesList.test.js`
- [ ] `cd client && npx vitest run src/pages/__tests__/MeetingSeriesList.test.jsx`

Closes #2036