### PR TITLE
feat: make series retrospective reachable from product navigation

### DIFF
--- a/client/src/components/meeting-details/SeriesNavigation.jsx
+++ b/client/src/components/meeting-details/SeriesNavigation.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { meetingSeriesApi } from "../../services";
 
 const SeriesNavigation = ({ meeting }) => {
@@ -9,16 +9,18 @@ const SeriesNavigation = ({ meeting }) => {
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
 
+  const seriesId = meeting?.series?._id || meeting?.series;
+
   useEffect(() => {
-    if (!meeting?.series) return;
+    if (!seriesId) return;
 
     const fetchSeriesData = async () => {
       try {
         setLoading(true);
         const [seriesRes, meetingsRes] = await Promise.all([
-          meetingSeriesApi.getSeriesById(meeting.series),
+          meetingSeriesApi.getSeriesById(seriesId),
           // Fetch complete series meetings without artificial 100 limit restriction (issue #915)
-          meetingSeriesApi.getSeriesMeetings(meeting.series, 1, 0),
+          meetingSeriesApi.getSeriesMeetings(seriesId, 1, 0),
         ]);
 
         if (seriesRes.data?.success) {
@@ -37,12 +39,12 @@ const SeriesNavigation = ({ meeting }) => {
     };
 
     fetchSeriesData();
-  }, [meeting?.series]);
+  }, [seriesId]);
 
-  if (!meeting?.series) return null;
+  if (!seriesId) return null;
   if (loading) {
     return (
-      <div className="mb-6 p-4 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse h-16"></div>
+      <div className="mb-6 h-16 animate-pulse rounded-xl bg-gray-100 p-4 dark:bg-gray-800"></div>
     );
   }
   if (!series || meetings.length === 0) return null;
@@ -59,10 +61,10 @@ const SeriesNavigation = ({ meeting }) => {
   const displayTotal = totalCount || meetings.length;
 
   return (
-    <div className="mb-6 flex items-center justify-between p-4 rounded-xl bg-blue-50 border border-blue-100 dark:bg-blue-900/20 dark:border-blue-800">
+    <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
       <div className="flex items-center gap-3 text-blue-900 dark:text-blue-100">
         <svg
-          className="w-5 h-5 text-blue-600 dark:text-blue-400"
+          className="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -82,14 +84,21 @@ const SeriesNavigation = ({ meeting }) => {
         </div>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
+        <Link
+          to={`/meeting-series/${seriesId}/retrospective`}
+          className="rounded-lg border border-indigo-200 bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700 dark:border-indigo-700"
+        >
+          Series Retrospective
+        </Link>
         <button
+          type="button"
           onClick={() => navigate(`/meeting/${prevMeeting._id}`)}
           disabled={!prevMeeting}
-          className="px-3 py-1.5 text-sm font-medium rounded-lg border border-blue-200 dark:border-blue-700 bg-white dark:bg-gray-800 text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1 cursor-pointer"
+          className="flex cursor-pointer items-center gap-1 rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-700 dark:bg-gray-800 dark:text-blue-300 dark:hover:bg-gray-700"
         >
           <svg
-            className="w-4 h-4"
+            className="h-4 w-4"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -104,13 +113,14 @@ const SeriesNavigation = ({ meeting }) => {
           Previous
         </button>
         <button
+          type="button"
           onClick={() => navigate(`/meeting/${nextMeeting._id}`)}
           disabled={!nextMeeting}
-          className="px-3 py-1.5 text-sm font-medium rounded-lg border border-blue-200 dark:border-blue-700 bg-white dark:bg-gray-800 text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1 cursor-pointer"
+          className="flex cursor-pointer items-center gap-1 rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-700 dark:bg-gray-800 dark:text-blue-300 dark:hover:bg-gray-700"
         >
           Next
           <svg
-            className="w-4 h-4"
+            className="h-4 w-4"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/client/src/components/meeting-details/__tests__/SeriesNavigation.test.jsx
+++ b/client/src/components/meeting-details/__tests__/SeriesNavigation.test.jsx
@@ -104,4 +104,41 @@ describe("SeriesNavigation Component (Issue #915)", () => {
     fireEvent.click(nextButton);
     expect(mockNavigate).toHaveBeenCalledWith("/meeting/meeting-106");
   });
+
+  it("links to series retrospective from a series meeting (Issue #2005)", async () => {
+    const mockSeriesId = "series-abc";
+    meetingSeriesApi.getSeriesById.mockResolvedValueOnce({
+      data: {
+        success: true,
+        series: { _id: mockSeriesId, title: "Weekly Sync" },
+      },
+    });
+    meetingSeriesApi.getSeriesMeetings.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [
+          { _id: "m1", seriesOccurrence: 1 },
+          { _id: "m2", seriesOccurrence: 2 },
+        ],
+        pagination: { total: 2 },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SeriesNavigation
+          meeting={{ _id: "m2", series: mockSeriesId, seriesOccurrence: 2 }}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /series retrospective/i }),
+      ).toHaveAttribute(
+        "href",
+        `/meeting-series/${mockSeriesId}/retrospective`,
+      );
+    });
+  });
 });

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import AppContent from "../context/AppContent";
 import { meetingApi } from "../services";
 import MeetingHeader from "../components/meeting-details/MeetingHeader";
+import SeriesNavigation from "../components/meeting-details/SeriesNavigation";
 import MeetingSummary from "../components/meeting-details/MeetingSummary";
 import MinutesApproval from "../components/meetings/MinutesApproval";
 import MeetingCollaborativeNotes from "../components/meeting-details/MeetingCollaborativeNotes";
@@ -327,6 +328,7 @@ const MeetingDetails = () => {
             onShare={() => setShareModalOpen(true)}
             onPresent={() => setIsPresentModeOpen(true)}
           />
+          <SeriesNavigation meeting={meeting} />
 
           <div className="p-6 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm mt-6 mb-6">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">

--- a/client/src/pages/SeriesRetrospective.jsx
+++ b/client/src/pages/SeriesRetrospective.jsx
@@ -26,6 +26,7 @@ const SeriesRetrospective = () => {
   const { seriesId } = useParams();
   const [activeTab, setActiveTab] = useState("overview");
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
   const [data, setData] = useState({
     overview: null,
     topics: null,
@@ -38,10 +39,15 @@ const SeriesRetrospective = () => {
   useEffect(() => {
     const loadData = async () => {
       setLoading(true);
+      setLoadError("");
       try {
         // Load overview immediately
         const overviewRes = await getSeriesRetrospectiveOverview(seriesId);
         setData((prev) => ({ ...prev, overview: overviewRes }));
+
+        if (overviewRes?.insufficientHistory) {
+          return;
+        }
 
         // Load others in background
         Promise.all([
@@ -66,7 +72,11 @@ const SeriesRetrospective = () => {
           });
       } catch (err) {
         console.error(err);
-        toast.error("Failed to load retrospective overview");
+        const message =
+          err?.response?.data?.message ||
+          "Failed to load retrospective overview";
+        setLoadError(message);
+        toast.error(message);
       } finally {
         setLoading(false);
       }
@@ -99,8 +109,66 @@ const SeriesRetrospective = () => {
     );
   }
 
+  if (loadError) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-16 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Could not load retrospective
+        </h1>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          {loadError}
+        </p>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <Link
+            to="/meeting-series"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+          >
+            Back to series list
+          </Link>
+          <Link
+            to="/dashboard"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200"
+          >
+            Dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (data.overview?.insufficientHistory) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-16 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+          Series Retrospective
+        </h1>
+        <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">
+          {data.overview.summary ||
+            "This series does not have enough meeting history yet."}
+        </p>
+        <p className="mt-2 text-xs text-gray-500">
+          Meetings recorded: {data.overview.metricsData?.totalMeetings ?? 0}
+        </p>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <Link
+            to="/meeting-series"
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+          >
+            Back to series list
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   const renderOverview = () => {
-    if (!data.overview) return null;
+    if (!data.overview) {
+      return (
+        <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-600">
+          No overview data available for this series.
+        </div>
+      );
+    }
     const { summary, metricsData } = data.overview;
     return (
       <div className="space-y-6">
@@ -118,7 +186,7 @@ const SeriesRetrospective = () => {
               Total Meetings
             </h3>
             <p className="mt-1 text-2xl font-semibold text-gray-900">
-              {metricsData.totalMeetings}
+              {metricsData?.totalMeetings ?? 0}
             </p>
           </div>
           <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
@@ -126,7 +194,7 @@ const SeriesRetrospective = () => {
               Action Item Completion
             </h3>
             <p className="mt-1 text-2xl font-semibold text-gray-900">
-              {metricsData.actionItemCompletionRate.toFixed(1)}%
+              {(metricsData?.actionItemCompletionRate ?? 0).toFixed(1)}%
             </p>
           </div>
           <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
@@ -134,7 +202,7 @@ const SeriesRetrospective = () => {
               Avg. Attendance
             </h3>
             <p className="mt-1 text-2xl font-semibold text-gray-900">
-              {metricsData.averageAttendance.toFixed(1)}%
+              {(metricsData?.averageAttendance ?? 0).toFixed(1)}%
             </p>
           </div>
           <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
@@ -142,7 +210,7 @@ const SeriesRetrospective = () => {
               Decision Follow-through
             </h3>
             <p className="mt-1 text-2xl font-semibold text-gray-900">
-              {metricsData.decisionFollowThroughRate.toFixed(1)}%
+              {(metricsData?.decisionFollowThroughRate ?? 0).toFixed(1)}%
             </p>
           </div>
         </div>
@@ -436,10 +504,10 @@ const SeriesRetrospective = () => {
           </p>
         </div>
         <Link
-          to="/dashboard"
+          to="/meeting-series"
           className="text-sm text-blue-600 hover:text-blue-800"
         >
-          Back to Dashboard
+          Back to series list
         </Link>
       </div>
 

--- a/client/src/pages/__tests__/SeriesRetrospectiveNav.test.jsx
+++ b/client/src/pages/__tests__/SeriesRetrospectiveNav.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import React from "react";
+import SeriesRetrospective from "../SeriesRetrospective.jsx";
+import * as api from "../../services/seriesRetrospectiveApi";
+
+vi.mock("../../services/seriesRetrospectiveApi", () => ({
+  getSeriesRetrospectiveOverview: vi.fn(),
+  getSeriesRetrospectiveTopics: vi.fn(),
+  getSeriesRetrospectiveActionItems: vi.fn(),
+  getSeriesRetrospectiveAttendance: vi.fn(),
+  getSeriesRetrospectiveSentiment: vi.fn(),
+  getSeriesRetrospectiveDecisions: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+describe("SeriesRetrospective empty/error UI (#2005)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows insufficient-history empty state", async () => {
+    api.getSeriesRetrospectiveOverview.mockResolvedValue({
+      success: true,
+      summary:
+        "This series needs more meeting history for a useful retrospective.",
+      metricsData: { totalMeetings: 1 },
+      insufficientHistory: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/meeting-series/s1/retrospective"]}>
+        <Routes>
+          <Route
+            path="/meeting-series/:seriesId/retrospective"
+            element={<SeriesRetrospective />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/needs more meeting history/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /back to series list/i }),
+      ).toHaveAttribute("href", "/meeting-series");
+    });
+  });
+
+  it("shows error UI when overview request fails", async () => {
+    api.getSeriesRetrospectiveOverview.mockRejectedValue({
+      response: { data: { message: "Meeting series not found" } },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/meeting-series/missing/retrospective"]}>
+        <Routes>
+          <Route
+            path="/meeting-series/:seriesId/retrospective"
+            element={<SeriesRetrospective />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Could not load retrospective/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Meeting series not found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/server/services/seriesRetrospectiveService.js
+++ b/server/services/seriesRetrospectiveService.js
@@ -226,7 +226,34 @@ export const getRetrospectiveOverview = async (seriesId, organizationId) => {
   const meetingIds = meetings.map((m) => m._id);
 
   if (meetingIds.length === 0) {
-    return { summary: "No meetings found for this series yet.", data: {} };
+    return {
+      summary: "No meetings found for this series yet.",
+      metricsData: {
+        totalMeetings: 0,
+        topTopics: [],
+        actionItemCompletionRate: 0,
+        averageAttendance: 0,
+        sentimentTrend: [],
+        decisionFollowThroughRate: 0,
+      },
+      insufficientHistory: true,
+    };
+  }
+
+  if (meetingIds.length < 2) {
+    return {
+      summary:
+        "This series needs more meeting history for a useful retrospective. Hold at least two occurrences, then reopen this page.",
+      metricsData: {
+        totalMeetings: meetings.length,
+        topTopics: [],
+        actionItemCompletionRate: 0,
+        averageAttendance: 0,
+        sentimentTrend: [],
+        decisionFollowThroughRate: 0,
+      },
+      insufficientHistory: true,
+    };
   }
 
   const [
@@ -273,5 +300,6 @@ export const getRetrospectiveOverview = async (seriesId, organizationId) => {
   return {
     summary,
     metricsData,
+    insufficientHistory: false,
   };
 };


### PR DESCRIPTION
## Summary
- Wire `SeriesNavigation` on meeting details with a one-click Series Retrospective CTA
- Empty state for insufficient series history; error UI when load fails
- Deep link `/meeting-series/:seriesId/retrospective` unchanged

## Test plan
- [ ] Open a series meeting → see Series Navigation → click **Serietrospective**
- [ ] Deep link `/meeting-series/:id/retrospective` still works
- [ ] Series with &lt; 2 meetings shows insufficient-history empty state
- [ ] Invalid series id shows error UI
- [ ] `cd client && npx vitest run src/components/meeting-details/__tests__/SeriesNavigation.test.jsx src/pages/__tests__/SeriesRetrospectiveNav.test.jsx`

Closes #2005