### PR TITLE
feat: wire SpeakerAttribution remapping UI (#1991)

### DIFF
--- a/client/src/components/meeting-details/SpeakerAttribution.jsx
+++ b/client/src/components/meeting-details/SpeakerAttribution.jsx
@@ -3,10 +3,17 @@ import { toast } from "react-toastify";
 import { Users, Check, X, Wand2, Trash2 } from "lucide-react";
 import { speakerMappingApi } from "../../services/speakerMappingApi";
 
-const SpeakerAttribution = ({ meetingId, participants }) => {
+const apiErrorMessage = (error, fallback) =>
+  error.response?.data?.message || fallback;
+
+const participantName = (participant) =>
+  typeof participant === "string" ? participant : participant?.name;
+
+const SpeakerAttribution = ({ meetingId, participants, onMappingChange }) => {
   const [mappings, setMappings] = useState([]);
   const [suggestions, setSuggestions] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   const [newLabel, setNewLabel] = useState("");
   const [newName, setNewName] = useState("");
@@ -14,9 +21,10 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
   const fetchMappings = async () => {
     try {
       const response = await speakerMappingApi.getMappings(meetingId);
-      setMappings(response.data.data);
+      setMappings(response.data.data || []);
     } catch (error) {
       console.error("Failed to load speaker mappings", error);
+      toast.error(apiErrorMessage(error, "Failed to load speaker mappings"));
     }
   };
 
@@ -24,10 +32,10 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
     setLoading(true);
     try {
       const response = await speakerMappingApi.suggestMappings(meetingId);
-      setSuggestions(response.data.data);
+      setSuggestions(response.data.data || []);
     } catch (error) {
       console.error(error);
-      toast.error("Failed to fetch suggestions");
+      toast.error(apiErrorMessage(error, "Failed to fetch suggestions"));
     } finally {
       setLoading(false);
     }
@@ -41,7 +49,8 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
   }, [meetingId]);
 
   const handleApply = async (originalLabel, mappedName) => {
-    if (!originalLabel || !mappedName) return;
+    if (!originalLabel || !mappedName || saving) return;
+    setSaving(true);
     try {
       await speakerMappingApi.saveAndApplyMapping(
         meetingId,
@@ -49,30 +58,36 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
         mappedName,
       );
       toast.success("Mapping applied successfully");
-      fetchMappings();
-      // Clear inputs if it was a manual mapping
+      await fetchMappings();
       if (newLabel === originalLabel) {
         setNewLabel("");
         setNewName("");
       }
-      // Remove from suggestions
-      setSuggestions(
-        suggestions.filter((s) => s.originalLabel !== originalLabel),
+      setSuggestions((prev) =>
+        prev.filter((s) => s.originalLabel !== originalLabel),
       );
+      onMappingChange?.();
     } catch (error) {
       console.error(error);
-      toast.error("Failed to apply mapping");
+      toast.error(apiErrorMessage(error, "Failed to apply mapping"));
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleRevert = async (mappingId) => {
+    if (saving) return;
+    setSaving(true);
     try {
       await speakerMappingApi.revertMapping(meetingId, mappingId);
       toast.success("Mapping reverted");
-      fetchMappings();
+      await fetchMappings();
+      onMappingChange?.();
     } catch (error) {
       console.error(error);
-      toast.error("Failed to revert mapping");
+      toast.error(apiErrorMessage(error, "Failed to revert mapping"));
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -123,17 +138,18 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
             list="participants-list-attribution"
           />
           <datalist id="participants-list-attribution">
-            {participants?.map((p, i) => (
-              <option key={i} value={p.name} />
-            ))}
+            {participants?.map((p, i) => {
+              const name = participantName(p);
+              return name ? <option key={i} value={name} /> : null;
+            })}
           </datalist>
         </div>
         <button
           onClick={() => handleApply(newLabel, newName)}
-          disabled={!newLabel || !newName}
+          disabled={!newLabel || !newName || saving}
           className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-md transition-colors"
         >
-          Apply
+          {saving ? "Saving..." : "Apply"}
         </button>
       </div>
 
@@ -166,7 +182,8 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
                         suggestion.options[0]?.name,
                       )
                     }
-                    className="p-1 text-green-600 hover:bg-green-50 rounded"
+                    disabled={saving || !suggestion.options[0]?.name}
+                    className="p-1 text-green-600 hover:bg-green-50 rounded disabled:opacity-50"
                     title="Accept suggestion"
                   >
                     <Check size={16} />
@@ -179,7 +196,8 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
                         ),
                       )
                     }
-                    className="p-1 text-gray-400 hover:bg-gray-100 rounded"
+                    disabled={saving}
+                    className="p-1 text-gray-400 hover:bg-gray-100 rounded disabled:opacity-50"
                     title="Dismiss"
                   >
                     <X size={16} />
@@ -220,7 +238,8 @@ const SpeakerAttribution = ({ meetingId, participants }) => {
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <button
                       onClick={() => handleRevert(mapping._id)}
-                      className="text-red-500 hover:text-red-700 transition-colors"
+                      disabled={saving}
+                      className="text-red-500 hover:text-red-700 transition-colors disabled:opacity-50"
                       title="Revert mapping"
                     >
                       <Trash2 size={16} />

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -10,6 +10,7 @@ import MinutesApproval from "../components/meetings/MinutesApproval";
 import MeetingCollaborativeNotes from "../components/meeting-details/MeetingCollaborativeNotes";
 import PersonalNotes from "../components/meeting-details/PersonalNotes";
 import MeetingTranscript from "../components/meeting-details/MeetingTranscript";
+import SpeakerAttribution from "../components/meeting-details/SpeakerAttribution";
 import MeetingParticipants from "../components/meeting-details/MeetingParticipants";
 import MeetingAgenda from "../components/meeting-details/MeetingAgenda";
 import MeetingMetadata from "../components/meeting-details/MeetingMetadata";
@@ -117,6 +118,17 @@ const MeetingDetails = () => {
 
     fetchMeetingDetails();
   }, [id]);
+
+  const refreshMeeting = async () => {
+    try {
+      const { data } = await meetingApi.getMeetingById(id);
+      if (data.success) {
+        setMeeting(data.meeting);
+      }
+    } catch (err) {
+      console.error("Error refreshing meeting after speaker mapping:", err);
+    }
+  };
 
   const handleBack = () => {
     if (
@@ -413,6 +425,14 @@ const MeetingDetails = () => {
 
           <div className="mt-6 mb-6">
             <HighlightReel meetingId={meeting._id} />
+          </div>
+
+          <div className="mt-6 mb-6">
+            <SpeakerAttribution
+              meetingId={meeting._id}
+              participants={meeting.participants}
+              onMappingChange={refreshMeeting}
+            />
           </div>
 
           <MeetingTranscript meeting={meeting} />

--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -20,6 +20,7 @@ import {
 import { toast } from "react-toastify";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
 import MeetingSentimentChart from "../components/MeetingSentimentChart";
+import SpeakerAttribution from "../components/meeting-details/SpeakerAttribution";
 import AppContent from "../context/AppContent.js";
 
 const HighlightedText = ({ text, query }) => {
@@ -450,6 +451,13 @@ const TranscriptViewer = () => {
 
         {/* Main Content */}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="mb-6">
+            <SpeakerAttribution
+              meetingId={meetingId}
+              participants={meeting?.participants}
+              onMappingChange={fetchTranscript}
+            />
+          </div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Transcript Content */}
             <div className="lg:col-span-2 space-y-4">

--- a/client/src/pages/__tests__/MeetingDetailsSpeakerAttribution.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsSpeakerAttribution.test.jsx
@@ -1,0 +1,204 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MeetingDetails from "../MeetingDetails.jsx";
+import { meetingApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="app-navbar">App Navbar</div>,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useUser: () => ({
+    user: { id: "user_123", publicMetadata: { dbUserId: "db_123" } },
+  }),
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getMeetingById: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/briefingApi", () => ({
+  getBriefing: vi.fn().mockResolvedValue({ data: null }),
+}));
+
+const appContextValue = {
+  userData: { _id: "user-1", role: "member" },
+  backendUrl: "http://localhost:5000",
+};
+
+vi.mock("../../components/meeting-details/MeetingHeader", () => ({
+  default: ({ meeting }) => (
+    <div data-testid="meeting-header">{meeting.title}</div>
+  ),
+}));
+vi.mock("../../components/meeting-details/MeetingSummary", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingCollaborativeNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTranscript", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingParticipants", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingAgenda", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingMetadata", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingActions", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/TranscriptAnnotations", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/RsvpPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/KeyMomentsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/HighlightReel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SentimentTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingGoalsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/shared-links/ShareModal", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingFollowUpBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PresentMode", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/PrepChecklist", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SpeakingTimeBreakdown", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/CarryForwardConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/RoleRotationConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/DuplicateDetectionPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/summaries/RecapStoryViewer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/BriefingBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/AgendaBuilder", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/GuestAccessManager", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PollSection", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FeedbackForm", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaTimer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/HealthScoreCard", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MinutesApproval", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PersonalNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FollowUpThreads", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/CommentSection", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingRisksPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/MeetingReadiness", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaPacingReport", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/ClipManager", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meeting-details/SpeakerAttribution", () => ({
+  default: ({ meetingId, participants }) => (
+    <div
+      data-testid="speaker-attribution"
+      data-meeting-id={meetingId}
+      data-participant-count={participants?.length ?? 0}
+    >
+      Speaker attribution for {meetingId}
+    </div>
+  ),
+}));
+
+const renderDetails = () =>
+  render(
+    <AppContent.Provider value={appContextValue}>
+      <MemoryRouter initialEntries={["/meetings/123"]}>
+        <Routes>
+          <Route path="/meetings/:id" element={<MeetingDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </AppContent.Provider>,
+  );
+
+describe("Meeting Details SpeakerAttribution mount (#1991)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mounts SpeakerAttribution with the meeting id and participants", async () => {
+    meetingApi.getMeetingById.mockResolvedValue({
+      data: {
+        success: true,
+        meeting: {
+          _id: "123",
+          title: "Quarterly Planning",
+          uploadedBy: "db_123",
+          participants: [{ name: "Alex" }, { name: "Sam" }],
+        },
+      },
+    });
+
+    renderDetails();
+
+    const section = await screen.findByTestId("speaker-attribution");
+    expect(section).toHaveTextContent("Speaker attribution for 123");
+    expect(section).toHaveAttribute("data-meeting-id", "123");
+    expect(section).toHaveAttribute("data-participant-count", "2");
+  });
+});


### PR DESCRIPTION
## Summary
- Mount `SpeakerAttribution` on Meeting Details and Transcript Viewer
- Refresh transcript/meeting after apply/revert
- Surface unauthorized/API errors in toasts; improve suggestion apply/dismiss + saving states

## Test plan
- [x] `npx vitest run src/pages/__tests__/MeetingDetailsSpeakerAttribution.test.jsx`
- [ ] Map a speaker label on Meeting Details and confirm transcript text updates
- [ ] Accept and dismiss auto-suggestions
- [ ] Revert a mapping
- [ ] Confirm unauthorized access shows an error toast

Closes #1991