### PR TITLE
feat: wire CommentSection threaded discussion on Meeting Details (#1989)

### DIFF
--- a/client/src/api/commentApi.js
+++ b/client/src/api/commentApi.js
@@ -2,7 +2,11 @@ import apiClient from "../services/apiClient";
 
 const API_URL = "/api/comments";
 
-export const createComment = async (meetingId, body, parentComment = null) => {
+export const createComment = async ({
+  meetingId,
+  body,
+  parentComment = null,
+}) => {
   const response = await apiClient.post(
     `${API_URL}`,
     {
@@ -20,10 +24,10 @@ export const getCommentsByMeeting = async (meetingId, page = 1, limit = 50) => {
     `${API_URL}/meeting/${meetingId}?page=${page}&limit=${limit}`,
     { withCredentials: true },
   );
-  return response.data;
+  return response.data.comments ?? [];
 };
 
-export const updateComment = async (commentId, body) => {
+export const updateComment = async (commentId, { body }) => {
   const response = await apiClient.patch(
     `${API_URL}/${commentId}`,
     { body },

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -37,6 +37,7 @@ import { getBriefing } from "../services/briefingApi";
 import GuestAccessManager from "../components/meetings/GuestAccessManager";
 import MeetingReadiness from "../components/MeetingReadiness";
 import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
+import CommentSection from "../components/meeting-details/CommentSection";
 import PollSection from "../components/meeting-details/PollSection";
 import FeedbackForm from "../components/meeting-details/FeedbackForm";
 import AgendaTimer from "../components/meeting-details/AgendaTimer";
@@ -424,6 +425,10 @@ const MeetingDetails = () => {
 
           <div className="mt-6 mb-6">
             <FollowUpThreads meetingId={meeting._id} />
+          </div>
+
+          <div className="mt-6 mb-6">
+            <CommentSection meetingId={meeting._id} />
           </div>
 
           <div className="mt-6 mb-6">

--- a/client/src/pages/__tests__/MeetingDetailsCommentSection.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsCommentSection.test.jsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MeetingDetails from "../MeetingDetails.jsx";
+import { meetingApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="app-navbar">App Navbar</div>,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useUser: () => ({
+    user: { id: "user_123", publicMetadata: { dbUserId: "db_123" } },
+  }),
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getMeetingById: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/briefingApi", () => ({
+  getBriefing: vi.fn().mockResolvedValue({ data: null }),
+}));
+
+const appContextValue = {
+  userData: { _id: "user-1", role: "member" },
+  backendUrl: "http://localhost:5000",
+};
+
+vi.mock("../../components/meeting-details/MeetingHeader", () => ({
+  default: ({ meeting }) => (
+    <div data-testid="meeting-header">{meeting.title}</div>
+  ),
+}));
+vi.mock("../../components/meeting-details/MeetingSummary", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingCollaborativeNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTranscript", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingParticipants", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingAgenda", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingMetadata", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingActions", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/TranscriptAnnotations", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/RsvpPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/KeyMomentsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/HighlightReel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SentimentTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingGoalsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/shared-links/ShareModal", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingFollowUpBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PresentMode", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/PrepChecklist", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SpeakingTimeBreakdown", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/CarryForwardConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/RoleRotationConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/DuplicateDetectionPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/summaries/RecapStoryViewer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/BriefingBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/AgendaBuilder", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/GuestAccessManager", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PollSection", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FeedbackForm", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaTimer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/HealthScoreCard", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MinutesApproval", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PersonalNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FollowUpThreads", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingRisksPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/MeetingReadiness", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaPacingReport", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/ClipManager", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meeting-details/CommentSection", () => ({
+  default: ({ meetingId }) => (
+    <div data-testid="comment-section" data-meeting-id={meetingId}>
+      Comments for {meetingId}
+    </div>
+  ),
+}));
+
+const renderDetails = () =>
+  render(
+    <AppContent.Provider value={appContextValue}>
+      <MemoryRouter initialEntries={["/meetings/123"]}>
+        <Routes>
+          <Route path="/meetings/:id" element={<MeetingDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </AppContent.Provider>,
+  );
+
+describe("Meeting Details CommentSection mount (#1989)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mounts CommentSection with the meeting id", async () => {
+    meetingApi.getMeetingById.mockResolvedValue({
+      data: {
+        success: true,
+        meeting: {
+          _id: "123",
+          title: "Quarterly Planning",
+          uploadedBy: "db_123",
+          participants: [],
+        },
+      },
+    });
+
+    renderDetails();
+
+    const section = await screen.findByTestId("comment-section");
+    expect(section).toHaveTextContent("Comments for 123");
+    expect(section).toHaveAttribute("data-meeting-id", "123");
+  });
+});


### PR DESCRIPTION
## Summary
- Mount `CommentSection` on Meeting Details for threaded meeting discussion
- Fix `commentApi` call signatures and paginated comment list parsing
- Add mount test for CommentSection on Meeting Details

## Test plan
- [x] CommentSection mount test passes
- [ ] Post / reply / edit / delete / react on a meeting
- [ ] Confirm org-scoped access (403 toast for other orgs)

Closes #1989