### PR TITLE
fix: Automation Rules client API missing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -169,6 +169,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1865,6 +1866,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1913,6 +1915,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3708,6 +3711,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3782,6 +3786,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4124,6 +4129,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4436,6 +4442,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4446,6 +4453,7 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4617,6 +4625,7 @@
       "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.10",
         "fflate": "^0.8.2",
@@ -4654,6 +4663,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5303,6 +5313,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -5536,6 +5547,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -6143,6 +6155,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6926,6 +6939,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7981,6 +7995,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -10912,6 +10927,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -11120,6 +11136,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
       "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -11149,6 +11166,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -11197,6 +11215,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
       "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
@@ -11325,6 +11344,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11365,6 +11385,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11453,7 +11474,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -11668,7 +11690,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11981,6 +12004,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
       "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -13481,6 +13505,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13603,6 +13628,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -13980,6 +14006,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14208,6 +14235,7 @@
       "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
       "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.109"
       },
@@ -14232,6 +14260,7 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
       "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -14280,6 +14309,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
       "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },

--- a/client/src/services/__tests__/automationRuleApi.test.js
+++ b/client/src/services/__tests__/automationRuleApi.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import api from "../apiClient.js";
+import {
+  fetchRules,
+  fetchRuleById,
+  createRule,
+  updateRule,
+  toggleRuleStatus,
+  deleteRule,
+} from "../automationRuleApi.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("automationRuleApi /api prefix verification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls GET /api/automation-rules when fetching rules", async () => {
+    api.get.mockResolvedValueOnce({ data: { data: { rules: [{ _id: "r1" }] } } });
+    const result = await fetchRules();
+    expect(api.get).toHaveBeenCalledWith("/api/automation-rules");
+    expect(result).toEqual([{ _id: "r1" }]);
+  });
+
+  it("calls GET /api/automation-rules/:id when fetching rule by ID", async () => {
+    api.get.mockResolvedValueOnce({ data: { data: { rule: { _id: "r1" } } } });
+    const result = await fetchRuleById("r1");
+    expect(api.get).toHaveBeenCalledWith("/api/automation-rules/r1");
+    expect(result).toEqual({ _id: "r1" });
+  });
+
+  it("calls POST /api/automation-rules when creating a rule", async () => {
+    const payload = { name: "Test Rule", trigger: {}, actions: [] };
+    api.post.mockResolvedValueOnce({
+      data: { data: { rule: { _id: "r1", ...payload } } },
+    });
+    const result = await createRule(payload);
+    expect(api.post).toHaveBeenCalledWith("/api/automation-rules", payload);
+    expect(result).toEqual({ _id: "r1", ...payload });
+  });
+
+  it("calls PUT /api/automation-rules/:id when updating a rule", async () => {
+    const payload = { name: "Updated Rule" };
+    api.put.mockResolvedValueOnce({
+      data: { data: { rule: { _id: "r1", ...payload } } },
+    });
+    const result = await updateRule("r1", payload);
+    expect(api.put).toHaveBeenCalledWith("/api/automation-rules/r1", payload);
+    expect(result).toEqual({ _id: "r1", ...payload });
+  });
+
+  it("calls PATCH /api/automation-rules/:id/toggle when toggling rule status", async () => {
+    api.patch.mockResolvedValueOnce({
+      data: { data: { rule: { _id: "r1", enabled: true } } },
+    });
+    const result = await toggleRuleStatus("r1", true);
+    expect(api.patch).toHaveBeenCalledWith("/api/automation-rules/r1/toggle", {
+      enabled: true,
+    });
+    expect(result).toEqual({ _id: "r1", enabled: true });
+  });
+
+  it("calls DELETE /api/automation-rules/:id when deleting a rule", async () => {
+    api.delete.mockResolvedValueOnce({ data: { data: { success: true } } });
+    const result = await deleteRule("r1");
+    expect(api.delete).toHaveBeenCalledWith("/api/automation-rules/r1");
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/client/src/services/automationRuleApi.js
+++ b/client/src/services/automationRuleApi.js
@@ -1,33 +1,34 @@
 import api from "./apiClient.js";
 
 export const fetchRules = async () => {
-  const response = await api.get("/automation-rules");
+  const response = await api.get("/api/automation-rules");
   return response.data.data.rules;
 };
 
 export const fetchRuleById = async (id) => {
-  const response = await api.get(`/automation-rules/${id}`);
+  const response = await api.get(`/api/automation-rules/${id}`);
   return response.data.data.rule;
 };
 
 export const createRule = async (ruleData) => {
-  const response = await api.post("/automation-rules", ruleData);
+  const response = await api.post("/api/automation-rules", ruleData);
   return response.data.data.rule;
 };
 
 export const updateRule = async (id, ruleData) => {
-  const response = await api.put(`/automation-rules/${id}`, ruleData);
+  const response = await api.put(`/api/automation-rules/${id}`, ruleData);
   return response.data.data.rule;
 };
 
 export const toggleRuleStatus = async (id, enabled) => {
-  const response = await api.patch(`/automation-rules/${id}/toggle`, {
+  const response = await api.patch(`/api/automation-rules/${id}/toggle`, {
     enabled,
   });
   return response.data.data.rule;
 };
 
 export const deleteRule = async (id) => {
-  const response = await api.delete(`/automation-rules/${id}`);
+  const response = await api.delete(`/api/automation-rules/${id}`);
   return response.data.data;
 };
+


### PR DESCRIPTION
## Changes Made
Updated Client API Routes in client/src/services/automationRuleApi.js:

fetchRules: api.get("/api/automation-rules")
fetchRuleById: api.get("/api/automation-rules/:id")
createRule: api.post("/api/automation-rules", ruleData)
updateRule: api.put("/api/automation-rules/:id", ruleData)
toggleRuleStatus: api.patch("/api/automation-rules/:id/toggle", { enabled })
deleteRule: api.delete("/api/automation-rules/:id")
Added Client API Smoke Test in client/src/services/__tests__/automationRuleApi.test.js
:

Asserts path shape, HTTP verbs, and payload passing for all 6 API endpoints.
## Verification
Ran endpoint assertions covering fetchRules, fetchRuleById, createRule, updateRule, toggleRuleStatus, and deleteRule. All 6 endpoints pass verification.


closes #1997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated automation rule requests to use the correct API route, improving reliability for listing, creating, updating, toggling, and deleting rules.

- **Tests**
  - Added coverage for automation rule API operations, including request methods, payloads, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->