### PR TITLE
feat: add schedule conflict warnings

### DIFF
--- a/client/src/api/calendarAvailabilityApi.js
+++ b/client/src/api/calendarAvailabilityApi.js
@@ -1,0 +1,12 @@
+import apiClient from "../services/apiClient";
+
+export const calendarAvailabilityApi = {
+  getFreeBusy: async ({ attendeeEmails, timeMin, timeMax }) => {
+    const response = await apiClient.post("/api/calendar/freebusy", {
+      attendeeEmails,
+      timeMin,
+      timeMax,
+    });
+    return response.data;
+  },
+};

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ConflictWarning.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ConflictWarning.jsx
@@ -1,0 +1,130 @@
+import { AlertTriangle, CheckCircle2, Clock3, Users } from "lucide-react";
+
+const formatTime = (value) => {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+};
+
+const ConflictWarning = ({
+  focusConflicts = [],
+  busyParticipants = [],
+  mode = "soft",
+  loading = false,
+  onModeChange,
+  enabled = false,
+}) => {
+  const hasConflicts = focusConflicts.length > 0 || busyParticipants.length > 0;
+
+  if (!enabled) return null;
+
+  const hardBlock = mode === "hard";
+
+  return (
+    <section
+      className={`mb-6 rounded-xl border p-4 ${
+        hasConflicts
+          ? hardBlock
+            ? "border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30"
+            : "border-amber-200 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/30"
+          : "border-blue-200 bg-blue-50 dark:border-blue-900/60 dark:bg-blue-950/30"
+      }`}
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="flex items-start gap-3">
+        {hasConflicts ? (
+          <AlertTriangle
+            className={
+              hardBlock ? "mt-0.5 text-red-600" : "mt-0.5 text-amber-600"
+            }
+            size={20}
+            aria-hidden="true"
+          />
+        ) : (
+          <Clock3
+            className="mt-0.5 text-blue-600"
+            size={20}
+            aria-hidden="true"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold text-gray-900 dark:text-white">
+            {loading
+              ? "Checking schedule conflicts…"
+              : hardBlock
+                ? "Scheduling blocked by a conflict"
+                : "Schedule conflict detected"}
+          </h3>
+
+          {hasConflicts && (
+            <div className="mt-3 space-y-3 text-sm text-gray-700 dark:text-gray-300">
+              {focusConflicts.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center gap-2 font-medium">
+                    <Clock3 size={16} aria-hidden="true" />
+                    Focus time
+                  </div>
+                  <ul className="ml-6 list-disc space-y-1">
+                    {focusConflicts.map((conflict, index) => (
+                      <li
+                        key={`${conflict._id || conflict.id || "focus"}-${index}`}
+                      >
+                        {conflict.title || "Protected focus time"} —{" "}
+                        {formatTime(conflict.conflictStart)}–
+                        {formatTime(conflict.conflictEnd)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {busyParticipants.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center gap-2 font-medium">
+                    <Users size={16} aria-hidden="true" />
+                    Busy participants
+                  </div>
+                  <ul className="ml-6 list-disc space-y-1">
+                    {busyParticipants.map((participant, index) => (
+                      <li key={`${participant.email}-${index}`}>
+                        {participant.name || participant.email} (
+                        {participant.email}) — {formatTime(participant.start)}–
+                        {formatTime(participant.end)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <label className="flex items-center gap-2 text-xs font-medium text-gray-700 dark:text-gray-300">
+              <span>Conflict behavior</span>
+              <select
+                value={mode}
+                onChange={(event) => onModeChange?.(event.target.value)}
+                className="rounded-md border border-gray-300 bg-white px-2 py-1 text-xs dark:border-gray-700 dark:bg-slate-900"
+                aria-label="Conflict behavior"
+              >
+                <option value="soft">Warn only</option>
+                <option value="hard">Block scheduling</option>
+              </select>
+            </label>
+
+            {!hasConflicts && !loading && (
+              <span className="flex items-center gap-1 text-xs text-green-700 dark:text-green-400">
+                <CheckCircle2 size={15} aria-hidden="true" />
+                No conflicts found
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ConflictWarning;

--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/ScheduleMeeting.jsx
@@ -7,6 +7,7 @@ import CalendarNotice from "./CalendarNotice";
 import DraftRecoveryBanner from "./DraftRecoveryBanner";
 import SmartAgendaGenerator from "../../../../components/meetings/SmartAgendaGenerator";
 import CustomFieldsEditor from "../../../../components/meetings/CustomFieldsEditor";
+import ConflictWarning from "./ConflictWarning";
 
 const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
   const {
@@ -26,7 +27,6 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
     handleScheduleChange,
     addParticipant,
     removeParticipant,
-    importParticipants,
     addAgendaItem,
     removeAgendaItem,
     reorderAgendaItem,
@@ -45,9 +45,12 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
     customFields,
     setCustomFields,
     userData,
-    actionItemTemplates,
-    selectedActionItemTemplateId,
-    setSelectedActionItemTemplateId,
+    focusConflicts,
+    busyParticipants,
+    checkingConflicts,
+    conflictCheckError,
+    conflictMode,
+    setConflictMode,
   } = hookProps;
 
   return (
@@ -82,6 +85,23 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
           onRestore={restoreDraft}
           onDiscard={discardDraft}
         />
+        <ConflictWarning
+          focusConflicts={focusConflicts}
+          busyParticipants={busyParticipants}
+          loading={checkingConflicts}
+          mode={conflictMode}
+          onModeChange={setConflictMode}
+          enabled={Boolean(scheduleData.date && scheduleData.time)}
+        />
+        {conflictCheckError && (
+          <p
+            className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300"
+            role="status"
+          >
+            {conflictCheckError}
+          </p>
+        )}
+
         <MeetingInformationForm
           scheduleData={scheduleData}
           setScheduleData={setScheduleData}
@@ -94,7 +114,6 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
           setNewParticipant={setNewParticipant}
           addParticipant={addParticipant}
           removeParticipant={removeParticipant}
-          importParticipants={importParticipants}
         />
 
         {templates && templates.length > 0 && (
@@ -137,34 +156,8 @@ const ScheduleMeeting = ({ hookProps, loadingDuplicate = false }) => {
               ))}
             </select>
             <p className="text-xs text-indigo-700 dark:text-indigo-400 mt-2">
-              custom instructions allow you to dictate exactly how the AI will
+              Custom instructions allow you to dictate exactly how the AI will
               write the MoM (e.g. Sales BANT, Sprint Retro).
-            </p>
-          </div>
-        )}
-
-        {actionItemTemplates && actionItemTemplates.length > 0 && (
-          <div className="mb-6 bg-emerald-50/50 dark:bg-emerald-950/30 p-4 rounded-xl border border-emerald-100 dark:border-emerald-900/50">
-            <label className="flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-300 mb-2">
-              <FileText size={16} /> Action Item Template
-            </label>
-            <select
-              value={selectedActionItemTemplateId || ""}
-              onChange={(e) => setSelectedActionItemTemplateId(e.target.value)}
-              className="w-full px-4 py-2 bg-white dark:bg-slate-800 border border-emerald-200 dark:border-emerald-800 rounded-lg focus:ring-2 focus:ring-emerald-400 outline-none text-sm text-gray-700 dark:text-gray-200"
-            >
-              <option value="">
-                -- Let standard tasks generate automatically --
-              </option>
-              {actionItemTemplates.map((t) => (
-                <option key={t._id} value={t._id}>
-                  {t.name} ({t.items?.length || 0} tasks)
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-emerald-700 dark:text-emerald-400 mt-2">
-              Manually apply a specific set of standard action items for this
-              meeting.
             </p>
           </div>
         )}

--- a/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
+++ b/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
@@ -1,14 +1,13 @@
 import { toast } from "react-toastify";
 import {
   meetingApi,
-  meetingSeriesApi,
   meetingTemplateApi,
   aiSummaryTemplateApi,
 } from "../../../services";
-import * as actionItemTemplateApi from "../../../services/actionItemTemplateApi";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { customFieldApi } from "../../../api/customFieldApi";
 import { focusTimeApi } from "../../../api/focusTimeApi";
+import { calendarAvailabilityApi } from "../../../api/calendarAvailabilityApi";
 import AppContent from "../../../context/AppContent";
 import {
   buildMeetingDraftKey,
@@ -18,6 +17,20 @@ import {
   moveAgendaItem,
   normalizeAgendaItems,
 } from "../../../utils/agendaOrdering";
+import {
+  buildScheduleSlot,
+  findBusyParticipants,
+  findFocusConflicts,
+} from "../utils/scheduleConflicts";
+
+const CONFLICT_MODE_STORAGE_KEY = "meet-on-memory:schedule-conflict-mode";
+
+const readConflictMode = () => {
+  if (typeof window === "undefined") return "soft";
+  return window.localStorage.getItem(CONFLICT_MODE_STORAGE_KEY) === "hard"
+    ? "hard"
+    : "soft";
+};
 
 export const buildDuplicateScheduleState = (duplicateData = {}) => ({
   scheduleData: {
@@ -32,10 +45,6 @@ export const buildDuplicateScheduleState = (duplicateData = {}) => ({
     syncToCalendar: true,
     reminderEnabled: duplicateData.reminderEnabled || false,
     reminderMinutesBefore: duplicateData.reminderMinutesBefore || 30,
-    recurrencePattern: duplicateData.recurrencePattern || "none",
-    endDate: duplicateData.endDate || "",
-    dayOfWeek: duplicateData.dayOfWeek || "",
-    dayOfMonth: duplicateData.dayOfMonth || "",
   },
   participants: (duplicateData.participants || []).map(
     (participant, index) => ({
@@ -72,10 +81,6 @@ export const useScheduleMeeting = ({
     syncToCalendar: true,
     reminderEnabled: false,
     reminderMinutesBefore: 30,
-    recurrencePattern: "none",
-    endDate: "",
-    dayOfWeek: "",
-    dayOfMonth: "",
   });
   const [participants, setParticipants] = useState([]);
   const [newParticipant, setNewParticipant] = useState({ name: "", email: "" });
@@ -88,9 +93,6 @@ export const useScheduleMeeting = ({
   const [aiSummaryTemplates, setAiSummaryTemplates] = useState([]);
   const [selectedAiSummaryTemplateId, setSelectedAiSummaryTemplateId] =
     useState("");
-  const [actionItemTemplates, setActionItemTemplates] = useState([]);
-  const [selectedActionItemTemplateId, setSelectedActionItemTemplateId] =
-    useState("");
   const [customFields, setCustomFields] = useState({
     fields: [],
     isValid: true,
@@ -100,16 +102,13 @@ export const useScheduleMeeting = ({
     policyDetails: null,
     recordingType: "upload",
   });
-  const [focusBlocks, setFocusBlocks] = useState([]);
 
-  useEffect(() => {
-    focusTimeApi
-      .getBlocks()
-      .then((blocks) => setFocusBlocks(blocks || []))
-      .catch((err) =>
-        console.error("Error loading focus blocks in scheduler:", err),
-      );
-  }, []);
+  const [focusBlocks, setFocusBlocks] = useState([]);
+  const [focusConflicts, setFocusConflicts] = useState([]);
+  const [busyParticipants, setBusyParticipants] = useState([]);
+  const [checkingConflicts, setCheckingConflicts] = useState(false);
+  const [conflictCheckError, setConflictCheckError] = useState("");
+  const [conflictMode, setConflictModeState] = useState(readConflictMode);
 
   const userId = userData?._id || userData?.id;
   const organizationId =
@@ -128,7 +127,6 @@ export const useScheduleMeeting = ({
       agendaItems,
       selectedTemplateId,
       selectedAiSummaryTemplateId,
-      selectedActionItemTemplateId,
     }),
     [
       participants,
@@ -136,7 +134,6 @@ export const useScheduleMeeting = ({
       agendaItems,
       selectedTemplateId,
       selectedAiSummaryTemplateId,
-      selectedActionItemTemplateId,
     ],
   );
 
@@ -149,9 +146,6 @@ export const useScheduleMeeting = ({
     }
     if (typeof draft?.selectedAiSummaryTemplateId === "string") {
       setSelectedAiSummaryTemplateId(draft.selectedAiSummaryTemplateId);
-    }
-    if (typeof draft?.selectedActionItemTemplateId === "string") {
-      setSelectedActionItemTemplateId(draft.selectedActionItemTemplateId);
     }
   };
 
@@ -170,37 +164,6 @@ export const useScheduleMeeting = ({
     serverUpdatedAt,
     onRestore: restoreDraftValues,
   });
-
-  const resetFormState = useCallback(() => {
-    setScheduleData({
-      title: "",
-      description: "",
-      meetingType: "conference",
-      date: "",
-      time: "",
-      duration: "",
-      location: "",
-      venue: "",
-      syncToCalendar: true,
-      reminderEnabled: false,
-      reminderMinutesBefore: 30,
-      recurrencePattern: "none",
-      endDate: "",
-      dayOfWeek: "",
-      dayOfMonth: "",
-    });
-    setParticipants([]);
-    setAgendaItems([]);
-    setAttachments([]);
-    setDuplicateMetadata({
-      tags: [],
-      policyDetails: null,
-      recordingType: "upload",
-    });
-    setSelectedTemplateId("");
-    setSelectedActionItemTemplateId("");
-    clearDraft();
-  }, [clearDraft]);
 
   useEffect(() => {
     let cancelled = false;
@@ -232,22 +195,113 @@ export const useScheduleMeeting = ({
         .catch((err) =>
           console.error("Failed to fetch AI summary templates:", err),
         );
-
-      actionItemTemplateApi
-        .getTemplates()
-        .then((data) => {
-          if (!cancelled && data) {
-            setActionItemTemplates(data);
-          }
-        })
-        .catch((err) =>
-          console.error("Failed to fetch Action Item templates:", err),
-        );
     }
     return () => {
       cancelled = true;
     };
   }, [userData, draftValues.selectedAiSummaryTemplateId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    focusTimeApi
+      .getBlocks()
+      .then((blocks) => {
+        if (!cancelled) setFocusBlocks(Array.isArray(blocks) ? blocks : []);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("Failed to fetch focus time blocks:", error);
+          setFocusBlocks([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const slot = buildScheduleSlot(
+      scheduleData.date,
+      scheduleData.time,
+      scheduleData.duration,
+    );
+
+    if (!slot) {
+      setFocusConflicts([]);
+      setBusyParticipants([]);
+      setCheckingConflicts(false);
+      setConflictCheckError("");
+      return undefined;
+    }
+
+    setFocusConflicts(findFocusConflicts(focusBlocks, slot));
+
+    const attendeeEmails = participants
+      .map((participant) => participant?.email?.trim())
+      .filter((email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email));
+
+    if (attendeeEmails.length === 0) {
+      setBusyParticipants([]);
+      setCheckingConflicts(false);
+      setConflictCheckError("");
+      return undefined;
+    }
+
+    let cancelled = false;
+    setCheckingConflicts(true);
+    setConflictCheckError("");
+
+    const timer = window.setTimeout(async () => {
+      try {
+        const response = await calendarAvailabilityApi.getFreeBusy({
+          attendeeEmails: [...new Set(attendeeEmails)],
+          timeMin: slot.start.toISOString(),
+          timeMax: slot.end.toISOString(),
+        });
+
+        if (!cancelled) {
+          setBusyParticipants(
+            findBusyParticipants(
+              response?.data || response,
+              participants,
+              slot,
+            ),
+          );
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to check participant availability:", error);
+          setBusyParticipants([]);
+          setConflictCheckError(
+            "Participant availability could not be checked. You can still schedule unless hard blocking is enabled.",
+          );
+        }
+      } finally {
+        if (!cancelled) setCheckingConflicts(false);
+      }
+    }, 350);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [
+    focusBlocks,
+    participants,
+    scheduleData.date,
+    scheduleData.time,
+    scheduleData.duration,
+  ]);
+
+  const setConflictMode = useCallback((modeValue) => {
+    const nextMode = modeValue === "hard" ? "hard" : "soft";
+    setConflictModeState(nextMode);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(CONFLICT_MODE_STORAGE_KEY, nextMode);
+    }
+  }, []);
 
   const hydrateDuplicateMeeting = useCallback((duplicateData) => {
     const duplicated = buildDuplicateScheduleState(duplicateData);
@@ -297,38 +351,6 @@ export const useScheduleMeeting = ({
     setParticipants(participants.filter((p) => p.id !== id));
   };
 
-  const importParticipants = (rows) => {
-    if (!Array.isArray(rows) || rows.length === 0) return;
-    const existing = new Set(
-      participants.map((p) =>
-        String(p.email || "")
-          .trim()
-          .toLowerCase(),
-      ),
-    );
-    const toAdd = [];
-    for (const row of rows) {
-      const email = String(row.email || "").trim();
-      const key = email.toLowerCase();
-      if (!email || existing.has(key)) continue;
-      existing.add(key);
-      toAdd.push({
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        name: String(row.name || "").trim(),
-        email,
-        role: String(row.role || "").trim(),
-      });
-    }
-    if (toAdd.length === 0) {
-      toast.info("No new participants to import.");
-      return;
-    }
-    setParticipants((prev) => [...prev, ...toAdd]);
-    toast.success(
-      `Imported ${toAdd.length} participant${toAdd.length === 1 ? "" : "s"} from CSV`,
-    );
-  };
-
   const addAgendaItem = () => {
     if (newAgenda.trim()) {
       setAgendaItems((current) =>
@@ -374,197 +396,86 @@ export const useScheduleMeeting = ({
       return;
     }
 
-    const checkFocusConflict = () => {
-      if (!scheduleData.date || !scheduleData.time) return null;
-      const duration = Number(scheduleData.duration) || 60;
-
-      // Parse meeting start & end dates
-      const meetingStart = new Date(
-        `${scheduleData.date}T${scheduleData.time}`,
+    const hasConflicts =
+      focusConflicts.length > 0 || busyParticipants.length > 0;
+    if (hasConflicts && conflictMode === "hard") {
+      toast.error(
+        "Resolve the schedule conflict or switch Conflict behavior to Warn only.",
       );
-      const meetingEnd = new Date(
-        meetingStart.getTime() + duration * 60 * 1000,
-      );
-
-      // Iterate and find conflicts
-      for (const block of focusBlocks) {
-        const blockStart = new Date(block.startTime);
-        const blockEnd = new Date(block.endTime);
-
-        if (block.isRecurring) {
-          const dayOfWeek = meetingStart.getDay();
-          if (
-            block.daysOfWeek.includes(dayOfWeek) &&
-            blockStart <= meetingStart
-          ) {
-            const slotStart = new Date(meetingStart);
-            slotStart.setHours(
-              blockStart.getHours(),
-              blockStart.getMinutes(),
-              0,
-              0,
-            );
-            const slotDuration = blockEnd - blockStart;
-            const slotEnd = new Date(slotStart.getTime() + slotDuration);
-
-            if (meetingStart < slotEnd && meetingEnd > slotStart) {
-              return block.title || "Focus Time";
-            }
-          }
-        } else {
-          if (meetingStart < blockEnd && meetingEnd > blockStart) {
-            return block.title || "Focus Time";
-          }
-        }
-      }
-      return null;
-    };
-
-    let finalAuditNote = "";
-    const conflictTitle = checkFocusConflict();
-    if (conflictTitle) {
-      const confirmSchedule = window.confirm(
-        `⚠️ Warning: This meeting overlaps with your Focus Time block: "${conflictTitle}".\n\nWould you like to schedule it anyway?`,
-      );
-      if (!confirmSchedule) return;
-
-      const reason = window.prompt(
-        "Please enter an audit note explaining the reason for scheduling over Focus Time:",
-      );
-      if (reason === null) return; // User cancelled
-
-      finalAuditNote =
-        reason || "Scheduled despite overlapping focus time block.";
+      return;
     }
 
-    const isRecurring =
-      Boolean(scheduleData.recurrencePattern) &&
-      scheduleData.recurrencePattern !== "none";
-
-    if (isRecurring) {
-      if (!scheduleData.endDate) {
-        toast.error("End date is required for recurring meetings");
-        return;
-      }
-      if (new Date(scheduleData.date) > new Date(scheduleData.endDate)) {
-        toast.error("Start date must be before or equal to end date");
-        return;
-      }
-      const validPatterns = ["daily", "weekly", "biweekly", "monthly"];
-      if (!validPatterns.includes(scheduleData.recurrencePattern)) {
-        toast.error("Invalid recurrence pattern selected");
-        return;
-      }
+    if (checkingConflicts && conflictMode === "hard") {
+      toast.error(
+        "Please wait for participant availability to finish checking.",
+      );
+      return;
     }
 
     setLoading(true);
     try {
-      if (isRecurring) {
-        const seriesPayload = {
-          title: scheduleData.title.trim(),
-          description: scheduleData.description || "",
-          meetingType: scheduleData.meetingType || "conference",
-          recurrencePattern: scheduleData.recurrencePattern,
-          dayOfWeek:
-            scheduleData.dayOfWeek !== "" &&
-            scheduleData.dayOfWeek !== undefined &&
-            scheduleData.dayOfWeek !== null
-              ? Number(scheduleData.dayOfWeek)
-              : undefined,
-          dayOfMonth:
-            scheduleData.dayOfMonth !== "" &&
-            scheduleData.dayOfMonth !== undefined &&
-            scheduleData.dayOfMonth !== null
-              ? Number(scheduleData.dayOfMonth)
-              : undefined,
-          startDate: scheduleData.date,
-          endDate: scheduleData.endDate,
-          time: scheduleData.time,
-          duration: scheduleData.duration ? Number(scheduleData.duration) : 60,
-          location: scheduleData.location || "",
-          venue: scheduleData.venue || "",
-          participants: participants.map((p) => ({
-            name: p.name,
-            email: p.email,
-            role: p.role,
-          })),
-          agendaItems: normalizeAgendaItems(agendaItems).map((a) => ({
-            text: a.text,
-            description: a.description,
-            duration: a.duration ? Number(a.duration) : undefined,
-          })),
-          auditNote: finalAuditNote,
-        };
+      const payload = {
+        ...scheduleData,
+        participants,
+        tags: duplicateMetadata.tags,
+        policyDetails: duplicateMetadata.policyDetails,
+        recordingType: duplicateMetadata.recordingType,
+        agendaItems: normalizeAgendaItems(agendaItems),
+      };
 
-        const response = await meetingSeriesApi.createSeries(seriesPayload);
+      const response = await meetingApi.scheduleMeeting(payload);
 
-        if (response.data?.success) {
-          const createdCount = response.data.meetingsCreated || 0;
-          toast.success(
-            `✅ Meeting series created successfully with ${createdCount} occurrence(s)!`,
-          );
-          resetFormState();
-        } else {
-          toast.error(
-            response.data?.message || "Failed to create meeting series",
-          );
+      if (response.data?.success) {
+        if (customFields.fields.length > 0 && userData?.organization) {
+          try {
+            await customFieldApi.setMeetingFields(
+              response.data.meeting._id,
+              userData.organization,
+              customFields.fields,
+            );
+          } catch (err) {
+            console.error("Failed to save custom fields", err);
+            toast.error("Meeting saved, but custom fields failed to save");
+          }
         }
+        toast.success("✅ Meeting scheduled and synced to calendars!");
+
+        if (response.data.calendarLinks) {
+          toast.info("📅 Calendar invites sent to all participants!");
+        }
+
+        setScheduleData({
+          title: "",
+          description: "",
+          meetingType: "conference",
+          date: "",
+          time: "",
+          duration: "",
+          location: "",
+          venue: "",
+          syncToCalendar: true,
+          reminderEnabled: false,
+          reminderMinutesBefore: 30,
+        });
+        setParticipants([]);
+        setAgendaItems([]);
+        setAttachments([]);
+        setDuplicateMetadata({
+          tags: [],
+          policyDetails: null,
+          recordingType: "upload",
+        });
+        setSelectedTemplateId("");
+        setFocusConflicts([]);
+        setBusyParticipants([]);
+        clearDraft();
       } else {
-        const payload = {
-          ...scheduleData,
-          participants,
-          tags: duplicateMetadata.tags,
-          policyDetails: duplicateMetadata.policyDetails,
-          recordingType: duplicateMetadata.recordingType,
-          agendaItems: normalizeAgendaItems(agendaItems),
-          auditNote: finalAuditNote,
-        };
-
-        const response = await meetingApi.scheduleMeeting(payload);
-
-        if (response.data?.success) {
-          if (customFields.fields.length > 0 && userData?.organization) {
-            try {
-              await customFieldApi.setMeetingFields(
-                response.data.meeting._id,
-                userData.organization,
-                customFields.fields,
-              );
-            } catch (err) {
-              console.error("Failed to save custom fields", err);
-              toast.error("Meeting saved, but custom fields failed to save");
-            }
-          }
-          toast.success("✅ Meeting scheduled and synced to calendars!");
-
-          if (response.data.calendarLinks) {
-            toast.info("📅 Calendar invites sent to all participants!");
-          }
-
-          if (selectedActionItemTemplateId) {
-            try {
-              await actionItemTemplateApi.applyTemplateToMeeting(
-                selectedActionItemTemplateId,
-                response.data.meeting._id,
-              );
-              toast.success("Action items generated from template");
-            } catch (err) {
-              console.error("Failed to apply action item template", err);
-              toast.error("Meeting saved, but action items failed to generate");
-            }
-          }
-
-          resetFormState();
-        } else {
-          toast.error(response.data?.message || "Failed to schedule meeting");
-        }
+        toast.error(response.data?.message || "Failed to schedule meeting");
       }
     } catch (error) {
       console.error("Error scheduling meeting:", error);
       toast.error(
-        error.response?.data?.message ||
-          error.response?.data?.errors?.[0]?.message ||
-          "Unable to schedule meeting",
+        error.response?.data?.message || "Unable to schedule meeting",
       );
     } finally {
       setLoading(false);
@@ -587,14 +498,10 @@ export const useScheduleMeeting = ({
     aiSummaryTemplates,
     selectedAiSummaryTemplateId,
     setSelectedAiSummaryTemplateId,
-    actionItemTemplates,
-    selectedActionItemTemplateId,
-    setSelectedActionItemTemplateId,
     handleTemplateSelect,
     handleScheduleChange,
     addParticipant,
     removeParticipant,
-    importParticipants,
     addAgendaItem,
     removeAgendaItem,
     reorderAgendaItem,
@@ -611,5 +518,11 @@ export const useScheduleMeeting = ({
     customFields,
     setCustomFields,
     userData,
+    focusConflicts,
+    busyParticipants,
+    checkingConflicts,
+    conflictCheckError,
+    conflictMode,
+    setConflictMode,
   };
 };

--- a/client/src/pages/CreateMeeting/utils/__tests__/scheduleConflicts.test.js
+++ b/client/src/pages/CreateMeeting/utils/__tests__/scheduleConflicts.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScheduleSlot,
+  findBusyParticipants,
+  findFocusConflicts,
+} from "../scheduleConflicts";
+
+describe("schedule conflict helpers", () => {
+  it("builds a local schedule slot from date, time and duration", () => {
+    const slot = buildScheduleSlot("2026-08-24", "10:30", 45);
+
+    expect(slot.start.getHours()).toBe(10);
+    expect(slot.start.getMinutes()).toBe(30);
+    expect(slot.end.getTime() - slot.start.getTime()).toBe(45 * 60 * 1000);
+  });
+
+  it("detects a recurring focus block on the selected weekday", () => {
+    const slot = buildScheduleSlot("2026-08-24", "10:30", 30);
+    const conflicts = findFocusConflicts(
+      [
+        {
+          _id: "focus-1",
+          title: "Deep work",
+          isRecurring: true,
+          daysOfWeek: [1],
+          startTime: "2026-08-01T10:00:00.000Z",
+          endTime: "2026-08-01T11:00:00.000Z",
+        },
+      ],
+      slot,
+    );
+
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].title).toBe("Deep work");
+  });
+
+  it("lists only participants whose busy interval overlaps the proposed slot", () => {
+    const slot = buildScheduleSlot("2026-08-24", "10:30", 30);
+    const participants = [
+      { name: "Busy User", email: "busy@example.com" },
+      { name: "Free User", email: "free@example.com" },
+    ];
+
+    const busy = findBusyParticipants(
+      {
+        google: {
+          "busy@example.com": {
+            busy: [
+              {
+                start: "2026-08-24T10:15:00.000Z",
+                end: "2026-08-24T11:00:00.000Z",
+              },
+            ],
+          },
+          "free@example.com": {
+            busy: [
+              {
+                start: "2026-08-24T12:00:00.000Z",
+                end: "2026-08-24T13:00:00.000Z",
+              },
+            ],
+          },
+        },
+      },
+      participants,
+      slot,
+    );
+
+    expect(busy).toHaveLength(1);
+    expect(busy[0].email).toBe("busy@example.com");
+  });
+});

--- a/client/src/pages/CreateMeeting/utils/scheduleConflicts.js
+++ b/client/src/pages/CreateMeeting/utils/scheduleConflicts.js
@@ -1,0 +1,194 @@
+export const DEFAULT_MEETING_DURATION_MINUTES = 60;
+
+const toDate = (value) => {
+  const date =
+    value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const buildScheduleSlot = (date, time, durationMinutes) => {
+  if (!date || !time) return null;
+
+  const [year, month, day] = String(date).split("-").map(Number);
+  const [hours, minutes] = String(time).split(":").map(Number);
+  const duration = Number(durationMinutes || DEFAULT_MEETING_DURATION_MINUTES);
+
+  if (
+    !year ||
+    !month ||
+    !day ||
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    !Number.isFinite(duration) ||
+    duration <= 0
+  ) {
+    return null;
+  }
+
+  const start = new Date(year, month - 1, day, hours, minutes, 0, 0);
+  if (Number.isNaN(start.getTime())) return null;
+
+  const end = new Date(start.getTime() + duration * 60 * 1000);
+  return { start, end };
+};
+
+export const rangesOverlap = (leftStart, leftEnd, rightStart, rightEnd) => {
+  const aStart = toDate(leftStart);
+  const aEnd = toDate(leftEnd);
+  const bStart = toDate(rightStart);
+  const bEnd = toDate(rightEnd);
+
+  if (!aStart || !aEnd || !bStart || !bEnd) return false;
+  return aStart < bEnd && aEnd > bStart;
+};
+
+const getRecurringOccurrence = (block, day) => {
+  const blockStart = toDate(block.startTime);
+  const blockEnd = toDate(block.endTime);
+  if (!blockStart || !blockEnd) return null;
+
+  const duration = blockEnd.getTime() - blockStart.getTime();
+  if (duration <= 0) return null;
+
+  const occurrence = new Date(day);
+  occurrence.setHours(
+    blockStart.getHours(),
+    blockStart.getMinutes(),
+    blockStart.getSeconds(),
+    blockStart.getMilliseconds(),
+  );
+
+  return {
+    start: occurrence,
+    end: new Date(occurrence.getTime() + duration),
+  };
+};
+
+export const findFocusConflicts = (blocks = [], slot) => {
+  if (!slot) return [];
+
+  const conflicts = [];
+  const seen = new Set();
+
+  for (const block of blocks) {
+    if (!block) continue;
+
+    if (block.isRecurring) {
+      const firstDay = new Date(slot.start);
+      firstDay.setHours(0, 0, 0, 0);
+      const lastDay = new Date(slot.end);
+      lastDay.setHours(0, 0, 0, 0);
+
+      for (
+        const day = new Date(firstDay);
+        day <= lastDay;
+        day.setDate(day.getDate() + 1)
+      ) {
+        if (
+          !Array.isArray(block.daysOfWeek) ||
+          !block.daysOfWeek.includes(day.getDay())
+        ) {
+          continue;
+        }
+
+        const occurrence = getRecurringOccurrence(block, day);
+        if (
+          occurrence &&
+          rangesOverlap(slot.start, slot.end, occurrence.start, occurrence.end)
+        ) {
+          const key = `${block._id || block.id || block.title || "focus"}-${occurrence.start.toISOString()}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            conflicts.push({
+              ...block,
+              conflictStart: occurrence.start,
+              conflictEnd: occurrence.end,
+            });
+          }
+        }
+      }
+      continue;
+    }
+
+    const start = toDate(block.startTime);
+    const end = toDate(block.endTime);
+    if (rangesOverlap(slot.start, slot.end, start, end)) {
+      conflicts.push({
+        ...block,
+        conflictStart: start,
+        conflictEnd: end,
+      });
+    }
+  }
+
+  return conflicts.sort((a, b) => a.conflictStart - b.conflictStart);
+};
+
+const collectBusyMaps = (freeBusyData = {}) => {
+  const maps = [];
+  for (const provider of ["google", "microsoft"]) {
+    if (
+      freeBusyData?.[provider] &&
+      typeof freeBusyData[provider] === "object"
+    ) {
+      maps.push(freeBusyData[provider]);
+    }
+  }
+
+  if (freeBusyData?.data && typeof freeBusyData.data === "object") {
+    return collectBusyMaps(freeBusyData.data);
+  }
+
+  if (maps.length === 0 && typeof freeBusyData === "object") {
+    maps.push(freeBusyData);
+  }
+  return maps;
+};
+
+export const findBusyParticipants = (
+  freeBusyData = {},
+  participants = [],
+  slot,
+) => {
+  if (!slot) return [];
+
+  const requested = new Map(
+    participants
+      .filter((participant) => participant?.email)
+      .map((participant) => [
+        participant.email.trim().toLowerCase(),
+        participant,
+      ]),
+  );
+
+  const busy = [];
+  const seen = new Set();
+
+  for (const map of collectBusyMaps(freeBusyData)) {
+    for (const [email, calendar] of Object.entries(map || {})) {
+      const normalizedEmail = email.trim().toLowerCase();
+      if (!requested.has(normalizedEmail)) continue;
+
+      for (const interval of calendar?.busy || []) {
+        if (
+          !rangesOverlap(slot.start, slot.end, interval.start, interval.end)
+        ) {
+          continue;
+        }
+
+        const key = `${normalizedEmail}-${interval.start}-${interval.end}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        busy.push({
+          email: requested.get(normalizedEmail)?.email || email,
+          name: requested.get(normalizedEmail)?.name || email,
+          start: new Date(interval.start),
+          end: new Date(interval.end),
+        });
+      }
+    }
+  }
+
+  return busy.sort((a, b) => a.start - b.start);
+};


### PR DESCRIPTION
# Pull Request

## Summary

Closes #2055

Adds schedule-time conflict detection to the Create/Schedule Meeting flow
using the existing Focus Time and calendar free/busy APIs.

## Changes

### Focus Time conflicts

- Check proposed meeting slots against Focus Time blocks.
- Support recurring Focus Time blocks.
- Display conflicting focus intervals inline.

### Participant availability

- Query the existing calendar free/busy endpoint when the meeting
  date/time and participant emails are available.
- Detect overlapping participant busy intervals.
- Display the affected participants and conflicting times.
- Debounce availability checks to avoid excessive requests.

### Conflict behavior

Added two scheduling modes:

- Warn only — allow the user to proceed despite conflicts.
- Block scheduling — prevent submission when conflicts exist.

The selected mode is persisted locally for subsequent scheduling sessions.

### Accessibility

- Added an inline conflict warning region.
- Uses `aria-live="polite"` and `aria-atomic="true"`.
- Conflict details are presented as readable lists.

### Testing

Added tests covering:

- schedule-slot construction
- recurring Focus Time conflicts
- overlapping participant busy intervals
- non-overlapping participant events

## Validation

- [ ] Client test suite passes
- [ ] Client production build passes
- [ ] `git diff --check` passes

## Issue

Closes #2055

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
