### PR TITLE
feat: wire SeriesNavigation on Meeting Details (#1994)

### DIFF
--- a/client/src/components/meeting-details/SeriesNavigation.jsx
+++ b/client/src/components/meeting-details/SeriesNavigation.jsx
@@ -9,7 +9,8 @@ const SeriesNavigation = ({ meeting }) => {
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
 
-  const seriesId = meeting?.series?._id || meeting?.series;
+  const seriesId =
+    meeting?.series?._id || meeting?.series || meeting?.seriesId || null;
 
   useEffect(() => {
     if (!seriesId) return;
@@ -84,7 +85,26 @@ const SeriesNavigation = ({ meeting }) => {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="sr-only" htmlFor="series-occurrence-select">
+          Jump to series occurrence
+        </label>
+        <select
+          id="series-occurrence-select"
+          value={meeting._id}
+          onChange={(e) => {
+            if (e.target.value && e.target.value !== meeting._id) {
+              navigate(`/meeting/${e.target.value}`);
+            }
+          }}
+          className="rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-sm font-medium text-blue-700 dark:border-blue-700 dark:bg-gray-800 dark:text-blue-300"
+        >
+          {meetings.map((m, index) => (
+            <option key={m._id} value={m._id}>
+              Occurrence {m.seriesOccurrence || index + 1}
+            </option>
+          ))}
+        </select>
         <Link
           to={`/meeting-series/${seriesId}/retrospective`}
           className="rounded-lg border border-indigo-200 bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-indigo-700 dark:border-indigo-700"
@@ -93,7 +113,7 @@ const SeriesNavigation = ({ meeting }) => {
         </Link>
         <button
           type="button"
-          onClick={() => navigate(`/meeting/${prevMeeting._id}`)}
+          onClick={() => prevMeeting && navigate(`/meeting/${prevMeeting._id}`)}
           disabled={!prevMeeting}
           className="flex cursor-pointer items-center gap-1 rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-700 dark:bg-gray-800 dark:text-blue-300 dark:hover:bg-gray-700"
         >
@@ -114,7 +134,7 @@ const SeriesNavigation = ({ meeting }) => {
         </button>
         <button
           type="button"
-          onClick={() => navigate(`/meeting/${nextMeeting._id}`)}
+          onClick={() => nextMeeting && navigate(`/meeting/${nextMeeting._id}`)}
           disabled={!nextMeeting}
           className="flex cursor-pointer items-center gap-1 rounded-lg border border-blue-200 bg-white px-3 py-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-700 dark:bg-gray-800 dark:text-blue-300 dark:hover:bg-gray-700"
         >

--- a/client/src/components/meeting-details/__tests__/SeriesNavigation.test.jsx
+++ b/client/src/components/meeting-details/__tests__/SeriesNavigation.test.jsx
@@ -105,6 +105,56 @@ describe("SeriesNavigation Component (Issue #915)", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/meeting/meeting-106");
   });
 
+  it("hides cleanly when the meeting is not part of a series (#1994)", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <SeriesNavigation meeting={{ _id: "solo-meeting", title: "Ad-hoc" }} />
+      </MemoryRouter>,
+    );
+
+    expect(meetingSeriesApi.getSeriesById).not.toHaveBeenCalled();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("supports seriesId alias and occurrence list navigation (#1994)", async () => {
+    const mockSeriesId = "series-xyz";
+    meetingSeriesApi.getSeriesById.mockResolvedValueOnce({
+      data: {
+        success: true,
+        series: { _id: mockSeriesId, title: "Standup" },
+      },
+    });
+    meetingSeriesApi.getSeriesMeetings.mockResolvedValueOnce({
+      data: {
+        success: true,
+        meetings: [
+          { _id: "m1", seriesOccurrence: 1 },
+          { _id: "m2", seriesOccurrence: 2 },
+        ],
+        pagination: { total: 2 },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SeriesNavigation
+          meeting={{ _id: "m1", seriesId: mockSeriesId, seriesOccurrence: 1 }}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/jump to series occurrence/i),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/jump to series occurrence/i), {
+      target: { value: "m2" },
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/meeting/m2");
+  });
+
   it("links to series retrospective from a series meeting (Issue #2005)", async () => {
     const mockSeriesId = "series-abc";
     meetingSeriesApi.getSeriesById.mockResolvedValueOnce({

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -329,7 +329,9 @@ const MeetingDetails = () => {
             onShare={() => setShareModalOpen(true)}
             onPresent={() => setIsPresentModeOpen(true)}
           />
-          <SeriesNavigation meeting={meeting} />
+          {(meeting.series || meeting.seriesId) && (
+            <SeriesNavigation meeting={meeting} />
+          )}
 
           <div className="p-6 bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-sm mt-6 mb-6">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">

--- a/client/src/pages/__tests__/MeetingDetailsSeriesNavigation.test.jsx
+++ b/client/src/pages/__tests__/MeetingDetailsSeriesNavigation.test.jsx
@@ -1,0 +1,230 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MeetingDetails from "../MeetingDetails.jsx";
+import { meetingApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="app-navbar">App Navbar</div>,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useUser: () => ({
+    user: { id: "user_123", publicMetadata: { dbUserId: "db_123" } },
+  }),
+}));
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    getMeetingById: vi.fn(),
+    deleteMeeting: vi.fn(),
+    updateMeeting: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/briefingApi", () => ({
+  getBriefing: vi.fn().mockResolvedValue({ data: null }),
+}));
+
+const appContextValue = {
+  userData: { _id: "user-1", role: "member" },
+  backendUrl: "http://localhost:5000",
+};
+
+vi.mock("../../components/meeting-details/MeetingHeader", () => ({
+  default: ({ meeting }) => (
+    <div data-testid="meeting-header">{meeting.title}</div>
+  ),
+}));
+vi.mock("../../components/meeting-details/MeetingSummary", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingCollaborativeNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTranscript", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingParticipants", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingAgenda", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingMetadata", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingActions", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/TranscriptAnnotations", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/RsvpPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/KeyMomentsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/HighlightReel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SentimentTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingGoalsPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/shared-links/ShareModal", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingFollowUpBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PresentMode", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/PrepChecklist", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/SpeakingTimeBreakdown", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/CarryForwardConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/RoleRotationConfig", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/DuplicateDetectionPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/MeetingTimeline", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/summaries/RecapStoryViewer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/BriefingBanner", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/AgendaBuilder", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/GuestAccessManager", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PollSection", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FeedbackForm", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaTimer", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/HealthScoreCard", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MinutesApproval", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/PersonalNotes", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/FollowUpThreads", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/CommentSection", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/SpeakerAttribution", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meetings/MeetingRisksPanel", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/MeetingReadiness", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/AgendaPacingReport", () => ({
+  default: () => null,
+}));
+vi.mock("../../components/meeting-details/ClipManager", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meeting-details/SeriesNavigation", () => ({
+  default: ({ meeting }) => (
+    <div
+      data-testid="series-navigation"
+      data-meeting-id={meeting?._id}
+      data-series-id={
+        meeting?.series?._id || meeting?.series || meeting?.seriesId || ""
+      }
+    >
+      Series nav for {meeting?._id}
+    </div>
+  ),
+}));
+
+const renderDetails = (path = "/meeting/123") =>
+  render(
+    <AppContent.Provider value={appContextValue}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/meeting/:id" element={<MeetingDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </AppContent.Provider>,
+  );
+
+describe("Meeting Details SeriesNavigation mount (#1994)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mounts SeriesNavigation for series meetings", async () => {
+    meetingApi.getMeetingById.mockResolvedValue({
+      data: {
+        success: true,
+        meeting: {
+          _id: "123",
+          title: "Weekly Sync #2",
+          uploadedBy: "db_123",
+          participants: [],
+          series: "series-1",
+        },
+      },
+    });
+
+    renderDetails();
+
+    const nav = await screen.findByTestId("series-navigation");
+    expect(nav).toHaveTextContent("Series nav for 123");
+    expect(nav).toHaveAttribute("data-series-id", "series-1");
+  });
+
+  it("does not mount SeriesNavigation for non-series meetings", async () => {
+    meetingApi.getMeetingById.mockResolvedValue({
+      data: {
+        success: true,
+        meeting: {
+          _id: "456",
+          title: "One-off Meeting",
+          uploadedBy: "db_123",
+          participants: [],
+        },
+      },
+    });
+
+    renderDetails("/meeting/456");
+
+    expect(await screen.findByTestId("meeting-header")).toHaveTextContent(
+      "One-off Meeting",
+    );
+    expect(screen.queryByTestId("series-navigation")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Mount `SeriesNavigation` on Meeting Details only when a series is present
- Support `series` / `seriesId`, prev/next, and occurrence list links to `/meeting/:id`
- Hide cleanly for non-series meetings

## Test plan
- [x] SeriesNavigation unit tests
- [x] MeetingDetails mount/hide tests
- [ ] Open a series meeting → prev/next and occurrence select work
- [ ] Open a non-series meeting → no series nav chrome

Closes #1994