### PR TITLE
enh: add Calendar connect entry points on the Calendar page

### DIFF
--- a/client/src/components/calendar/CalendarSyncPanel.jsx
+++ b/client/src/components/calendar/CalendarSyncPanel.jsx
@@ -1,0 +1,292 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import {
+  Calendar as CalendarIcon,
+  RefreshCw,
+  CheckCircle2,
+  AlertCircle,
+  Link as LinkIcon,
+  ExternalLink,
+  Loader2,
+  Cloud,
+} from "lucide-react";
+import apiClient from "../../services/apiClient.js";
+import {
+  validateCalendarOAuthAuthUrl,
+  CALENDAR_OAUTH_FALLBACK_PATH,
+} from "../../utils/validateCalendarOAuthRedirect.js";
+import { validateRedirect } from "../../utils/validateRedirect.js";
+
+const CalendarSyncPanel = ({ onSyncComplete, isCompact = false }) => {
+  const navigate = useNavigate();
+  const [integrations, setIntegrations] = useState([]);
+  const [setLoading] = useState(true);
+  const [resyncing, setResyncing] = useState({});
+
+  const fetchIntegrations = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await apiClient.get("/api/calendar/status");
+      if (res.data?.success) {
+        setIntegrations(res.data.integrations || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch calendar status:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchIntegrations();
+  }, [fetchIntegrations]);
+
+  const connectProvider = async (provider) => {
+    try {
+      const res = await apiClient.get(`/api/calendar/${provider}/connect`);
+      const redirectUrl = res.data?.url || res.data?.authUrl;
+      if (res.data?.success && redirectUrl) {
+        const safeAuthUrl = validateCalendarOAuthAuthUrl(redirectUrl);
+        if (safeAuthUrl) {
+          window.location.href = safeAuthUrl;
+          return;
+        }
+        toast.error(`Invalid authorization URL for ${provider}`);
+        window.location.assign(
+          validateRedirect(CALENDAR_OAUTH_FALLBACK_PATH, "/settings"),
+        );
+      } else {
+        toast.error(`Failed to get authorization URL for ${provider}`);
+      }
+    } catch (err) {
+      console.error(`Failed to connect ${provider}:`, err);
+      toast.error(`Failed to connect ${provider} calendar`);
+    }
+  };
+
+  const handleResync = async (provider) => {
+    setResyncing((prev) => ({ ...prev, [provider]: true }));
+    try {
+      const res = await apiClient.post(`/api/calendar/resync/${provider}`);
+      if (res.data?.success) {
+        toast.success(`Successfully resynced ${provider} calendar`);
+        fetchIntegrations();
+        if (onSyncComplete) onSyncComplete();
+      } else {
+        toast.error(res.data?.message || `Failed to resync ${provider}`);
+      }
+    } catch (err) {
+      console.error(`Failed to resync ${provider}:`, err);
+      toast.error(`Failed to resync ${provider} calendar`);
+    } finally {
+      setResyncing((prev) => ({ ...prev, [provider]: false }));
+    }
+  };
+
+  const getProviderInfo = (providerKey) => {
+    const integration = integrations.find((i) => i.provider === providerKey);
+    const isConnected =
+      integration?.syncStatus === "connected" ||
+      integration?.syncStatus === "active" ||
+      integration?.connected === true ||
+      integration?.syncEnabled === true;
+    const needsReauth = integration?.syncStatus === "needs_reauth";
+    return { integration, isConnected, needsReauth };
+  };
+
+  const googleInfo = getProviderInfo("google");
+  const outlookInfo = getProviderInfo("outlook");
+
+  if (isCompact) {
+    return (
+      <div
+        className="flex flex-wrap items-center gap-2"
+        data-testid="calendar-sync-badges"
+      >
+        {/* Google Status Badge */}
+        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border text-xs font-semibold bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 shadow-xs">
+          <Cloud className="w-3.5 h-3.5 text-blue-500" />
+          <span className="text-slate-700 dark:text-slate-200">Google:</span>
+          {googleInfo.isConnected ? (
+            <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400 font-bold">
+              <CheckCircle2 className="w-3 h-3" /> Connected
+            </span>
+          ) : googleInfo.needsReauth ? (
+            <button
+              onClick={() => connectProvider("google")}
+              className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400 hover:underline font-bold cursor-pointer"
+            >
+              <AlertCircle className="w-3 h-3" /> Reconnect
+            </button>
+          ) : (
+            <button
+              onClick={() => connectProvider("google")}
+              className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline font-bold cursor-pointer"
+            >
+              <LinkIcon className="w-3 h-3" /> Connect
+            </button>
+          )}
+          {googleInfo.isConnected && (
+            <button
+              onClick={() => handleResync("google")}
+              disabled={resyncing["google"]}
+              className="ml-1 p-0.5 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-md cursor-pointer disabled:opacity-50"
+              title="Resync Google Calendar"
+              aria-label="Resync Google Calendar"
+            >
+              <RefreshCw
+                className={`w-3 h-3 ${resyncing["google"] ? "animate-spin text-blue-600" : ""}`}
+              />
+            </button>
+          )}
+        </div>
+
+        {/* Outlook Status Badge */}
+        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl border text-xs font-semibold bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 shadow-xs">
+          <Cloud className="w-3.5 h-3.5 text-cyan-600 dark:text-cyan-400" />
+          <span className="text-slate-700 dark:text-slate-200">Outlook:</span>
+          {outlookInfo.isConnected ? (
+            <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400 font-bold">
+              <CheckCircle2 className="w-3 h-3" /> Connected
+            </span>
+          ) : outlookInfo.needsReauth ? (
+            <button
+              onClick={() => connectProvider("outlook")}
+              className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400 hover:underline font-bold cursor-pointer"
+            >
+              <AlertCircle className="w-3 h-3" /> Reconnect
+            </button>
+          ) : (
+            <button
+              onClick={() => connectProvider("outlook")}
+              className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline font-bold cursor-pointer"
+            >
+              <LinkIcon className="w-3 h-3" /> Connect
+            </button>
+          )}
+          {outlookInfo.isConnected && (
+            <button
+              onClick={() => handleResync("outlook")}
+              disabled={resyncing["outlook"]}
+              className="ml-1 p-0.5 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-md cursor-pointer disabled:opacity-50"
+              title="Resync Outlook Calendar"
+              aria-label="Resync Outlook Calendar"
+            >
+              <RefreshCw
+                className={`w-3 h-3 ${resyncing["outlook"] ? "animate-spin text-blue-600" : ""}`}
+              />
+            </button>
+          )}
+        </div>
+
+        {/* Manage Settings Deep-Link */}
+        <button
+          onClick={() => navigate("/settings")}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-slate-700 dark:text-slate-300 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 rounded-xl transition-all shadow-xs cursor-pointer"
+          title="Manage Calendar Integrations in Settings"
+        >
+          <CalendarIcon className="w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />
+          <span>Manage Sync</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="bg-slate-50 dark:bg-slate-800/60 border border-slate-200/80 dark:border-slate-700 rounded-2xl p-5 shadow-xs mb-6"
+      data-testid="calendar-sync-panel"
+    >
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2.5 bg-blue-100 dark:bg-blue-900/40 rounded-xl text-blue-600 dark:text-blue-400">
+            <CalendarIcon className="w-5 h-5" />
+          </div>
+          <div>
+            <h3 className="text-sm font-bold text-slate-900 dark:text-white flex items-center gap-2">
+              Calendar Integrations & Sync
+            </h3>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+              Two-way calendar sync for Google & Microsoft Outlook
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">
+          {/* Google Connect/Resync */}
+          <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-xs font-medium">
+            <span className="font-bold text-slate-800 dark:text-slate-200">
+              Google Calendar
+            </span>
+            {googleInfo.isConnected ? (
+              <>
+                <span className="text-emerald-600 dark:text-emerald-400 font-semibold flex items-center gap-1">
+                  <CheckCircle2 className="w-3.5 h-3.5" /> Connected
+                </span>
+                <button
+                  onClick={() => handleResync("google")}
+                  disabled={resyncing["google"]}
+                  className="px-2.5 py-1 text-xs font-bold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg hover:bg-blue-100 cursor-pointer disabled:opacity-50 inline-flex items-center gap-1"
+                >
+                  <RefreshCw
+                    className={`w-3 h-3 ${resyncing["google"] ? "animate-spin" : ""}`}
+                  />
+                  Resync
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => connectProvider("google")}
+                className="px-2.5 py-1 text-xs font-bold text-white bg-blue-600 hover:bg-blue-500 rounded-lg shadow-xs cursor-pointer inline-flex items-center gap-1"
+              >
+                <LinkIcon className="w-3 h-3" /> Connect Google
+              </button>
+            )}
+          </div>
+
+          {/* Outlook Connect/Resync */}
+          <div className="flex items-center gap-2 px-3 py-2 rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-xs font-medium">
+            <span className="font-bold text-slate-800 dark:text-slate-200">
+              Outlook
+            </span>
+            {outlookInfo.isConnected ? (
+              <>
+                <span className="text-emerald-600 dark:text-emerald-400 font-semibold flex items-center gap-1">
+                  <CheckCircle2 className="w-3.5 h-3.5" /> Connected
+                </span>
+                <button
+                  onClick={() => handleResync("outlook")}
+                  disabled={resyncing["outlook"]}
+                  className="px-2.5 py-1 text-xs font-bold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30 rounded-lg hover:bg-blue-100 cursor-pointer disabled:opacity-50 inline-flex items-center gap-1"
+                >
+                  <RefreshCw
+                    className={`w-3 h-3 ${resyncing["outlook"] ? "animate-spin" : ""}`}
+                  />
+                  Resync
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={() => connectProvider("outlook")}
+                className="px-2.5 py-1 text-xs font-bold text-white bg-cyan-600 hover:bg-cyan-500 rounded-lg shadow-xs cursor-pointer inline-flex items-center gap-1"
+              >
+                <LinkIcon className="w-3 h-3" /> Connect Outlook
+              </button>
+            )}
+          </div>
+
+          <button
+            onClick={() => navigate("/settings")}
+            className="p-2 text-slate-500 hover:text-slate-800 dark:hover:text-slate-200 rounded-xl hover:bg-slate-200/50 dark:hover:bg-slate-700 transition-all cursor-pointer"
+            title="Settings & Integrations"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CalendarSyncPanel;

--- a/client/src/components/calendar/__tests__/CalendarSyncPanel.test.jsx
+++ b/client/src/components/calendar/__tests__/CalendarSyncPanel.test.jsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import CalendarSyncPanel from "../CalendarSyncPanel.jsx";
+import apiClient from "../../../services/apiClient.js";
+import { toast } from "react-toastify";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("CalendarSyncPanel Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and renders calendar status badges in compact mode", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        integrations: [
+          { provider: "google", syncStatus: "connected", syncEnabled: true },
+          {
+            provider: "outlook",
+            syncStatus: "disconnected",
+            syncEnabled: false,
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CalendarSyncPanel isCompact />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("calendar-sync-badges")).toBeInTheDocument();
+      expect(screen.getByText("Google:")).toBeInTheDocument();
+      expect(screen.getByText("Outlook:")).toBeInTheDocument();
+      expect(screen.getByText("Manage Sync")).toBeInTheDocument();
+    });
+  });
+
+  it("triggers resync action and notifies parent on completion", async () => {
+    const onSyncComplete = vi.fn();
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        integrations: [
+          { provider: "google", syncStatus: "connected", syncEnabled: true },
+        ],
+      },
+    });
+
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: "Resynced google calendar",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CalendarSyncPanel onSyncComplete={onSyncComplete} isCompact />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Resync Google Calendar")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle("Resync Google Calendar"));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/calendar/resync/google",
+      );
+      expect(toast.success).toHaveBeenCalledWith(
+        "Successfully resynced google calendar",
+      );
+      expect(onSyncComplete).toHaveBeenCalled();
+    });
+  });
+
+  it("renders full sync panel with Connect buttons when not compact", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        integrations: [],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CalendarSyncPanel />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("calendar-sync-panel")).toBeInTheDocument();
+      expect(screen.getByText("Connect Google")).toBeInTheDocument();
+      expect(screen.getByText("Connect Outlook")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -6,6 +6,7 @@ import { useRBAC } from "../hooks/useRBAC.js";
 import { useCalendarEvents } from "../hooks/useCalendarEvents";
 import CalendarGrid from "../components/calendar/CalendarGrid";
 import MeetingDetailsModal from "../components/calendar/MeetingDetailsModal";
+import CalendarSyncPanel from "../components/calendar/CalendarSyncPanel.jsx";
 import { getWeekDays } from "../components/calendar/calendarUtils";
 import {
   Calendar as CalendarIcon,
@@ -43,6 +44,7 @@ const Calendar = () => {
     uniqueOrgs,
     hasMore,
     loadMoreMeetings,
+    invalidateCache,
     focusBlocks,
   } = useCalendarEvents();
 
@@ -130,14 +132,8 @@ const Calendar = () => {
             </p>
           </div>
 
-          <div className="flex items-center gap-3 w-full md:w-auto">
-            <button
-              onClick={() => navigate("/settings")}
-              className="inline-flex items-center gap-2 px-4 py-2 text-xs font-bold text-slate-700 bg-white dark:bg-slate-800 dark:text-slate-200 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700 active:bg-slate-100 rounded-xl transition-all shadow-xs cursor-pointer w-full md:w-auto justify-center"
-            >
-              <CalendarIcon className="w-4 h-4 text-blue-600 dark:text-blue-400" />
-              Calendar Integrations
-            </button>
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full md:w-auto">
+            <CalendarSyncPanel onSyncComplete={invalidateCache} isCompact />
             <RoleGate resource="meetings" action="create">
               <button
                 onClick={() => navigate("/create-meeting")}
@@ -290,27 +286,36 @@ const Calendar = () => {
           </div>
         ) : filteredMeetings.length === 0 ? (
           /* Empty State */
-          <div className="flex-1 min-h-[400px] flex flex-col justify-center items-center bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-8 text-center shadow-xs">
-            <div className="w-16 h-16 bg-slate-50 dark:bg-slate-800 rounded-full flex items-center justify-center mb-4 border border-slate-100 dark:border-slate-700">
-              <Inbox className="w-7 h-7 text-slate-400" />
+          <div className="flex-1 min-h-[400px] flex flex-col justify-center items-center bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-8 text-center shadow-xs space-y-6">
+            <div className="flex flex-col items-center">
+              <div className="w-16 h-16 bg-slate-50 dark:bg-slate-800 rounded-full flex items-center justify-center mb-4 border border-slate-100 dark:border-slate-700">
+                <Inbox className="w-7 h-7 text-slate-400" />
+              </div>
+              <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+                No Scheduled Meetings Found
+              </h3>
+              <p className="text-slate-500 dark:text-slate-400 text-xs sm:text-sm mt-1 max-w-md">
+                {canCreateMeeting
+                  ? "There are no meetings scheduled matching the selected filters. Connect your Google or Outlook calendar to auto-sync events, change your filters, or schedule a new meeting."
+                  : "There are no meetings scheduled matching the selected filters. Connect your Google or Outlook calendar or adjust your filters."}
+              </p>
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+                <RoleGate resource="meetings" action="create">
+                  <button
+                    onClick={() => navigate("/create-meeting")}
+                    className="inline-flex items-center gap-2 px-4 py-2 text-xs font-bold text-white bg-blue-600 hover:bg-blue-500 active:bg-blue-700 rounded-xl transition-all shadow-xs cursor-pointer"
+                  >
+                    <Plus className="w-4 h-4" />
+                    Schedule New Meeting
+                  </button>
+                </RoleGate>
+              </div>
             </div>
-            <h3 className="text-lg font-bold text-slate-800 dark:text-white">
-              No Scheduled Meetings
-            </h3>
-            <p className="text-slate-500 dark:text-slate-400 text-xs sm:text-sm mt-1 max-w-sm">
-              {canCreateMeeting
-                ? "There are no meetings scheduled matching the selected filters. Change filters or create a new meeting."
-                : "There are no meetings scheduled matching the selected filters. Try adjusting your filters."}
-            </p>
-            <RoleGate resource="meetings" action="create">
-              <button
-                onClick={() => navigate("/create-meeting")}
-                className="mt-5 inline-flex items-center gap-2 px-4 py-2 text-xs font-bold text-white bg-blue-600 hover:bg-blue-500 active:bg-blue-700 rounded-xl transition-all shadow-xs cursor-pointer"
-              >
-                <Plus className="w-4 h-4" />
-                Schedule New Meeting
-              </button>
-            </RoleGate>
+
+            {/* Embedded Calendar Integrations & Connect CTA Panel */}
+            <div className="w-full max-w-2xl text-left">
+              <CalendarSyncPanel onSyncComplete={invalidateCache} />
+            </div>
           </div>
         ) : (
           <>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -315,6 +315,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1003,6 +1004,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1049,30 +1051,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2668,6 +2649,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
       "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.4",
@@ -3212,6 +3194,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.1.0.tgz",
       "integrity": "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -4415,6 +4398,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4879,6 +4863,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -5243,6 +5228,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -6399,6 +6385,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
       "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6637,7 +6624,8 @@
       "version": "0.0.1666840",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
       "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7074,6 +7062,7 @@
       "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7679,6 +7668,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7722,6 +7712,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.2.0"
       },
@@ -9427,7 +9418,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11057,6 +11048,7 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11510,6 +11502,22 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -11554,6 +11562,52 @@
         "socks": {
           "optional": true
         }
+      }
+    },
+    "node_modules/mongoose/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongoose/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/mongoose/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/mongoose/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/mpath": {
@@ -12401,7 +12455,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -12968,6 +13022,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-6.1.0.tgz",
       "integrity": "sha512-0kvUPM8RHP/ZMa0xYaDTcG5e8tIGW6kz6MToVT0V8iOnk6bkXp2jncGRGe2bZEk41lZwiDspUqjZCSk5ohjcKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "6.1.0",
         "@redis/client": "6.1.0",
@@ -13598,6 +13653,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
       "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.21.0"
@@ -14260,6 +14316,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14743,6 +14800,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -15163,6 +15221,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15418,8 +15477,9 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
       "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
       },
@@ -15525,6 +15585,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary of Fix
### Root Cause
Google & Outlook calendar connection/resync actions were previously only accessible inside Settings (CalendarIntegrations.jsx), while the main Calendar.jsx page lacked connection status indicators and entry points for syncing or linking calendars.

### Changes Made
Created CalendarSyncPanel Component in client/src/components/calendar/CalendarSyncPanel.jsx
:

Queries /api/calendar/status on mount to fetch Google and Outlook sync statuses (connected, needs_reauth, disconnected).
Renders live status badges (Connected / Reconnect / Connect) with last sync status indicators.
Provides instant "Resync" triggers (/api/calendar/resync/${provider}) with spinning feedback that invalidates the local calendar events cache upon completion to immediately refresh the grid.
Provides direct OAuth Connect entry points for Google (/api/calendar/google/connect) and Outlook (/api/calendar/outlook/connect).
Features a "Manage Sync" deep-link button that navigates directly to Settings.
Integrated Connection Status Badges & CTAs in Calendar.jsx:

Header Toolbar: Embedded <CalendarSyncPanel isCompact /> right beside "Schedule Meeting" for constant visibility while browsing the calendar.
Empty State: Added <CalendarSyncPanel /> directly inside the empty state container (filteredMeetings.length === 0), prompting users to connect or resync their calendars when no meetings are found.
Added Unit Tests:



CalendarSyncPanel.test.jsx: Tests rendering compact badges, full integration panels, triggering resync API, and firing OAuth connect flows.


closes #2006