### PR TITLE
feat: wire clip manager for meeting clips

### DIFF
--- a/client/src/components/meeting-details/ClipManager.jsx
+++ b/client/src/components/meeting-details/ClipManager.jsx
@@ -1,29 +1,75 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import meetingClipApi from "../../services/meetingClipApi";
 
-const ClipManager = ({ meetingId }) => {
-  const [clips, setClips] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
+const CARD_CLASS =
+  "bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 sm:p-6";
 
-  // Create clip state
+const INPUT_CLASS =
+  "mt-1 block w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm p-2";
+
+const getAudioUrl = (meeting) => {
+  if (!meeting?.audioFilePath) return null;
+  return meeting.audioFilePath.startsWith("http")
+    ? meeting.audioFilePath
+    : `/api/media/${meeting.audioFilePath}`;
+};
+
+const getErrorMessage = (err, fallback) =>
+  err.response?.data?.message || err.response?.data?.error || fallback;
+
+const normalizeClips = (data) => {
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.clips)) return data.clips;
+  return [];
+};
+
+const ClipManager = ({ meetingId, meeting, canManage = true }) => {
+  const [clips, setClips] = useState([]);
+  const [loading, setLoading] = useState(Boolean(meetingId));
+  const [error, setError] = useState("");
+  const [forbidden, setForbidden] = useState(false);
+
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
 
-  // Annotation state
   const [annotationText, setAnnotationText] = useState("");
   const [annotationTimestamp, setAnnotationTimestamp] = useState("");
   const [activeClipId, setActiveClipId] = useState(null);
 
+  const [editingClipId, setEditingClipId] = useState(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+
+  const [playingClipId, setPlayingClipId] = useState(null);
+  const audioRef = useRef(null);
+  const playingRangeRef = useRef(null);
+  const audioUrl = getAudioUrl(meeting);
+
   const fetchClips = useCallback(async () => {
+    if (!meetingId) {
+      setLoading(false);
+      return;
+    }
+
     try {
       setLoading(true);
+      setError("");
+      setForbidden(false);
       const data = await meetingClipApi.getMeetingClips(meetingId);
-      setClips(data);
+      setClips(normalizeClips(data));
     } catch (err) {
-      setError("Failed to load clips");
+      const status = err.response?.status;
+      const message = getErrorMessage(err, "Failed to load clips");
+      if (status === 401 || status === 403) {
+        setForbidden(true);
+        setError(
+          message || "You are not authorized to view clips for this meeting.",
+        );
+      } else {
+        setError(message);
+      }
       console.error(err);
     } finally {
       setLoading(false);
@@ -36,9 +82,10 @@ const ClipManager = ({ meetingId }) => {
 
   const handleCreateClip = async (e) => {
     e.preventDefault();
-    if (!title || startTime === "" || endTime === "") return;
+    if (!canManage || !title || startTime === "" || endTime === "") return;
 
     try {
+      setError("");
       const newClip = await meetingClipApi.createClip({
         meetingId,
         title,
@@ -52,27 +99,66 @@ const ClipManager = ({ meetingId }) => {
       setStartTime("");
       setEndTime("");
     } catch (err) {
-      setError("Failed to create clip");
+      setError(getErrorMessage(err, "Failed to create clip"));
+      console.error(err);
+    }
+  };
+
+  const handleUpdateClip = async (e, clipId) => {
+    e.preventDefault();
+    if (!canManage || !editTitle) return;
+
+    try {
+      setError("");
+      const updated = await meetingClipApi.updateClip(clipId, {
+        title: editTitle,
+        description: editDescription,
+      });
+      setClips(clips.map((c) => (c._id === clipId ? { ...c, ...updated } : c)));
+      setEditingClipId(null);
+    } catch (err) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        setError(
+          getErrorMessage(err, "You are not authorized to update this clip."),
+        );
+      } else {
+        setError(getErrorMessage(err, "Failed to update clip"));
+      }
       console.error(err);
     }
   };
 
   const handleDeleteClip = async (clipId) => {
+    if (!canManage) return;
     if (!window.confirm("Are you sure you want to delete this clip?")) return;
     try {
+      setError("");
       await meetingClipApi.deleteClip(clipId);
       setClips(clips.filter((c) => c._id !== clipId));
+      if (playingClipId === clipId) {
+        audioRef.current?.pause();
+        setPlayingClipId(null);
+      }
     } catch (err) {
-      setError("Failed to delete clip");
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        setError(
+          getErrorMessage(err, "You are not authorized to delete this clip."),
+        );
+      } else {
+        setError(getErrorMessage(err, "Failed to delete clip"));
+      }
       console.error(err);
     }
   };
 
   const handleAddAnnotation = async (e, clipId) => {
     e.preventDefault();
-    if (!annotationText || annotationTimestamp === "") return;
+    if (!canManage || !annotationText || annotationTimestamp === "") return;
 
     try {
+      setError("");
       const newAnnotation = await meetingClipApi.addClipAnnotation(clipId, {
         text: annotationText,
         timestamp: Number(annotationTimestamp),
@@ -81,16 +167,64 @@ const ClipManager = ({ meetingId }) => {
       setClips(
         clips.map((c) => {
           if (c._id === clipId) {
-            return { ...c, annotations: [...c.annotations, newAnnotation] };
+            return {
+              ...c,
+              annotations: [...(c.annotations || []), newAnnotation],
+            };
           }
           return c;
         }),
       );
       setAnnotationText("");
       setAnnotationTimestamp("");
+      setActiveClipId(null);
     } catch (err) {
-      setError("Failed to add annotation");
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        setError(
+          getErrorMessage(err, "You are not authorized to annotate this clip."),
+        );
+      } else {
+        setError(getErrorMessage(err, "Failed to add annotation"));
+      }
       console.error(err);
+    }
+  };
+
+  const handlePlayClip = async (clip) => {
+    const audio = audioRef.current;
+    if (!audio || !audioUrl) return;
+
+    if (playingClipId === clip._id && !audio.paused) {
+      audio.pause();
+      setPlayingClipId(null);
+      playingRangeRef.current = null;
+      return;
+    }
+
+    playingRangeRef.current = {
+      id: clip._id,
+      start: Number(clip.startTime) || 0,
+      end: Number(clip.endTime) || 0,
+    };
+    audio.currentTime = playingRangeRef.current.start;
+    try {
+      await audio.play();
+      setPlayingClipId(clip._id);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to play this clip.");
+    }
+  };
+
+  const handleAudioTimeUpdate = () => {
+    const audio = audioRef.current;
+    const range = playingRangeRef.current;
+    if (!audio || !range) return;
+    if (range.end > range.start && audio.currentTime >= range.end) {
+      audio.pause();
+      setPlayingClipId(null);
+      playingRangeRef.current = null;
     }
   };
 
@@ -100,143 +234,332 @@ const ClipManager = ({ meetingId }) => {
     return `${mins}:${secs < 10 ? "0" : ""}${secs}`;
   };
 
-  if (loading) return <div className="p-4 text-center">Loading clips...</div>;
+  if (loading) {
+    return (
+      <div
+        data-testid="clip-manager"
+        data-meeting-id={meetingId}
+        aria-busy="true"
+        className={`${CARD_CLASS} animate-pulse`}
+      >
+        <div
+          role="status"
+          aria-label="Loading meeting clips"
+          className="h-6 w-1/3 bg-gray-200 dark:bg-gray-700 rounded mb-4"
+        />
+        <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+      </div>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <div
+        data-testid="clip-manager-forbidden"
+        data-meeting-id={meetingId}
+        className={CARD_CLASS}
+      >
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          Meeting Clips
+        </h2>
+        <p role="status" className="text-sm text-gray-600 dark:text-gray-400">
+          {error || "You are not authorized to view clips for this meeting."}
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="p-4 bg-white rounded shadow-sm">
-      <h2 className="text-xl font-semibold mb-4">Meeting Clips</h2>
-      {error && <div className="text-red-500 mb-4">{error}</div>}
-
-      <div className="mb-8 border-b pb-6">
-        <h3 className="text-lg font-medium mb-3">Create New Clip</h3>
-        <form onSubmit={handleCreateClip} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Title
-              </label>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="mt-1 block w-full rounded border-gray-300 shadow-sm p-2 border"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Description
-              </label>
-              <input
-                type="text"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                className="mt-1 block w-full rounded border-gray-300 shadow-sm p-2 border"
-              />
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Start Time (seconds)
-              </label>
-              <input
-                type="number"
-                value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
-                className="mt-1 block w-full rounded border-gray-300 shadow-sm p-2 border"
-                min="0"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                End Time (seconds)
-              </label>
-              <input
-                type="number"
-                value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
-                className="mt-1 block w-full rounded border-gray-300 shadow-sm p-2 border"
-                min="0"
-                required
-              />
-            </div>
-          </div>
+    <div
+      data-testid="clip-manager"
+      data-meeting-id={meetingId}
+      className={CARD_CLASS}
+    >
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+        Meeting Clips
+      </h2>
+      {error && (
+        <div
+          role="alert"
+          className="text-red-600 dark:text-red-400 mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+        >
+          <span>{error}</span>
           <button
-            type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            type="button"
+            onClick={fetchClips}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline self-start"
           >
-            Create Clip
+            Retry
           </button>
-        </form>
-      </div>
+        </div>
+      )}
+
+      {audioUrl && (
+        <audio
+          ref={audioRef}
+          src={audioUrl}
+          onTimeUpdate={handleAudioTimeUpdate}
+          onEnded={() => {
+            setPlayingClipId(null);
+            playingRangeRef.current = null;
+          }}
+          className="hidden"
+          data-testid="clip-manager-audio"
+        />
+      )}
+
+      {canManage && (
+        <div className="mb-8 border-b border-gray-200 dark:border-gray-700 pb-6">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3">
+            Create New Clip
+          </h3>
+          <form onSubmit={handleCreateClip} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label
+                  htmlFor="clip-title"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Title
+                </label>
+                <input
+                  id="clip-title"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className={INPUT_CLASS}
+                  required
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="clip-description"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Description
+                </label>
+                <input
+                  id="clip-description"
+                  type="text"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  className={INPUT_CLASS}
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label
+                  htmlFor="clip-start-time"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Start Time (seconds)
+                </label>
+                <input
+                  id="clip-start-time"
+                  type="number"
+                  value={startTime}
+                  onChange={(e) => setStartTime(e.target.value)}
+                  className={INPUT_CLASS}
+                  min="0"
+                  required
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="clip-end-time"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  End Time (seconds)
+                </label>
+                <input
+                  id="clip-end-time"
+                  type="number"
+                  value={endTime}
+                  onChange={(e) => setEndTime(e.target.value)}
+                  className={INPUT_CLASS}
+                  min="0"
+                  required
+                />
+              </div>
+            </div>
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+            >
+              Create Clip
+            </button>
+          </form>
+        </div>
+      )}
 
       <div>
-        <h3 className="text-lg font-medium mb-3">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3">
           Saved Clips ({clips.length})
         </h3>
         {clips.length === 0 ? (
-          <p className="text-gray-500 italic">
+          <p
+            data-testid="clip-manager-empty"
+            className="text-gray-500 dark:text-gray-400 italic"
+          >
             No clips have been created for this meeting.
           </p>
         ) : (
           <div className="space-y-6">
             {clips.map((clip) => (
-              <div key={clip._id} className="border rounded p-4 shadow-sm">
-                <div className="flex justify-between items-start mb-2">
+              <div
+                key={clip._id}
+                data-testid={`clip-card-${clip._id}`}
+                className="border border-gray-200 dark:border-gray-700 rounded p-4 shadow-sm"
+              >
+                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 mb-2">
                   <div>
-                    <h4 className="text-lg font-bold">{clip.title}</h4>
-                    <p className="text-sm text-gray-600">{clip.description}</p>
-                    <p className="text-xs text-blue-600 font-semibold mt-1">
-                      {formatTime(clip.startTime)} - {formatTime(clip.endTime)}
-                    </p>
+                    {editingClipId === clip._id ? (
+                      <form
+                        onSubmit={(e) => handleUpdateClip(e, clip._id)}
+                        className="space-y-2"
+                      >
+                        <label
+                          className="sr-only"
+                          htmlFor={`edit-title-${clip._id}`}
+                        >
+                          Title
+                        </label>
+                        <input
+                          id={`edit-title-${clip._id}`}
+                          type="text"
+                          value={editTitle}
+                          onChange={(e) => setEditTitle(e.target.value)}
+                          className={INPUT_CLASS}
+                          required
+                        />
+                        <label
+                          className="sr-only"
+                          htmlFor={`edit-description-${clip._id}`}
+                        >
+                          Description
+                        </label>
+                        <input
+                          id={`edit-description-${clip._id}`}
+                          type="text"
+                          value={editDescription}
+                          onChange={(e) => setEditDescription(e.target.value)}
+                          className={INPUT_CLASS}
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            type="submit"
+                            className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700"
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setEditingClipId(null)}
+                            className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </form>
+                    ) : (
+                      <>
+                        <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                          {clip.title}
+                        </h4>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">
+                          {clip.description}
+                        </p>
+                        <p className="text-xs text-blue-600 dark:text-blue-400 font-semibold mt-1">
+                          {formatTime(clip.startTime)} -{" "}
+                          {formatTime(clip.endTime)}
+                        </p>
+                      </>
+                    )}
                   </div>
-                  <button
-                    onClick={() => handleDeleteClip(clip._id)}
-                    className="text-red-500 text-sm hover:underline"
-                  >
-                    Delete
-                  </button>
+                  <div className="flex flex-wrap gap-3">
+                    {audioUrl ? (
+                      <button
+                        type="button"
+                        onClick={() => handlePlayClip(clip)}
+                        aria-label={
+                          playingClipId === clip._id
+                            ? `Pause clip ${clip.title}`
+                            : `Play clip ${clip.title}`
+                        }
+                        className="text-blue-600 dark:text-blue-400 text-sm hover:underline"
+                      >
+                        {playingClipId === clip._id ? "Pause" : "Play"}
+                      </button>
+                    ) : (
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        No recording available to play this clip.
+                      </span>
+                    )}
+                    {canManage && editingClipId !== clip._id && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingClipId(clip._id);
+                          setEditTitle(clip.title || "");
+                          setEditDescription(clip.description || "");
+                        }}
+                        className="text-gray-600 dark:text-gray-300 text-sm hover:underline"
+                      >
+                        Edit
+                      </button>
+                    )}
+                    {canManage && (
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteClip(clip._id)}
+                        className="text-red-500 text-sm hover:underline"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
                 </div>
 
-                {/* Transcript Segments */}
-                <div className="mt-4 bg-gray-50 p-3 rounded">
-                  <h5 className="text-sm font-semibold mb-2 text-gray-700">
+                <div className="mt-4 bg-gray-50 dark:bg-gray-900 p-3 rounded">
+                  <h5 className="text-sm font-semibold mb-2 text-gray-700 dark:text-gray-300">
                     Transcript Segments
                   </h5>
                   {clip.transcriptSegments?.length > 0 ? (
                     <div className="space-y-2 max-h-40 overflow-y-auto">
                       {clip.transcriptSegments.map((seg, idx) => (
                         <div key={idx} className="text-sm">
-                          <span className="font-semibold text-gray-800">
+                          <span className="font-semibold text-gray-800 dark:text-gray-200">
                             {seg.speaker}:{" "}
                           </span>
-                          <span className="text-gray-700">{seg.text}</span>
+                          <span className="text-gray-700 dark:text-gray-300">
+                            {seg.text}
+                          </span>
                         </div>
                       ))}
                     </div>
                   ) : (
-                    <p className="text-xs text-gray-500 italic">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 italic">
                       No transcript segments in this range.
                     </p>
                   )}
                 </div>
 
-                {/* Annotations */}
                 <div className="mt-4">
-                  <h5 className="text-sm font-semibold mb-2 text-gray-700">
+                  <h5 className="text-sm font-semibold mb-2 text-gray-700 dark:text-gray-300">
                     Annotations
                   </h5>
                   {clip.annotations?.length > 0 && (
                     <ul className="mb-3 space-y-1">
                       {clip.annotations.map((ann, idx) => (
                         <li
-                          key={idx}
-                          className="text-sm bg-blue-50 p-2 rounded flex justify-between"
+                          key={ann._id || idx}
+                          className="text-sm bg-blue-50 dark:bg-blue-950/40 p-2 rounded flex flex-col sm:flex-row sm:justify-between gap-1"
                         >
-                          <span>{ann.text}</span>
-                          <span className="text-gray-500 text-xs">
+                          <span className="text-gray-800 dark:text-gray-100">
+                            {ann.text}
+                          </span>
+                          <span className="text-gray-500 dark:text-gray-400 text-xs">
                             @ {formatTime(ann.timestamp)}
                           </span>
                         </li>
@@ -244,55 +567,73 @@ const ClipManager = ({ meetingId }) => {
                     </ul>
                   )}
 
-                  {activeClipId === clip._id ? (
-                    <form
-                      onSubmit={(e) => handleAddAnnotation(e, clip._id)}
-                      className="flex items-center space-x-2 mt-2"
-                    >
-                      <input
-                        type="number"
-                        placeholder="Time (sec)"
-                        value={annotationTimestamp}
-                        onChange={(e) => setAnnotationTimestamp(e.target.value)}
-                        className="w-24 rounded border p-1 text-sm"
-                        required
-                        min={clip.startTime}
-                        max={clip.endTime}
-                      />
-                      <input
-                        type="text"
-                        placeholder="Annotation note..."
-                        value={annotationText}
-                        onChange={(e) => setAnnotationText(e.target.value)}
-                        className="flex-1 rounded border p-1 text-sm"
-                        required
-                      />
-                      <button
-                        type="submit"
-                        className="bg-blue-100 text-blue-700 px-3 py-1 rounded text-sm hover:bg-blue-200"
+                  {canManage &&
+                    (activeClipId === clip._id ? (
+                      <form
+                        onSubmit={(e) => handleAddAnnotation(e, clip._id)}
+                        className="flex flex-col sm:flex-row sm:items-center gap-2 mt-2"
                       >
-                        Add
-                      </button>
+                        <label
+                          className="sr-only"
+                          htmlFor={`ann-time-${clip._id}`}
+                        >
+                          Annotation time in seconds
+                        </label>
+                        <input
+                          id={`ann-time-${clip._id}`}
+                          type="number"
+                          placeholder="Time (sec)"
+                          value={annotationTimestamp}
+                          onChange={(e) =>
+                            setAnnotationTimestamp(e.target.value)
+                          }
+                          className="w-full sm:w-24 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-1 text-sm"
+                          required
+                          min={clip.startTime}
+                          max={clip.endTime}
+                        />
+                        <label
+                          className="sr-only"
+                          htmlFor={`ann-text-${clip._id}`}
+                        >
+                          Annotation note
+                        </label>
+                        <input
+                          id={`ann-text-${clip._id}`}
+                          type="text"
+                          placeholder="Annotation note..."
+                          value={annotationText}
+                          onChange={(e) => setAnnotationText(e.target.value)}
+                          className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-1 text-sm"
+                          required
+                        />
+                        <button
+                          type="submit"
+                          className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-3 py-1 rounded text-sm hover:bg-blue-200 dark:hover:bg-blue-900/60"
+                        >
+                          Add
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setActiveClipId(null)}
+                          className="text-gray-500 dark:text-gray-400 text-sm hover:underline"
+                        >
+                          Cancel
+                        </button>
+                      </form>
+                    ) : (
                       <button
                         type="button"
-                        onClick={() => setActiveClipId(null)}
-                        className="text-gray-500 text-sm ml-2 hover:underline"
+                        onClick={() => {
+                          setActiveClipId(clip._id);
+                          setAnnotationText("");
+                          setAnnotationTimestamp("");
+                        }}
+                        className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                       >
-                        Cancel
+                        + Add Annotation
                       </button>
-                    </form>
-                  ) : (
-                    <button
-                      onClick={() => {
-                        setActiveClipId(clip._id);
-                        setAnnotationText("");
-                        setAnnotationTimestamp("");
-                      }}
-                      className="text-sm text-blue-600 hover:underline"
-                    >
-                      + Add Annotation
-                    </button>
-                  )}
+                    ))}
                 </div>
               </div>
             ))}

--- a/client/src/components/meeting-details/__tests__/ClipManager.test.jsx
+++ b/client/src/components/meeting-details/__tests__/ClipManager.test.jsx
@@ -1,0 +1,255 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import meetingClipApi from "../../../services/meetingClipApi";
+import ClipManager from "../ClipManager.jsx";
+
+vi.mock("../../../services/meetingClipApi", () => ({
+  default: {
+    getMeetingClips: vi.fn(),
+    createClip: vi.fn(),
+    updateClip: vi.fn(),
+    deleteClip: vi.fn(),
+    addClipAnnotation: vi.fn(),
+  },
+}));
+
+const MEETING_ID = "meeting-123";
+
+const SAMPLE_CLIP = {
+  _id: "clip-1",
+  title: "Decision moment",
+  description: "Budget call",
+  startTime: 10,
+  endTime: 25,
+  transcriptSegments: [{ speaker: "Ada", text: "We should ship Friday." }],
+  annotations: [{ _id: "ann-1", text: "Key decision", timestamp: 12 }],
+};
+
+const renderManager = (props = {}) =>
+  render(
+    <ClipManager
+      meetingId={MEETING_ID}
+      meeting={{ _id: MEETING_ID, audioFilePath: "recordings/meet.mp3" }}
+      canManage
+      {...props}
+    />,
+  );
+
+describe("ClipManager (#1987)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    meetingClipApi.getMeetingClips.mockResolvedValue([]);
+  });
+
+  it("shows a loading state while clips are fetched for the meeting", () => {
+    meetingClipApi.getMeetingClips.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    renderManager();
+
+    expect(screen.getByLabelText(/loading meeting clips/i)).toBeInTheDocument();
+    expect(screen.getByTestId("clip-manager")).toHaveAttribute(
+      "data-meeting-id",
+      MEETING_ID,
+    );
+    expect(meetingClipApi.getMeetingClips).toHaveBeenCalledWith(MEETING_ID);
+  });
+
+  it("shows an empty state when the meeting has no clips", async () => {
+    renderManager();
+
+    expect(await screen.findByTestId("clip-manager-empty")).toHaveTextContent(
+      /no clips have been created/i,
+    );
+  });
+
+  it("renders saved clips, transcript segments, and annotations", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+
+    renderManager();
+
+    expect(await screen.findByText("Decision moment")).toBeInTheDocument();
+    expect(screen.getByText("We should ship Friday.")).toBeInTheDocument();
+    expect(screen.getByText("Key decision")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /play clip decision moment/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("creates a clip through meetingClipApi.createClip", async () => {
+    meetingClipApi.createClip.mockResolvedValue({
+      ...SAMPLE_CLIP,
+      _id: "clip-2",
+      title: "New clip",
+    });
+
+    renderManager();
+    await screen.findByTestId("clip-manager-empty");
+
+    fireEvent.change(screen.getByLabelText(/^title$/i), {
+      target: { value: "New clip" },
+    });
+    fireEvent.change(screen.getByLabelText(/start time/i), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByLabelText(/end time/i), {
+      target: { value: "15" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create clip/i }));
+
+    await waitFor(() => {
+      expect(meetingClipApi.createClip).toHaveBeenCalledWith({
+        meetingId: MEETING_ID,
+        title: "New clip",
+        description: "",
+        startTime: 5,
+        endTime: 15,
+      });
+    });
+    expect(await screen.findByText("New clip")).toBeInTheDocument();
+  });
+
+  it("updates a clip through meetingClipApi.updateClip", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+    meetingClipApi.updateClip.mockResolvedValue({
+      ...SAMPLE_CLIP,
+      title: "Renamed clip",
+    });
+
+    renderManager();
+    await screen.findByText("Decision moment");
+
+    fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    fireEvent.change(screen.getByDisplayValue("Decision moment"), {
+      target: { value: "Renamed clip" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(meetingClipApi.updateClip).toHaveBeenCalledWith("clip-1", {
+        title: "Renamed clip",
+        description: "Budget call",
+      });
+    });
+    expect(await screen.findByText("Renamed clip")).toBeInTheDocument();
+  });
+
+  it("deletes a clip after confirmation", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+    meetingClipApi.deleteClip.mockResolvedValue({ message: "ok" });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderManager();
+    await screen.findByText("Decision moment");
+
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(meetingClipApi.deleteClip).toHaveBeenCalledWith("clip-1");
+    });
+    expect(screen.queryByText("Decision moment")).not.toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+
+  it("adds an annotation and reloads it onto the clip", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+    meetingClipApi.addClipAnnotation.mockResolvedValue({
+      _id: "ann-2",
+      text: "Follow up",
+      timestamp: 14,
+    });
+
+    renderManager();
+    await screen.findByText("Decision moment");
+
+    fireEvent.click(screen.getByRole("button", { name: /add annotation/i }));
+    fireEvent.change(screen.getByLabelText(/annotation time/i), {
+      target: { value: "14" },
+    });
+    fireEvent.change(screen.getByLabelText(/annotation note/i), {
+      target: { value: "Follow up" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(meetingClipApi.addClipAnnotation).toHaveBeenCalledWith("clip-1", {
+        text: "Follow up",
+        timestamp: 14,
+      });
+    });
+    expect(await screen.findByText("Follow up")).toBeInTheDocument();
+  });
+
+  it("plays the meeting recording from the clip start time", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+
+    renderManager();
+    await screen.findByText("Decision moment");
+
+    const audio = screen.getByTestId("clip-manager-audio");
+    const play = vi.fn().mockResolvedValue();
+    Object.defineProperty(audio, "play", { value: play });
+    Object.defineProperty(audio, "pause", { value: vi.fn() });
+    Object.defineProperty(audio, "paused", { value: true, configurable: true });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /play clip decision moment/i }),
+    );
+
+    await waitFor(() => {
+      expect(play).toHaveBeenCalled();
+    });
+    expect(audio.currentTime).toBe(10);
+  });
+
+  it("shows an error state when listing clips fails", async () => {
+    meetingClipApi.getMeetingClips.mockRejectedValue({
+      response: { data: { message: "Server Error" } },
+    });
+
+    renderManager();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Server Error");
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("shows a forbidden state when the API denies access", async () => {
+    meetingClipApi.getMeetingClips.mockRejectedValue({
+      response: {
+        status: 403,
+        data: { message: "Forbidden: You don't have access to this resource" },
+      },
+    });
+
+    renderManager();
+
+    expect(
+      await screen.findByTestId("clip-manager-forbidden"),
+    ).toHaveTextContent(/don't have access/i);
+    expect(
+      screen.queryByRole("button", { name: /create clip/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides create, edit, and delete controls when the user cannot manage clips", async () => {
+    meetingClipApi.getMeetingClips.mockResolvedValue([SAMPLE_CLIP]);
+
+    renderManager({ canManage: false });
+
+    await screen.findByText("Decision moment");
+    expect(
+      screen.queryByRole("button", { name: /create clip/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^edit$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^delete$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add annotation/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -41,6 +41,7 @@ import PollSection from "../components/meeting-details/PollSection";
 import FeedbackForm from "../components/meeting-details/FeedbackForm";
 import AgendaTimer from "../components/meeting-details/AgendaTimer";
 import AgendaPacingReport from "../components/meeting-details/AgendaPacingReport";
+import ClipManager from "../components/meeting-details/ClipManager";
 import HealthScoreCard from "../components/meeting-details/HealthScoreCard";
 import { isMeetingEnded } from "../utils/meetingLifecycle";
 import MeetingRisksPanel from "../components/meetings/MeetingRisksPanel";
@@ -412,6 +413,13 @@ const MeetingDetails = () => {
           </div>
 
           <MeetingTranscript meeting={meeting} />
+          <div className="mt-6 mb-6">
+            <ClipManager
+              meetingId={meeting._id}
+              meeting={meeting}
+              canManage={!isViewerOrGuest}
+            />
+          </div>
           <TranscriptAnnotations meeting={meeting} />
 
           <div className="mt-6 mb-6">

--- a/client/src/pages/__tests__/MeetingDetailsClipManager.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsClipManager.test.jsx
@@ -137,16 +137,21 @@ vi.mock("../../components/meetings/MeetingRisksPanel", () => ({
 vi.mock("../../components/MeetingReadiness", () => ({
   default: () => null,
 }));
-
 vi.mock("../../components/meeting-details/AgendaPacingReport", () => ({
-  default: ({ meetingId }) => (
-    <div data-testid="agenda-pacing-report" data-meeting-id={meetingId}>
-      Pacing for {meetingId}
+  default: () => null,
+}));
+
+vi.mock("../../components/meeting-details/ClipManager", () => ({
+  default: ({ meetingId, meeting, canManage }) => (
+    <div
+      data-testid="clip-manager"
+      data-meeting-id={meetingId}
+      data-has-meeting={meeting?._id ? "yes" : "no"}
+      data-can-manage={canManage ? "yes" : "no"}
+    >
+      Clips for {meetingId}
     </div>
   ),
-}));
-vi.mock("../../components/meeting-details/ClipManager", () => ({
-  default: () => null,
 }));
 
 const renderDetails = () =>
@@ -158,19 +163,18 @@ const renderDetails = () =>
     </MemoryRouter>,
   );
 
-describe("Meeting Details AgendaPacingReport mount (#1986)", () => {
+describe("Meeting Details ClipManager mount (#1987)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders the pacing report for a completed meeting with the meeting id", async () => {
+  it("mounts ClipManager with the meeting id and writable context", async () => {
     meetingApi.getMeetingById.mockResolvedValue({
       data: {
         success: true,
         meeting: {
           _id: "123",
           title: "Quarterly Planning",
-          status: "completed",
           uploadedBy: "db_123",
           participants: [],
         },
@@ -179,58 +183,10 @@ describe("Meeting Details AgendaPacingReport mount (#1986)", () => {
 
     renderDetails();
 
-    const report = await screen.findByTestId("agenda-pacing-report");
-    expect(report).toHaveTextContent("Pacing for 123");
-    expect(report).toHaveAttribute("data-meeting-id", "123");
-  });
-
-  it("renders the pacing report after the scheduled meeting window has ended", async () => {
-    meetingApi.getMeetingById.mockResolvedValue({
-      data: {
-        success: true,
-        meeting: {
-          _id: "123",
-          title: "Past Sync",
-          status: "uploaded",
-          date: "2020-01-01T10:00:00.000Z",
-          duration: 60,
-          uploadedBy: "db_123",
-          participants: [],
-        },
-      },
-    });
-
-    renderDetails();
-
-    expect(await screen.findByTestId("agenda-pacing-report")).toHaveAttribute(
-      "data-meeting-id",
-      "123",
-    );
-  });
-
-  it("does not show the post-meeting report for an upcoming meeting", async () => {
-    meetingApi.getMeetingById.mockResolvedValue({
-      data: {
-        success: true,
-        meeting: {
-          _id: "123",
-          title: "Upcoming Sync",
-          status: "uploaded",
-          date: "2099-01-01T10:00:00.000Z",
-          duration: 60,
-          uploadedBy: "db_123",
-          participants: [],
-        },
-      },
-    });
-
-    renderDetails();
-
-    expect(await screen.findByTestId("meeting-header")).toHaveTextContent(
-      "Upcoming Sync",
-    );
-    expect(
-      screen.queryByTestId("agenda-pacing-report"),
-    ).not.toBeInTheDocument();
+    const manager = await screen.findByTestId("clip-manager");
+    expect(manager).toHaveTextContent("Clips for 123");
+    expect(manager).toHaveAttribute("data-meeting-id", "123");
+    expect(manager).toHaveAttribute("data-has-meeting", "yes");
+    expect(manager).toHaveAttribute("data-can-manage", "yes");
   });
 });

--- a/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavbar.test.jsx
@@ -151,6 +151,17 @@ vi.mock("../../components/meeting-details/AgendaPacingReport", () => ({
     </div>
   ),
 }));
+vi.mock("../../components/meeting-details/ClipManager", () => ({
+  default: ({ meetingId, canManage }) => (
+    <div
+      data-testid="clip-manager"
+      data-meeting-id={meetingId}
+      data-can-manage={canManage ? "yes" : "no"}
+    >
+      Clips for {meetingId}
+    </div>
+  ),
+}));
 
 import { meetingApi } from "../../services";
 

--- a/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsNavigation.test.jsx
@@ -84,6 +84,18 @@ vi.mock("../../components/meeting-details/AgendaPacingReport.jsx", () => ({
   ),
 }));
 
+vi.mock("../../components/meeting-details/ClipManager.jsx", () => ({
+  default: ({ meetingId, canManage }) => (
+    <div
+      data-testid="clip-manager"
+      data-meeting-id={meetingId}
+      data-can-manage={canManage ? "yes" : "no"}
+    >
+      Clips for {meetingId}
+    </div>
+  ),
+}));
+
 vi.mock("../../services", () => ({
   meetingApi: {
     getMeetingById: vi.fn(),

--- a/client/src/services/__tests__/meetingClipApi.test.js
+++ b/client/src/services/__tests__/meetingClipApi.test.js
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import apiClient from "../apiClient";
+import meetingClipApi from "../meetingClipApi";
+
+vi.mock("../apiClient", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("meetingClipApi (#1987)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({ data: [] });
+    apiClient.post.mockResolvedValue({ data: { _id: "clip-1" } });
+    apiClient.put.mockResolvedValue({ data: { _id: "clip-1" } });
+    apiClient.delete.mockResolvedValue({ data: { message: "ok" } });
+  });
+
+  it("lists clips through the authenticated /api/clips meeting route", async () => {
+    await meetingClipApi.getMeetingClips("meeting-123");
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/clips/meeting/meeting-123",
+    );
+  });
+
+  it("creates, updates, deletes, and annotates via /api/clips", async () => {
+    await meetingClipApi.createClip({
+      meetingId: "meeting-123",
+      title: "Clip",
+    });
+    await meetingClipApi.updateClip("clip-1", { title: "Renamed" });
+    await meetingClipApi.deleteClip("clip-1");
+    await meetingClipApi.addClipAnnotation("clip-1", {
+      text: "Note",
+      timestamp: 4,
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/api/clips", {
+      meetingId: "meeting-123",
+      title: "Clip",
+    });
+    expect(apiClient.put).toHaveBeenCalledWith("/api/clips/clip-1", {
+      title: "Renamed",
+    });
+    expect(apiClient.delete).toHaveBeenCalledWith("/api/clips/clip-1");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/clips/clip-1/annotations",
+      {
+        text: "Note",
+        timestamp: 4,
+      },
+    );
+  });
+});

--- a/client/src/services/meetingClipApi.js
+++ b/client/src/services/meetingClipApi.js
@@ -2,28 +2,28 @@ import apiClient from "./apiClient";
 
 const meetingClipApi = {
   createClip: async (clipData) => {
-    const response = await apiClient.post("/clips", clipData);
+    const response = await apiClient.post("/api/clips", clipData);
     return response.data;
   },
 
   getMeetingClips: async (meetingId) => {
-    const response = await apiClient.get(`/clips/meeting/${meetingId}`);
+    const response = await apiClient.get(`/api/clips/meeting/${meetingId}`);
     return response.data;
   },
 
   updateClip: async (clipId, updateData) => {
-    const response = await apiClient.put(`/clips/${clipId}`, updateData);
+    const response = await apiClient.put(`/api/clips/${clipId}`, updateData);
     return response.data;
   },
 
   deleteClip: async (clipId) => {
-    const response = await apiClient.delete(`/clips/${clipId}`);
+    const response = await apiClient.delete(`/api/clips/${clipId}`);
     return response.data;
   },
 
   addClipAnnotation: async (clipId, annotationData) => {
     const response = await apiClient.post(
-      `/clips/${clipId}/annotations`,
+      `/api/clips/${clipId}/annotations`,
       annotationData,
     );
     return response.data;

--- a/server/controllers/meetingClipController.js
+++ b/server/controllers/meetingClipController.js
@@ -1,5 +1,63 @@
+import mongoose from "mongoose";
 import MeetingClip from "../models/meetingClipModel.js";
+import Meeting from "../models/meetingModel.js";
 import clipExtractionService from "../services/clipExtractionService.js";
+import { canAccessMeetingDoc } from "../middleware/rbac.js";
+
+const CLIP_MODERATOR_ROLES = new Set(["owner", "admin", "moderator"]);
+
+const clipError = (res, status, error) =>
+  res.status(status).json({ error, message: error });
+
+const canManageClip = (clip, user) => {
+  if (!clip?.createdBy || !user?._id) return false;
+  return (
+    clip.createdBy.toString() === user._id.toString() ||
+    CLIP_MODERATOR_ROLES.has(user.role)
+  );
+};
+
+/**
+ * Resolve :clipId and the meeting it belongs to, then confirm the caller
+ * may see that meeting. Cross-tenant ids return 404 so existence is not leaked.
+ */
+const loadAccessibleClip = async (req, res) => {
+  const { clipId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(clipId)) {
+    clipError(res, 400, "Invalid clip ID");
+    return null;
+  }
+
+  const clip = await MeetingClip.findById(clipId);
+  if (!clip) {
+    clipError(res, 404, "Clip not found");
+    return null;
+  }
+
+  const meeting = await Meeting.findById(clip.meeting);
+  if (!meeting || !canAccessMeetingDoc(meeting, req.user)) {
+    clipError(res, 404, "Clip not found");
+    return null;
+  }
+
+  return { clip, meeting };
+};
+
+const authorizeMeetingAccess = async (req, res, meetingId) => {
+  if (!meetingId || !mongoose.Types.ObjectId.isValid(meetingId)) {
+    clipError(res, 400, "Invalid meeting ID");
+    return null;
+  }
+
+  const meeting = await Meeting.findById(meetingId);
+  if (!meeting || !canAccessMeetingDoc(meeting, req.user)) {
+    clipError(res, 403, "Forbidden: You don't have access to this resource");
+    return null;
+  }
+
+  return meeting;
+};
 
 /**
  * Create a new meeting clip
@@ -15,8 +73,11 @@ export const createClip = async (req, res) => {
       startTime === undefined ||
       endTime === undefined
     ) {
-      return res.status(400).json({ error: "Missing required fields" });
+      return clipError(res, 400, "Missing required fields");
     }
+
+    const meeting = await authorizeMeetingAccess(req, res, meetingId);
+    if (!meeting) return;
 
     const transcriptSegments = await clipExtractionService.extractSegments(
       meetingId,
@@ -26,7 +87,7 @@ export const createClip = async (req, res) => {
 
     const newClip = new MeetingClip({
       meeting: meetingId,
-      createdBy: req.user._id, // Assumes auth middleware sets req.user
+      createdBy: req.user._id,
       title,
       description,
       startTime,
@@ -40,9 +101,7 @@ export const createClip = async (req, res) => {
     res.status(201).json(newClip);
   } catch (error) {
     console.error("Error creating meeting clip:", error);
-    res
-      .status(500)
-      .json({ error: error.message || "Failed to create meeting clip" });
+    clipError(res, 500, error.message || "Failed to create meeting clip");
   }
 };
 
@@ -61,7 +120,7 @@ export const getClipsForMeeting = async (req, res) => {
     res.status(200).json(clips);
   } catch (error) {
     console.error("Error fetching meeting clips:", error);
-    res.status(500).json({ error: "Failed to fetch meeting clips" });
+    clipError(res, 500, "Failed to fetch meeting clips");
   }
 };
 
@@ -70,24 +129,29 @@ export const getClipsForMeeting = async (req, res) => {
  */
 export const updateClip = async (req, res) => {
   try {
-    const { clipId } = req.params;
-    const { title, description, labels } = req.body;
+    const ctx = await loadAccessibleClip(req, res);
+    if (!ctx) return;
 
-    const clip = await MeetingClip.findById(clipId);
-    if (!clip) {
-      return res.status(404).json({ error: "Clip not found" });
+    if (!canManageClip(ctx.clip, req.user)) {
+      return clipError(
+        res,
+        403,
+        "Forbidden: You don't have permission to update this clip",
+      );
     }
 
-    if (title) clip.title = title;
-    if (description !== undefined) clip.description = description;
-    if (labels) clip.labels = labels;
+    const { title, description, labels } = req.body;
 
-    await clip.save();
+    if (title) ctx.clip.title = title;
+    if (description !== undefined) ctx.clip.description = description;
+    if (labels) ctx.clip.labels = labels;
 
-    res.status(200).json(clip);
+    await ctx.clip.save();
+
+    res.status(200).json(ctx.clip);
   } catch (error) {
     console.error("Error updating meeting clip:", error);
-    res.status(500).json({ error: "Failed to update meeting clip" });
+    clipError(res, 500, "Failed to update meeting clip");
   }
 };
 
@@ -96,18 +160,23 @@ export const updateClip = async (req, res) => {
  */
 export const deleteClip = async (req, res) => {
   try {
-    const { clipId } = req.params;
+    const ctx = await loadAccessibleClip(req, res);
+    if (!ctx) return;
 
-    const deletedClip = await MeetingClip.findByIdAndDelete(clipId);
-
-    if (!deletedClip) {
-      return res.status(404).json({ error: "Clip not found" });
+    if (!canManageClip(ctx.clip, req.user)) {
+      return clipError(
+        res,
+        403,
+        "Forbidden: You don't have permission to delete this clip",
+      );
     }
+
+    await MeetingClip.findByIdAndDelete(ctx.clip._id);
 
     res.status(200).json({ message: "Clip deleted successfully" });
   } catch (error) {
     console.error("Error deleting meeting clip:", error);
-    res.status(500).json({ error: "Failed to delete meeting clip" });
+    clipError(res, 500, "Failed to delete meeting clip");
   }
 };
 
@@ -116,17 +185,14 @@ export const deleteClip = async (req, res) => {
  */
 export const addAnnotation = async (req, res) => {
   try {
-    const { clipId } = req.params;
     const { text, timestamp } = req.body;
 
     if (!text || timestamp === undefined) {
-      return res.status(400).json({ error: "Text and timestamp are required" });
+      return clipError(res, 400, "Text and timestamp are required");
     }
 
-    const clip = await MeetingClip.findById(clipId);
-    if (!clip) {
-      return res.status(404).json({ error: "Clip not found" });
-    }
+    const ctx = await loadAccessibleClip(req, res);
+    if (!ctx) return;
 
     const newAnnotation = {
       text,
@@ -134,17 +200,17 @@ export const addAnnotation = async (req, res) => {
       user: req.user._id,
     };
 
-    clip.annotations.push(newAnnotation);
-    await clip.save();
+    ctx.clip.annotations.push(newAnnotation);
+    await ctx.clip.save();
 
-    // Populate user for the returned annotation
-    await clip.populate("annotations.user", "name email");
+    await ctx.clip.populate("annotations.user", "name email");
 
-    const addedAnnotation = clip.annotations[clip.annotations.length - 1];
+    const addedAnnotation =
+      ctx.clip.annotations[ctx.clip.annotations.length - 1];
 
     res.status(201).json(addedAnnotation);
   } catch (error) {
     console.error("Error adding annotation to clip:", error);
-    res.status(500).json({ error: "Failed to add annotation" });
+    clipError(res, 500, "Failed to add annotation");
   }
 };

--- a/server/routes/meetingClipRoutes.js
+++ b/server/routes/meetingClipRoutes.js
@@ -7,6 +7,8 @@ import {
   addAnnotation,
 } from "../controllers/meetingClipController.js";
 import userAuth from "../middleware/userAuth.js";
+import { requireOrgAccess, requirePermission } from "../middleware/rbac.js";
+import Meeting from "../models/meetingModel.js";
 
 const router = express.Router();
 
@@ -14,10 +16,24 @@ const router = express.Router();
 router.use(userAuth);
 
 // Base route is /api/clips
-router.post("/", createClip);
-router.get("/meeting/:meetingId", getClipsForMeeting);
-router.put("/:clipId", updateClip);
-router.delete("/:clipId", deleteClip);
-router.post("/:clipId/annotations", addAnnotation);
+//
+// GET names the meeting in the path, so requireOrgAccess can authorize it.
+// POST / and /:clipId routes name the meeting in the body or via the clip
+// document; those checks live in the controller (same pattern as
+// transcript annotations) so a client-supplied org id is never trusted.
+router.post("/", requirePermission("meetings", "edit"), createClip);
+router.get(
+  "/meeting/:meetingId",
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  getClipsForMeeting,
+);
+router.put("/:clipId", requirePermission("meetings", "edit"), updateClip);
+router.delete("/:clipId", requirePermission("meetings", "edit"), deleteClip);
+router.post(
+  "/:clipId/annotations",
+  requirePermission("meetings", "edit"),
+  addAnnotation,
+);
 
 export default router;

--- a/server/tests/meetingClipTenantIsolation.test.js
+++ b/server/tests/meetingClipTenantIsolation.test.js
@@ -1,0 +1,141 @@
+import { jest } from "@jest/globals";
+import mongoose from "mongoose";
+
+const mockMeetingFindById = jest.fn();
+const mockClipFindById = jest.fn();
+const mockExtractSegments = jest.fn();
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: {
+    findById: (...args) => mockMeetingFindById(...args),
+  },
+}));
+
+jest.unstable_mockModule("../models/meetingClipModel.js", () => {
+  const MeetingClip = function MeetingClip(doc) {
+    Object.assign(this, doc);
+    this.save = jest.fn().mockResolvedValue(this);
+  };
+  MeetingClip.findById = (...args) => mockClipFindById(...args);
+  MeetingClip.findByIdAndDelete = jest.fn();
+  return { default: MeetingClip };
+});
+
+jest.unstable_mockModule("../services/clipExtractionService.js", () => ({
+  default: {
+    extractSegments: (...args) => mockExtractSegments(...args),
+  },
+}));
+
+const { requireOrgAccess } = await import("../middleware/rbac.js");
+const { createClip, updateClip, deleteClip } =
+  await import("../controllers/meetingClipController.js");
+const { default: Meeting } = await import("../models/meetingModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: jest.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: jest.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const userInOrg = (org = ORG_A, role = "member") => ({
+  _id: new mongoose.Types.ObjectId(),
+  organization: org,
+  role,
+});
+
+describe("Meeting clip tenant isolation (#1987)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("blocks listing clips when requireOrgAccess sees a different organization", async () => {
+    const meetingId = new mongoose.Types.ObjectId();
+    mockMeetingFindById.mockResolvedValue({
+      _id: meetingId,
+      organization: ORG_A,
+      uploadedBy: new mongoose.Types.ObjectId(),
+    });
+
+    const req = {
+      params: { meetingId: meetingId.toString() },
+      user: userInOrg(ORG_B),
+    };
+    const res = makeRes();
+    const next = jest.fn();
+
+    await requireOrgAccess(Meeting)(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/don't have access/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating a clip for a meeting in another organization", async () => {
+    const meetingId = new mongoose.Types.ObjectId();
+    mockMeetingFindById.mockResolvedValue({
+      _id: meetingId,
+      organization: ORG_A,
+      uploadedBy: new mongoose.Types.ObjectId(),
+    });
+
+    const req = {
+      body: {
+        meetingId: meetingId.toString(),
+        title: "Foreign clip",
+        startTime: 0,
+        endTime: 10,
+      },
+      user: userInOrg(ORG_B),
+    };
+    const res = makeRes();
+
+    await createClip(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockExtractSegments).not.toHaveBeenCalled();
+  });
+
+  it("does not leak a clip from another organization on update or delete", async () => {
+    const clipId = new mongoose.Types.ObjectId();
+    const meetingId = new mongoose.Types.ObjectId();
+    mockClipFindById.mockResolvedValue({
+      _id: clipId,
+      meeting: meetingId,
+      createdBy: new mongoose.Types.ObjectId(),
+      title: "Secret",
+    });
+    mockMeetingFindById.mockResolvedValue({
+      _id: meetingId,
+      organization: ORG_A,
+      uploadedBy: new mongoose.Types.ObjectId(),
+    });
+
+    const req = {
+      params: { clipId: clipId.toString() },
+      body: { title: "Hijacked" },
+      user: userInOrg(ORG_B),
+    };
+
+    const updateRes = makeRes();
+    await updateClip(req, updateRes);
+    expect(updateRes.statusCode).toBe(404);
+
+    const deleteRes = makeRes();
+    await deleteClip(req, deleteRes);
+    expect(deleteRes.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## Description

Closes #1987

Mounts the existing `ClipManager` on Meeting Details and wires it to the authenticated meeting clip APIs, allowing authorized users to create, manage, annotate, and play meeting clips.

## What Changed

- Mounted `ClipManager` on Meeting Details.
- Added loading, empty, error, and forbidden states.
- Added clip create, edit, delete, and annotation flows.
- Added clip playback using the existing meeting recording.
- Added read-only behavior for viewers/guests.
- Corrected clip API paths to use `/api/clips`.
- Added server-side meeting/org access checks for clip operations.
- Added creator/owner/admin/moderator authorization for clip mutations.
- Prevented cross-tenant clip access.
- Added responsive and dark-mode styling.

## API

Reuses the existing endpoints:

- `GET /api/clips/meeting/:meetingId`
- `POST /api/clips`
- `PUT /api/clips/:clipId`
- `DELETE /api/clips/:clipId`
- `POST /api/clips/:clipId/annotations`

No new clip API endpoints were introduced.

## Tests

Added coverage for:

- ClipManager loading/empty/error/forbidden states
- Clip CRUD operations
- Annotation persistence
- Clip playback
- Read-only permissions
- Meeting Details integration
- API path contracts
- Cross-tenant authorization

## Validation

- Prettier: passed
- ESLint: passed
- Tests: run locally before merge