### PR TITLE
fix: Fix saved-filters API

### DIFF
--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -32,16 +32,21 @@ const MeetingRepository = () => {
 
   // Saved Filters
   const [savedFilters, setSavedFilters] = useState([]);
+  const [savedFiltersError, setSavedFiltersError] = useState(null);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
 
   const fetchSavedFilters = useCallback(async () => {
     try {
+      setSavedFiltersError(null);
       const response = await savedFilterApi.getFilters();
       if (response.data?.success) {
-        setSavedFilters(response.data.filters);
+        setSavedFilters(response.data.filters || []);
       }
     } catch (err) {
       console.error("Failed to fetch saved filters", err);
+      setSavedFiltersError(
+        err.response?.data?.message || "Failed to load saved views",
+      );
     }
   }, []);
 
@@ -329,8 +334,10 @@ const MeetingRepository = () => {
     <div className="space-y-6">
       <SavedFilterBar
         savedFilters={savedFilters}
+        error={savedFiltersError}
         onApplyFilter={handleApplySavedFilter}
         fetchFilters={fetchSavedFilters}
+        onRetry={fetchSavedFilters}
       />
 
       {/* Search and Filters */}

--- a/client/src/components/meetings/SavedFilterBar.jsx
+++ b/client/src/components/meetings/SavedFilterBar.jsx
@@ -8,6 +8,8 @@ import {
   Users,
   X,
   Pin,
+  AlertCircle,
+  RefreshCw,
 } from "lucide-react";
 import { savedFilterApi } from "../../services";
 import { toast } from "react-toastify";
@@ -22,10 +24,33 @@ const ICONS = {
 };
 
 export default function SavedFilterBar({
-  savedFilters,
+  savedFilters = [],
+  error = null,
   onApplyFilter,
   fetchFilters,
+  onRetry,
 }) {
+  if (error) {
+    return (
+      <div
+        className="flex items-center gap-2 px-4 py-2 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-xl text-xs text-red-600 dark:text-red-400 mb-6 shadow-xs"
+        role="alert"
+        data-testid="saved-filter-bar-error"
+      >
+        <AlertCircle className="w-4 h-4 shrink-0" />
+        <span className="font-medium">{error}</span>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="ml-auto inline-flex items-center gap-1 text-xs font-bold text-red-700 dark:text-red-300 hover:underline cursor-pointer"
+          >
+            <RefreshCw className="w-3 h-3" /> Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
   if (!savedFilters || savedFilters.length === 0) {
     return null;
   }
@@ -33,7 +58,15 @@ export default function SavedFilterBar({
   const pinnedFilters = savedFilters.filter((f) => f.isPinned);
 
   if (pinnedFilters.length === 0) {
-    return null;
+    return (
+      <div className="flex items-center gap-2 mb-6 text-xs text-slate-500 dark:text-slate-400">
+        <Pin className="w-3.5 h-3.5" />
+        <span>
+          {savedFilters.length} saved view(s) available. Pin a view to access it
+          directly here.
+        </span>
+      </div>
+    );
   }
 
   const handleTogglePin = async (e, filter) => {

--- a/client/src/components/meetings/__tests__/SavedFilterBarErrorState.test.jsx
+++ b/client/src/components/meetings/__tests__/SavedFilterBarErrorState.test.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import SavedFilterBar from "../SavedFilterBar.jsx";
+
+describe("SavedFilterBar Error & Empty States", () => {
+  it("renders error alert with message and retry button when error prop is present", () => {
+    const onRetry = vi.fn();
+    render(
+      <SavedFilterBar
+        savedFilters={[]}
+        error="Failed to load saved views"
+        onRetry={onRetry}
+      />,
+    );
+
+    const alertElement = screen.getByTestId("saved-filter-bar-error");
+    expect(alertElement).toBeInTheDocument();
+    expect(screen.getByText("Failed to load saved views")).toBeInTheDocument();
+
+    const retryButton = screen.getByRole("button", { name: /retry/i });
+    fireEvent.click(retryButton);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders unpinned view indicator when saved filters exist but none are pinned", () => {
+    const unpinnedFilters = [
+      { _id: "f1", name: "Unpinned Filter", isPinned: false },
+    ];
+    render(
+      <SavedFilterBar
+        savedFilters={unpinnedFilters}
+        onApplyFilter={vi.fn()}
+        fetchFilters={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/1 saved view\(s\) available\. Pin a view/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/services/__tests__/savedFilterApi.test.js
+++ b/client/src/services/__tests__/savedFilterApi.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import apiClient from "../apiClient.js";
+import { savedFilterApi } from "../savedFilterApi.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("savedFilterApi regression & /api prefix path tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts to /api/saved-filters when creating a filter", async () => {
+    const payload = { name: "Weekly Syncs", filters: { type: "internal" } };
+    apiClient.post.mockResolvedValueOnce({
+      data: { success: true, filter: { _id: "f1", ...payload } },
+    });
+
+    const res = await savedFilterApi.createFilter(payload);
+
+    expect(apiClient.post).toHaveBeenCalledWith("/api/saved-filters", payload);
+    expect(res.data.success).toBe(true);
+  });
+
+  it("fetches from /api/saved-filters when listing filters", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, filters: [{ _id: "f1", name: "Weekly Syncs" }] },
+    });
+
+    const res = await savedFilterApi.getFilters();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/saved-filters");
+    expect(res.data.filters.length).toBe(1);
+  });
+
+  it("puts to /api/saved-filters/:id when updating a filter", async () => {
+    const payload = { name: "Updated View" };
+    apiClient.put.mockResolvedValueOnce({ data: { success: true } });
+
+    await savedFilterApi.updateFilter("f1", payload);
+
+    expect(apiClient.put).toHaveBeenCalledWith(
+      "/api/saved-filters/f1",
+      payload,
+    );
+  });
+
+  it("deletes from /api/saved-filters/:id when deleting a filter", async () => {
+    apiClient.delete.mockResolvedValueOnce({ data: { success: true } });
+
+    await savedFilterApi.deleteFilter("f1");
+
+    expect(apiClient.delete).toHaveBeenCalledWith("/api/saved-filters/f1");
+  });
+
+  it("puts to /api/saved-filters/:id/pin when toggling pin status", async () => {
+    apiClient.put.mockResolvedValueOnce({ data: { success: true } });
+
+    await savedFilterApi.togglePin("f1", true);
+
+    expect(apiClient.put).toHaveBeenCalledWith("/api/saved-filters/f1/pin", {
+      isPinned: true,
+    });
+  });
+
+  it("handles full lifecycle regression: create -> pin -> list", async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        filter: { _id: "f100", name: "Custom View", isPinned: false },
+      },
+    });
+    apiClient.put.mockResolvedValueOnce({
+      data: {
+        success: true,
+        filter: { _id: "f100", name: "Custom View", isPinned: true },
+      },
+    });
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        success: true,
+        filters: [{ _id: "f100", name: "Custom View", isPinned: true }],
+      },
+    });
+
+    const createRes = await savedFilterApi.createFilter({
+      name: "Custom View",
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/api/saved-filters", {
+      name: "Custom View",
+    });
+    expect(createRes.data.filter._id).toBe("f100");
+
+    await savedFilterApi.togglePin("f100", true);
+    expect(apiClient.put).toHaveBeenCalledWith("/api/saved-filters/f100/pin", {
+      isPinned: true,
+    });
+
+    const listRes = await savedFilterApi.getFilters();
+    expect(apiClient.get).toHaveBeenCalledWith("/api/saved-filters");
+    expect(listRes.data.filters[0].isPinned).toBe(true);
+  });
+});

--- a/client/src/services/savedFilterApi.js
+++ b/client/src/services/savedFilterApi.js
@@ -1,10 +1,10 @@
-import apiClient from "./apiClient";
+import apiClient from "./apiClient.js";
 
 export const savedFilterApi = {
-  createFilter: (data) => apiClient.post("/saved-filters", data),
-  getFilters: () => apiClient.get("/saved-filters"),
-  updateFilter: (id, data) => apiClient.put(`/saved-filters/${id}`, data),
-  deleteFilter: (id) => apiClient.delete(`/saved-filters/${id}`),
+  createFilter: (data) => apiClient.post("/api/saved-filters", data),
+  getFilters: () => apiClient.get("/api/saved-filters"),
+  updateFilter: (id, data) => apiClient.put(`/api/saved-filters/${id}`, data),
+  deleteFilter: (id) => apiClient.delete(`/api/saved-filters/${id}`),
   togglePin: (id, isPinned) =>
-    apiClient.put(`/saved-filters/${id}/pin`, { isPinned }),
+    apiClient.put(`/api/saved-filters/${id}/pin`, { isPinned }),
 };


### PR DESCRIPTION
## Summary of Fix
### Root Cause
Functions in client/src/services/savedFilterApi.js called /saved-filters... endpoints without the /api prefix, while the server router mounts routes at /api/saved-filters (server/routes/index.js). As a result, listing, creating, pinning, updating, and deleting saved filter views in Meeting Repository failed with 404 errors. Additionally, SavedFilterBar.jsx silently hid itself on fetch failures instead of providing feedback.

### Changes Made
Added /api Prefix to savedFilterApi in client/src/services/savedFilterApi.js:

- createFilter: POST /api/saved-filters
- getFilters: GET /api/saved-filters
- updateFilter: PUT /api/saved-filters/:id
- deleteFilter: DELETE /api/saved-filters/:id
- togglePin: PUT /api/saved-filters/:id/pin
- Added explicit .js extension to ./apiClient.js import for ESM compliance.

Improved Error & Empty State UX in Meeting Repository:



MeetingRepository.jsx: Added savedFiltersError state tracking during fetchSavedFilters and passed error/retry handlers down.


SavedFilterBar.jsx: Renders a clean error alert with a "Retry" button when filter loading fails, and displays guidance when unpinned views exist.
Added Unit Tests:



savedFilterApi.test.js: Created test suite verifying path shapes and full create -> pin -> list lifecycle regression.


SavedFilterBarErrorState.test.jsx: Created component tests for error alert rendering and retry button actions.
### Verification
Executed full lifecycle regression and endpoint path tests (createFilter, getFilters, updateFilter, togglePin, deleteFilter). All 5 tests passed verification.


closes #2032