### PR TITLE
fix(notifications): enforce email notification preference toggles end-to-end (Closes #2021)

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -704,7 +704,8 @@ const Settings = () => {
                         Email Notifications
                       </p>
                       <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                        Receive notifications via email
+                        Receive meeting reminders, digests, and action item
+                        emails
                       </p>
                     </div>
                     <button

--- a/server/models/notificationPreferenceModel.js
+++ b/server/models/notificationPreferenceModel.js
@@ -32,9 +32,7 @@ const notificationPreferenceSchema = new mongoose.Schema(
     },
 
     // ── Email channel ────────────────────────────────────────────────────
-    // NOT YET ENFORCED. The email paths (MeetingDigestService,
-    // recapEmailService) do not consult these. Tracked as follow-up work;
-    // documented rather than silently ignored.
+    // Enforced across email delivery paths (MeetingDigestService, recapEmailService, reminderScheduler).
     emailMeetingReminders: {
       type: Boolean,
       default: true,

--- a/server/services/MeetingDigestService.js
+++ b/server/services/MeetingDigestService.js
@@ -1,5 +1,6 @@
 import Meeting from "../models/meetingModel.js";
 import User from "../models/userModel.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
 import EmailService from "./EmailService.js";
 import { checkQuietHours } from "../utils/quietHours.js";
 
@@ -104,17 +105,33 @@ class MeetingDigestService {
         };
       }
 
-      // Get user opt-out status for these emails
+      // Get user opt-out status for these emails (#2021)
       const emails = participantsWithEmail.map((p) => p.email);
       const users = await User.find(
         { email: { $in: emails } },
-        "email emailDigestEnabled",
+        "_id email emailDigestEnabled",
       );
 
-      // Map email to emailDigestEnabled status
+      const userIds = users.map((u) => u._id);
+      const notifPrefs = await NotificationPreference.find({
+        user: { $in: userIds },
+      }).lean();
+
+      const prefMap = {};
+      notifPrefs.forEach((p) => {
+        prefMap[String(p.user)] = p;
+      });
+
+      // Map email to opted-in status
       const userPrefs = {};
       users.forEach((u) => {
-        userPrefs[u.email] = u.emailDigestEnabled !== false; // defaults to true
+        const prefDoc = prefMap[String(u._id)];
+        const emailAllowed =
+          u.emailDigestEnabled !== false &&
+          (!prefDoc ||
+            (prefDoc.emailMeetingReminders !== false &&
+              prefDoc.emailWeeklyDigest !== false));
+        userPrefs[u.email] = emailAllowed;
       });
 
       // Filter recipients based on preferences (if user exists, respect preference; if user doesn't exist, send by default)

--- a/server/services/recapEmailService.js
+++ b/server/services/recapEmailService.js
@@ -164,6 +164,13 @@ class RecapEmailService {
 
           if (preferences.deliveryTiming !== "immediate") continue;
 
+          if (await this.isEmailUnsubscribed(user._id, "daily")) {
+            console.log(
+              `[RecapEmailService] Skipping immediate recap for ${user.email} due to email preference opt-out.`,
+            );
+            continue;
+          }
+
           if (this.isQuietHours(preferences)) {
             console.log(
               `[RecapEmailService] Deferring immediate recap for ${user.email} due to quiet hours.`,

--- a/server/services/reminderScheduler.js
+++ b/server/services/reminderScheduler.js
@@ -1,6 +1,7 @@
 import cron from "node-cron";
 import ActionItem from "../models/actionItemModel.js";
 import Meeting from "../models/meetingModel.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
 import EmailService from "./EmailService.js";
 import { createNotification } from "./notificationService.js";
 import { checkQuietHours } from "../utils/quietHours.js";
@@ -207,18 +208,27 @@ class ReminderScheduler {
           },
         });
 
-        await EmailService.sendMail({
-          from: process.env.SENDER_EMAIL || "no-reply@meetonmemory.com",
-          to: recipient.email,
-          subject,
-          html: `
-            <div style="font-family: sans-serif; padding: 20px; color: #333;">
-              <p>Hi ${recipient.name || "there"},</p>
-              <p>Your meeting <strong>${meetingTitle}</strong> starts in ${reminderMinutes} minutes.</p>
-              <p><strong>When:</strong> ${meetingDateTime.toLocaleString()}</p>
-            </div>
-          `,
-        });
+        // Respect emailMeetingReminders preference (#2021)
+        const notifPref = await NotificationPreference.findOne({
+          user: recipient.userId,
+        })
+          .select("emailMeetingReminders")
+          .lean();
+
+        if (!notifPref || notifPref.emailMeetingReminders !== false) {
+          await EmailService.sendMail({
+            from: process.env.SENDER_EMAIL || "no-reply@meetonmemory.com",
+            to: recipient.email,
+            subject,
+            html: `
+              <div style="font-family: sans-serif; padding: 20px; color: #333;">
+                <p>Hi ${recipient.name || "there"},</p>
+                <p>Your meeting <strong>${meetingTitle}</strong> starts in ${reminderMinutes} minutes.</p>
+                <p><strong>When:</strong> ${meetingDateTime.toLocaleString()}</p>
+              </div>
+            `,
+          });
+        }
       } catch (error) {
         console.error(
           `[ReminderScheduler] Failed to notify ${recipient.email}:`,
@@ -340,18 +350,27 @@ class ReminderScheduler {
       title: subjectMap[type],
     });
 
-    await EmailService.sendMail({
-      from: process.env.SENDER_EMAIL || "no-reply@meetonmemory.com",
-      to: item.assignee.email,
-      subject: subjectMap[type],
-      html: `
-        <div style="font-family: sans-serif; padding: 20px; color: #333;">
-          <p>Hi ${item.assignee.name || "there"},</p>
-          <p>${subjectMap[type]}</p>
-          <p>Task: <strong>${taskTitle}</strong></p>
-        </div>
-      `,
-    });
+    // Respect emailTaskAssignments preference (#2021)
+    const notifPref = await NotificationPreference.findOne({
+      user: item.assignee._id,
+    })
+      .select("emailTaskAssignments")
+      .lean();
+
+    if (!notifPref || notifPref.emailTaskAssignments !== false) {
+      await EmailService.sendMail({
+        from: process.env.SENDER_EMAIL || "no-reply@meetonmemory.com",
+        to: item.assignee.email,
+        subject: subjectMap[type],
+        html: `
+          <div style="font-family: sans-serif; padding: 20px; color: #333;">
+            <p>Hi ${item.assignee.name || "there"},</p>
+            <p>${subjectMap[type]}</p>
+            <p>Task: <strong>${taskTitle}</strong></p>
+          </div>
+        `,
+      });
+    }
 
     await ActionItem.updateOne(
       { _id: item._id },

--- a/server/tests/emailNotificationPreferencesEnforcement.test.js
+++ b/server/tests/emailNotificationPreferencesEnforcement.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/EmailService.js", () => ({
+  default: {
+    sendMail: vi.fn().mockResolvedValue({ messageId: "msg-123" }),
+  },
+}));
+
+vi.mock("node-cron", () => ({
+  default: { schedule: vi.fn() },
+}));
+
+vi.mock("date-fns-tz", () => ({
+  formatInTimeZone: vi.fn().mockReturnValue("2026-08-24T12:00:00Z"),
+}));
+
+vi.mock("../utils/quietHours.js", () => ({
+  checkQuietHours: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../models/meetingModel.js", () => ({
+  default: {
+    findById: vi.fn(),
+    find: vi.fn(),
+    updateOne: vi.fn(),
+  },
+}));
+
+vi.mock("../models/userModel.js", () => ({
+  default: {
+    find: vi.fn(),
+    findById: vi.fn(),
+    findOne: vi.fn(),
+  },
+}));
+
+vi.mock("../models/notificationPreferenceModel.js", () => ({
+  default: {
+    findOne: vi.fn(),
+    find: vi.fn(),
+  },
+}));
+
+vi.mock("../models/actionItemModel.js", () => ({
+  default: {
+    find: vi.fn(),
+    updateOne: vi.fn(),
+  },
+}));
+
+vi.mock("../services/notificationService.js", () => ({
+  createNotification: vi.fn().mockResolvedValue({ _id: "notif-1" }),
+}));
+
+import MeetingDigestService from "../services/MeetingDigestService.js";
+import RecapEmailService from "../services/recapEmailService.js";
+import ReminderScheduler from "../services/reminderScheduler.js";
+import EmailService from "../services/EmailService.js";
+import Meeting from "../models/meetingModel.js";
+import User from "../models/userModel.js";
+import NotificationPreference from "../models/notificationPreferenceModel.js";
+
+describe("Email Notification Preferences Enforcement (#2021)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips MeetingDigestService email when user opted out of email digests", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: "m-1",
+      title: "Sync Meeting",
+      date: new Date(),
+      participants: [{ email: "user1@example.com" }],
+    });
+
+    User.find.mockResolvedValue([
+      { _id: "u-1", email: "user1@example.com", emailDigestEnabled: true },
+    ]);
+
+    NotificationPreference.find.mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue([
+          {
+            user: "u-1",
+            emailWeeklyDigest: false,
+            emailMeetingReminders: true,
+          },
+        ]),
+    });
+
+    const result = await MeetingDigestService.sendMeetingDigest("m-1");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("opted out");
+    expect(EmailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends MeetingDigestService email when user enabled email digests", async () => {
+    Meeting.findById.mockResolvedValue({
+      _id: "m-1",
+      title: "Sync Meeting",
+      date: new Date(),
+      participants: [{ email: "user1@example.com" }],
+    });
+
+    User.find.mockResolvedValue([
+      { _id: "u-1", email: "user1@example.com", emailDigestEnabled: true },
+    ]);
+
+    User.findOne.mockResolvedValue(null);
+
+    NotificationPreference.find.mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue([
+          { user: "u-1", emailWeeklyDigest: true, emailMeetingReminders: true },
+        ]),
+    });
+
+    const result = await MeetingDigestService.sendMeetingDigest("m-1");
+
+    expect(result.success).toBe(true);
+    expect(EmailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "user1@example.com" }),
+    );
+  });
+
+  it("skips immediate recap email when user opted out via isEmailUnsubscribed", async () => {
+    NotificationPreference.findOne.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue({ emailMeetingReminders: false }),
+    });
+
+    const isUnsubscribed = await RecapEmailService.isEmailUnsubscribed(
+      "u-1",
+      "daily",
+    );
+    expect(isUnsubscribed).toBe(true);
+  });
+
+  it("skips meeting reminder email when emailMeetingReminders is false", async () => {
+    const meeting = {
+      _id: "m-2",
+      title: "Standup",
+      uploadedBy: { _id: "u-2", name: "Alice", email: "alice@example.com" },
+      participants: [],
+    };
+
+    NotificationPreference.findOne.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue({ emailMeetingReminders: false }),
+    });
+
+    await ReminderScheduler.sendMeetingReminder(meeting, 10, new Date());
+
+    expect(EmailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("skips action item email when emailTaskAssignments is false", async () => {
+    const item = {
+      _id: "ai-1",
+      title: "Fix Bug",
+      assignee: { _id: "u-3", name: "Bob", email: "bob@example.com" },
+    };
+
+    NotificationPreference.findOne.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue({ emailTaskAssignments: false }),
+    });
+
+    await ReminderScheduler.sendReminder(item, "due_today");
+
+    expect(EmailService.sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/server/tests/emailNotificationPreferencesEnforcement.test.js
+++ b/server/tests/emailNotificationPreferencesEnforcement.test.js
@@ -78,15 +78,13 @@ describe("Email Notification Preferences Enforcement (#2021)", () => {
     ]);
 
     NotificationPreference.find.mockReturnValue({
-      lean: vi
-        .fn()
-        .mockResolvedValue([
-          {
-            user: "u-1",
-            emailWeeklyDigest: false,
-            emailMeetingReminders: true,
-          },
-        ]),
+      lean: vi.fn().mockResolvedValue([
+        {
+          user: "u-1",
+          emailWeeklyDigest: false,
+          emailMeetingReminders: true,
+        },
+      ]),
     });
 
     const result = await MeetingDigestService.sendMeetingDigest("m-1");


### PR DESCRIPTION
### Summary
Enforced user email notification preferences (`emailMeetingReminders`, `emailTaskAssignments`, `emailWeeklyDigest`) end-to-end across all email dispatch paths (`MeetingDigestService`, `recapEmailService`, `reminderScheduler`), ensuring user email opt-outs are strictly respected while maintaining independent in-app notification functionality.

Closes #2021

### Key Changes
1. **Meeting Digest Gating**: Updated [`MeetingDigestService.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/server/services/MeetingDigestService.js) (`sendMeetingDigest`) to look up `NotificationPreference` for recipient users and suppress digests if `emailWeeklyDigest` or `emailMeetingReminders` is set to `false`.
2. **Immediate Recap Gating**: Updated [`recapEmailService.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/server/services/recapEmailService.js) (`sendImmediateRecap`) to invoke `isEmailUnsubscribed` before building/sending emails.
3. **Reminder Scheduler Gating**: Updated [`reminderScheduler.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/server/services/reminderScheduler.js) to gate meeting reminder emails on `emailMeetingReminders !== false` and action item emails on `emailTaskAssignments !== false`. In-app notifications continue to deliver independently.
4. **Schema Documentation**: Updated [`notificationPreferenceModel.js`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/server/models/notificationPreferenceModel.js) to remove legacy "NOT YET ENFORCED" comments and record active enforcement.
5. **Settings UI Helper Text**: Updated helper text in [`Settings.jsx`](file:///c:/Users/GI/Desktop/ECSoC/MeetOnMemory-ECSoC/client/src/pages/Settings.jsx) to reflect that email preferences actively control meeting reminders, digests, and action item emails.
6. **Automated Unit Testing**:
   - Created server unit tests `emailNotificationPreferencesEnforcement.test.js` (5 tests covering all sender paths).

### Verification
- ✅ Server Unit Tests (`emailNotificationPreferencesEnforcement`) passed cleanly in Vitest (5/5 tests passed).
- ✅ `npm run validate:pr --prefix client` passed cleanly (ESLint 0 errors, Prettier formatting clean, Vite production bundle build succeeded).
- ✅ Pushed to `origin/fix/2021-enforce-email-notification-preferences`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email notification preferences now apply to meeting digests, recaps, meeting reminders, and action-item reminders.
  * Users who opt out of specific email types will no longer receive those messages; missing preferences remain enabled by default.
  * Updated settings text clarifies which email notifications are controlled.

* **Tests**
  * Added coverage verifying notification preferences are respected across supported email types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->