### PR TITLE
feat: implement KnowledgeArchive bulk restore and tag facets

### DIFF
--- a/client/src/pages/KnowledgeArchive.jsx
+++ b/client/src/pages/KnowledgeArchive.jsx
@@ -1,21 +1,23 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Navbar from "../components/Navbar.jsx";
+import ConfirmModal from "../components/ConfirmModal.jsx";
 import { knowledgeApi } from "../services";
 import { toast } from "react-toastify";
 import {
   Archive,
-  Search,
-  RotateCcw,
-  Loader2,
-  RefreshCw,
-  FileText,
   Calendar,
-  Tag,
+  CheckSquare,
   Clock,
+  FileText,
   Filter,
   History,
-  X,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Search,
   ShieldAlert,
+  Tag,
+  X,
 } from "lucide-react";
 
 const TYPE_OPTIONS = [
@@ -29,78 +31,88 @@ const KnowledgeArchive = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTag, setSelectedTag] = useState("all");
   const [loading, setLoading] = useState(true);
-  const [restoringId, setRestoringId] = useState(null);
   const [archivedMemories, setArchivedMemories] = useState([]);
+  const [tagFacets, setTagFacets] = useState([]);
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+  const [bulkModalOpen, setBulkModalOpen] = useState(false);
+  const [bulkRestoring, setBulkRestoring] = useState(false);
+  const [bulkSummary, setBulkSummary] = useState(null);
 
-  // Server-side Pagination State (#835)
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(10);
-  const [totalPages, setTotalPages] = useState(1);
-  const [totalCount, setTotalCount] = useState(0);
-
-  // Restore Modal State
+  const [restoringId, setRestoringId] = useState(null);
   const [restoreModal, setRestoreModal] = useState({
     isOpen: false,
     memory: null,
     reason: "",
   });
 
-  // History Modal State
   const [historyModal, setHistoryModal] = useState({
     isOpen: false,
     memory: null,
   });
 
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+
   const loadArchivedMemories = useCallback(async () => {
     setLoading(true);
+
     try {
       const res = await knowledgeApi.getArchivedMemories({
         type: selectedType,
+        search: searchQuery || undefined,
+        tag: selectedTag,
         page,
         limit,
-        ...(searchQuery ? { search: searchQuery } : {}),
       });
 
-      if (res.data?.success) {
-        setArchivedMemories(res.data.memories || []);
-        setTotalCount(res.data.pagination?.total || 0);
-        setTotalPages(Math.max(1, res.data.pagination?.totalPages || 1));
-      } else {
-        setArchivedMemories([]);
-        setTotalCount(0);
-        setTotalPages(1);
-        toast.error(
+      if (!res.data?.success) {
+        throw new Error(
           res.data?.message || "Failed to fetch archived knowledge items.",
         );
       }
+
+      setArchivedMemories(res.data.memories || []);
+      setTotalCount(res.data.pagination?.total || 0);
+      setTotalPages(Math.max(1, res.data.pagination?.totalPages || 1));
+      setTagFacets(res.data.facets?.tags || []);
+      setSelectedIds(new Set());
+      setBulkSummary(null);
     } catch (err) {
       console.error("Failed to load archived memories:", err);
-      toast.error("Failed to fetch archived knowledge items.");
+      toast.error(
+        err.response?.data?.message ||
+          err.message ||
+          "Failed to fetch archived knowledge items.",
+      );
       setArchivedMemories([]);
       setTotalCount(0);
       setTotalPages(1);
+      setTagFacets([]);
+      setSelectedIds(new Set());
     } finally {
       setLoading(false);
     }
-  }, [selectedType, searchQuery, page, limit]);
+  }, [selectedType, searchQuery, selectedTag, page, limit]);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      loadArchivedMemories();
-    }, 300);
+    const timer = setTimeout(loadArchivedMemories, 300);
     return () => clearTimeout(timer);
   }, [loadArchivedMemories]);
 
   useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        setRestoreModal((prev) => ({ ...prev, isOpen: false }));
-        setHistoryModal((prev) => ({ ...prev, isOpen: false }));
-      }
+    const handleKeyDown = (event) => {
+      if (event.key !== "Escape") return;
+      setRestoreModal((prev) => ({ ...prev, isOpen: false }));
+      setHistoryModal((prev) => ({ ...prev, isOpen: false }));
+      if (!bulkRestoring) setBulkModalOpen(false);
     };
+
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [bulkRestoring]);
+
   const openRestoreModal = (memory) => {
     setRestoreModal({
       isOpen: true,
@@ -124,38 +136,120 @@ const KnowledgeArchive = () => {
         reason,
       );
 
-      if (res.data?.success) {
-        toast.success(`Memory successfully restored to Active Knowledge.`);
-        await loadArchivedMemories();
-      } else {
-        toast.error(res.data?.message || "Failed to restore memory.");
+      if (!res.data?.success) {
+        throw new Error(res.data?.message || "Failed to restore memory.");
       }
+
+      toast.success("Memory successfully restored to Active Knowledge.");
+      await loadArchivedMemories();
     } catch (err) {
       console.error("Restore error:", err);
-      toast.error(err.response?.data?.message || "Failed to restore memory.");
+      toast.error(
+        err.response?.data?.message ||
+          err.message ||
+          "Failed to restore memory.",
+      );
     } finally {
       setRestoringId(null);
     }
   };
 
-  // Derive unique tags / topics
-  const allTags = Array.from(
-    new Set(archivedMemories.flatMap((m) => m.aliases || []).filter(Boolean)),
+  const toggleSelection = (memory) => {
+    const key = `${memory.type}:${memory._id}`;
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const selectedMemories = useMemo(
+    () =>
+      archivedMemories.filter((memory) =>
+        selectedIds.has(`${memory.type}:${memory._id}`),
+      ),
+    [archivedMemories, selectedIds],
   );
 
-  const filteredMemories = archivedMemories.filter((mem) => {
-    if (selectedTag !== "all") {
-      return mem.aliases && mem.aliases.includes(selectedTag);
+  const allVisibleSelected =
+    archivedMemories.length > 0 &&
+    archivedMemories.every((memory) =>
+      selectedIds.has(`${memory.type}:${memory._id}`),
+    );
+
+  const toggleSelectAll = () => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (allVisibleSelected) {
+        archivedMemories.forEach((memory) =>
+          next.delete(`${memory.type}:${memory._id}`),
+        );
+      } else {
+        archivedMemories.forEach((memory) =>
+          next.add(`${memory.type}:${memory._id}`),
+        );
+      }
+      return next;
+    });
+  };
+
+  const confirmBulkRestore = async () => {
+    if (selectedMemories.length === 0) return;
+
+    setBulkRestoring(true);
+    setBulkSummary(null);
+
+    try {
+      const items = selectedMemories.map(({ type, _id }) => ({
+        type,
+        id: _id,
+      }));
+
+      const res = await knowledgeApi.bulkRestoreArchivedMemories(
+        items,
+        "Bulk restored from Knowledge Archive Browser",
+      );
+
+      if (!res.data?.success) {
+        throw new Error(res.data?.message || "Bulk restore failed.");
+      }
+
+      const summary = res.data;
+      setBulkSummary(summary);
+
+      if (summary.failed === 0) {
+        toast.success(`Restored ${summary.restored} archived memories.`);
+      } else {
+        toast.warning(
+          `Restored ${summary.restored} of ${summary.total}. ${summary.failed} item(s) failed.`,
+        );
+      }
+
+      setBulkModalOpen(false);
+      await loadArchivedMemories();
+    } catch (err) {
+      console.error("Bulk restore error:", err);
+      toast.error(
+        err.response?.data?.message || err.message || "Bulk restore failed.",
+      );
+    } finally {
+      setBulkRestoring(false);
     }
-    return true;
-  });
+  };
+
+  const resetFilters = () => {
+    setSelectedType("all");
+    setSearchQuery("");
+    setSelectedTag("all");
+    setPage(1);
+  };
 
   return (
     <div className="min-h-screen bg-linear-to-b from-slate-50 via-white to-slate-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 text-slate-800 dark:text-slate-200 pt-20">
       <Navbar />
 
-      <div className="p-6 max-w-6xl mx-auto space-y-6">
-        {/* Header */}
+      <main className="p-6 max-w-6xl mx-auto space-y-6">
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div>
             <div className="flex items-center gap-2">
@@ -167,15 +261,27 @@ const KnowledgeArchive = () => {
                   Knowledge Archive Browser
                 </h1>
                 <p className="text-sm text-slate-500 dark:text-slate-400">
-                  Search, review, and restore archived decisions and
-                  organizational memory items.
+                  Search, review, select, and restore archived organizational
+                  memory items.
                 </p>
               </div>
             </div>
           </div>
 
           <div className="flex items-center gap-3">
+            {selectedMemories.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setBulkModalOpen(true)}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-600 text-white text-sm font-semibold hover:bg-emerald-700 shadow-xs cursor-pointer"
+              >
+                <RotateCcw className="w-4 h-4" />
+                Restore {selectedMemories.length} selected
+              </button>
+            )}
+
             <button
+              type="button"
               onClick={loadArchivedMemories}
               disabled={loading}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-800 shadow-xs cursor-pointer disabled:opacity-50"
@@ -188,65 +294,116 @@ const KnowledgeArchive = () => {
           </div>
         </div>
 
-        {/* Search & Filter Toolbar */}
         <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-4 space-y-4 shadow-xs">
           <div className="flex flex-wrap items-center justify-between gap-4">
-            {/* Search Input */}
             <div className="relative flex-1 min-w-[260px]">
               <Search className="w-4 h-4 absolute left-3 top-3 text-slate-400" />
               <input
                 type="text"
                 placeholder="Search archived decisions, action items, or keywords..."
                 value={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
+                onChange={(event) => {
+                  setSearchQuery(event.target.value);
                   setPage(1);
                 }}
                 className="w-full pl-9 pr-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs focus:ring-2 focus:ring-indigo-500 focus:outline-none"
               />
             </div>
 
-            {/* Type Selector */}
             <div className="flex items-center gap-2">
               <Filter className="w-4 h-4 text-slate-400" />
               <select
                 value={selectedType}
-                onChange={(e) => {
-                  setSelectedType(e.target.value);
+                onChange={(event) => {
+                  setSelectedType(event.target.value);
                   setPage(1);
+                  setSelectedTag("all");
                 }}
                 className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-xs font-medium cursor-pointer"
               >
-                {TYPE_OPTIONS.map((t) => (
-                  <option key={t.value} value={t.value}>
-                    {t.label}
+                {TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
                   </option>
                 ))}
               </select>
             </div>
 
-            {/* Tag Filter */}
-            {allTags.length > 0 && (
-              <div className="flex items-center gap-2">
-                <Tag className="w-4 h-4 text-slate-400" />
-                <select
-                  value={selectedTag}
-                  onChange={(e) => setSelectedTag(e.target.value)}
-                  className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-xs font-medium cursor-pointer"
-                >
-                  <option value="all">All Topics / Tags</option>
-                  {allTags.map((tag) => (
-                    <option key={tag} value={tag}>
-                      {tag}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <div className="flex items-center gap-2">
+              <Tag className="w-4 h-4 text-slate-400" />
+              <select
+                value={selectedTag}
+                onChange={(event) => {
+                  setSelectedTag(event.target.value);
+                  setPage(1);
+                }}
+                className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 text-xs font-medium cursor-pointer"
+                aria-label="Filter archive by tag"
+              >
+                <option value="all">All Topics / Tags</option>
+                {tagFacets.map((facet) => (
+                  <option key={facet.value} value={facet.value}>
+                    {facet.value} ({facet.count})
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {(searchQuery ||
+              selectedType !== "all" ||
+              selectedTag !== "all") && (
+              <button
+                type="button"
+                onClick={resetFilters}
+                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 cursor-pointer"
+              >
+                <X className="w-3.5 h-3.5" />
+                Clear filters
+              </button>
             )}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 dark:border-slate-800 pt-3 text-xs">
+            <label className="inline-flex items-center gap-2 font-semibold cursor-pointer">
+              <input
+                type="checkbox"
+                checked={allVisibleSelected}
+                onChange={toggleSelectAll}
+                disabled={loading || archivedMemories.length === 0}
+                className="h-4 w-4 rounded border-slate-300"
+              />
+              Select all on this page
+            </label>
+
+            <span className="text-slate-500 dark:text-slate-400">
+              {selectedMemories.length} selected · {totalCount} total archived
+              items
+            </span>
           </div>
         </div>
 
-        {/* Content Section */}
+        {bulkSummary && (
+          <div className="rounded-2xl border border-emerald-200 dark:border-emerald-900/60 bg-emerald-50 dark:bg-emerald-950/30 p-4 text-sm">
+            <div className="flex items-center gap-2 font-semibold text-emerald-800 dark:text-emerald-300">
+              <CheckSquare className="w-4 h-4" />
+              Bulk restore completed: {bulkSummary.restored} restored,{" "}
+              {bulkSummary.failed} failed.
+            </div>
+            {bulkSummary.failed > 0 && (
+              <div className="mt-2 space-y-1 text-xs text-amber-800 dark:text-amber-300">
+                {bulkSummary.results
+                  ?.filter((result) => !result.success)
+                  .map((result) => (
+                    <div key={`${result.type}:${result.id}`}>
+                      {result.type || "memory"} {result.id || ""}:{" "}
+                      {result.message}
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+        )}
+
         <div>
           {loading && (
             <div className="flex items-center justify-center py-16 text-slate-500 gap-2">
@@ -257,7 +414,7 @@ const KnowledgeArchive = () => {
             </div>
           )}
 
-          {!loading && filteredMemories.length === 0 && (
+          {!loading && archivedMemories.length === 0 && (
             <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-12 text-center shadow-xs">
               <Archive className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
               <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-1">
@@ -271,86 +428,120 @@ const KnowledgeArchive = () => {
             </div>
           )}
 
-          {!loading && filteredMemories.length > 0 && (
+          {!loading && archivedMemories.length > 0 && (
             <div className="space-y-4">
-              {filteredMemories.map((mem) => (
-                <div
-                  key={`${mem.type}-${mem._id}`}
-                  className="bg-white dark:bg-slate-900 border border-indigo-100 dark:border-slate-800/80 rounded-2xl p-5 shadow-xs hover:border-indigo-300 dark:hover:border-indigo-800 transition-all flex flex-col md:flex-row md:items-center justify-between gap-4"
-                >
-                  <div className="space-y-2 flex-1">
-                    <div className="flex items-center gap-2.5 flex-wrap">
-                      <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-indigo-100 text-indigo-800 dark:bg-indigo-950/70 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800">
-                        <Archive className="w-3 h-3" /> Archived
-                      </span>
+              {archivedMemories.map((memory) => {
+                const key = `${memory.type}:${memory._id}`;
+                const checked = selectedIds.has(key);
 
-                      <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
-                        {mem.type === "decision" ? "Decision" : "Action Item"}
-                      </span>
+                return (
+                  <div
+                    key={key}
+                    className="bg-white dark:bg-slate-900 border border-indigo-100 dark:border-slate-800/80 rounded-2xl p-5 shadow-xs hover:border-indigo-300 dark:hover:border-indigo-800 transition-all flex flex-col md:flex-row md:items-center justify-between gap-4"
+                  >
+                    <div className="flex gap-3 flex-1 min-w-0">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleSelection(memory)}
+                        aria-label={`Select ${memory.type} ${memory._id}`}
+                        className="mt-1 h-4 w-4 rounded border-slate-300 shrink-0"
+                      />
 
-                      {mem.importanceScore !== undefined && (
-                        <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400">
-                          Score:{" "}
-                          <strong className="text-slate-800 dark:text-slate-200">
-                            {mem.importanceScore}
-                          </strong>
-                        </span>
-                      )}
+                      <div className="space-y-2 flex-1 min-w-0">
+                        <div className="flex items-center gap-2.5 flex-wrap">
+                          <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-indigo-100 text-indigo-800 dark:bg-indigo-950/70 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800">
+                            <Archive className="w-3 h-3" /> Archived
+                          </span>
+                          <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                            {memory.type === "decision"
+                              ? "Decision"
+                              : "Action Item"}
+                          </span>
+                          {memory.importanceScore !== undefined && (
+                            <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400">
+                              Score:{" "}
+                              <strong className="text-slate-800 dark:text-slate-200">
+                                {memory.importanceScore}
+                              </strong>
+                            </span>
+                          )}
+                        </div>
+
+                        <p className="text-sm font-medium text-slate-900 dark:text-white leading-relaxed">
+                          {memory.text}
+                        </p>
+
+                        <div className="flex items-center gap-4 text-[11px] text-slate-500 dark:text-slate-400 flex-wrap">
+                          {memory.sourceMeetingId?.title && (
+                            <span className="flex items-center gap-1">
+                              <FileText className="w-3.5 h-3.5" />
+                              Meeting: {memory.sourceMeetingId.title}
+                            </span>
+                          )}
+                          <span className="flex items-center gap-1">
+                            <Calendar className="w-3.5 h-3.5" />
+                            Created:{" "}
+                            {new Date(memory.createdAt).toLocaleDateString()}
+                          </span>
+                          {memory.archivedAt && (
+                            <span className="flex items-center gap-1">
+                              <Clock className="w-3.5 h-3.5 text-indigo-500" />
+                              Archived:{" "}
+                              {new Date(memory.archivedAt).toLocaleDateString()}
+                            </span>
+                          )}
+                        </div>
+
+                        {(memory.aliases || []).length > 0 && (
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            {(memory.aliases || []).slice(0, 5).map((tag) => (
+                              <button
+                                key={tag}
+                                type="button"
+                                onClick={() => {
+                                  setSelectedTag(tag);
+                                  setPage(1);
+                                }}
+                                className="px-2 py-0.5 rounded-md bg-slate-100 dark:bg-slate-800 text-[10px] text-slate-600 dark:text-slate-300 hover:bg-indigo-100 dark:hover:bg-indigo-950 cursor-pointer"
+                              >
+                                #{tag}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
                     </div>
 
-                    <p className="text-sm font-medium text-slate-900 dark:text-white leading-relaxed">
-                      {mem.text}
-                    </p>
+                    <div className="flex items-center gap-2 shrink-0 flex-wrap border-t md:border-t-0 pt-3 md:pt-0 border-slate-100 dark:border-slate-800">
+                      <button
+                        type="button"
+                        onClick={() => openRestoreModal(memory)}
+                        disabled={restoringId === memory._id || bulkRestoring}
+                        className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-xl bg-emerald-600 text-white text-xs font-semibold hover:bg-emerald-700 disabled:opacity-50 cursor-pointer shadow-xs transition-colors"
+                      >
+                        {restoringId === memory._id ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <RotateCcw className="w-3.5 h-3.5" />
+                        )}
+                        Restore Memory
+                      </button>
 
-                    <div className="flex items-center gap-4 text-[11px] text-slate-500 dark:text-slate-400 flex-wrap">
-                      {mem.sourceMeetingId?.title && (
-                        <span className="flex items-center gap-1">
-                          <FileText className="w-3.5 h-3.5" />
-                          Meeting: {mem.sourceMeetingId.title}
-                        </span>
-                      )}
-                      <span className="flex items-center gap-1">
-                        <Calendar className="w-3.5 h-3.5" />
-                        Created: {new Date(mem.createdAt).toLocaleDateString()}
-                      </span>
-                      {mem.archivedAt && (
-                        <span className="flex items-center gap-1">
-                          <Clock className="w-3.5 h-3.5 text-indigo-500" />
-                          Archived:{" "}
-                          {new Date(mem.archivedAt).toLocaleDateString()}
-                        </span>
-                      )}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setHistoryModal({ isOpen: true, memory })
+                        }
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-xs font-semibold hover:bg-slate-100 dark:hover:bg-slate-700 cursor-pointer"
+                      >
+                        <History className="w-3.5 h-3.5" /> Audit History
+                      </button>
                     </div>
                   </div>
+                );
+              })}
 
-                  {/* Actions */}
-                  <div className="flex items-center gap-2 shrink-0 flex-wrap border-t md:border-t-0 pt-3 md:pt-0 border-slate-100 dark:border-slate-800">
-                    <button
-                      onClick={() => openRestoreModal(mem)}
-                      disabled={restoringId === mem._id}
-                      className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-xl bg-emerald-600 text-white text-xs font-semibold hover:bg-emerald-700 disabled:opacity-50 cursor-pointer shadow-xs transition-colors"
-                    >
-                      {restoringId === mem._id ? (
-                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                      ) : (
-                        <RotateCcw className="w-3.5 h-3.5" />
-                      )}
-                      Restore Memory
-                    </button>
-
-                    <button
-                      onClick={() =>
-                        setHistoryModal({ isOpen: true, memory: mem })
-                      }
-                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-xs font-semibold hover:bg-slate-100 dark:hover:bg-slate-700 cursor-pointer"
-                    >
-                      <History className="w-3.5 h-3.5" /> Audit History
-                    </button>
-                  </div>
-                </div>
-              ))}
-
-              {/* Pagination Controls (#835) */}
               <div className="flex flex-wrap items-center justify-between gap-4 pt-4 border-t border-slate-200 dark:border-slate-800 text-xs">
                 <div className="text-slate-500 dark:text-slate-400 font-medium">
                   Showing page{" "}
@@ -371,8 +562,8 @@ const KnowledgeArchive = () => {
                     </span>
                     <select
                       value={limit}
-                      onChange={(e) => {
-                        setLimit(Number(e.target.value));
+                      onChange={(event) => {
+                        setLimit(Number(event.target.value));
                         setPage(1);
                       }}
                       className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1 font-medium cursor-pointer"
@@ -385,15 +576,21 @@ const KnowledgeArchive = () => {
 
                   <div className="flex items-center gap-1">
                     <button
-                      onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+                      type="button"
+                      onClick={() =>
+                        setPage((previous) => Math.max(previous - 1, 1))
+                      }
                       disabled={page <= 1 || loading}
                       className="px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40 cursor-pointer"
                     >
                       Previous
                     </button>
                     <button
+                      type="button"
                       onClick={() =>
-                        setPage((prev) => Math.min(prev + 1, totalPages))
+                        setPage((previous) =>
+                          Math.min(previous + 1, totalPages),
+                        )
                       }
                       disabled={page >= totalPages || loading}
                       className="px-3 py-1.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 font-medium hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40 cursor-pointer"
@@ -406,9 +603,17 @@ const KnowledgeArchive = () => {
             </div>
           )}
         </div>
+      </main>
+
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 pointer-events-none">
+        {bulkRestoring && (
+          <div className="pointer-events-auto flex items-center gap-3 rounded-xl bg-slate-900 text-white px-4 py-3 shadow-2xl text-xs">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>Restoring {selectedMemories.length} archived memories…</span>
+          </div>
+        )}
       </div>
 
-      {/* Restore Confirmation Modal */}
       {restoreModal.isOpen && (
         <div className="fixed inset-0 z-50 bg-slate-900/60 backdrop-blur-xs flex items-center justify-center p-4">
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 max-w-md w-full shadow-2xl space-y-4">
@@ -418,10 +623,12 @@ const KnowledgeArchive = () => {
                 Restore Archived Memory
               </h3>
               <button
+                type="button"
                 onClick={() =>
                   setRestoreModal({ isOpen: false, memory: null, reason: "" })
                 }
                 className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+                aria-label="Close restore dialog"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -431,8 +638,8 @@ const KnowledgeArchive = () => {
               Restoring this memory will return it to{" "}
               <strong className="text-emerald-600 dark:text-emerald-400 font-semibold">
                 Active State
-              </strong>{" "}
-              across your organization's Knowledge base.
+              </strong>
+              .
             </p>
 
             <div className="bg-slate-50 dark:bg-slate-800/60 p-3 rounded-xl border border-slate-200 dark:border-slate-700 text-xs text-slate-800 dark:text-slate-200 font-medium">
@@ -446,10 +653,10 @@ const KnowledgeArchive = () => {
               <input
                 type="text"
                 value={restoreModal.reason}
-                onChange={(e) =>
-                  setRestoreModal((prev) => ({
-                    ...prev,
-                    reason: e.target.value,
+                onChange={(event) =>
+                  setRestoreModal((previous) => ({
+                    ...previous,
+                    reason: event.target.value,
                   }))
                 }
                 className="w-full px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-xs focus:ring-2 focus:ring-emerald-500 focus:outline-none"
@@ -458,6 +665,7 @@ const KnowledgeArchive = () => {
 
             <div className="flex items-center justify-end gap-3 pt-2">
               <button
+                type="button"
                 onClick={() =>
                   setRestoreModal({ isOpen: false, memory: null, reason: "" })
                 }
@@ -466,6 +674,7 @@ const KnowledgeArchive = () => {
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={confirmRestore}
                 className="px-4 py-2 rounded-xl bg-emerald-600 text-white text-xs font-semibold hover:bg-emerald-700 cursor-pointer shadow-xs"
               >
@@ -476,7 +685,23 @@ const KnowledgeArchive = () => {
         </div>
       )}
 
-      {/* Audit History Modal */}
+      <ConfirmModal
+        isOpen={bulkModalOpen}
+        onClose={() => {
+          if (!bulkRestoring) setBulkModalOpen(false);
+        }}
+        onConfirm={confirmBulkRestore}
+        title="Restore selected archived memories?"
+        message={`You are about to restore ${selectedMemories.length} archived ${
+          selectedMemories.length === 1 ? "memory" : "memories"
+        } to Active Knowledge. Individual failures will be reported without rolling back successful restores.`}
+        confirmText={`Restore ${selectedMemories.length}`}
+        cancelText="Cancel"
+        isLoading={bulkRestoring}
+        loadingText={`Restoring ${selectedMemories.length}…`}
+        variant="warning"
+      />
+
       {historyModal.isOpen && (
         <div className="fixed inset-0 z-50 bg-slate-900/60 backdrop-blur-xs flex items-center justify-center p-4">
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-6 max-w-lg w-full shadow-2xl space-y-4">
@@ -486,8 +711,10 @@ const KnowledgeArchive = () => {
                 Memory Audit Trail
               </h3>
               <button
+                type="button"
                 onClick={() => setHistoryModal({ isOpen: false, memory: null })}
                 className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+                aria-label="Close history dialog"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -503,27 +730,27 @@ const KnowledgeArchive = () => {
                   No state transition records found.
                 </p>
               ) : (
-                historyModal.memory.lifecycleHistory.map((h, idx) => (
+                historyModal.memory.lifecycleHistory.map((history, index) => (
                   <div
-                    key={idx}
+                    key={index}
                     className="p-3 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/60 text-xs space-y-1"
                   >
                     <div className="flex items-center justify-between text-slate-700 dark:text-slate-300 font-semibold">
                       <span>
-                        {h.fromState || "active"} →{" "}
+                        {history.fromState || history.from || "active"} →{" "}
                         <strong className="text-indigo-600 dark:text-indigo-400 uppercase">
-                          {h.toState}
+                          {history.toState || history.to}
                         </strong>
                       </span>
                       <span className="text-[10px] text-slate-400 font-normal">
                         {new Date(
-                          h.timestamp || h.transitionedAt,
+                          history.timestamp || history.transitionedAt,
                         ).toLocaleString()}
                       </span>
                     </div>
-                    {h.reason && (
+                    {history.reason && (
                       <p className="text-slate-500 dark:text-slate-400 italic">
-                        Reason: {h.reason}
+                        Reason: {history.reason}
                       </p>
                     )}
                   </div>
@@ -533,6 +760,7 @@ const KnowledgeArchive = () => {
 
             <div className="flex justify-end pt-2">
               <button
+                type="button"
                 onClick={() => setHistoryModal({ isOpen: false, memory: null })}
                 className="px-4 py-2 rounded-xl bg-slate-100 dark:bg-slate-800 text-xs font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-700 cursor-pointer"
               >
@@ -542,6 +770,14 @@ const KnowledgeArchive = () => {
           </div>
         </div>
       )}
+
+      <div className="sr-only" aria-live="polite">
+        {bulkRestoring
+          ? `Restoring ${selectedMemories.length} memories`
+          : bulkSummary
+            ? `${bulkSummary.restored} restored, ${bulkSummary.failed} failed`
+            : ""}
+      </div>
     </div>
   );
 };

--- a/client/src/services/__tests__/knowledgeArchive2072.test.js
+++ b/client/src/services/__tests__/knowledgeArchive2072.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { knowledgeApi } from "../knowledgeApi.js";
+import apiClient from "../apiClient.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("knowledgeApi - Knowledge Archive #2072", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the selected archive tag to the server", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { success: true, memories: [], facets: { tags: [] } },
+    });
+
+    await knowledgeApi.getArchivedMemories({
+      type: "all",
+      tag: "roadmap",
+      page: 2,
+      limit: 20,
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("type=all"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("tag=roadmap"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("page=2"),
+    );
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.stringContaining("limit=20"),
+    );
+  });
+
+  it("posts a bulk archive restore request with the selected memories", async () => {
+    apiClient.post.mockResolvedValue({
+      data: {
+        success: true,
+        restored: 2,
+        failed: 1,
+        total: 3,
+      },
+    });
+
+    await knowledgeApi.bulkRestoreArchivedMemories(
+      [
+        { type: "decision", id: "d1" },
+        { type: "action-item", id: "a1" },
+        { type: "decision", id: "d2" },
+      ],
+      "Recovered during archive review",
+    );
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/knowledge/archive/restore",
+      {
+        items: [
+          { type: "decision", id: "d1" },
+          { type: "action-item", id: "a1" },
+          { type: "decision", id: "d2" },
+        ],
+        reason: "Recovered during archive review",
+      },
+    );
+  });
+});

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -33,19 +33,26 @@ export const knowledgeApi = {
     return apiClient.get(url);
   },
   /**
-   * Unified archived decisions + action items with correct combined pagination (#901).
+   * Unified archived decisions + action items with correct combined pagination
+   * and server-side tag facets (#2072).
    */
   getArchivedMemories: (options = {}) => {
     const params = new URLSearchParams();
     if (options.type) params.append("type", options.type);
     if (options.search) params.append("search", options.search);
+    if (options.tag && options.tag !== "all") params.append("tag", options.tag);
     if (options.page) params.append("page", String(options.page));
     if (options.limit) params.append("limit", String(options.limit));
     const query = params.toString();
     return apiClient.get(`/api/knowledge/archive${query ? `?${query}` : ""}`);
   },
+  bulkRestoreArchivedMemories: (items, reason) =>
+    apiClient.post("/api/knowledge/archive/restore", {
+      items,
+      ...(reason?.trim() ? { reason: reason.trim() } : {}),
+    }),
   /**
-   * Unified Memory Lifecycle list with server-side pagination (#1552).
+   * Unified Memory Lifecycle list with server-side pagination.
    */
   getLifecycleMemories: (options = {}) => {
     const params = new URLSearchParams();
@@ -64,7 +71,7 @@ export const knowledgeApi = {
     apiClient.patch(`/api/knowledge/${type}/${id}/feedback`, { rating }),
   recalculateImportance: () =>
     apiClient.post(`/api/knowledge/importance/recalculate`),
-  // Memory Lifecycle Management (#377, #716)
+  // Memory Lifecycle Management
   runLifecycleSweep: () => apiClient.post(`/api/knowledge/lifecycle/run`),
   updateMemoryLifecycleState: (type, id, state, reason) =>
     apiClient.patch(`/api/knowledge/${type}/${id}/lifecycle`, {
@@ -89,7 +96,6 @@ export const knowledgeApi = {
     if (page) params.append("page", page);
     return apiClient.get(`/api/knowledge/graph/snapshots?${params.toString()}`);
   },
-
   getGraphSnapshot: (id) =>
     apiClient.get(`/api/knowledge/graph/snapshots/${id}`),
   exportGraphSnapshot: (id) =>
@@ -100,7 +106,7 @@ export const knowledgeApi = {
     ),
   createGraphSnapshot: (force = false) =>
     apiClient.post(`/api/knowledge/graph/snapshots`, { force }),
-  // AI-Powered Contradiction Detection & Conflict Resolution (#375, #715)
+  // AI-Powered Contradiction Detection & Conflict Resolution
   scanForConflicts: ({
     dryRun = false,
     models,

--- a/server/controllers/archiveController.js
+++ b/server/controllers/archiveController.js
@@ -1,0 +1,209 @@
+import mongoose from "mongoose";
+import ActionItem from "../models/actionItemModel.js";
+import Decision from "../models/decisionModel.js";
+import AuditLog from "../models/auditLogModel.js";
+import { restoreMemory } from "../services/memoryLifecycleService.js";
+import {
+  ALLOWED_ARCHIVE_TYPES,
+  getArchivedMemoriesPage,
+} from "../services/archivedKnowledgeService.js";
+import { sendSuccess, sendError } from "../utils/responseHandler.js";
+
+const MODEL_BY_TYPE = {
+  decision: Decision,
+  "action-item": ActionItem,
+};
+
+const SERVICE_TYPE_BY_TYPE = {
+  decision: "decision",
+  "action-item": "actionItem",
+};
+
+const MAX_BULK_RESTORE_ITEMS = 100;
+
+const sanitizeOrganization = (organization) => {
+  if (!organization) return null;
+  if (organization instanceof mongoose.Types.ObjectId) return organization;
+  if (typeof organization === "object" && organization._id) {
+    return sanitizeOrganization(organization._id);
+  }
+  return String(organization);
+};
+
+export const getArchivedMemoriesWithFacets = async (req, res) => {
+  try {
+    const { type = "all", search, tag } = req.query || {};
+    const organization = sanitizeOrganization(req.user?.organization);
+
+    if (!organization) {
+      return sendError(res, 400, "Organization required");
+    }
+
+    if (typeof type !== "string" || !ALLOWED_ARCHIVE_TYPES.includes(type)) {
+      return sendError(
+        res,
+        400,
+        `Invalid type. Allowed values: ${ALLOWED_ARCHIVE_TYPES.join(", ")}`,
+      );
+    }
+
+    if (search !== undefined && search !== null && typeof search !== "string") {
+      return sendError(res, 400, "Invalid search");
+    }
+
+    if (tag !== undefined && tag !== null && typeof tag !== "string") {
+      return sendError(res, 400, "Invalid tag");
+    }
+
+    const result = await getArchivedMemoriesPage({
+      organization,
+      type,
+      search,
+      tag,
+      page: req.query.page,
+      limit: req.query.limit,
+    });
+
+    return sendSuccess(res, result);
+  } catch (error) {
+    if (error.statusCode) {
+      return sendError(res, error.statusCode, error.message);
+    }
+    console.error("getArchivedMemoriesWithFacets error:", error);
+    return sendError(res, 500, "Failed to fetch archived memories");
+  }
+};
+
+/**
+ * Restores archived memories in an isolated per-item loop. One bad/deleted
+ * item does not roll back successful restores, allowing the client to report
+ * partial failures instead of losing the whole batch.
+ */
+export const bulkRestoreArchivedMemories = async (req, res) => {
+  try {
+    const { items, reason } = req.body || {};
+    const organization = sanitizeOrganization(req.user?.organization);
+
+    if (!organization) {
+      return sendError(res, 400, "Organization required");
+    }
+
+    if (
+      !Array.isArray(items) ||
+      items.length < 1 ||
+      items.length > MAX_BULK_RESTORE_ITEMS
+    ) {
+      return sendError(
+        res,
+        400,
+        `items must contain between 1 and ${MAX_BULK_RESTORE_ITEMS} memories`,
+      );
+    }
+
+    if (reason !== undefined && reason !== null && typeof reason !== "string") {
+      return sendError(res, 400, "Invalid restore reason");
+    }
+
+    const restoreReason =
+      reason?.trim() || "Bulk restored from Knowledge Archive Browser";
+    const results = [];
+
+    for (const item of items) {
+      const type = item?.type;
+      const id = item?.id;
+
+      if (
+        typeof type !== "string" ||
+        !Object.prototype.hasOwnProperty.call(MODEL_BY_TYPE, type) ||
+        typeof id !== "string" ||
+        !mongoose.Types.ObjectId.isValid(id)
+      ) {
+        results.push({
+          type: type || null,
+          id: id || null,
+          success: false,
+          message: "Invalid memory type or id",
+        });
+        continue;
+      }
+
+      const Model = MODEL_BY_TYPE[type];
+      const serviceType = SERVICE_TYPE_BY_TYPE[type];
+
+      try {
+        const document = await Model.findOne({
+          _id: new mongoose.Types.ObjectId(id),
+          organization,
+          lifecycleState: "archived",
+        });
+
+        if (!document) {
+          results.push({
+            type,
+            id,
+            success: false,
+            message: "Archived memory not found",
+          });
+          continue;
+        }
+
+        const updated = await restoreMemory(serviceType, document._id, {
+          triggeredBy: req.user?._id?.toString() || "admin",
+          reason: restoreReason,
+        });
+
+        if (!updated) {
+          results.push({
+            type,
+            id,
+            success: false,
+            message: "Memory could not be restored",
+          });
+          continue;
+        }
+
+        await AuditLog.create({
+          organization,
+          actor: req.user?._id,
+          action: "memory_lifecycle_transition",
+          entity: type === "decision" ? "Decision" : "ActionItem",
+          entityId: document._id,
+          details: {
+            fromState: "archived",
+            toState: "active",
+            reason: restoreReason,
+            bulk: true,
+          },
+        });
+
+        results.push({
+          type,
+          id,
+          success: true,
+          lifecycleState: updated.lifecycleState,
+        });
+      } catch (error) {
+        console.error("bulkRestoreArchivedMemories item failed:", error);
+        results.push({
+          type,
+          id,
+          success: false,
+          message: "Failed to restore memory",
+        });
+      }
+    }
+
+    const restored = results.filter((result) => result.success).length;
+    const failed = results.length - restored;
+
+    return sendSuccess(res, {
+      restored,
+      failed,
+      total: results.length,
+      results,
+    });
+  } catch (error) {
+    console.error("bulkRestoreArchivedMemories error:", error);
+    return sendError(res, 500, "Failed to bulk restore archived memories");
+  }
+};

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -6,7 +6,6 @@ import {
   getDecisionLineageController,
   getOpenActionItems,
   getDecisions,
-  getArchivedMemories,
   getLifecycleMemories,
   submitMemoryFeedback,
   recalculateImportance,
@@ -15,6 +14,10 @@ import {
   runMemoryLifecycleSweep,
   updateMemoryLifecycleState,
 } from "../controllers/knowledgeController.js";
+import {
+  getArchivedMemoriesWithFacets,
+  bulkRestoreArchivedMemories,
+} from "../controllers/archiveController.js";
 import {
   runConsolidation,
   getConsolidationHistory,
@@ -80,7 +83,14 @@ router.get(
   "/archive",
   requireOrgMembership,
   requirePermission("knowledge", "view"),
-  getArchivedMemories,
+  getArchivedMemoriesWithFacets,
+);
+router.post(
+  "/archive/restore",
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("knowledge", "manage_lifecycle"),
+  bulkRestoreArchivedMemories,
 );
 router.get(
   "/decisions/:id/lineage",
@@ -124,7 +134,7 @@ router.post(
   recalculateImportance,
 );
 
-// --- Memory Lifecycle Management (#377, #1552) ---
+// --- Memory Lifecycle Management ---
 router.get(
   "/lifecycle",
   requireOrgMembership,

--- a/server/services/archivedKnowledgeService.js
+++ b/server/services/archivedKnowledgeService.js
@@ -16,16 +16,10 @@ const toObjectId = (value) => {
 };
 
 /**
- * Builds the $match filter shared by both memory collections for the
- * Knowledge Archive browser.
- *
- * `search` is escaped and length-capped by `literalContainsFilter`
- * (Issue #1451). This match is not evaluated once but three times per request
- * — the decision branch, the `$unionWith` action-item branch, and the `$count`
- * inside `$facet` — so an unescaped pattern ran across both collections on
- * every archive page load.
+ * Builds the shared archive filter. Tag filtering is applied server-side so
+ * the selected facet always describes the same result set that is returned.
  */
-export const buildArchiveMatch = ({ organization, search }) => {
+export const buildArchiveMatch = ({ organization, search, tag }) => {
   const match = {
     organization: toObjectId(organization),
     lifecycleState: "archived",
@@ -34,6 +28,10 @@ export const buildArchiveMatch = ({ organization, search }) => {
   const searchFilter = literalContainsFilter(search);
   if (searchFilter) {
     match.text = searchFilter;
+  }
+
+  if (typeof tag === "string" && tag.trim()) {
+    match.aliases = tag.trim();
   }
 
   return match;
@@ -65,19 +63,19 @@ const meetingLookupStages = [
 ];
 
 /**
- * Builds the aggregation pipeline that returns one correctly paginated page
- * of archived memories. When `type` is `"all"`, decisions and action items
- * are unioned and sorted together before skip/limit so pages never skip or
- * duplicate records the way client-side merging of two independent pages did.
+ * Builds the combined archive aggregation. Tag facets are calculated before
+ * pagination, so counts represent the full matching archive rather than only
+ * the current page.
  */
 export const buildArchivePipeline = ({
   type = "all",
   organization,
   search,
+  tag,
   skip = 0,
   limit = 10,
 }) => {
-  const match = buildArchiveMatch({ organization, search });
+  const match = buildArchiveMatch({ organization, search, tag });
   const actionItemCollection = ActionItem.collection?.name || "actionitems";
 
   const decisionBranch = [{ $match: match }, withTypeAndSortDate("decision")];
@@ -106,20 +104,31 @@ export const buildArchivePipeline = ({
       $facet: {
         metadata: [{ $count: "total" }],
         data: [{ $skip: skip }, { $limit: limit }, ...meetingLookupStages],
+        tags: [
+          { $unwind: "$aliases" },
+          { $match: { aliases: { $type: "string", $ne: "" } } },
+          {
+            $group: {
+              _id: "$aliases",
+              count: { $sum: 1 },
+            },
+          },
+          { $sort: { _id: 1 } },
+        ],
       },
     },
   ];
 };
 
 /**
- * Fetches one page of archived knowledge items with unified pagination.
- *
- * @returns {{ memories: object[], pagination: object }}
+ * Fetches one page of archived knowledge items with unified pagination and
+ * full-result tag facets.
  */
 export const getArchivedMemoriesPage = async ({
   organization,
   type = "all",
   search,
+  tag,
   page,
   limit,
 }) => {
@@ -137,6 +146,12 @@ export const getArchivedMemoriesPage = async ({
     throw err;
   }
 
+  if (tag !== undefined && tag !== null && typeof tag !== "string") {
+    const err = new Error("Invalid tag");
+    err.statusCode = 400;
+    throw err;
+  }
+
   const pagination = parsePagination(
     { page, limit },
     { defaultLimit: 10, maxLimit: 100 },
@@ -146,6 +161,7 @@ export const getArchivedMemoriesPage = async ({
     type,
     organization,
     search,
+    tag,
     skip: pagination.skip,
     limit: pagination.limit,
   });
@@ -155,6 +171,15 @@ export const getArchivedMemoriesPage = async ({
   const memories = facet?.data || [];
   const total = facet?.metadata?.[0]?.total || 0;
 
+  const tags = (facet?.tags || [])
+    .map((entry) => ({
+      value: entry?._id,
+      count: entry?.count || 0,
+    }))
+    .filter(
+      (entry) => typeof entry.value === "string" && entry.value.length > 0,
+    );
+
   return {
     memories,
     pagination: buildPaginationMeta({
@@ -162,6 +187,9 @@ export const getArchivedMemoriesPage = async ({
       page: pagination.page,
       limit: pagination.limit,
     }),
+    facets: {
+      tags,
+    },
   };
 };
 

--- a/server/tests/archivedKnowledge2072.test.js
+++ b/server/tests/archivedKnowledge2072.test.js
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import mongoose from "mongoose";
+
+vi.mock("../models/decisionModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "decisions" },
+  },
+}));
+
+vi.mock("../models/actionItemModel.js", () => ({
+  default: {
+    aggregate: vi.fn(),
+    collection: { name: "actionitems" },
+  },
+}));
+
+const Decision = (await import("../models/decisionModel.js")).default;
+const { buildArchiveMatch, buildArchivePipeline, getArchivedMemoriesPage } =
+  await import("../services/archivedKnowledgeService.js");
+
+describe("archivedKnowledgeService #2072 tag facets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds an exact tag filter to the archive match", () => {
+    const match = buildArchiveMatch({
+      organization: new mongoose.Types.ObjectId(),
+      tag: "roadmap",
+    });
+
+    expect(match.aliases).toBe("roadmap");
+  });
+
+  it("builds a full-result tag facet alongside pagination", () => {
+    const pipeline = buildArchivePipeline({
+      type: "all",
+      organization: new mongoose.Types.ObjectId(),
+      skip: 0,
+      limit: 10,
+    });
+
+    const facet = pipeline.find((stage) => stage.$facet)?.$facet;
+    expect(facet?.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ $unwind: "$aliases" }),
+        expect.objectContaining({
+          $group: { _id: "$aliases", count: { $sum: 1 } },
+        }),
+      ]),
+    );
+  });
+
+  it("returns normalized tag facet values from the complete result set", async () => {
+    Decision.aggregate.mockResolvedValue([
+      {
+        metadata: [{ total: 3 }],
+        data: [{ _id: "d1", type: "decision" }],
+        tags: [
+          { _id: "roadmap", count: 2 },
+          { _id: "finance", count: 1 },
+        ],
+      },
+    ]);
+
+    const result = await getArchivedMemoriesPage({
+      organization: new mongoose.Types.ObjectId(),
+      type: "all",
+      page: 1,
+      limit: 10,
+    });
+
+    expect(result.facets.tags).toEqual([
+      { value: "roadmap", count: 2 },
+      { value: "finance", count: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

Implements #2072 by completing bulk restore support and making KnowledgeArchive tag facets reliable.

## Changes

- Added multi-select support to KnowledgeArchive.
- Added select-all support for the current archive page.
- Added bulk archived-memory restore API.
- Added per-item failure isolation and partial-failure reporting.
- Added bulk restore confirmation using the existing ConfirmModal.
- Added server-side tag filtering.
- Added full-result tag facet counts instead of page-local tag counts.
- Added bulk restore progress/status feedback.
- Added client API tests for tag filtering and bulk restore.
- Added server tests for archive tag facets.

## API

### GET `/api/knowledge/archive`

Supports:

- `type`
- `search`
- `tag`
- `page`
- `limit`

Response now includes:

```json
{
  "facets": {
    "tags": [
      {
        "value": "roadmap",
        "count": 4
      }
    ]
  }
}
```

closes #2072 

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
