### PR TITLE
fix: Fix meeting-cost client

### DIFF
--- a/client/src/pages/MeetingCostAnalytics.jsx
+++ b/client/src/pages/MeetingCostAnalytics.jsx
@@ -77,8 +77,12 @@ const MeetingCostAnalytics = () => {
       }
     } catch (err) {
       console.error("Error fetching cost data:", err);
-      setError("We could not load meeting cost analytics. Please try again.");
-      toast.error("Failed to load analytics");
+      const errMsg =
+        err.response?.data?.message ||
+        err.message ||
+        "We could not load meeting cost analytics. Please try again.";
+      setError(errMsg);
+      toast.error(err.response?.data?.message || "Failed to load analytics");
     } finally {
       setLoading(false);
     }
@@ -107,7 +111,9 @@ const MeetingCostAnalytics = () => {
       toast.success("Export downloaded");
     } catch (err) {
       console.error("Error exporting data:", err);
-      toast.error("Export failed");
+      toast.error(
+        err.response?.data?.message || err.message || "Export failed",
+      );
     } finally {
       setExporting(false);
     }

--- a/client/src/services/__tests__/meetingCostApi.test.js
+++ b/client/src/services/__tests__/meetingCostApi.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import apiClient from "../apiClient.js";
+import {
+  getCostConfig,
+  updateCostConfig,
+  getOrgCostAnalytics,
+  getMemberTimeStats,
+  exportCostReport,
+} from "../meetingCostApi.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe("meetingCostApi /api prefix & path shape tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls GET /api/meeting-cost/config for getCostConfig", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, config: { currency: "USD" } },
+    });
+
+    const result = await getCostConfig();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/meeting-cost/config");
+    expect(result).toEqual({ success: true, config: { currency: "USD" } });
+  });
+
+  it("calls PUT /api/meeting-cost/config for updateCostConfig", async () => {
+    const payload = { currency: "EUR", defaultHourlyRate: 75 };
+    apiClient.put.mockResolvedValueOnce({ data: { success: true } });
+
+    const result = await updateCostConfig(payload);
+
+    expect(apiClient.put).toHaveBeenCalledWith(
+      "/api/meeting-cost/config",
+      payload,
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("calls GET /api/meeting-cost/analytics/org for getOrgCostAnalytics", async () => {
+    const params = { startDate: "2026-01-01", endDate: "2026-01-31" };
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, data: { totalCost: 1000 } },
+    });
+
+    const result = await getOrgCostAnalytics(params);
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/meeting-cost/analytics/org",
+      {
+        params: { startDate: "2026-01-01", endDate: "2026-01-31" },
+      },
+    );
+    expect(result).toEqual({ success: true, data: { totalCost: 1000 } });
+  });
+
+  it("calls GET /api/meeting-cost/analytics/members for getMemberTimeStats", async () => {
+    const params = { startDate: "2026-01-01" };
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    const result = await getMemberTimeStats(params);
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/meeting-cost/analytics/members",
+      { params: { startDate: "2026-01-01" } },
+    );
+    expect(result).toEqual({ success: true, data: [] });
+  });
+
+  it("calls GET /api/meeting-cost/analytics/export with responseType blob for exportCostReport", async () => {
+    const params = { startDate: "2026-01-01" };
+    apiClient.get.mockResolvedValueOnce({ data: new Blob([]) });
+
+    const result = await exportCostReport(params);
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/meeting-cost/analytics/export",
+      {
+        params: { startDate: "2026-01-01" },
+        responseType: "blob",
+      },
+    );
+    expect(result).toBeInstanceOf(Blob);
+  });
+});

--- a/client/src/services/meetingCostApi.js
+++ b/client/src/services/meetingCostApi.js
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from "./apiClient.js";
 
 export const getCostConfig = async () => {
   const response = await apiClient.get("/api/meeting-cost/config");


### PR DESCRIPTION
## Summary of Fix
### Root Cause
All client API functions in client/src/services/meetingCostApi.js call endpoints under /api/meeting-cost/* (matching server/routes/index.js). However, meetingCostApi.js imported ./apiClient without the explicit .js extension required by Node.js ES Module resolution, preventing imports in ESM environments. Additionally, specific API error messages (e.g. 403 Forbidden / 401 Unauthorized / network errors) were masked as generic messages on the analytics page.

### Changes Made
Fixed ESM Import in client/src/services/meetingCostApi.js:

Corrected ./apiClient import to ./apiClient.js.
Ensured all 5 client paths retain /api/meeting-cost prefix:
getCostConfig: GET /api/meeting-cost/config
updateCostConfig: PUT /api/meeting-cost/config
getOrgCostAnalytics: GET /api/meeting-cost/analytics/org
getMemberTimeStats: GET /api/meeting-cost/analytics/members
exportCostReport: GET /api/meeting-cost/analytics/export
Surfaced Detailed API Error Messages in 

client/src/pages/MeetingCostAnalytics.jsx:

Updated fetchData and handleExport error handlers to extract and display server-returned error messages (err.response?.data?.message) via toast notifications and the error banner.
Added Unit Tests:



meetingCostApi.test.js: Created test suite asserting path shapes, HTTP verbs (GET/PUT), query parameters, and responseType: "blob" for export.
### Verification
Executed path shape and endpoint assertion tests for getCostConfig, updateCostConfig, getOrgCostAnalytics, getMemberTimeStats, and exportCostReport. All 5 endpoints passed verification.


closes #2031