### PR TITLE
feat: mount agenda timer in meeting room

### DIFF
--- a/client/src/components/meeting-details/AgendaTimer.jsx
+++ b/client/src/components/meeting-details/AgendaTimer.jsx
@@ -10,21 +10,30 @@ import {
   readAgendaElapsedMs,
   summarizeAgendaTiming,
 } from "../../utils/agendaTiming";
+import { canManageAgendaTimer } from "../../utils/agendaTimerAccess";
 import { createClerkSocketOptions } from "../../services/apiClient.js";
 
-const AgendaTimer = ({ meeting }) => {
+const AgendaTimer = ({
+  meeting,
+  socket: externalSocket = null,
+  readOnly = false,
+  compact = false,
+}) => {
   const { backendUrl, userData } = useContext(AppContent);
-  const [agendaItems, setAgendaItems] = useState(meeting.agendaItems || []);
+  const [agendaItems, setAgendaItems] = useState(meeting?.agendaItems || []);
   const [activeItem, setActiveItem] = useState(null);
   const [elapsedMs, setElapsedMs] = useState(0);
-  const socketRef = useRef(null);
+  const ownedSocketRef = useRef(null);
   const timerRef = useRef(null);
   const overrunNotifiedRef = useRef(new Set());
 
-  const isOrganizerOrAdmin = meeting.uploadedBy === userData?._id;
+  const canManage = !readOnly && canManageAgendaTimer(meeting, userData);
 
   useEffect(() => {
-    // Find active item
+    setAgendaItems(meeting?.agendaItems || []);
+  }, [meeting?.agendaItems]);
+
+  useEffect(() => {
     const currentActive = agendaItems.find((item) => item.status === "active");
     setActiveItem(currentActive || null);
     setElapsedMs(readAgendaElapsedMs(currentActive));
@@ -36,13 +45,6 @@ const AgendaTimer = ({ meeting }) => {
       return undefined;
     }
 
-    // Issue #1159 — this used to be `setElapsedMs((prev) => prev + 1000)`, so
-    // the displayed time was a count of ticks rather than a measurement.
-    // Browsers clamp `setInterval` to roughly once a minute in a backgrounded
-    // tab, which is exactly where a live meeting timer spends its time: the
-    // clock fell minutes behind and never caught up, and the overrun warning
-    // fired late or not at all. Recomputing from `startedAt` makes a dropped
-    // tick cost nothing but a late repaint.
     const tick = () => setElapsedMs(readAgendaElapsedMs(activeItem));
 
     tick();
@@ -51,9 +53,8 @@ const AgendaTimer = ({ meeting }) => {
     return () => clearInterval(timerRef.current);
   }, [activeItem]);
 
-  // Warn once per item as soon as it runs past its planned duration.
   useEffect(() => {
-    if (!activeItem) return;
+    if (!activeItem || compact) return;
     const { isOverrun } = getItemTiming(activeItem, elapsedMs);
     if (!isOverrun || overrunNotifiedRef.current.has(activeItem._id)) return;
 
@@ -61,51 +62,78 @@ const AgendaTimer = ({ meeting }) => {
     toast.warning(
       `"${activeItem.text}" has passed its planned ${activeItem.duration} min`,
     );
-  }, [activeItem, elapsedMs]);
+  }, [activeItem, elapsedMs, compact]);
 
   useEffect(() => {
+    const meetingId = meeting?._id;
+    if (!meetingId) return undefined;
+
     let cancelled = false;
+    let ownedSocket = null;
 
-    (async () => {
-      const opts = await createClerkSocketOptions({
-        transports: ["websocket"],
-      });
-      if (cancelled) return;
+    const onTimerUpdated = ({ item, action }) => {
+      if (!item?._id) return;
+      setAgendaItems((prev) =>
+        prev.map((ai) => {
+          if (ai._id === item._id) return item;
+          if (action === "start" && ai.status === "active") {
+            return { ...ai, status: "pending" };
+          }
+          return ai;
+        }),
+      );
+    };
 
-      socketRef.current = io(backendUrl, opts);
+    const attach = (sock) => {
+      if (!sock?.on) return () => {};
+      sock.on("agenda_timer_updated", onTimerUpdated);
+      return () => sock.off?.("agenda_timer_updated", onTimerUpdated);
+    };
 
-      socketRef.current.on("connect", () => {
-        socketRef.current.emit("join-meeting", {
-          roomId: meeting._id,
-          userInfo: { name: userData?.name },
+    let detach = () => {};
+
+    if (externalSocket) {
+      detach = attach(externalSocket);
+    } else {
+      (async () => {
+        const opts = await createClerkSocketOptions({
+          transports: ["websocket"],
         });
-      });
+        if (cancelled) return;
 
-      socketRef.current.on("agenda_timer_updated", ({ item, action }) => {
-        setAgendaItems((prev) =>
-          prev.map((ai) => {
-            if (ai._id === item._id) return item;
-            // If action is start, other items should be pending if they were active
-            if (action === "start" && ai.status === "active") {
-              return { ...ai, status: "pending" };
-            }
-            return ai;
-          }),
-        );
-      });
-    })();
+        ownedSocket = io(backendUrl, opts);
+        if (cancelled) {
+          ownedSocket.disconnect();
+          return;
+        }
+        ownedSocketRef.current = ownedSocket;
+
+        ownedSocket.on("connect", () => {
+          ownedSocket.emit("join-meeting", {
+            roomId: meetingId,
+            userInfo: { name: userData?.name },
+          });
+        });
+
+        detach = attach(ownedSocket);
+      })();
+    }
 
     return () => {
       cancelled = true;
-      if (socketRef.current) socketRef.current.disconnect();
+      detach();
+      ownedSocket?.disconnect();
+      if (ownedSocketRef.current && ownedSocketRef.current === ownedSocket) {
+        ownedSocketRef.current = null;
+      }
     };
-  }, [backendUrl, meeting._id, userData?.name]);
+  }, [backendUrl, meeting?._id, userData?.name, externalSocket]);
 
   const handleStart = async (itemId) => {
+    if (!canManage) return;
     try {
       const res = await meetingApi.startAgendaItem(meeting._id, itemId);
       if (res.data.success) {
-        // Optimistic update
         setAgendaItems((prev) =>
           prev.map((ai) => {
             if (ai._id === itemId) return res.data.item;
@@ -116,10 +144,12 @@ const AgendaTimer = ({ meeting }) => {
       }
     } catch (err) {
       console.error("Failed to start item:", err);
+      toast.error(err.response?.data?.message || "Failed to start agenda item");
     }
   };
 
   const handleStop = async (itemId) => {
+    if (!canManage) return;
     try {
       const res = await meetingApi.stopAgendaItem(meeting._id, itemId);
       if (res.data.success) {
@@ -129,10 +159,12 @@ const AgendaTimer = ({ meeting }) => {
       }
     } catch (err) {
       console.error("Failed to stop item:", err);
+      toast.error(err.response?.data?.message || "Failed to stop agenda item");
     }
   };
 
   const handleSkip = async (itemId) => {
+    if (!canManage) return;
     try {
       const res = await meetingApi.skipAgendaItem(meeting._id, itemId);
       if (res.data.success) {
@@ -142,15 +174,59 @@ const AgendaTimer = ({ meeting }) => {
       }
     } catch (err) {
       console.error("Failed to skip item:", err);
+      toast.error(err.response?.data?.message || "Failed to skip agenda item");
     }
   };
 
-  if (!agendaItems || agendaItems.length === 0) return null;
+  if (!meeting?._id || !agendaItems || agendaItems.length === 0) return null;
 
   const summary = summarizeAgendaTiming(agendaItems, elapsedMs);
+  const activeTiming = activeItem ? getItemTiming(activeItem, elapsedMs) : null;
+
+  if (compact) {
+    return (
+      <div
+        data-testid="agenda-timer-banner"
+        data-meeting-id={meeting._id}
+        className="flex flex-wrap items-center justify-between gap-2 px-4 py-2 bg-gray-950 border-b border-gray-800 text-sm"
+      >
+        <div className="min-w-0 text-gray-200">
+          {activeItem ? (
+            <span className="flex flex-wrap items-center gap-2">
+              <span className="text-gray-400">Now</span>
+              <span className="font-medium truncate">{activeItem.text}</span>
+              {activeTiming?.isOverrun ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-red-900/40 px-2 py-0.5 text-xs font-medium text-red-300">
+                  <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                  Over by {formatClock(activeTiming.overrunMs)}
+                </span>
+              ) : activeTiming?.hasPlan ? (
+                <span className="rounded-full bg-blue-900/40 px-2 py-0.5 text-xs font-medium text-blue-300">
+                  {formatClock(activeTiming.remainingMs)} left
+                </span>
+              ) : null}
+            </span>
+          ) : (
+            <span className="text-gray-400">No agenda item running</span>
+          )}
+        </div>
+        {summary.isOverrun && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-red-900/40 px-2 py-0.5 text-xs font-medium text-red-300">
+            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+            Meeting {formatClock(summary.overrunMs)} over
+          </span>
+        )}
+      </div>
+    );
+  }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6">
+    <div
+      data-testid="agenda-timer"
+      data-meeting-id={meeting._id}
+      data-readonly={readOnly ? "yes" : "no"}
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-6"
+    >
       <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Live Agenda
@@ -263,41 +339,47 @@ const AgendaTimer = ({ meeting }) => {
                     )}
                   </div>
 
-                  {isOrganizerOrAdmin && !isCompleted && !isSkipped && (
+                  {canManage && !isCompleted && !isSkipped && (
                     <div className="flex gap-2">
                       {!isActive ? (
                         <button
+                          type="button"
                           onClick={() => handleStart(item._id)}
-                          className="p-2 bg-blue-100 text-blue-600 rounded-full hover:bg-blue-200 transition"
+                          className="p-2 bg-blue-100 text-blue-600 rounded-full hover:bg-blue-200 transition dark:bg-blue-900/40 dark:text-blue-300"
                           title="Start Item"
+                          aria-label={`Start ${item.text}`}
                         >
                           <Play size={18} />
                         </button>
                       ) : (
                         <button
+                          type="button"
                           onClick={() => handleStop(item._id)}
-                          className="p-2 bg-red-100 text-red-600 rounded-full hover:bg-red-200 transition"
+                          className="p-2 bg-red-100 text-red-600 rounded-full hover:bg-red-200 transition dark:bg-red-900/40 dark:text-red-300"
                           title="Stop Item"
+                          aria-label={`Stop ${item.text}`}
                         >
                           <Square size={18} />
                         </button>
                       )}
                       <button
+                        type="button"
                         onClick={() => handleSkip(item._id)}
-                        className="p-2 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition"
+                        className="p-2 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition dark:bg-gray-700 dark:text-gray-300"
                         title="Skip Item"
+                        aria-label={`Skip ${item.text}`}
                       >
                         <SkipForward size={18} />
                       </button>
                     </div>
                   )}
                   {isCompleted && (
-                    <span className="text-sm font-medium text-green-600 bg-green-100 px-2 py-1 rounded">
+                    <span className="text-sm font-medium text-green-600 bg-green-100 px-2 py-1 rounded dark:bg-green-900/40 dark:text-green-300">
                       Done
                     </span>
                   )}
                   {isSkipped && (
-                    <span className="text-sm font-medium text-gray-600 bg-gray-200 px-2 py-1 rounded">
+                    <span className="text-sm font-medium text-gray-600 bg-gray-200 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-300">
                       Skipped
                     </span>
                   )}

--- a/client/src/components/meeting-details/__tests__/AgendaTimer.test.jsx
+++ b/client/src/components/meeting-details/__tests__/AgendaTimer.test.jsx
@@ -1,0 +1,294 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { io } from "socket.io-client";
+import AppContent from "../../../context/AppContent";
+import { meetingApi } from "../../../services";
+import AgendaTimer from "../AgendaTimer.jsx";
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../services/apiClient.js", () => ({
+  createClerkSocketOptions: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../../services", () => ({
+  meetingApi: {
+    startAgendaItem: vi.fn(),
+    stopAgendaItem: vi.fn(),
+    skipAgendaItem: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const ORG_A = "org-a";
+const HOST = {
+  _id: "host-1",
+  name: "Ada",
+  role: "member",
+  organization: ORG_A,
+};
+
+const PENDING_ITEM = {
+  _id: "item-1",
+  text: "Review design",
+  duration: 5,
+  status: "pending",
+  actualDuration: 0,
+};
+
+const makeMeeting = (items = [PENDING_ITEM], extras = {}) => ({
+  _id: "meeting-123",
+  uploadedBy: HOST._id,
+  organization: ORG_A,
+  agendaItems: items,
+  ...extras,
+});
+
+const renderTimer = (userData, extraProps = {}, meeting = makeMeeting()) =>
+  render(
+    <AppContent.Provider
+      value={{ userData, backendUrl: "http://localhost:5000" }}
+    >
+      <AgendaTimer meeting={meeting} {...extraProps} />
+    </AppContent.Provider>,
+  );
+
+describe("AgendaTimer (#1985)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    meetingApi.startAgendaItem.mockResolvedValue({
+      data: {
+        success: true,
+        item: {
+          ...PENDING_ITEM,
+          status: "active",
+          startedAt: new Date().toISOString(),
+        },
+      },
+    });
+    meetingApi.stopAgendaItem.mockResolvedValue({
+      data: { success: true, item: { ...PENDING_ITEM, status: "completed" } },
+    });
+    meetingApi.skipAgendaItem.mockResolvedValue({
+      data: { success: true, item: { ...PENDING_ITEM, status: "skipped" } },
+    });
+  });
+
+  it("mounts with meeting context and planned remaining time for participants", () => {
+    renderTimer({
+      _id: "member-9",
+      name: "Pat",
+      role: "member",
+      organization: ORG_A,
+    });
+
+    expect(screen.getByTestId("agenda-timer")).toHaveAttribute(
+      "data-meeting-id",
+      "meeting-123",
+    );
+    expect(screen.getByText("Review design")).toBeInTheDocument();
+    expect(screen.getByText(/planned: 5 min/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /start review design/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets the meeting host start, stop, and skip items", async () => {
+    const { unmount } = renderTimer(HOST);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /start review design/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /skip review design/i }),
+    );
+
+    await waitFor(() => {
+      expect(meetingApi.startAgendaItem).toHaveBeenCalledWith(
+        "meeting-123",
+        "item-1",
+      );
+      expect(meetingApi.skipAgendaItem).toHaveBeenCalledWith(
+        "meeting-123",
+        "item-1",
+      );
+    });
+
+    unmount();
+
+    const activeItem = {
+      ...PENDING_ITEM,
+      status: "active",
+      startedAt: new Date().toISOString(),
+    };
+    renderTimer(HOST, {}, makeMeeting([activeItem]));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /stop review design/i }),
+    );
+    await waitFor(() => {
+      expect(meetingApi.stopAgendaItem).toHaveBeenCalledWith(
+        "meeting-123",
+        "item-1",
+      );
+    });
+  });
+
+  it("lets a same-organization admin mutate the timer", async () => {
+    renderTimer({
+      _id: "admin-1",
+      name: "Bo",
+      role: "admin",
+      organization: { _id: ORG_A },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /start review design/i }),
+    );
+
+    await waitFor(() => {
+      expect(meetingApi.startAgendaItem).toHaveBeenCalledWith(
+        "meeting-123",
+        "item-1",
+      );
+    });
+  });
+
+  it("hides mutation controls in read-only mode", () => {
+    renderTimer(HOST, { readOnly: true });
+
+    expect(screen.getByTestId("agenda-timer")).toHaveAttribute(
+      "data-readonly",
+      "yes",
+    );
+    expect(
+      screen.queryByRole("button", { name: /start review design/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not call the timer API when an unauthorized user cannot see controls", () => {
+    renderTimer({
+      _id: "outsider",
+      role: "admin",
+      organization: "org-b",
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /start|stop|skip/i }),
+    ).not.toBeInTheDocument();
+    expect(meetingApi.startAgendaItem).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing meeting socket instead of opening a second connection", () => {
+    const socket = {
+      on: vi.fn(),
+      off: vi.fn(),
+      emit: vi.fn(),
+      disconnect: vi.fn(),
+    };
+
+    const { unmount } = renderTimer(HOST, { socket });
+
+    expect(io).not.toHaveBeenCalled();
+    expect(socket.on).toHaveBeenCalledWith(
+      "agenda_timer_updated",
+      expect.any(Function),
+    );
+
+    unmount();
+    expect(socket.disconnect).not.toHaveBeenCalled();
+    expect(socket.off).toHaveBeenCalledWith(
+      "agenda_timer_updated",
+      expect.any(Function),
+    );
+  });
+
+  it("updates the current item when the existing socket emits a timer event", () => {
+    const listeners = {};
+    const socket = {
+      on: (event, handler) => {
+        listeners[event] = handler;
+      },
+      off: vi.fn(),
+    };
+
+    renderTimer(
+      {
+        _id: "member-9",
+        role: "member",
+        organization: ORG_A,
+      },
+      { socket, compact: true },
+    );
+
+    expect(screen.getByText(/no agenda item running/i)).toBeInTheDocument();
+
+    listeners.agenda_timer_updated({
+      action: "start",
+      item: {
+        ...PENDING_ITEM,
+        status: "active",
+        startedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(screen.getByText("Review design")).toBeInTheDocument();
+    expect(screen.getByText(/left/i)).toBeInTheDocument();
+  });
+
+  it("shows the overrun warning for an active item past its plan", () => {
+    const overrunItem = {
+      ...PENDING_ITEM,
+      status: "active",
+      duration: 1,
+      startedAt: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    };
+
+    renderTimer(HOST, {}, makeMeeting([overrunItem]));
+
+    expect(screen.getByText(/over by/i)).toBeInTheDocument();
+  });
+
+  it("shows remaining time on the compact live banner", () => {
+    const activeItem = {
+      ...PENDING_ITEM,
+      status: "active",
+      startedAt: new Date().toISOString(),
+    };
+
+    renderTimer(
+      {
+        _id: "member-9",
+        role: "member",
+        organization: ORG_A,
+      },
+      { compact: true },
+      makeMeeting([activeItem]),
+    );
+
+    expect(screen.getByTestId("agenda-timer-banner")).toHaveAttribute(
+      "data-meeting-id",
+      "meeting-123",
+    );
+    expect(screen.getByText("Review design")).toBeInTheDocument();
+    expect(screen.getByText(/left/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /start review design/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/meetings/MeetingHeader.jsx
+++ b/client/src/components/meetings/MeetingHeader.jsx
@@ -11,6 +11,7 @@ import {
   Lightbulb,
   DoorOpen,
   BarChart3,
+  Timer,
   ShieldAlert,
 } from "lucide-react";
 
@@ -40,6 +41,7 @@ export default function MeetingHeader({
   const isTranscriptOpen = activePanel === "transcript";
   const isBreakoutRoomsOpen = activePanel === "breakoutRooms";
   const isPollsOpen = activePanel === "polls";
+  const isAgendaOpen = activePanel === "agenda";
 
   return (
     <header
@@ -156,6 +158,24 @@ export default function MeetingHeader({
           <BarChart3 size={16} />
           <span className="hidden sm:inline">
             {isPollsOpen ? "Hide Polls" : "Polls"}
+          </span>
+        </button>
+
+        {/* Agenda Timer Toggle */}
+        <button
+          type="button"
+          onClick={() => onTogglePanel("agenda")}
+          aria-pressed={isAgendaOpen}
+          className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
+            isAgendaOpen
+              ? "bg-indigo-600 text-white hover:bg-indigo-700"
+              : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
+          }`}
+          title={isAgendaOpen ? "Hide live agenda" : "Open live agenda"}
+        >
+          <Timer size={16} />
+          <span className="hidden sm:inline">
+            {isAgendaOpen ? "Hide Agenda" : "Agenda"}
           </span>
         </button>
 

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -39,6 +39,7 @@ import MeetingReadiness from "../components/MeetingReadiness";
 import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
 import PollSection from "../components/meeting-details/PollSection";
 import FeedbackForm from "../components/meeting-details/FeedbackForm";
+import AgendaTimer from "../components/meeting-details/AgendaTimer";
 import MeetingRisksPanel from "../components/meetings/MeetingRisksPanel";
 import { Award, ShieldAlert } from "lucide-react";
 
@@ -510,6 +511,9 @@ const MeetingDetails = () => {
           />
 
           <MeetingAgenda meeting={meeting} />
+          <div className="mt-6 mb-6">
+            <AgendaTimer meeting={meeting} readOnly />
+          </div>
           <MeetingMetadata meeting={meeting} />
           {currentUser?.publicMetadata?.dbUserId === meeting.uploadedBy && (
             <GuestAccessManager meetingId={meeting._id} />

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -16,6 +16,7 @@ import CollaborativeEditor from "../components/meetings/CollaborativeEditor.jsx"
 import ParkingLotPanel from "../components/meetings/ParkingLotPanel.jsx";
 import BreakoutRoomPanel from "../components/meeting-room/BreakoutRoomPanel.jsx";
 import PollSection from "../components/meeting-details/PollSection.jsx";
+import AgendaTimer from "../components/meeting-details/AgendaTimer.jsx";
 import PeerVideo from "../components/meetings/PeerVideo.jsx";
 import MeetingHeader from "../components/meetings/MeetingHeader.jsx";
 import MeetingControlBar from "../components/meetings/MeetingControlBar.jsx";
@@ -60,6 +61,7 @@ const MEETING_ROOM_PANELS = {
   TRANSCRIPT: "transcript",
   BREAKOUT_ROOMS: "breakoutRooms",
   POLLS: "polls",
+  AGENDA: "agenda",
 };
 
 const MeetingRoom = () => {
@@ -114,6 +116,7 @@ const MeetingRoom = () => {
   const showTranscript = activePanel === MEETING_ROOM_PANELS.TRANSCRIPT;
   const showBreakoutRooms = activePanel === MEETING_ROOM_PANELS.BREAKOUT_ROOMS;
   const showPolls = activePanel === MEETING_ROOM_PANELS.POLLS;
+  const showAgenda = activePanel === MEETING_ROOM_PANELS.AGENDA;
 
   // Transcription state
   const [showCaptions] = useState(true);
@@ -566,15 +569,21 @@ const MeetingRoom = () => {
 
       {/* ---------- ACTIVE MEETING SCREEN ---------- */}
       {joined && !meetingEnded && userRole === "facilitator" && meeting && (
-        <FacilitatorDashboard
-          meeting={meeting}
-          onAdvanceAgenda={() => {
-            // emit socket event to advance agenda
-          }}
-          onNudgeParticipant={() => {
-            toast.success("Nudge sent to participant");
-          }}
-        />
+        <div className="flex-1 flex flex-col min-h-0">
+          <AgendaTimer
+            meeting={meeting}
+            socket={socketRef?.current || socket}
+          />
+          <FacilitatorDashboard
+            meeting={meeting}
+            onAdvanceAgenda={() => {
+              // emit socket event to advance agenda
+            }}
+            onNudgeParticipant={() => {
+              toast.success("Nudge sent to participant");
+            }}
+          />
+        </div>
       )}
 
       {joined && !meetingEnded && userRole !== "facilitator" && (
@@ -590,6 +599,14 @@ const MeetingRoom = () => {
             toggleTranscription={toggleTranscription}
           />
           <ReactionOverlay reactions={reactions} />
+
+          {meeting && (
+            <AgendaTimer
+              meeting={meeting}
+              socket={socketRef?.current || socket}
+              compact
+            />
+          )}
 
           {/* Main content area: video grid + notes panel */}
           <div className="flex-1 flex min-h-0 overflow-hidden">
@@ -717,6 +734,20 @@ const MeetingRoom = () => {
                   socket={socketRef?.current || socket}
                   title="Live Polls"
                 />
+              </div>
+            )}
+
+            {showAgenda && (
+              <div
+                data-testid="meeting-room-agenda-panel"
+                className="w-full md:w-[360px] lg:w-[400px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-y-auto flex flex-col transition-all duration-300"
+              >
+                {meeting ? (
+                  <AgendaTimer
+                    meeting={meeting}
+                    socket={socketRef?.current || socket}
+                  />
+                ) : null}
               </div>
             )}
 

--- a/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
@@ -130,6 +130,9 @@ vi.mock("../../components/meeting-details/AgendaTimer", () => ({
       data-readonly={readOnly ? "yes" : "no"}
     >
       Agenda for {meeting?._id}
+    </div>
+  ),
+}));
 vi.mock("../../components/meeting-details/HealthScoreCard", () => ({
   default: ({ meetingId, organizationId }) => (
     <div

--- a/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
@@ -122,6 +122,17 @@ vi.mock("../../components/meeting-details/FeedbackForm", () => ({
     </div>
   ),
 }));
+vi.mock("../../components/meeting-details/AgendaTimer", () => ({
+  default: ({ meeting, readOnly }) => (
+    <div
+      data-testid="agenda-timer"
+      data-meeting-id={meeting?._id}
+      data-readonly={readOnly ? "yes" : "no"}
+    >
+      Agenda for {meeting?._id}
+    </div>
+  ),
+}));
 
 import { meetingApi } from "../../services";
 
@@ -177,6 +188,10 @@ describe("MeetingDetails Navbar Integration (#1637)", () => {
     expect(feedbackForm).toHaveTextContent("Feedback for 123");
     expect(feedbackForm).toHaveAttribute("data-meeting-id", "123");
     expect(feedbackForm).toHaveAttribute("data-organization-id", "org-42");
+    const agendaTimer = screen.getByTestId("agenda-timer");
+    expect(agendaTimer).toHaveTextContent("Agenda for 123");
+    expect(agendaTimer).toHaveAttribute("data-meeting-id", "123");
+    expect(agendaTimer).toHaveAttribute("data-readonly", "yes");
   });
 
   it("renders Navbar in error state", async () => {

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -60,6 +60,10 @@ vi.mock("../../components/meeting-details/AgendaTimer.jsx", () => ({
       data-readonly={readOnly ? "yes" : "no"}
     >
       Agenda for {meeting?._id}
+    </div>
+  ),
+}));
+
 vi.mock("../../components/meeting-details/HealthScoreCard.jsx", () => ({
   default: ({ meetingId, organizationId }) => (
     <div

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -52,6 +52,18 @@ vi.mock("../../components/meeting-details/FeedbackForm.jsx", () => ({
   ),
 }));
 
+vi.mock("../../components/meeting-details/AgendaTimer.jsx", () => ({
+  default: ({ meeting, readOnly }) => (
+    <div
+      data-testid="agenda-timer"
+      data-meeting-id={meeting?._id}
+      data-readonly={readOnly ? "yes" : "no"}
+    >
+      Agenda for {meeting?._id}
+    </div>
+  ),
+}));
+
 vi.mock("../../services", () => ({
   meetingApi: {
     getMeetingById: vi.fn(),

--- a/client/src/pages/__tests__/MeetingRoomPanelState.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomPanelState.test.jsx
@@ -107,6 +107,19 @@ vi.mock("../../components/meeting-details/PollSection.jsx", () => ({
   ),
 }));
 
+vi.mock("../../components/meeting-details/AgendaTimer.jsx", () => ({
+  default: ({ meeting, socket, compact, readOnly }) => (
+    <div
+      data-testid={compact ? "agenda-timer-banner" : "agenda-timer"}
+      data-meeting-id={meeting?._id}
+      data-has-socket={socket ? "yes" : "no"}
+      data-readonly={readOnly ? "yes" : "no"}
+    >
+      Agenda for {meeting?._id}
+    </div>
+  ),
+}));
+
 vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({
   default: () => <div data-testid="captions">Captions</div>,
 }));
@@ -243,19 +256,29 @@ describe("MeetingRoom exclusive panel state (#1648)", () => {
     fireEvent.click(screen.getByRole("button", { name: /parking lot/i }));
     fireEvent.click(screen.getByRole("button", { name: /transcript/i }));
     fireEvent.click(screen.getByRole("button", { name: /^polls$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^agenda$/i }));
 
     const visiblePanels = [
       screen.queryByTestId("meeting-room-notes-panel"),
       screen.queryByTestId("meeting-room-parking-lot-panel"),
       screen.queryByTestId("meeting-room-transcript-panel"),
       screen.queryByTestId("meeting-room-polls-panel"),
+      screen.queryByTestId("meeting-room-agenda-panel"),
     ].filter(Boolean);
 
     expect(visiblePanels).toHaveLength(1);
-    expect(screen.getByTestId("meeting-room-polls-panel")).toBeInTheDocument();
-    const pollSection = screen.getByTestId("poll-section");
-    expect(pollSection).toHaveTextContent("Live Polls");
-    expect(pollSection).toHaveAttribute("data-meeting-id", "room-panel-123");
-    expect(pollSection).toHaveAttribute("data-has-socket", "yes");
+    expect(screen.getByTestId("meeting-room-agenda-panel")).toBeInTheDocument();
+  });
+
+  it("opens the live agenda panel and reuses the meeting socket", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /^agenda$/i }));
+
+    expect(screen.getByTestId("meeting-room-agenda-panel")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-room-polls-panel"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/__tests__/MeetingRoomTimer.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomTimer.test.jsx
@@ -78,6 +78,10 @@ vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({
   default: () => <div data-testid="captions">Captions</div>,
 }));
 
+vi.mock("../../components/meeting-details/AgendaTimer.jsx", () => ({
+  default: () => <div data-testid="agenda-timer">Agenda</div>,
+}));
+
 vi.mock("../../components/meetings/DeviceSetupModal.jsx", () => {
   const MockDeviceSetupModal = ({ onSetupComplete }) => {
     React.useEffect(() => {

--- a/client/src/utils/__tests__/agendaTimerAccess.test.js
+++ b/client/src/utils/__tests__/agendaTimerAccess.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { canManageAgendaTimer } from "../agendaTimerAccess";
+
+const ORG_A = "org-a";
+const ORG_B = "org-b";
+const HOST_ID = "host-1";
+
+const meeting = {
+  uploadedBy: HOST_ID,
+  organization: ORG_A,
+};
+
+describe("canManageAgendaTimer (#1985)", () => {
+  it("allows the meeting uploader", () => {
+    expect(
+      canManageAgendaTimer(meeting, {
+        _id: HOST_ID,
+        organization: ORG_A,
+        role: "member",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows a same-organization admin or owner", () => {
+    expect(
+      canManageAgendaTimer(meeting, {
+        _id: "admin-1",
+        organization: { _id: ORG_A },
+        role: "admin",
+      }),
+    ).toBe(true);
+    expect(
+      canManageAgendaTimer(meeting, {
+        _id: "owner-1",
+        organization: ORG_A,
+        role: "owner",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects same-org members who are not the uploader", () => {
+    expect(
+      canManageAgendaTimer(meeting, {
+        _id: "member-1",
+        organization: ORG_A,
+        role: "member",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects admins from another organization", () => {
+    expect(
+      canManageAgendaTimer(meeting, {
+        _id: "admin-b",
+        organization: ORG_B,
+        role: "admin",
+      }),
+    ).toBe(false);
+  });
+});

--- a/client/src/utils/agendaTimerAccess.js
+++ b/client/src/utils/agendaTimerAccess.js
@@ -1,0 +1,23 @@
+/**
+ * Mirrors server/controllers/agendaTimerController.js `canManageTimers`.
+ * Mutation stays limited to the meeting uploader or a same-org admin/owner.
+ */
+export const canManageAgendaTimer = (meeting, user) => {
+  if (!meeting || !user) return false;
+
+  const userId = (user._id ?? user.id)?.toString();
+  if (!userId) return false;
+
+  const uploadedBy = meeting.uploadedBy?._id || meeting.uploadedBy;
+  const isUploader = uploadedBy?.toString() === userId;
+
+  const meetingOrg = meeting.organization?._id || meeting.organization;
+  const userOrg = user.organization?._id || user.organization;
+  const sameOrg = Boolean(
+    meetingOrg && userOrg && meetingOrg.toString() === userOrg.toString(),
+  );
+  const isOrgAdmin =
+    sameOrg && (user.role === "admin" || user.role === "owner");
+
+  return Boolean(isUploader || isOrgAdmin);
+};


### PR DESCRIPTION
## Description

Closes #1985.

Mounts the existing AgendaTimer into the live Meeting Room and Meeting Details, with permission-aware controls and realtime timer updates.

## What Changed

- Mounted AgendaTimer in the live Meeting Room.
- Added compact timer banner and Agenda panel integration.
- Reused the existing meeting socket for realtime timer updates.
- Added read-only timer display on Meeting Details.
- Added host/admin authorization for start, stop, and skip actions.
- Participants can see current item, remaining time, and overrun state.
- Unauthorized users cannot mutate timer state.
- Added centralized timer access checks.

## Tests

Added coverage for:

- Host/admin timer actions
- Unauthorized/read-only users
- Socket reuse
- Realtime participant updates
- Overrun state
- Meeting Room timer/banner/panel
- Meeting Details read-only mount

## Security

- Preserves existing backend RBAC.
- Organization ownership is respected for admin access.
- No additional socket connection is created.
- Existing timer API and business logic remain unchanged.

Closes #1985