### PR TITLE
perf: add indexes for frequently queried fields

### DIFF
--- a/server/models/attachmentModel.js
+++ b/server/models/attachmentModel.js
@@ -38,6 +38,7 @@ const attachmentSchema = new mongoose.Schema(
 );
 
 attachmentSchema.index({ meeting: 1, createdAt: -1 });
+attachmentSchema.index({ uploadedBy: 1 });
 
 const Attachment = mongoose.model("Attachment", attachmentSchema);
 export default Attachment;

--- a/server/models/commentModel.js
+++ b/server/models/commentModel.js
@@ -58,6 +58,7 @@ const commentSchema = new mongoose.Schema(
 // Indexes for quick lookups
 commentSchema.index({ meeting: 1, createdAt: 1 });
 commentSchema.index({ parentComment: 1 });
+commentSchema.index({ organization: 1 });
 
 const Comment = mongoose.model("Comment", commentSchema);
 export default Comment;

--- a/server/models/pollModel.js
+++ b/server/models/pollModel.js
@@ -67,6 +67,7 @@ const pollSchema = new mongoose.Schema(
 // Indexes
 pollSchema.index({ meeting: 1, createdAt: -1 });
 pollSchema.index({ isClosed: 1, expiresAt: 1 });
+pollSchema.index({ organization: 1 });
 
 const Poll = mongoose.model("Poll", pollSchema);
 export default Poll;

--- a/server/models/sharedLinkModel.js
+++ b/server/models/sharedLinkModel.js
@@ -62,4 +62,8 @@ const sharedLinkSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
+sharedLinkSchema.index({ organizationId: 1 });
+sharedLinkSchema.index({ resourceId: 1 });
+sharedLinkSchema.index({ createdBy: 1 });
+
 export default mongoose.model("SharedLink", sharedLinkSchema);

--- a/server/models/transcriptModel.js
+++ b/server/models/transcriptModel.js
@@ -119,6 +119,7 @@ const transcriptSchema = new mongoose.Schema(
 transcriptSchema.index({ meeting: 1 });
 transcriptSchema.index({ status: 1 });
 transcriptSchema.index({ createdAt: -1 });
+transcriptSchema.index({ organizationId: 1 });
 
 const Transcript = mongoose.model("Transcript", transcriptSchema);
 export default Transcript;

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -68,6 +68,9 @@ const userSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
+userSchema.index({ organization: 1 });
+userSchema.index({ organization: 1, role: 1 });
+
 const userModel = mongoose.models.user || mongoose.model("user", userSchema);
 if (!mongoose.models.User) {
   mongoose.model("User", userSchema);

--- a/server/tests/frequentlyQueriedFieldIndexes.test.js
+++ b/server/tests/frequentlyQueriedFieldIndexes.test.js
@@ -1,0 +1,58 @@
+import userModel from "../models/userModel.js";
+import Transcript from "../models/transcriptModel.js";
+import Comment from "../models/commentModel.js";
+import Attachment from "../models/attachmentModel.js";
+import SharedLink from "../models/sharedLinkModel.js";
+import Poll from "../models/pollModel.js";
+
+const indexSpecs = (model) => model.schema.indexes().map(([keys]) => keys);
+
+const hasExactIndex = (model, expected) =>
+  indexSpecs(model).some((keys) => {
+    const expectedFields = Object.keys(expected);
+    const actualFields = Object.keys(keys);
+    return (
+      expectedFields.length === actualFields.length &&
+      expectedFields.every((field) => keys[field] === expected[field])
+    );
+  });
+
+describe("frequently queried organization/user indexes (#1772)", () => {
+  it("declares user organization and organization+role indexes", () => {
+    expect(hasExactIndex(userModel, { organization: 1 })).toBe(true);
+    expect(hasExactIndex(userModel, { organization: 1, role: 1 })).toBe(true);
+    expect(hasExactIndex(userModel, { email: 1 })).toBe(true);
+    expect(hasExactIndex(userModel, { clerkUserId: 1 })).toBe(true);
+  });
+
+  it("declares a transcript organizationId index without dropping existing ones", () => {
+    expect(hasExactIndex(Transcript, { organizationId: 1 })).toBe(true);
+    expect(hasExactIndex(Transcript, { meeting: 1 })).toBe(true);
+    expect(hasExactIndex(Transcript, { status: 1 })).toBe(true);
+    expect(hasExactIndex(Transcript, { createdAt: -1 })).toBe(true);
+  });
+
+  it("declares a comment organization index without dropping existing ones", () => {
+    expect(hasExactIndex(Comment, { organization: 1 })).toBe(true);
+    expect(hasExactIndex(Comment, { meeting: 1, createdAt: 1 })).toBe(true);
+    expect(hasExactIndex(Comment, { parentComment: 1 })).toBe(true);
+  });
+
+  it("declares an attachment uploadedBy index without dropping existing ones", () => {
+    expect(hasExactIndex(Attachment, { uploadedBy: 1 })).toBe(true);
+    expect(hasExactIndex(Attachment, { meeting: 1, createdAt: -1 })).toBe(true);
+  });
+
+  it("declares shared-link organization, resource, and creator indexes", () => {
+    expect(hasExactIndex(SharedLink, { organizationId: 1 })).toBe(true);
+    expect(hasExactIndex(SharedLink, { resourceId: 1 })).toBe(true);
+    expect(hasExactIndex(SharedLink, { createdBy: 1 })).toBe(true);
+    expect(hasExactIndex(SharedLink, { hash: 1 })).toBe(true);
+  });
+
+  it("declares a poll organization index without dropping existing ones", () => {
+    expect(hasExactIndex(Poll, { organization: 1 })).toBe(true);
+    expect(hasExactIndex(Poll, { meeting: 1, createdAt: -1 })).toBe(true);
+    expect(hasExactIndex(Poll, { isClosed: 1, expiresAt: 1 })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Closes #1772.

Adds database indexes for frequently queried organization and user reference fields to improve MongoDB query performance as data scales.

## What Changed

Added indexes for:

- `User.organization`
- `User.organization + role`
- `Transcript.organizationId`
- `Comment.organization`
- `Attachment.uploadedBy`
- `SharedLink.organizationId`
- `SharedLink.resourceId`
- `SharedLink.createdBy`
- `Poll.organization`

Existing indexes and schema behavior were preserved.

## Tests

Added regression coverage verifying the new indexes and existing indexes.

## Verification

- Confirmed all indexed fields exist in their respective schemas.
- Confirmed no duplicate indexes were introduced.
- Existing compound and unique indexes remain unchanged.

## Performance

These indexes allow frequently used organization/user lookups to use indexed queries instead of collection scans, improving scalability as the database grows.

Closes #1772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved response times for frequently used searches and lookups across attachments, comments, polls, shared links, transcripts, and user data.

* **Tests**
  * Added coverage to verify that required database indexes are configured correctly while preserving existing indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->