### PR TITLE
fix: Fix bulk meeting actions

### DIFF
--- a/client/src/components/meetings/BulkActionBar.jsx
+++ b/client/src/components/meetings/BulkActionBar.jsx
@@ -1,14 +1,24 @@
 import React, { useState } from "react";
-import { Archive, Trash2, Download, Tag, X, Check } from "lucide-react";
+import {
+  Archive,
+  Trash2,
+  Download,
+  Tag,
+  X,
+  Check,
+  AlertCircle,
+} from "lucide-react";
 
 const BulkActionBar = ({
   selectedCount,
   isProcessing,
+  errorMessage,
   onArchive,
   onDelete,
   onExport,
   onTag,
   onCancel,
+  onClearError,
 }) => {
   const [isTagging, setIsTagging] = useState(false);
   const [tagInput, setTagInput] = useState("");
@@ -28,7 +38,26 @@ const BulkActionBar = ({
   };
 
   return (
-    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 animate-in slide-in-from-bottom-10 fade-in duration-300">
+    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 animate-in slide-in-from-bottom-10 fade-in duration-300 flex flex-col items-center gap-2">
+      {errorMessage && (
+        <div
+          className="flex items-center gap-2 bg-red-100 dark:bg-red-900/80 text-red-700 dark:text-red-200 text-xs font-medium px-4 py-1.5 rounded-full border border-red-300 dark:border-red-700 shadow-md"
+          role="alert"
+          data-testid="bulk-action-bar-error"
+        >
+          <AlertCircle className="w-4 h-4 shrink-0" />
+          <span className="truncate max-w-sm">{errorMessage}</span>
+          {onClearError && (
+            <button
+              onClick={onClearError}
+              className="text-red-500 hover:text-red-700 dark:hover:text-red-100 ml-1 p-0.5 rounded-full"
+              title="Dismiss error"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+      )}
       <div className="bg-white dark:bg-gray-800 shadow-2xl rounded-full border border-gray-200 dark:border-gray-700 px-6 py-3 flex items-center gap-6">
         {/* Count Indicator */}
         <div className="flex items-center gap-2">

--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -107,6 +107,8 @@ const MeetingRepository = () => {
     selectedMeetings,
     toggleSelection,
     isProcessing,
+    errorMessage,
+    clearError,
     handleBulkArchive,
     handleBulkTag,
     handleBulkSoftDelete,
@@ -453,11 +455,13 @@ const MeetingRepository = () => {
         <BulkActionBar
           selectedCount={selectedMeetings.size}
           isProcessing={isProcessing}
+          errorMessage={errorMessage}
           onArchive={handleBulkArchive}
           onDelete={handleBulkSoftDelete}
           onExport={handleBulkExport}
           onTag={handleBulkTag}
           onCancel={toggleBulkMode}
+          onClearError={clearError}
         />
       )}
     </div>

--- a/client/src/components/meetings/__tests__/BulkActionBar.test.jsx
+++ b/client/src/components/meetings/__tests__/BulkActionBar.test.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import BulkActionBar from "../BulkActionBar.jsx";
+
+describe("BulkActionBar Component", () => {
+  it("renders count and action buttons when selectedCount > 0", () => {
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        isProcessing={false}
+        onArchive={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        onTag={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Selected")).toBeInTheDocument();
+    expect(screen.getByTitle("Archive")).toBeInTheDocument();
+    expect(screen.getByTitle("Delete")).toBeInTheDocument();
+    expect(screen.getByTitle("Export as ZIP")).toBeInTheDocument();
+    expect(screen.getByTitle("Add Tags")).toBeInTheDocument();
+  });
+
+  it("does not render when selectedCount is 0", () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={0}
+        isProcessing={false}
+        onArchive={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        onTag={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("surfaces API errors when errorMessage is provided", () => {
+    const onClearError = vi.fn();
+    render(
+      <BulkActionBar
+        selectedCount={2}
+        isProcessing={false}
+        errorMessage="Permission denied to delete meetings."
+        onArchive={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        onTag={vi.fn()}
+        onCancel={vi.fn()}
+        onClearError={onClearError}
+      />,
+    );
+
+    const errorElement = screen.getByTestId("bulk-action-bar-error");
+    expect(errorElement).toBeInTheDocument();
+    expect(
+      screen.getByText("Permission denied to delete meetings."),
+    ).toBeInTheDocument();
+
+    const dismissButton = screen.getByTitle("Dismiss error");
+    fireEvent.click(dismissButton);
+    expect(onClearError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/hooks/useBulkMeetingActions.js
+++ b/client/src/hooks/useBulkMeetingActions.js
@@ -8,10 +8,16 @@ const useBulkMeetingActions = (onSuccess) => {
   const [isBulkMode, setIsBulkMode] = useState(false);
   const [selectedMeetings, setSelectedMeetings] = useState(new Set());
   const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const clearError = useCallback(() => {
+    setErrorMessage(null);
+  }, []);
 
   const toggleBulkMode = useCallback(() => {
     setIsBulkMode((prev) => !prev);
     setSelectedMeetings(new Set());
+    setErrorMessage(null);
   }, []);
 
   const toggleSelection = useCallback((meetingId) => {
@@ -34,6 +40,7 @@ const useBulkMeetingActions = (onSuccess) => {
 
   const clearSelection = useCallback(() => {
     setSelectedMeetings(new Set());
+    setErrorMessage(null);
   }, []);
 
   const selectAll = useCallback((meetingIds) => {
@@ -57,6 +64,7 @@ const useBulkMeetingActions = (onSuccess) => {
 
     try {
       setIsProcessing(true);
+      setErrorMessage(null);
       const meetingIds = Array.from(selectedMeetings);
       const response = await actionFn(meetingIds);
 
@@ -71,9 +79,12 @@ const useBulkMeetingActions = (onSuccess) => {
       }
     } catch (err) {
       console.error(`Bulk ${actionName} failed:`, err);
-      toast.error(
-        err.response?.data?.message || `Failed to perform ${actionName}.`,
-      );
+      const message =
+        err.response?.data?.message ||
+        err.message ||
+        `Failed to perform ${actionName}.`;
+      setErrorMessage(message);
+      toast.error(message);
     } finally {
       setIsProcessing(false);
     }
@@ -112,6 +123,7 @@ const useBulkMeetingActions = (onSuccess) => {
 
     try {
       setIsProcessing(true);
+      setErrorMessage(null);
       const meetingIds = Array.from(selectedMeetings);
       const response = await bulkMeetingApi.bulkExport(meetingIds, format);
 
@@ -139,7 +151,12 @@ const useBulkMeetingActions = (onSuccess) => {
       setIsBulkMode(false);
     } catch (err) {
       console.error("Bulk Export failed:", err);
-      toast.error("Failed to export meetings.");
+      const message =
+        err.response?.data?.message ||
+        err.message ||
+        "Failed to export meetings.";
+      setErrorMessage(message);
+      toast.error(message);
     } finally {
       setIsProcessing(false);
     }
@@ -153,6 +170,8 @@ const useBulkMeetingActions = (onSuccess) => {
     clearSelection,
     selectAll,
     isProcessing,
+    errorMessage,
+    clearError,
     handleBulkArchive,
     handleBulkTag,
     handleBulkSoftDelete,

--- a/client/src/services/__tests__/bulkMeetingApi.test.js
+++ b/client/src/services/__tests__/bulkMeetingApi.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axiosInstance from "../apiClient.js";
+import bulkMeetingApi from "../bulkMeetingApi.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+describe("bulkMeetingApi path construction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts to /api/bulk/meetings/archive for bulkArchive", async () => {
+    axiosInstance.post.mockResolvedValueOnce({ data: { success: true } });
+    const meetingIds = ["m1", "m2"];
+
+    await bulkMeetingApi.bulkArchive(meetingIds);
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/bulk/meetings/archive",
+      {
+        meetingIds: ["m1", "m2"],
+      },
+    );
+  });
+
+  it("posts to /api/bulk/meetings/tag for bulkTag", async () => {
+    axiosInstance.post.mockResolvedValueOnce({ data: { success: true } });
+    const meetingIds = ["m1"];
+    const tags = ["urgent", "client"];
+
+    await bulkMeetingApi.bulkTag(meetingIds, tags);
+
+    expect(axiosInstance.post).toHaveBeenCalledWith("/api/bulk/meetings/tag", {
+      meetingIds: ["m1"],
+      tags: ["urgent", "client"],
+    });
+  });
+
+  it("posts to /api/bulk/meetings/delete for bulkSoftDelete", async () => {
+    axiosInstance.post.mockResolvedValueOnce({ data: { success: true } });
+    const meetingIds = ["m1", "m2"];
+
+    await bulkMeetingApi.bulkSoftDelete(meetingIds);
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/bulk/meetings/delete",
+      {
+        meetingIds: ["m1", "m2"],
+      },
+    );
+  });
+
+  it("posts to /api/bulk/meetings/restore for bulkRestore", async () => {
+    axiosInstance.post.mockResolvedValueOnce({ data: { success: true } });
+    const meetingIds = ["m1"];
+
+    await bulkMeetingApi.bulkRestore(meetingIds);
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/bulk/meetings/restore",
+      {
+        meetingIds: ["m1"],
+      },
+    );
+  });
+
+  it("posts to /api/bulk/meetings/export for bulkExport with responseType blob", async () => {
+    axiosInstance.post.mockResolvedValueOnce({ data: new Blob([]) });
+    const meetingIds = ["m1", "m2"];
+
+    await bulkMeetingApi.bulkExport(meetingIds, "json");
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/bulk/meetings/export",
+      { meetingIds: ["m1", "m2"], format: "json" },
+      { responseType: "blob" },
+    );
+  });
+});

--- a/client/src/services/bulkMeetingApi.js
+++ b/client/src/services/bulkMeetingApi.js
@@ -1,6 +1,6 @@
 import axiosInstance from "./apiClient.js";
 
-const BASE_URL = "/bulk/meetings";
+const BASE_URL = "/api/bulk/meetings";
 
 const bulkMeetingApi = {
   bulkArchive: (meetingIds) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -301,6 +301,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -661,6 +662,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],


### PR DESCRIPTION
## Summary of Fix
### Root Cause
bulkMeetingApi.js was using BASE_URL = "/bulk/meetings", whereas the backend router mounts bulk meeting routes at /api/bulk/meetings (server/routes/index.js). As a result, multi-select bulk operations (archive, tag, delete, restore, export) failed with 404. Furthermore, error messages were not displayed directly in the BulkActionBar UI.

### Changes Made
Updated Base API Path in client/src/services/bulkMeetingApi.js:

Changed BASE_URL to "/api/bulk/meetings".
All bulk operations (bulkArchive, bulkTag, bulkSoftDelete, bulkRestore, bulkExport) now target /api/bulk/meetings/*.
Surfaced API Errors in BulkActionBar:



useBulkMeetingActions.js: Added state tracking for errorMessage and exposed clearError. Populates error message from err.response?.data?.message on failed bulk operations.


BulkActionBar.jsx: Renders a dismissible alert badge directly above the bulk action bar when errorMessage is set.


MeetingRepository.jsx: Passes errorMessage and clearError from the hook down to <BulkActionBar />.
Added Unit Tests:



bulkMeetingApi.test.js: Asserts correct /api/bulk/meetings/* path construction, HTTP verbs, and payloads for all 5 bulk actions.


BulkActionBar.test.jsx: Asserts component rendering and error message display in the bulk action bar.


closes #1998