### PR TITLE
feat: wire NoteVersionHistory restore/diff for collab notes (#1995)

### DIFF
--- a/client/src/components/NoteVersionHistory.jsx
+++ b/client/src/components/NoteVersionHistory.jsx
@@ -111,7 +111,7 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
         `/api/note-versions/version/${selectedVersionId}/restore`,
       );
       if (res.data.success) {
-        toast.success("Version restored successfully");
+        toast.success(res.data.message || "Version restored successfully");
         setShowRestoreConfirm(false);
         if (onRestored) {
           onRestored(res.data.meeting);
@@ -119,7 +119,7 @@ const NoteVersionHistory = ({ meetingId, field, onClose, onRestored }) => {
         fetchHistory();
       }
     } catch (err) {
-      toast.error("Failed to restore version");
+      toast.error(err.response?.data?.message || "Failed to restore version");
       console.error(err);
     }
   };

--- a/client/src/components/meetings/CollaborativeEditor.jsx
+++ b/client/src/components/meetings/CollaborativeEditor.jsx
@@ -1,18 +1,24 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Collaboration from "@tiptap/extension-collaboration";
 import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
 import Placeholder from "@tiptap/extension-placeholder";
+import { History } from "lucide-react";
 import { useCollaborativeNote } from "../../hooks/useCollaborativeNote";
 import PresenceAvatars from "./PresenceAvatars";
 import VersionHistory from "./VersionHistory";
+import NoteVersionHistory from "../NoteVersionHistory";
 
 /**
- * @desc Main collaborative editor component integrating Tiptap with Yjs.
- * Handles real-time sync, cursor presence, and read-only modes.
+ * @desc Main collaborative editor pane (Tiptap + Yjs). Remount via `key` after
+ * a note-version restore so the CRDT reconnects to the restored document.
  */
-const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
+const CollaborativeEditorPane = ({
+  meetingId,
+  isReadOnly = false,
+  onOpenHistory,
+}) => {
   const {
     ydoc,
     isConnected,
@@ -77,14 +83,12 @@ const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
           "prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none focus:outline-none dark:prose-invert min-h-[400px] px-8 py-4",
       },
     },
-    onUpdate: ({ editor }) => {
-      // Broadcast cursor position on every update (typing)
-      const { from, to } = editor.state.selection;
+    onUpdate: ({ editor: ed }) => {
+      const { from, to } = ed.state.selection;
       broadcastCursor(from, to);
     },
-    onSelectionUpdate: ({ editor }) => {
-      // Broadcast cursor position on selection change (clicking/arrow keys)
-      const { from, to } = editor.state.selection;
+    onSelectionUpdate: ({ editor: ed }) => {
+      const { from, to } = ed.state.selection;
       broadcastCursor(from, to);
     },
   });
@@ -101,7 +105,11 @@ const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
     <div className="flex h-[calc(100vh-200px)] bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
       {/* Left Sidebar: Version History */}
       <div className="w-64 border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 flex-shrink-0 hidden md:block">
-        <VersionHistory meetingId={meetingId} onSaveSnapshot={saveSnapshot} />
+        <VersionHistory
+          meetingId={meetingId}
+          onSaveSnapshot={saveSnapshot}
+          onOpenFullHistory={onOpenHistory}
+        />
       </div>
 
       {/* Main Editor Area */}
@@ -121,7 +129,18 @@ const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
             </span>
           </div>
 
-          <PresenceAvatars users={activeUsers} />
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onOpenHistory}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-2.5 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+              data-testid="open-note-version-history"
+            >
+              <History className="w-3.5 h-3.5" />
+              Diff & Restore
+            </button>
+            <PresenceAvatars users={activeUsers} />
+          </div>
         </div>
 
         {/* Tiptap Editor Content */}
@@ -156,6 +175,39 @@ const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
         }
       `}</style>
     </div>
+  );
+};
+
+/**
+ * @desc Collaborative notes editor with NoteVersionHistory restore/diff dialog.
+ */
+const CollaborativeEditor = ({ meetingId, isReadOnly = false }) => {
+  const [showHistory, setShowHistory] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const handleRestored = useCallback(() => {
+    setShowHistory(false);
+    // Remount so the CRDT reconnects against the restored meeting state
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  return (
+    <>
+      <CollaborativeEditorPane
+        key={reloadKey}
+        meetingId={meetingId}
+        isReadOnly={isReadOnly}
+        onOpenHistory={() => setShowHistory(true)}
+      />
+      {showHistory && (
+        <NoteVersionHistory
+          meetingId={meetingId}
+          field="collaborativeNotes"
+          onClose={() => setShowHistory(false)}
+          onRestored={handleRestored}
+        />
+      )}
+    </>
   );
 };
 

--- a/client/src/components/meetings/VersionHistory.jsx
+++ b/client/src/components/meetings/VersionHistory.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { toast } from "react-toastify";
 import apiClient from "../../services/apiClient";
 
 /**
- * @desc Sidebar component displaying the version history (snapshots) of the meeting note.
- * Allows users to view past versions and manually trigger new snapshots.
+ * @desc Sidebar listing collaborative-notes snapshots from `/api/note-versions`.
+ * Full restore/diff UI lives in NoteVersionHistory (opened via onOpenFullHistory).
  */
-const VersionHistory = ({ meetingId, onSaveSnapshot }) => {
+const VersionHistory = ({ meetingId, onSaveSnapshot, onOpenFullHistory }) => {
   const [history, setHistory] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -13,10 +14,30 @@ const VersionHistory = ({ meetingId, onSaveSnapshot }) => {
   const fetchHistory = useCallback(async () => {
     try {
       setIsLoading(true);
-      const { data } = await apiClient.get(`/api/notes/${meetingId}/history`);
-      setHistory(data.data || []);
+      // Align with NoteVersionHistory / noteVersionRoutes (#1995)
+      const { data } = await apiClient.get(
+        `/api/note-versions/${meetingId}/collaborativeNotes/history`,
+      );
+      const versions = data.versions || data.data?.versions || [];
+      setHistory(
+        versions.map((s) => ({
+          _id: s._id,
+          version: s.version,
+          title:
+            s.changeSource === "user_edit"
+              ? "User Edit"
+              : s.changeSource === "ai_processing"
+                ? "AI Processing"
+                : "System Snapshot",
+          createdBy: s.changedBy,
+          createdAt: s.createdAt,
+        })),
+      );
     } catch (error) {
       console.error("Failed to fetch history:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to fetch version history",
+      );
     } finally {
       setIsLoading(false);
     }
@@ -36,10 +57,11 @@ const VersionHistory = ({ meetingId, onSaveSnapshot }) => {
       if (response.success) {
         await fetchHistory(); // Refresh list
       } else {
-        alert("Failed to save snapshot: " + response.error);
+        toast.error("Failed to save snapshot: " + (response.error || ""));
       }
     } catch (error) {
       console.error("Error saving snapshot:", error);
+      toast.error("Failed to save snapshot");
     } finally {
       setIsSaving(false);
     }
@@ -59,52 +81,66 @@ const VersionHistory = ({ meetingId, onSaveSnapshot }) => {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between gap-2">
         <h3 className="font-bold text-gray-900 dark:text-white text-sm uppercase tracking-wider">
           Version History
         </h3>
-        <button
-          onClick={handleSaveSnapshot}
-          disabled={isSaving}
-          className="p-1.5 text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors disabled:opacity-50"
-          title="Save current version"
-        >
-          {isSaving ? (
-            <svg
-              className="animate-spin w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
+        <div className="flex items-center gap-1">
+          {onOpenFullHistory && (
+            <button
+              type="button"
+              onClick={onOpenFullHistory}
+              className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-950/40 rounded-md"
+              title="Open restore and diff"
+              data-testid="sidebar-open-note-version-history"
             >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              ></circle>
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-              />
-            </svg>
+              Diff
+            </button>
           )}
-        </button>
+          <button
+            type="button"
+            onClick={handleSaveSnapshot}
+            disabled={isSaving}
+            className="p-1.5 text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors disabled:opacity-50"
+            title="Save current version"
+          >
+            {isSaving ? (
+              <svg
+                className="animate-spin w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            ) : (
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto custom-scrollbar p-2">
@@ -125,7 +161,9 @@ const VersionHistory = ({ meetingId, onSaveSnapshot }) => {
           <div className="space-y-2">
             {history.map((snapshot) => (
               <button
-                key={snapshot._id}
+                key={snapshot._id || snapshot.version}
+                type="button"
+                onClick={onOpenFullHistory}
                 className="w-full text-left p-3 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors group border border-transparent hover:border-gray-200 dark:hover:border-gray-600"
               >
                 <div className="flex items-center justify-between mb-1">

--- a/client/src/components/meetings/__tests__/CollaborativeEditorNoteVersionHistory.test.jsx
+++ b/client/src/components/meetings/__tests__/CollaborativeEditorNoteVersionHistory.test.jsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CollaborativeEditor from "../CollaborativeEditor.jsx";
+
+vi.mock("../../../hooks/useCollaborativeNote", () => ({
+  useCollaborativeNote: () => ({
+    ydoc: { getText: () => ({}) },
+    isConnected: true,
+    isLoading: false,
+    activeUsers: [],
+    userColor: "#3366ff",
+    broadcastCursor: vi.fn(),
+    saveSnapshot: vi.fn().mockResolvedValue({ success: true }),
+  }),
+}));
+
+vi.mock("@tiptap/react", () => ({
+  useEditor: () => ({
+    state: { selection: { from: 0, to: 0 } },
+  }),
+  EditorContent: () => <div data-testid="editor-content" />,
+}));
+
+vi.mock("@tiptap/starter-kit", () => ({
+  default: { configure: () => ({}) },
+}));
+vi.mock("@tiptap/extension-collaboration", () => ({
+  default: { configure: () => ({}) },
+}));
+vi.mock("@tiptap/extension-collaboration-cursor", () => ({
+  default: { configure: () => ({}) },
+}));
+vi.mock("@tiptap/extension-placeholder", () => ({
+  default: { configure: () => ({}) },
+}));
+
+vi.mock("../PresenceAvatars", () => ({
+  default: () => <div data-testid="presence" />,
+}));
+
+vi.mock("../VersionHistory", () => ({
+  default: ({ onOpenFullHistory }) => (
+    <button
+      type="button"
+      onClick={onOpenFullHistory}
+      data-testid="sidebar-diff"
+    >
+      Sidebar Diff
+    </button>
+  ),
+}));
+
+vi.mock("../../NoteVersionHistory", () => ({
+  default: ({ meetingId, field, onClose }) => (
+    <div
+      data-testid="note-version-history"
+      data-meeting-id={meetingId}
+      data-field={field}
+      role="dialog"
+    >
+      <button type="button" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+describe("CollaborativeEditor NoteVersionHistory wiring (#1995)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens NoteVersionHistory for collaborativeNotes from Diff & Restore", () => {
+    render(<CollaborativeEditor meetingId="meet-42" />);
+
+    expect(
+      screen.queryByTestId("note-version-history"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("open-note-version-history"));
+
+    const dialog = screen.getByTestId("note-version-history");
+    expect(dialog).toHaveAttribute("data-meeting-id", "meet-42");
+    expect(dialog).toHaveAttribute("data-field", "collaborativeNotes");
+  });
+
+  it("opens NoteVersionHistory from the sidebar Diff control", () => {
+    render(<CollaborativeEditor meetingId="meet-42" />);
+
+    fireEvent.click(screen.getByTestId("sidebar-diff"));
+    expect(screen.getByTestId("note-version-history")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Attach `NoteVersionHistory` to collaborative notes (Meeting Details / Meeting Room editor)
- Restore confirmation with success/error toasts; remount editor after restore
- Align sidebar history with `/api/note-versions` contract

## Test plan
- [x] CollaborativeEditor open-history tests
- [x] NoteVersionHistory a11y tests
- [ ] Open Diff & Restore from collab notes, view a diff
- [ ] Confirm restore updates notes and refreshes the editor
- [ ] Escape closes the dialog

Closes #1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to full note version history from the collaborative editor and sidebar.
  * Added controls for viewing differences between saved snapshots.
  * Improved version history loading, saving, and restoration feedback with clearer notifications and loading states.

* **Bug Fixes**
  * Restore errors now display the server-provided message when available, with a fallback message otherwise.

* **Tests**
  * Added coverage for opening note version history from the editor and Diff controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->