### PR TITLE
feat: mount health score on meeting details

### DIFF
--- a/client/src/components/meeting-details/HealthScoreCard.jsx
+++ b/client/src/components/meeting-details/HealthScoreCard.jsx
@@ -1,69 +1,218 @@
-import React, { useState, useEffect } from "react";
-import { meetingHealthApi } from "../../services/meetingHealthApi";
+import React, {
+  useState,
+  useEffect,
+  useContext,
+  useRef,
+  useCallback,
+} from "react";
+import { Link } from "react-router-dom";
 import { toast } from "react-toastify";
+import { meetingHealthApi } from "../../services/meetingHealthApi";
+import RBACContext from "../../context/RBACContext.jsx";
 
-const HealthScoreCard = ({ meetingId }) => {
+const CARD_CLASS =
+  "bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6";
+
+const getScoreColor = (score) => {
+  if (score >= 80) return "text-green-500";
+  if (score >= 60) return "text-yellow-500";
+  return "text-red-500";
+};
+
+const getScoreBg = (score) => {
+  if (score >= 80) return "bg-green-500";
+  if (score >= 60) return "bg-yellow-500";
+  return "bg-red-500";
+};
+
+const HealthScoreCard = ({ meetingId, organizationId }) => {
+  const rbac = useContext(RBACContext);
+  const canCalculate = rbac?.hasPermission("meetings", "view") ?? false;
+  const canViewOrgHealth = rbac?.hasPermission("reports", "view") ?? false;
+
   const [healthData, setHealthData] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(Boolean(meetingId));
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+  const [forbidden, setForbidden] = useState(false);
+  const inFlightRef = useRef(false);
+
+  const fetchHealth = useCallback(
+    async ({ isRefresh = false } = {}) => {
+      if (!meetingId || inFlightRef.current) return;
+
+      inFlightRef.current = true;
+      if (isRefresh) {
+        setRefreshing(true);
+      } else {
+        setLoading(true);
+      }
+
+      try {
+        const res = await meetingHealthApi.getMeetingHealth(meetingId);
+        if (res.success && res.data) {
+          setHealthData(res.data);
+          setError(null);
+          setForbidden(false);
+        } else {
+          setHealthData(null);
+          setForbidden(false);
+          setError("Meeting health has not been calculated yet.");
+        }
+      } catch (err) {
+        console.error("Failed to fetch meeting health", err);
+        const status = err.response?.status;
+        const message =
+          err.response?.data?.message || "Failed to fetch meeting health";
+
+        if (status === 401 || status === 403) {
+          setForbidden(true);
+          setHealthData(null);
+          setError(
+            message ||
+              "You are not authorized to view this meeting's health score.",
+          );
+        } else {
+          setForbidden(false);
+          setHealthData(null);
+          setError(message);
+          toast.error(message);
+        }
+      } finally {
+        inFlightRef.current = false;
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [meetingId],
+  );
 
   useEffect(() => {
-    const fetchHealth = async () => {
-      try {
-        setLoading(true);
-        const res = await meetingHealthApi.getMeetingHealth(meetingId);
-        if (res.success) {
-          setHealthData(res.data);
-        } else {
-          toast.error("Failed to fetch meeting health");
-        }
-      } catch (error) {
-        console.error("Failed to fetch meeting health", error);
-        toast.error("Failed to fetch meeting health");
-      } finally {
-        setLoading(false);
-      }
-    };
+    inFlightRef.current = false;
+    setHealthData(null);
+    setError(null);
+    setForbidden(false);
 
-    if (meetingId) {
-      fetchHealth();
+    if (!meetingId) {
+      setLoading(false);
+      return;
     }
-  }, [meetingId]);
+
+    fetchHealth();
+  }, [meetingId, fetchHealth]);
+
+  const handleCalculateOrRefresh = () => {
+    if (!canCalculate || forbidden || inFlightRef.current) return;
+    fetchHealth({ isRefresh: true });
+  };
+
+  const orgLink = canViewOrgHealth ? (
+    <Link
+      to="/meeting-health"
+      className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+    >
+      View organization health
+    </Link>
+  ) : null;
 
   if (loading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6 animate-pulse">
-        <div className="h-6 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
-        <div className="h-24 bg-gray-200 dark:bg-gray-700 rounded"></div>
+      <div
+        data-testid="meeting-health-score-card"
+        data-meeting-id={meetingId}
+        data-organization-id={organizationId || ""}
+        aria-busy="true"
+        className={`${CARD_CLASS} animate-pulse`}
+      >
+        <div
+          role="status"
+          aria-label="Loading meeting health score"
+          className="h-6 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-4"
+        />
+        <div className="h-24 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <div
+        data-testid="meeting-health-score-forbidden"
+        data-meeting-id={meetingId}
+        data-organization-id={organizationId || ""}
+        className={CARD_CLASS}
+      >
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          Meeting Health Score
+        </h3>
+        <p role="status" className="text-sm text-gray-600 dark:text-gray-400">
+          {error ||
+            "You are not authorized to view this meeting's health score."}
+        </p>
       </div>
     );
   }
 
   if (!healthData) {
-    return null; // Don't show anything if no data
+    return (
+      <div
+        data-testid="meeting-health-score-empty"
+        data-meeting-id={meetingId}
+        data-organization-id={organizationId || ""}
+        className={CARD_CLASS}
+      >
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-2">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Meeting Health Score
+          </h3>
+          {orgLink}
+        </div>
+        <p role="status" className="text-sm text-gray-600 dark:text-gray-400">
+          {error || "Meeting health has not been calculated yet."}
+        </p>
+        {canCalculate ? (
+          <button
+            type="button"
+            disabled={refreshing}
+            onClick={handleCalculateOrRefresh}
+            className="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors disabled:opacity-50"
+          >
+            {refreshing ? "Calculating..." : "Calculate score"}
+          </button>
+        ) : null}
+      </div>
+    );
   }
 
-  const { compositeScore, factors, recommendations } = healthData;
-
-  const getScoreColor = (score) => {
-    if (score >= 80) return "text-green-500";
-    if (score >= 60) return "text-yellow-500";
-    return "text-red-500";
-  };
-
-  const getScoreBg = (score) => {
-    if (score >= 80) return "bg-green-500";
-    if (score >= 60) return "bg-yellow-500";
-    return "bg-red-500";
-  };
+  const { compositeScore, factors = {}, recommendations } = healthData;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6">
-      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
-        Meeting Health Score
-      </h3>
+    <div
+      data-testid="meeting-health-score-card"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+      className={CARD_CLASS}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Meeting Health Score
+        </h3>
+        <div className="flex flex-wrap items-center gap-3">
+          {orgLink}
+          {canCalculate ? (
+            <button
+              type="button"
+              disabled={refreshing}
+              onClick={handleCalculateOrRefresh}
+              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors disabled:opacity-50"
+            >
+              {refreshing ? "Refreshing..." : "Refresh score"}
+            </button>
+          ) : null}
+        </div>
+      </div>
 
       <div className="flex flex-col md:flex-row gap-6 items-start">
-        {/* Overall Score */}
         <div className="flex-shrink-0 flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-750 rounded-full w-32 h-32 border-4 border-gray-100 dark:border-gray-700">
           <span
             className={`text-3xl font-bold ${getScoreColor(compositeScore)}`}
@@ -75,7 +224,6 @@ const HealthScoreCard = ({ meetingId }) => {
           </span>
         </div>
 
-        {/* Factors */}
         <div className="flex-grow grid grid-cols-1 sm:grid-cols-2 gap-4 w-full">
           {Object.entries(factors).map(([key, value]) => (
             <div key={key} className="flex flex-col">
@@ -93,14 +241,13 @@ const HealthScoreCard = ({ meetingId }) => {
                 <div
                   className={`${getScoreBg(value)} h-2 rounded-full`}
                   style={{ width: `${value}%` }}
-                ></div>
+                />
               </div>
             </div>
           ))}
         </div>
       </div>
 
-      {/* Recommendations */}
       {recommendations && recommendations.length > 0 && (
         <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
           <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-2">

--- a/client/src/components/meeting-details/__tests__/HealthScoreCard.test.jsx
+++ b/client/src/components/meeting-details/__tests__/HealthScoreCard.test.jsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "react-toastify";
+import { RBACProvider } from "../../../context/RBACContext.jsx";
+import { meetingHealthApi } from "../../../services/meetingHealthApi";
+import HealthScoreCard from "../HealthScoreCard.jsx";
+
+vi.mock("../../../services/meetingHealthApi", () => ({
+  meetingHealthApi: {
+    getMeetingHealth: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const MEETING_ID = "meeting-123";
+const ORG_ID = "org-42";
+
+const HEALTH_RECORD = {
+  meetingId: MEETING_ID,
+  organization: ORG_ID,
+  compositeScore: 84,
+  factors: {
+    agendaCoverage: 90,
+    timeAdherence: 80,
+    engagement: 75,
+    actionItemClarity: 85,
+    sentiment: 90,
+  },
+  recommendations: [
+    "Great job! This meeting scored highly across all health metrics.",
+  ],
+};
+
+const renderCard = (role = "member", props = {}) =>
+  render(
+    <MemoryRouter>
+      <RBACProvider userRole={role}>
+        <HealthScoreCard
+          meetingId={MEETING_ID}
+          organizationId={ORG_ID}
+          {...props}
+        />
+      </RBACProvider>
+    </MemoryRouter>,
+  );
+
+describe("HealthScoreCard (#1984)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    meetingHealthApi.getMeetingHealth.mockResolvedValue({
+      success: true,
+      data: HEALTH_RECORD,
+    });
+  });
+
+  it("mounts with meeting and organization context and loads the existing health API", async () => {
+    renderCard();
+
+    expect(
+      screen.getByLabelText(/loading meeting health score/i),
+    ).toBeInTheDocument();
+
+    const card = await screen.findByTestId("meeting-health-score-card");
+    expect(card).toHaveAttribute("data-meeting-id", MEETING_ID);
+    expect(card).toHaveAttribute("data-organization-id", ORG_ID);
+    expect(meetingHealthApi.getMeetingHealth).toHaveBeenCalledWith(MEETING_ID);
+    expect(
+      screen.getByRole("heading", { name: /meeting health score/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("84")).toBeInTheDocument();
+  });
+
+  it("shows a forbidden empty state and hides calculate when the API rejects access", async () => {
+    meetingHealthApi.getMeetingHealth.mockRejectedValue({
+      response: {
+        status: 403,
+        data: {
+          message: "Forbidden: Organization membership required",
+        },
+      },
+    });
+
+    renderCard();
+
+    const forbidden = await screen.findByTestId(
+      "meeting-health-score-forbidden",
+    );
+    expect(forbidden).toHaveTextContent(
+      "Forbidden: Organization membership required",
+    );
+    expect(
+      screen.queryByRole("button", { name: /calculate score|refresh score/i }),
+    ).not.toBeInTheDocument();
+    expect(meetingHealthApi.getMeetingHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an empty state when health has not been calculated yet", async () => {
+    meetingHealthApi.getMeetingHealth.mockResolvedValue({
+      success: true,
+      data: null,
+    });
+
+    renderCard();
+
+    const empty = await screen.findByTestId("meeting-health-score-empty");
+    expect(empty).toHaveTextContent(
+      "Meeting health has not been calculated yet.",
+    );
+    expect(
+      screen.getByRole("button", { name: /calculate score/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces fetch errors with toast and an empty retry state", async () => {
+    meetingHealthApi.getMeetingHealth.mockRejectedValue({
+      response: {
+        status: 500,
+        data: { message: "Server Error" },
+      },
+    });
+
+    renderCard();
+
+    expect(
+      await screen.findByTestId("meeting-health-score-empty"),
+    ).toHaveTextContent("Server Error");
+    expect(toast.error).toHaveBeenCalledWith("Server Error");
+    expect(
+      screen.getByRole("button", { name: /calculate score/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("lets a permitted member calculate from the empty state via the existing GET API", async () => {
+    meetingHealthApi.getMeetingHealth
+      .mockResolvedValueOnce({ success: true, data: null })
+      .mockResolvedValueOnce({ success: true, data: HEALTH_RECORD });
+
+    renderCard("member");
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /calculate score/i }),
+    );
+
+    await waitFor(() => {
+      expect(meetingHealthApi.getMeetingHealth).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText("84")).toBeInTheDocument();
+  });
+
+  it("lets a permitted member refresh a loaded score", async () => {
+    renderCard("member");
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /refresh score/i }),
+    );
+
+    await waitFor(() => {
+      expect(meetingHealthApi.getMeetingHealth).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("hides calculate and refresh when the caller cannot view meetings", async () => {
+    meetingHealthApi.getMeetingHealth.mockResolvedValue({
+      success: true,
+      data: null,
+    });
+
+    renderCard(null);
+
+    await screen.findByTestId("meeting-health-score-empty");
+    expect(
+      screen.queryByRole("button", { name: /calculate score|refresh score/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("links to the organization Meeting Health dashboard when reports.view is allowed", async () => {
+    renderCard("member");
+
+    const link = await screen.findByRole("link", {
+      name: /view organization health/i,
+    });
+    expect(link).toHaveAttribute("href", "/meeting-health");
+  });
+
+  it("hides the organization dashboard link for roles without reports.view", async () => {
+    renderCard("guest");
+
+    await screen.findByTestId("meeting-health-score-card");
+    expect(
+      screen.queryByRole("link", { name: /view organization health/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /refresh score/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -39,6 +39,7 @@ import MeetingReadiness from "../components/MeetingReadiness";
 import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
 import PollSection from "../components/meeting-details/PollSection";
 import FeedbackForm from "../components/meeting-details/FeedbackForm";
+import HealthScoreCard from "../components/meeting-details/HealthScoreCard";
 import MeetingRisksPanel from "../components/meetings/MeetingRisksPanel";
 import { Award, ShieldAlert } from "lucide-react";
 
@@ -380,6 +381,14 @@ const MeetingDetails = () => {
             </div>
           </div>
           <MeetingSummary meeting={meeting} />
+          <div className="mt-6 mb-6">
+            <HealthScoreCard
+              meetingId={meeting._id}
+              organizationId={
+                meeting.organization?._id || meeting.organization || undefined
+              }
+            />
+          </div>
           <MinutesApproval meeting={meeting} />
           <MeetingCollaborativeNotes meeting={meeting} />
 

--- a/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
@@ -122,6 +122,17 @@ vi.mock("../../components/meeting-details/FeedbackForm", () => ({
     </div>
   ),
 }));
+vi.mock("../../components/meeting-details/HealthScoreCard", () => ({
+  default: ({ meetingId, organizationId }) => (
+    <div
+      data-testid="meeting-health-score-card"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+    >
+      Health for {meetingId}
+    </div>
+  ),
+}));
 
 import { meetingApi } from "../../services";
 
@@ -177,6 +188,10 @@ describe("MeetingDetails Navbar Integration (#1637)", () => {
     expect(feedbackForm).toHaveTextContent("Feedback for 123");
     expect(feedbackForm).toHaveAttribute("data-meeting-id", "123");
     expect(feedbackForm).toHaveAttribute("data-organization-id", "org-42");
+    const healthCard = screen.getByTestId("meeting-health-score-card");
+    expect(healthCard).toHaveTextContent("Health for 123");
+    expect(healthCard).toHaveAttribute("data-meeting-id", "123");
+    expect(healthCard).toHaveAttribute("data-organization-id", "org-42");
   });
 
   it("renders Navbar in error state", async () => {

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -52,6 +52,18 @@ vi.mock("../../components/meeting-details/FeedbackForm.jsx", () => ({
   ),
 }));
 
+vi.mock("../../components/meeting-details/HealthScoreCard.jsx", () => ({
+  default: ({ meetingId, organizationId }) => (
+    <div
+      data-testid="meeting-health-score-card"
+      data-meeting-id={meetingId}
+      data-organization-id={organizationId || ""}
+    >
+      Health for {meetingId}
+    </div>
+  ),
+}));
+
 vi.mock("../../services", () => ({
   meetingApi: {
     getMeetingById: vi.fn(),


### PR DESCRIPTION
## Description

Closes #1984.

Mounts the existing `HealthScoreCard` on Meeting Details so users can view and refresh meeting health scores in the context of the meeting.

## What Changed

- Mounted `HealthScoreCard` on Meeting Details with meeting and organization context.
- Added loading, error, forbidden, empty, and scored states.
- Added permission-aware Calculate/Refresh actions.
- Added organization-level Meeting Health dashboard link for authorized users.
- Preserved existing health-score APIs and backend scoring logic.
- Added regression coverage for integration, states, permissions, and dashboard linking.

## Security & Authorization

- Uses the existing organization-scoped health API.
- Calculate/Refresh is available only with the required meeting permission.
- Unauthorized users receive a clear forbidden state.
- Existing backend authorization remains unchanged.

## Tests

Added coverage for:

- Meeting Details integration
- Meeting/org context
- Loading and error states
- Empty/not-yet-calculated state
- Forbidden access
- Calculate/Refresh permissions
- Meeting Health dashboard link

Closes #1984