### PR TITLE
feat: add recycle bin bulk purge preview modal and typed confirmation (#2274)

### DIFF
--- a/client/src/components/PurgeRecycleBinModal.jsx
+++ b/client/src/components/PurgeRecycleBinModal.jsx
@@ -1,0 +1,297 @@
+import React, { useEffect, useState } from "react";
+import { AlertTriangle, X, Loader2, Info } from "lucide-react";
+import { meetingApi } from "../services/meetingApi.js";
+import { toast } from "react-toastify";
+
+const PurgeRecycleBinModal = ({ isOpen, onClose, onSuccess }) => {
+  const [loading, setLoading] = useState(true);
+  const [purging, setPurging] = useState(false);
+  const [preview, setPreview] = useState(null);
+  const [confirmInput, setConfirmInput] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchPreview();
+      setConfirmInput("");
+    }
+  }, [isOpen]);
+
+  const fetchPreview = async () => {
+    try {
+      setLoading(true);
+      const { data } = await meetingApi.getPurgePreview();
+      if (data.success) {
+        setPreview(data.data);
+      }
+    } catch (error) {
+      console.error("Error fetching purge preview:", error);
+      toast.error("Failed to fetch purge preview data.");
+      onClose();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePurge = async () => {
+    if (confirmInput !== "PURGE") return;
+    try {
+      setPurging(true);
+      const { data } = await meetingApi.purgeTrash();
+      if (data.success) {
+        toast.success(
+          `Successfully purged ${data.data?.deletedCount || 0} meetings from recycle bin.`,
+        );
+        if (onSuccess) onSuccess();
+        onClose();
+      }
+    } catch (error) {
+      console.error("Error purging recycle bin:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to purge recycle bin.",
+      );
+    } finally {
+      setPurging(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs animate-in fade-in duration-200"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="relative w-full max-w-lg bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-100 dark:border-gray-800 p-6 overflow-hidden max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b pb-4 mb-4 dark:border-gray-800">
+          <div className="flex items-center gap-3">
+            <div className="p-2.5 bg-red-100 dark:bg-red-950/40 text-red-600 dark:text-red-400 rounded-xl">
+              <AlertTriangle size={22} />
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white">
+                Purge Recycle Bin Preview
+              </h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Review data retention sweep impact and bulk purge preview
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={purging}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors p-1"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto space-y-5 pr-1 py-1">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-16 text-gray-500">
+              <Loader2 className="animate-spin w-8 h-8 text-blue-600 mb-2" />
+              <span className="text-sm font-medium">
+                Loading retention policy preview...
+              </span>
+            </div>
+          ) : (
+            <>
+              {/* Org Policy Header */}
+              <div className="p-3 bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/80 rounded-xl text-blue-800 dark:text-blue-300 text-xs flex gap-2">
+                <Info size={16} className="shrink-0 mt-0.5" />
+                <div>
+                  <span className="font-semibold block mb-0.5">
+                    Active Org Data Retention Policy
+                  </span>
+                  <span>
+                    Status: {preview?.policy?.enabled ? "Enabled" : "Disabled"}{" "}
+                    | Retention Period: {preview?.policy?.retentionPeriodDays}{" "}
+                    days | Grace Period: {preview?.policy?.gracePeriodDays} days
+                  </span>
+                </div>
+              </div>
+
+              {/* Data Retention Sweep Preview Section */}
+              <div className="space-y-2">
+                <span className="font-semibold text-xs text-gray-500 uppercase tracking-wider block">
+                  Upcoming Sweep Deletions (Grace Period Expiry)
+                </span>
+                <div className="p-4 bg-slate-50 dark:bg-slate-800/40 rounded-xl border border-slate-100 dark:border-slate-800">
+                  <div className="flex justify-between items-baseline mb-3">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      Total Expired Meetings to Hard Delete:
+                    </span>
+                    <span className="text-lg font-bold text-red-600 dark:text-red-400">
+                      {preview?.sweep?.totalCount || 0}
+                    </span>
+                  </div>
+
+                  {/* Types breakdown */}
+                  {preview?.sweep?.totalCount > 0 && (
+                    <div className="mb-4">
+                      <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 block mb-1.5">
+                        Breakdown by type:
+                      </span>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(preview?.sweep?.countsByType || {}).map(
+                          ([type, count]) => (
+                            <span
+                              key={type}
+                              className="px-2 py-0.5 rounded-lg text-xs bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-medium capitalize"
+                            >
+                              {type}: {count}
+                            </span>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Sample list */}
+                  {preview?.sweep?.samples?.length > 0 ? (
+                    <div>
+                      <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 block mb-1.5">
+                        Oldest expired meetings sample:
+                      </span>
+                      <ul className="space-y-1.5">
+                        {preview.sweep.samples.map((sample, idx) => (
+                          <li
+                            key={idx}
+                            className="text-xs text-gray-700 dark:text-gray-300 truncate list-disc list-inside"
+                          >
+                            <span className="font-semibold capitalize">
+                              [{sample.meetingType}]
+                            </span>{" "}
+                            {sample.title} (Created:{" "}
+                            {new Date(sample.createdAt).toLocaleDateString()})
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium block">
+                      No meetings are currently past the expiration threshold.
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Recycle Bin manual purge Section */}
+              <div className="space-y-2">
+                <span className="font-semibold text-xs text-gray-500 uppercase tracking-wider block">
+                  Manual Purge Preview (All Trash Items)
+                </span>
+                <div className="p-4 bg-slate-50 dark:bg-slate-800/40 rounded-xl border border-slate-100 dark:border-slate-800">
+                  <div className="flex justify-between items-baseline mb-3">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      Total Trash Meetings to Permanently Purge:
+                    </span>
+                    <span className="text-lg font-bold text-red-600 dark:text-red-400">
+                      {preview?.trash?.totalCount || 0}
+                    </span>
+                  </div>
+
+                  {/* Types breakdown */}
+                  {preview?.trash?.totalCount > 0 && (
+                    <div className="mb-4">
+                      <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 block mb-1.5">
+                        Breakdown by type:
+                      </span>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(preview?.trash?.countsByType || {}).map(
+                          ([type, count]) => (
+                            <span
+                              key={type}
+                              className="px-2 py-0.5 rounded-lg text-xs bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-medium capitalize"
+                            >
+                              {type}: {count}
+                            </span>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Sample list */}
+                  {preview?.trash?.samples?.length > 0 ? (
+                    <div>
+                      <span className="text-xs font-semibold text-gray-600 dark:text-gray-400 block mb-1.5">
+                        Trash meetings sample:
+                      </span>
+                      <ul className="space-y-1.5">
+                        {preview.trash.samples.map((sample, idx) => (
+                          <li
+                            key={idx}
+                            className="text-xs text-gray-700 dark:text-gray-300 truncate list-disc list-inside"
+                          >
+                            <span className="font-semibold capitalize">
+                              [{sample.meetingType}]
+                            </span>{" "}
+                            {sample.title} (Deleted:{" "}
+                            {new Date(sample.deletedAt).toLocaleDateString()})
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-gray-500 block font-medium">
+                      Recycle bin is currently empty.
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {/* Typed confirm verification field */}
+              <div className="pt-2 border-t dark:border-gray-800 space-y-2">
+                <label className="text-sm font-semibold text-gray-700 dark:text-gray-300 block">
+                  To confirm permanent purge, type{" "}
+                  <code className="text-red-600 dark:text-red-400 font-mono font-bold bg-red-50 dark:bg-red-950/30 px-1 py-0.5 rounded">
+                    PURGE
+                  </code>{" "}
+                  below:
+                </label>
+                <input
+                  type="text"
+                  value={confirmInput}
+                  onChange={(e) => setConfirmInput(e.target.value)}
+                  placeholder='Type "PURGE" to verify bulk delete'
+                  className="w-full px-3.5 py-2.5 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-red-500 font-medium text-sm transition-all"
+                  disabled={purging || preview?.trash?.totalCount === 0}
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div className="border-t pt-4 mt-4 dark:border-gray-800 flex items-center justify-end gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={purging}
+            className="px-4 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-slate-800 hover:bg-gray-200 dark:hover:bg-slate-700 rounded-xl transition-colors disabled:opacity-50 cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handlePurge}
+            disabled={
+              purging ||
+              confirmInput !== "PURGE" ||
+              preview?.trash?.totalCount === 0
+            }
+            className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-semibold text-white bg-red-600 hover:bg-red-700 disabled:bg-gray-300 dark:disabled:bg-gray-800 disabled:text-gray-500 rounded-xl transition-colors disabled:cursor-not-allowed cursor-pointer shadow-md shadow-red-500/10"
+          >
+            {purging && <Loader2 size={16} className="animate-spin" />}
+            <span>Purge Recycle Bin</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PurgeRecycleBinModal;

--- a/client/src/pages/MeetingRecycleBin.jsx
+++ b/client/src/pages/MeetingRecycleBin.jsx
@@ -6,6 +6,7 @@ import Navbar from "../components/Navbar.jsx";
 import ConfirmModal from "../components/ConfirmModal.jsx";
 import AppContent from "../context/AppContent.js";
 import { meetingApi } from "../services/meetingApi.js";
+import PurgeRecycleBinModal from "../components/PurgeRecycleBinModal.jsx";
 
 const MeetingRecycleBin = () => {
   const navigate = useNavigate();
@@ -19,6 +20,7 @@ const MeetingRecycleBin = () => {
   // Modal target state (#1341)
   const [restoreTarget, setRestoreTarget] = useState(null);
   const [purgeTarget, setPurgeTarget] = useState(null);
+  const [isPurgeModalOpen, setIsPurgeModalOpen] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
 
   const loadMeetings = useCallback(
@@ -94,26 +96,36 @@ const MeetingRecycleBin = () => {
               Deleted meetings can be restored before permanent removal.
             </p>
           </div>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              loadMeetings(1, search);
-            }}
-            className="flex gap-2"
-          >
-            <input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search deleted meetings"
-              className="rounded-lg border px-3 py-2 bg-white dark:bg-gray-900"
-            />
-            <button
-              className="rounded-lg bg-blue-600 px-4 py-2 text-white"
-              aria-label="Search"
+          <div className="flex flex-wrap items-center gap-3">
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                loadMeetings(1, search);
+              }}
+              className="flex gap-2"
             >
-              <Search size={18} />
-            </button>
-          </form>
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search deleted meetings"
+                className="rounded-lg border px-3 py-2 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800"
+              />
+              <button
+                className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+                aria-label="Search"
+              >
+                <Search size={18} />
+              </button>
+            </form>
+            {canPurge && meetings.length > 0 && (
+              <button
+                onClick={() => setIsPurgeModalOpen(true)}
+                className="inline-flex items-center gap-2 rounded-lg bg-red-600 hover:bg-red-700 px-4 py-2.5 text-white font-semibold text-sm cursor-pointer transition-colors shadow-sm"
+              >
+                <Trash2 size={16} /> Purge Recycle Bin
+              </button>
+            )}
+          </div>
         </div>
 
         {loading ? (
@@ -210,6 +222,12 @@ const MeetingRecycleBin = () => {
         confirmText="Delete Forever"
         variant="danger"
         isLoading={actionLoading}
+      />
+
+      <PurgeRecycleBinModal
+        isOpen={isPurgeModalOpen}
+        onClose={() => setIsPurgeModalOpen(false)}
+        onSuccess={() => loadMeetings(1)}
       />
     </div>
   );

--- a/client/src/pages/__tests__/MeetingRecycleBinPurge.test.jsx
+++ b/client/src/pages/__tests__/MeetingRecycleBinPurge.test.jsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MeetingRecycleBin from "../MeetingRecycleBin.jsx";
+import { meetingApi } from "../../services/meetingApi.js";
+import AppContent from "../../context/AppContent.js";
+import { BrowserRouter } from "react-router-dom";
+
+// Mock services/apis
+vi.mock("../../services/meetingApi.js", () => ({
+  meetingApi: {
+    getDeletedMeetings: vi.fn(),
+    getPurgePreview: vi.fn(),
+    purgeTrash: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const renderWithContext = (ui, { userRole = "admin" } = {}) => {
+  const contextValue = {
+    userData: { id: "user_1", role: userRole },
+  };
+
+  return render(
+    <BrowserRouter>
+      <AppContent.Provider value={contextValue}>{ui}</AppContent.Provider>
+    </BrowserRouter>,
+  );
+};
+
+describe("MeetingRecycleBin Bulk Purge and Preview Modal (#2274)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows purge button, displays preview counts/samples, requires typing PURGE to confirm", async () => {
+    // 1. Mock trash list response
+    meetingApi.getDeletedMeetings.mockResolvedValue({
+      data: {
+        success: true,
+        meetings: [
+          {
+            _id: "m1",
+            title: "Old Meeting in Trash",
+            deletedAt: new Date().toISOString(),
+            meetingType: "conference",
+          },
+        ],
+        pagination: { page: 1, totalPages: 1 },
+      },
+    });
+
+    // 2. Mock preview response
+    meetingApi.getPurgePreview.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          policy: {
+            enabled: true,
+            retentionPeriodDays: 30,
+            gracePeriodDays: 7,
+          },
+          trash: {
+            totalCount: 1,
+            countsByType: { conference: 1 },
+            samples: [
+              {
+                title: "Old Meeting in Trash",
+                meetingType: "conference",
+                deletedAt: new Date().toISOString(),
+              },
+            ],
+          },
+          sweep: {
+            totalCount: 2,
+            countsByType: { internal: 2 },
+            samples: [
+              {
+                title: "Ancient internal sync",
+                meetingType: "internal",
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    // 3. Mock purge action
+    meetingApi.purgeTrash.mockResolvedValue({
+      data: { success: true, deletedCount: 1 },
+    });
+
+    renderWithContext(<MeetingRecycleBin />);
+
+    // Wait for page to load and render the purge button
+    await waitFor(() => {
+      expect(screen.getByText("Purge Recycle Bin")).toBeInTheDocument();
+    });
+
+    // Open modal
+    fireEvent.click(screen.getByText("Purge Recycle Bin"));
+
+    // Verify modal is loading and then renders preview stats
+    await waitFor(() => {
+      expect(screen.getByText("Purge Recycle Bin Preview")).toBeInTheDocument();
+      expect(
+        screen.getByText("Total Trash Meetings to Permanently Purge:"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("conference: 1")).toBeInTheDocument();
+      expect(
+        screen.getByText("Total Expired Meetings to Hard Delete:"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("internal: 2")).toBeInTheDocument();
+    });
+
+    const purgeSubmitBtn = screen.getByRole("button", {
+      name: "Purge Recycle Bin",
+    });
+    expect(purgeSubmitBtn).toBeDisabled();
+
+    // Type incorrect value
+    const input = screen.getByPlaceholderText(
+      'Type "PURGE" to verify bulk delete',
+    );
+    fireEvent.change(input, { target: { value: "DELETE" } });
+    expect(purgeSubmitBtn).toBeDisabled();
+
+    // Type correct value
+    fireEvent.change(input, { target: { value: "PURGE" } });
+    expect(purgeSubmitBtn).toBeEnabled();
+
+    // Submit bulk purge
+    fireEvent.click(purgeSubmitBtn);
+
+    await waitFor(() => {
+      expect(meetingApi.purgeTrash).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -28,6 +28,10 @@ export const meetingApi = {
   permanentlyDeleteMeeting: (id) =>
     apiClient.delete(`/api/meetings/${id}/permanent`),
 
+  getPurgePreview: () => apiClient.get("/api/meetings/trash/purge-preview"),
+
+  purgeTrash: () => apiClient.delete("/api/meetings/trash/purge"),
+
   updateMeeting: (id, data) => apiClient.patch(`/api/meetings/${id}`, data),
 
   exportMeeting: (id, format) =>

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -748,3 +748,31 @@ export const getMeetingClip = async (req, res) => {
       .json({ success: false, message: "Server error fetching clip" });
   }
 };
+
+export const getPurgePreviewController = async (req, res, next) => {
+  try {
+    const preview = await MeetingService.getPurgePreview(req.user.organization);
+    return sendSuccess(res, preview);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const purgeTrashController = async (req, res, next) => {
+  try {
+    const actorId = getUserId(req);
+    const result = await MeetingService.purgeTrash(req.user.organization);
+
+    await AuditService.logAction({
+      actorId,
+      action: "RECYCLE_BIN_PURGED",
+      entity: "Meeting",
+      organizationId: req.user.organization,
+      details: { deletedCount: result.deletedCount },
+    });
+
+    return sendSuccess(res, result, "Recycle bin purged successfully");
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -27,6 +27,8 @@ import {
   getDeletedMeetings,
   restoreDeletedMeeting,
   permanentlyDeleteMeeting,
+  getPurgePreviewController,
+  purgeTrashController,
   searchMeetingsByText, // 🆕 NEW: Voice/Text Search
   archiveMeeting,
   restoreMeeting,
@@ -326,6 +328,23 @@ router.get(
   requireOrgMembership,
   requirePermission("meetings", "view"),
   getDeletedMeetings,
+);
+router.get(
+  "/trash/purge-preview",
+  userAuth,
+  requireAdminOrOwner,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getPurgePreviewController,
+);
+router.delete(
+  "/trash/purge",
+  userAuth,
+  writeLimiter,
+  requireAdminOrOwner,
+  requireOrgMembership,
+  requirePermission("meetings", "edit"),
+  purgeTrashController,
 );
 router.post(
   "/:id/restore-deleted",

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -31,6 +31,7 @@ import {
   escapeRegExp,
 } from "../utils/meetingSoftDelete.js";
 import { meetingSupportsServerAi } from "../utils/transcriptEncryption.js";
+import DataRetentionService from "./dataRetentionService.js";
 
 // AI / calendar / queue / transcription stacks are loaded on demand. Static
 // imports pull @xenova/transformers, axios diamonds, and related graphs into
@@ -908,4 +909,124 @@ export const notifyLiveMeetingParticipants = async (
   });
 
   return { count: dbUsers.length };
+};
+
+export const getPurgePreview = async (organizationId) => {
+  const policy = await DataRetentionService.getPolicy(organizationId);
+  const now = new Date();
+
+  const retentionPeriodDays = policy?.retentionPeriodDays || 365;
+  const gracePeriodDays = policy?.gracePeriodDays || 30;
+
+  const expirationDate = new Date(
+    now.getTime() -
+      (retentionPeriodDays + gracePeriodDays) * 24 * 60 * 60 * 1000,
+  );
+
+  const baseQuery = {
+    organization: organizationId,
+  };
+
+  if (policy?.exemptTags && policy.exemptTags.length > 0) {
+    baseQuery.tags = { $nin: policy.exemptTags };
+  }
+
+  // 1. All soft-deleted meetings in the trash
+  const trashQuery = {
+    organization: organizationId,
+    deletedAt: { $ne: null },
+  };
+
+  const totalTrashCount = await Meeting.countDocuments(trashQuery);
+
+  const trashTypes = await Meeting.aggregate([
+    { $match: trashQuery },
+    { $group: { _id: "$meetingType", count: { $sum: 1 } } },
+  ]);
+  const trashCountsByType = {};
+  trashTypes.forEach((t) => {
+    trashCountsByType[t._id || "conference"] = t.count;
+  });
+
+  const trashSamplesDocs = await Meeting.find(trashQuery)
+    .select("title meetingType deletedAt")
+    .sort({ deletedAt: -1 })
+    .limit(5);
+  const trashSamples = trashSamplesDocs.map((d) => ({
+    title: d.title,
+    meetingType: d.meetingType || "conference",
+    deletedAt: d.deletedAt,
+  }));
+
+  // 2. Upcoming retention deletions (hard delete)
+  const sweepQuery = {
+    ...baseQuery,
+    createdAt: { $lte: expirationDate },
+  };
+
+  const totalSweepCount = await Meeting.countDocuments(sweepQuery);
+
+  const sweepTypes = await Meeting.aggregate([
+    { $match: sweepQuery },
+    { $group: { _id: "$meetingType", count: { $sum: 1 } } },
+  ]);
+  const sweepCountsByType = {};
+  sweepTypes.forEach((t) => {
+    sweepCountsByType[t._id || "conference"] = t.count;
+  });
+
+  const sweepSamplesDocs = await Meeting.find(sweepQuery)
+    .select("title meetingType createdAt")
+    .sort({ createdAt: 1 })
+    .limit(5);
+  const sweepSamples = sweepSamplesDocs.map((d) => ({
+    title: d.title,
+    meetingType: d.meetingType || "conference",
+    createdAt: d.createdAt,
+  }));
+
+  return {
+    policy: {
+      enabled: policy?.enabled || false,
+      retentionPeriodDays,
+      gracePeriodDays,
+    },
+    trash: {
+      totalCount: totalTrashCount,
+      countsByType: trashCountsByType,
+      samples: trashSamples,
+    },
+    sweep: {
+      totalCount: totalSweepCount,
+      countsByType: sweepCountsByType,
+      samples: sweepSamples,
+    },
+  };
+};
+
+export const purgeTrash = async (organizationId) => {
+  const query = {
+    organization: organizationId,
+    deletedAt: { $ne: null },
+  };
+
+  const meetingsToPurge = await Meeting.find(query).select("_id");
+  const meetingIds = meetingsToPurge.map((m) => m._id);
+
+  const result = await Meeting.deleteMany(query);
+
+  if (meetingIds.length > 0) {
+    meetingIds.forEach((id) => {
+      try {
+        scheduleDeleteFromPinecone(id.toString());
+      } catch (err) {
+        console.error(
+          `Failed to delete pinecone index for meeting ${id}:`,
+          err,
+        );
+      }
+    });
+  }
+
+  return { deletedCount: result.deletedCount };
 };

--- a/server/tests/meetingPurgePreview.test.js
+++ b/server/tests/meetingPurgePreview.test.js
@@ -1,0 +1,137 @@
+import request from "supertest";
+import { app } from "../server.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
+import Organization from "../models/organizationModel.js";
+import DataRetentionPolicy from "../models/dataRetentionPolicyModel.js";
+import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
+
+let owner;
+let organization;
+let headers;
+
+beforeEach(async () => {
+  await Promise.all([
+    Meeting.deleteMany({}),
+    Organization.deleteMany({}),
+    User.deleteMany({ email: /purge-test/ }),
+    DataRetentionPolicy.deleteMany({}),
+  ]);
+
+  owner = await User.create({
+    name: "Purge Admin",
+    email: `purge-test-${Date.now()}@example.com`,
+    password: "Password123!",
+    role: "owner",
+    clerkUserId: `user_purge_${Date.now()}`,
+  });
+  organization = await Organization.create({
+    name: "Purge Test Org",
+    slug: `purge-test-org-${Date.now()}`,
+    owner: owner._id,
+  });
+  owner.organization = organization._id;
+  await owner.save();
+
+  headers = authHeader(
+    createClerkTestToken({
+      clerkUserId: owner.clerkUserId,
+      email: owner.email,
+    }),
+  );
+
+  // Set up Data Retention Policy
+  await DataRetentionPolicy.create({
+    organization: organization._id,
+    enabled: true,
+    retentionPeriodDays: 30,
+    gracePeriodDays: 7,
+  });
+});
+
+describe("Meeting Recycle Bin Purge and Preview (#2274)", () => {
+  it("returns purge preview with counts, types, and samples respecting retention policy", async () => {
+    // 1. Create an active meeting (not in trash)
+    await Meeting.create({
+      uploadedBy: owner._id,
+      organization: organization._id,
+      title: "Active Meeting",
+      meetingType: "conference",
+      date: new Date(),
+    });
+
+    // 2. Create a soft-deleted meeting (in trash)
+    await Meeting.create({
+      uploadedBy: owner._id,
+      organization: organization._id,
+      title: "Deleted Meeting",
+      meetingType: "policy",
+      date: new Date(),
+      deletedAt: new Date(),
+    });
+
+    // 3. Create an old meeting that is eligible for sweep/deletion
+    const oldDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000); // 40 days old (retention + grace = 37)
+    await Meeting.create({
+      uploadedBy: owner._id,
+      organization: organization._id,
+      title: "Old Expired Meeting",
+      meetingType: "internal",
+      date: oldDate,
+      createdAt: oldDate,
+    });
+
+    const res = await request(app)
+      .get("/api/meetings/trash/purge-preview")
+      .set(headers);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const { trash, sweep, policy } = res.body.data;
+    expect(policy.enabled).toBe(true);
+    expect(policy.retentionPeriodDays).toBe(30);
+
+    // Trash section checks
+    expect(trash.totalCount).toBe(1);
+    expect(trash.countsByType.policy).toBe(1);
+    expect(trash.samples[0].title).toBe("Deleted Meeting");
+
+    // Sweep section checks
+    expect(sweep.totalCount).toBe(1);
+    expect(sweep.countsByType.internal).toBe(1);
+    expect(sweep.samples[0].title).toBe("Old Expired Meeting");
+  });
+
+  it("purges all soft-deleted meetings in the trash on DELETE", async () => {
+    // 1. Create one active meeting
+    const active = await Meeting.create({
+      uploadedBy: owner._id,
+      organization: organization._id,
+      title: "Keep Me",
+      date: new Date(),
+    });
+
+    // 2. Create one soft-deleted meeting
+    const deleted = await Meeting.create({
+      uploadedBy: owner._id,
+      organization: organization._id,
+      title: "Purge Me",
+      date: new Date(),
+      deletedAt: new Date(),
+    });
+
+    const res = await request(app)
+      .delete("/api/meetings/trash/purge")
+      .set(headers);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.deletedCount).toBe(1);
+
+    // Check database state
+    expect(await Meeting.findById(deleted._id)).toBeNull();
+    expect(await Meeting.findById(active._id)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR implements bulk purging for the meeting recycle bin, introducing a detailed preview modal that outlines the impact of manual purging and automated data retention sweeps. To prevent accidental permanent deletion of data, administrators must verify the operation by typing a confirmation phrase (`PURGE`).

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2274

---

## ✨ Changes Made
- **Database & Backend**:
  - Implemented `getPurgePreview` in `MeetingService` grouping trash and sweep items by `meetingType` and including oldest sample titles.
  - Implemented `purgeTrash` performing bulk database deletions of soft-deleted meeting documents.
  - Exposed routes `GET /api/meetings/trash/purge-preview` and `DELETE /api/meetings/trash/purge`.
  - Created `meetingPurgePreview.test.js` checking preview and bulk purge endpoint controllers.
- **Client & Views**:
  - Added `getPurgePreview` and `purgeTrash` client requests in `meetingApi.js`.
  - Created `PurgeRecycleBinModal.jsx` displaying upcoming sweep items, trash counts, type breakdowns, sample titles, and typed confirmation verification box.
  - Added "Purge Recycle Bin" action button in `MeetingRecycleBin.jsx` header.
  - Created `MeetingRecycleBinPurge.test.jsx` checking UI interaction and modal flows.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend tests
cd server && npm run test tests/meetingPurgePreview.test.js

# Client tests
cd .. && npm run test client/src/pages/__tests__/MeetingRecycleBinPurge.test.jsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recycle-bin purge option for administrators and owners.
  * Added a preview showing retention details, meeting counts, type breakdowns, and sample items.
  * Permanent deletion requires typing `PURGE` for confirmation.
  * Added success and error notifications, loading states, cancellation, and automatic list refresh after purging.

* **Bug Fixes**
  * Improved recycle-bin controls with dark-mode styling.

* **Tests**
  * Added coverage for purge previews, confirmation behavior, deletion results, and retention-based cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->