### PR TITLE
feat: E2EE meeting-key export / import / share UX (#2030)

### DIFF
--- a/client/src/components/meeting-details/MeetingKeyManager.jsx
+++ b/client/src/components/meeting-details/MeetingKeyManager.jsx
@@ -1,0 +1,192 @@
+import React, { useRef, useState } from "react";
+import { KeyRound, Upload, Download, AlertTriangle } from "lucide-react";
+import { toast } from "react-toastify";
+import {
+  loadMeetingKey,
+  saveMeetingKey,
+  exportMeetingKeyBundle,
+  importMeetingKeyBundle,
+  serializeMeetingKeyBundle,
+  parseMeetingKeyBundle,
+  meetingKeyBundleFilename,
+} from "../../utils/encryption/index.js";
+
+/**
+ * Issue #2030 — meeting-key export / import / share UX.
+ *
+ * Export wraps the browser-local meeting key in a passphrase-protected bundle
+ * (safe to email/save), and import restores it on another device so the same
+ * encrypted transcript can be decrypted there. When a key is missing this also
+ * renders recovery guidance instead of leaving the user at a dead end.
+ */
+const MeetingKeyManager = ({ meetingId, hasLocalKey, onKeyImported, missingKey = false }) => {
+  const [mode, setMode] = useState(missingKey ? "import" : null); // 'export' | 'import' | null
+  const [passphrase, setPassphrase] = useState("");
+  const [busy, setBusy] = useState(false);
+  const fileRef = useRef(null);
+  const [pendingBundle, setPendingBundle] = useState(null);
+
+  const reset = () => {
+    setPassphrase("");
+    setPendingBundle(null);
+    if (fileRef.current) fileRef.current.value = "";
+  };
+
+  const handleExport = async () => {
+    const base64Key = loadMeetingKey(meetingId);
+    if (!base64Key) {
+      toast.error("No meeting key is stored in this browser to export.");
+      return;
+    }
+    try {
+      setBusy(true);
+      const bundle = await exportMeetingKeyBundle(base64Key, passphrase, meetingId);
+      const blob = new Blob([serializeMeetingKeyBundle(bundle)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = meetingKeyBundleFilename(meetingId);
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success("Encrypted key file downloaded. Share the passphrase separately.");
+      setMode(null);
+      reset();
+    } catch (err) {
+      toast.error(err.message || "Failed to export key.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFilePick = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setPendingBundle(parseMeetingKeyBundle(await file.text()));
+    } catch (err) {
+      setPendingBundle(null);
+      toast.error(err.message || "Invalid key file.");
+    }
+  };
+
+  const handleImport = async () => {
+    if (!pendingBundle) {
+      toast.error("Choose a .momkey file first.");
+      return;
+    }
+    try {
+      setBusy(true);
+      const { base64Key } = await importMeetingKeyBundle(pendingBundle, passphrase);
+      saveMeetingKey(meetingId, base64Key);
+      toast.success("Meeting key imported. Decrypting transcript…");
+      setMode(null);
+      reset();
+      onKeyImported?.();
+    } catch (err) {
+      toast.error(err.message || "Failed to import key.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-3">
+      {missingKey && (
+        <div className="mb-3 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">This transcript is encrypted and the key isn’t on this device.</p>
+            <p className="mt-1 text-xs">
+              Import the meeting key below (a <code>.momkey</code> file + its passphrase), or export it
+              from the original device under “Export key.” Without the key, the ciphertext cannot be read.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        {hasLocalKey && (
+          <button
+            type="button"
+            onClick={() => {
+              setMode(mode === "export" ? null : "export");
+              reset();
+            }}
+            className="flex items-center gap-1 rounded-md px-3 py-1 text-sm text-emerald-700 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
+          >
+            <Download size={14} /> Export key
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            setMode(mode === "import" ? null : "import");
+            reset();
+          }}
+          className="flex items-center gap-1 rounded-md px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 dark:text-indigo-400 dark:hover:bg-indigo-950/40"
+        >
+          <Upload size={14} /> Import key
+        </button>
+      </div>
+
+      {mode === "export" && (
+        <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/50">
+          <p className="mb-2 flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400">
+            <KeyRound size={12} /> Set a passphrase to protect the exported key. Anyone with the file{" "}
+            <strong>and</strong> the passphrase can read this meeting — share them over separate channels.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              placeholder="Passphrase (min 8 chars)"
+              className="flex-1 rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800"
+            />
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={busy}
+              className="rounded-md bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+            >
+              {busy ? "Exporting…" : "Download key file"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mode === "import" && (
+        <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/50">
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".momkey,application/json"
+            onChange={handleFilePick}
+            className="mb-2 block w-full text-xs text-gray-600 dark:text-gray-400 file:mr-2 file:rounded file:border-0 file:bg-indigo-600 file:px-3 file:py-1 file:text-white"
+          />
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              placeholder="Passphrase"
+              className="flex-1 rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800"
+            />
+            <button
+              type="button"
+              onClick={handleImport}
+              disabled={busy || !pendingBundle}
+              className="rounded-md bg-indigo-600 px-3 py-1 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {busy ? "Importing…" : "Import key"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MeetingKeyManager;

--- a/client/src/components/meeting-details/MeetingTranscript.jsx
+++ b/client/src/components/meeting-details/MeetingTranscript.jsx
@@ -3,11 +3,14 @@ import { useNavigate } from "react-router-dom";
 import { FileText, ExternalLink, Lock, Shield } from "lucide-react";
 import { toast } from "react-toastify";
 import GlossaryHighlighter from "./GlossaryHighlighter";
+import MeetingKeyManager from "./MeetingKeyManager";
 import { useMeetingTranscriptText } from "../../hooks/useMeetingTranscriptText.js";
+import { loadMeetingKey } from "../../utils/encryption/index.js";
 
 const MeetingTranscript = ({ meeting }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [encrypting, setEncrypting] = useState(false);
+  const [keyVersion, setKeyVersion] = useState(0);
   const navigate = useNavigate();
   const {
     plaintext,
@@ -16,7 +19,7 @@ const MeetingTranscript = ({ meeting }) => {
     loading,
     e2eeEnabled,
     encryptAndStore,
-  } = useMeetingTranscriptText(meeting);
+  } = useMeetingTranscriptText(meeting, keyVersion);
 
   if (!meeting) return null;
 
@@ -25,6 +28,8 @@ const MeetingTranscript = ({ meeting }) => {
   const hasEncrypted = Boolean(
     meeting.isTranscriptEncrypted || meeting.encryptedTranscript,
   );
+  const hasLocalKey = Boolean(meeting._id && loadMeetingKey(meeting._id));
+  const missingKey = hasEncrypted && !hasLocalKey;
 
   if (!transcript && !hasEncrypted && !loading) {
     return (
@@ -127,10 +132,19 @@ const MeetingTranscript = ({ meeting }) => {
           Decrypting transcript…
         </p>
       )}
-      {error && (
+      {error && !missingKey && (
         <div className="mb-3 text-sm text-amber-800 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-md p-3">
           {error}
         </div>
+      )}
+
+      {hasEncrypted && (
+        <MeetingKeyManager
+          meetingId={meeting._id}
+          hasLocalKey={hasLocalKey}
+          missingKey={missingKey}
+          onKeyImported={() => setKeyVersion((v) => v + 1)}
+        />
       )}
 
       {transcript ? (

--- a/client/src/hooks/useMeetingTranscriptText.js
+++ b/client/src/hooks/useMeetingTranscriptText.js
@@ -16,7 +16,7 @@ import apiClient from "../services/apiClient.js";
  * Resolve displayable transcript text for a meeting (Issue #1335).
  * Handles legacy plaintext and encrypted payloads.
  */
-export const useMeetingTranscriptText = (meeting) => {
+export const useMeetingTranscriptText = (meeting, refreshToken = 0) => {
   const [plaintext, setPlaintext] = useState("");
   const [isEncrypted, setIsEncrypted] = useState(false);
   const [error, setError] = useState(null);
@@ -72,7 +72,9 @@ export const useMeetingTranscriptText = (meeting) => {
     return () => {
       cancelled = true;
     };
-  }, [meeting]);
+    // refreshToken lets callers force a re-decrypt after importing a key
+    // without refetching the meeting (Issue #2030).
+  }, [meeting, refreshToken]);
 
   /**
    * Encrypt current plaintext (or provided text) and persist ciphertext to server.

--- a/client/src/utils/encryption/__tests__/meetingKeyExport.test.js
+++ b/client/src/utils/encryption/__tests__/meetingKeyExport.test.js
@@ -1,0 +1,90 @@
+/**
+ * Issue #2030 — passphrase-wrapped meeting-key export/import tests.
+ * Uses Node's webcrypto so tests run without a browser.
+ */
+
+import { webcrypto } from "node:crypto";
+import { describe, it, expect, beforeAll } from "vitest";
+import { Buffer } from "buffer";
+
+beforeAll(() => {
+  if (!globalThis.crypto) globalThis.crypto = webcrypto;
+  if (typeof globalThis.btoa !== "function") {
+    globalThis.btoa = (str) => Buffer.from(str, "binary").toString("base64");
+  }
+  if (typeof globalThis.atob !== "function") {
+    globalThis.atob = (str) => Buffer.from(str, "base64").toString("binary");
+  }
+});
+
+const {
+  exportMeetingKeyBundle,
+  importMeetingKeyBundle,
+  isMeetingKeyBundle,
+  serializeMeetingKeyBundle,
+  parseMeetingKeyBundle,
+  meetingKeyBundleFilename,
+  MEETING_KEY_BUNDLE_TYPE,
+} = await import("../meetingKeyExport.js");
+const { generateKey, exportKey, importKey, encryptTranscript, decryptTranscript } =
+  await import("../transcriptCrypto.js");
+
+const makeBase64Key = async () => exportKey(await generateKey());
+
+describe("meetingKeyExport (Issue #2030)", () => {
+  it("round-trips a key through export → import with the right passphrase", async () => {
+    const base64Key = await makeBase64Key();
+    const bundle = await exportMeetingKeyBundle(base64Key, "correct horse battery", "meeting-123");
+    expect(isMeetingKeyBundle(bundle)).toBe(true);
+    expect(bundle.type).toBe(MEETING_KEY_BUNDLE_TYPE);
+    // The wrapped key must NOT appear in the bundle in the clear.
+    expect(JSON.stringify(bundle)).not.toContain(base64Key);
+
+    const { base64Key: recovered, meetingId } = await importMeetingKeyBundle(
+      bundle,
+      "correct horse battery",
+    );
+    expect(recovered).toBe(base64Key);
+    expect(meetingId).toBe("meeting-123");
+  });
+
+  it("a second device can decrypt the same transcript after importing the key", async () => {
+    // Device A: encrypt a transcript with a fresh key, then export the key.
+    const key = await generateKey();
+    const base64Key = await exportKey(key);
+    const payload = await encryptTranscript("board meeting notes: ship it", key);
+    const bundle = await exportMeetingKeyBundle(base64Key, "team-passphrase-9", "m-9");
+
+    // Device B: import the bundle, rebuild the key, decrypt.
+    const { base64Key: importedB64 } = await importMeetingKeyBundle(bundle, "team-passphrase-9");
+    const keyB = await importKey(importedB64);
+    expect(await decryptTranscript(payload, keyB)).toBe("board meeting notes: ship it");
+  });
+
+  it("rejects a wrong passphrase", async () => {
+    const bundle = await exportMeetingKeyBundle(await makeBase64Key(), "the-right-one", "m1");
+    await expect(importMeetingKeyBundle(bundle, "the-wrong-one")).rejects.toThrow(/passphrase/i);
+  });
+
+  it("rejects a tampered bundle", async () => {
+    const bundle = await exportMeetingKeyBundle(await makeBase64Key(), "passphrase-xy", "m1");
+    const tampered = { ...bundle, ct: bundle.ct.slice(0, -4) + (bundle.ct.slice(-4) === "AAAA" ? "BBBB" : "AAAA") };
+    await expect(importMeetingKeyBundle(tampered, "passphrase-xy")).rejects.toThrow();
+  });
+
+  it("enforces a minimum passphrase length", async () => {
+    await expect(exportMeetingKeyBundle(await makeBase64Key(), "short", "m1")).rejects.toThrow(/8 characters/i);
+  });
+
+  it("serializes and parses a bundle file; rejects non-bundle input", async () => {
+    const bundle = await exportMeetingKeyBundle(await makeBase64Key(), "passphrase-xy", "m42");
+    const text = serializeMeetingKeyBundle(bundle);
+    expect(parseMeetingKeyBundle(text)).toEqual(bundle);
+    expect(() => parseMeetingKeyBundle("{}")).toThrow(/valid meeting-key bundle/i);
+    expect(() => parseMeetingKeyBundle("not json")).toThrow(/valid JSON/i);
+  });
+
+  it("suggests a filename scoped to the meeting", () => {
+    expect(meetingKeyBundleFilename("abcdef1234567890")).toMatch(/\.momkey$/);
+  });
+});

--- a/client/src/utils/encryption/index.js
+++ b/client/src/utils/encryption/index.js
@@ -31,3 +31,15 @@ export {
   clearMeetingKey,
   meetingKeyStorageKey,
 } from "./meetingKeyStore.js";
+
+export {
+  exportMeetingKeyBundle,
+  importMeetingKeyBundle,
+  isMeetingKeyBundle,
+  serializeMeetingKeyBundle,
+  parseMeetingKeyBundle,
+  meetingKeyBundleFilename,
+  MEETING_KEY_BUNDLE_VERSION,
+  MEETING_KEY_BUNDLE_TYPE,
+  MEETING_KEY_FILE_EXTENSION,
+} from "./meetingKeyExport.js";

--- a/client/src/utils/encryption/meetingKeyExport.js
+++ b/client/src/utils/encryption/meetingKeyExport.js
@@ -1,0 +1,164 @@
+/**
+ * Issue #2030 — portable meeting-key export / import.
+ *
+ * The per-meeting AES-GCM key (see meetingKeyStore) never leaves the browser, so
+ * a transcript encrypted on one device is unreadable on another until the key is
+ * moved across. Handing the raw key around in the clear would defeat E2EE, so we
+ * wrap it in a *passphrase-protected* bundle: PBKDF2(passphrase) derives an
+ * AES-GCM wrapping key that encrypts the meeting key. The bundle is safe to send
+ * over email/chat or save as a file — it is useless without the passphrase, which
+ * is shared out-of-band.
+ *
+ * Bundle shape (JSON):
+ *   { v, type, meetingId, kdf:{name,hash,iterations,salt}, iv, ct }
+ */
+
+export const MEETING_KEY_BUNDLE_VERSION = 1;
+export const MEETING_KEY_BUNDLE_TYPE = "meetonmemory.e2ee.meeting-key";
+export const MEETING_KEY_FILE_EXTENSION = ".momkey";
+
+const PBKDF2_ITERATIONS = 210000;
+const PBKDF2_HASH = "SHA-256";
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+const WRAP_ALG = "AES-GCM";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const bufferToBase64 = (buffer) => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+};
+
+const base64ToBytes = (base64) => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+};
+
+/** Derive an AES-GCM wrapping key from a passphrase + salt via PBKDF2. */
+const deriveWrappingKey = async (passphrase, saltBytes) => {
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: saltBytes,
+      iterations: PBKDF2_ITERATIONS,
+      hash: PBKDF2_HASH,
+    },
+    baseKey,
+    { name: WRAP_ALG, length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+};
+
+/**
+ * Wrap a base64 meeting key into a passphrase-protected, shareable bundle.
+ * @param {string} base64Key - the raw meeting key (from loadMeetingKey/exportKey)
+ * @param {string} passphrase - protects the bundle; shared out-of-band
+ * @param {string} meetingId
+ */
+export const exportMeetingKeyBundle = async (base64Key, passphrase, meetingId) => {
+  if (!base64Key || typeof base64Key !== "string") {
+    throw new Error("A meeting key is required to export.");
+  }
+  if (!passphrase || passphrase.length < 8) {
+    throw new Error("Passphrase must be at least 8 characters.");
+  }
+
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const wrappingKey = await deriveWrappingKey(passphrase, salt);
+
+  const ctBuffer = await crypto.subtle.encrypt(
+    { name: WRAP_ALG, iv },
+    wrappingKey,
+    textEncoder.encode(base64Key),
+  );
+
+  return {
+    v: MEETING_KEY_BUNDLE_VERSION,
+    type: MEETING_KEY_BUNDLE_TYPE,
+    meetingId: meetingId ? String(meetingId) : null,
+    kdf: {
+      name: "PBKDF2",
+      hash: PBKDF2_HASH,
+      iterations: PBKDF2_ITERATIONS,
+      salt: bufferToBase64(salt),
+    },
+    iv: bufferToBase64(iv),
+    ct: bufferToBase64(ctBuffer),
+  };
+};
+
+/** True when `value` looks like a meeting-key bundle produced by export. */
+export const isMeetingKeyBundle = (value) =>
+  Boolean(
+    value &&
+      typeof value === "object" &&
+      value.type === MEETING_KEY_BUNDLE_TYPE &&
+      value.kdf &&
+      typeof value.kdf.salt === "string" &&
+      typeof value.iv === "string" &&
+      typeof value.ct === "string",
+  );
+
+/**
+ * Unwrap a bundle back into { meetingId, base64Key } using the passphrase.
+ * Throws a friendly error on a wrong passphrase or tampered bundle.
+ */
+export const importMeetingKeyBundle = async (bundle, passphrase) => {
+  if (!isMeetingKeyBundle(bundle)) {
+    throw new Error("This file is not a valid meeting-key bundle.");
+  }
+  if (!passphrase) {
+    throw new Error("Enter the passphrase used when the key was exported.");
+  }
+
+  const salt = base64ToBytes(bundle.kdf.salt);
+  const iv = base64ToBytes(bundle.iv);
+  const ct = base64ToBytes(bundle.ct);
+  const wrappingKey = await deriveWrappingKey(passphrase, salt);
+
+  let base64Key;
+  try {
+    const plainBuffer = await crypto.subtle.decrypt({ name: WRAP_ALG, iv }, wrappingKey, ct);
+    base64Key = textDecoder.decode(plainBuffer);
+  } catch {
+    throw new Error("Wrong passphrase, or the key file has been modified.");
+  }
+
+  return { meetingId: bundle.meetingId, base64Key };
+};
+
+/** Serialize a bundle to a downloadable JSON string. */
+export const serializeMeetingKeyBundle = (bundle) => JSON.stringify(bundle, null, 2);
+
+/** Parse a bundle file's text back into an object (throws on invalid JSON/shape). */
+export const parseMeetingKeyBundle = (text) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("This file is not valid JSON.");
+  }
+  if (!isMeetingKeyBundle(parsed)) {
+    throw new Error("This file is not a valid meeting-key bundle.");
+  }
+  return parsed;
+};
+
+/** Suggested filename for an exported bundle. */
+export const meetingKeyBundleFilename = (meetingId) =>
+  `meeting-${meetingId ? String(meetingId).slice(-8) : "key"}${MEETING_KEY_FILE_EXTENSION}`;


### PR DESCRIPTION
Closes #2030

### Problem
E2EE meeting keys live only in the browser that created them (`meetingKeyStore`), so an encrypted transcript was **unreadable on any other device or by any teammate**, and a missing key showed an error with no path forward — E2EE wasn’t usable for real teams.

### What this adds
- **`utils/encryption/meetingKeyExport.js`** — wraps the per-meeting AES-GCM key in a **passphrase-protected bundle**: `PBKDF2-SHA256` (210k iterations) derives an AES-GCM wrapping key that encrypts the meeting key. The bundle is safe to save or send (email/chat) and is useless without the passphrase, which is shared out-of-band. Exposes `exportMeetingKeyBundle` / `importMeetingKeyBundle` + (de)serialize/validate helpers.
- **`MeetingKeyManager.jsx`** —
  - **Export key**: set a passphrase → downloads an encrypted `.momkey` file with clear warnings.
  - **Import key**: choose the file + passphrase → key restored on this device.
  - **Recovery guidance**: when an encrypted transcript has no local key, an explainer + import panel replaces the dead-end error.
- Wired into `MeetingTranscript.jsx`; `useMeetingTranscriptText` takes an optional refresh token so an imported key **re-decrypts immediately** without a refetch. (Backward compatible — the only caller passes it.)

### Acceptance criteria
- [x] User can export and import a meeting key successfully
- [x] Second device can decrypt the same transcript (covered by a test that encrypts on “device A”, exports, then imports + decrypts as “device B”)
- [x] Missing key shows recovery guidance (not a blank crash)

### Tests
`utils/encryption/__tests__/meetingKeyExport.test.js` — export→import round-trip, **second-device decryption**, wrong-passphrase + tamper rejection, passphrase-length enforcement, and file (de)serialization. Green (7 new; the existing crypto + MeetingDetails render suites still pass — 19 total in that run).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted meeting-key export and import using passphrase-protected `.momkey` files.
  * Added meeting transcript controls for exporting keys, importing keys, and recovering access when a key is missing.
  * Transcripts automatically retry decryption after a key is imported.
  * Added clear success and error notifications for key management actions.

* **Tests**
  * Added coverage for successful transfers, invalid passphrases, tampered files, validation, and transcript decryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->