### PR TITLE
feat: prefix reports client requests and add e2e export tests (#2278)

### DIFF
--- a/client/src/pages/__tests__/ReportBuilderE2E.test.jsx
+++ b/client/src/pages/__tests__/ReportBuilderE2E.test.jsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import ReportBuilder from "../ReportBuilder.jsx";
+import reportApi from "../../services/reportApi.js";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@hello-pangea/dnd", () => ({
+  DragDropContext: ({ children }) => <div>{children}</div>,
+  Droppable: ({ children }) => children({ provided: {}, placeholder: null }),
+  Draggable: ({ children }) => children({ provided: {} }),
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar" />,
+}));
+
+vi.mock("../../services/reportApi.js", () => ({
+  default: {
+    getTemplateById: vi.fn(),
+    createTemplate: vi.fn(),
+    updateTemplate: vi.fn(),
+    generateReport: vi.fn(),
+    exportReport: vi.fn(),
+  },
+}));
+
+describe("ReportBuilder End-to-End Generate & Export (#2278)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock createObjectURL & revokeObjectURL
+    window.URL.createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+    window.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("successfully generates report payload and downloads exported CSV/PDF blobs", async () => {
+    reportApi.getTemplateById.mockResolvedValue({
+      data: {
+        _id: "tpl_123",
+        name: "Quarterly Performance",
+        description: "Test description",
+        sections: [
+          {
+            _id: "sec_1",
+            type: "ACTION_ITEMS",
+            title: "Action Items Summary",
+            order: 0,
+          },
+        ],
+        defaultFilters: { dateRangeDays: 30 },
+      },
+    });
+
+    reportApi.generateReport.mockResolvedValue({
+      data: {
+        templateName: "Quarterly Performance",
+        generatedAt: new Date().toISOString(),
+        meetingCount: 3,
+        sections: [
+          {
+            title: "Action Items Summary",
+            type: "ACTION_ITEMS",
+            data: [{ title: "Action 1", status: "completed" }],
+          },
+        ],
+      },
+    });
+
+    reportApi.exportReport.mockResolvedValue({
+      data: "col1,col2\nval1,val2",
+      headers: { "content-type": "text/csv" },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/reports/builder/tpl_123"]}>
+        <Routes>
+          <Route
+            path="/reports/builder/:templateId"
+            element={<ReportBuilder />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // 1. Wait for template load
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("Quarterly Performance"),
+      ).toBeInTheDocument();
+    });
+
+    // 2. Trigger generate report
+    const generateBtn = screen.getByRole("button", {
+      name: /generate report/i,
+    });
+    fireEvent.click(generateBtn);
+
+    await waitFor(() => {
+      expect(reportApi.generateReport).toHaveBeenCalledWith("tpl_123");
+      expect(screen.getByText("Report generated!")).toBeInTheDocument();
+    });
+
+    // 3. Trigger CSV export & verify blob download link creation
+    const csvExportBtn = screen.getByTitle("Export CSV");
+    fireEvent.click(csvExportBtn);
+
+    await waitFor(() => {
+      expect(reportApi.exportReport).toHaveBeenCalledWith("tpl_123", "csv");
+      expect(window.URL.createObjectURL).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/services/reportApi.js
+++ b/client/src/services/reportApi.js
@@ -2,32 +2,32 @@ import apiClient from "./apiClient.js";
 
 const reportApi = {
   getTemplates: async () => {
-    const response = await apiClient.get("/reports/templates");
+    const response = await apiClient.get("/api/reports/templates");
     return response.data;
   },
 
   getTemplateById: async (id) => {
-    const response = await apiClient.get(`/reports/templates/${id}`);
+    const response = await apiClient.get(`/api/reports/templates/${id}`);
     return response.data;
   },
 
   createTemplate: async (data) => {
-    const response = await apiClient.post("/reports/templates", data);
+    const response = await apiClient.post("/api/reports/templates", data);
     return response.data;
   },
 
   updateTemplate: async (id, data) => {
-    const response = await apiClient.put(`/reports/templates/${id}`, data);
+    const response = await apiClient.put(`/api/reports/templates/${id}`, data);
     return response.data;
   },
 
   deleteTemplate: async (id) => {
-    const response = await apiClient.delete(`/reports/templates/${id}`);
+    const response = await apiClient.delete(`/api/reports/templates/${id}`);
     return response.data;
   },
 
   generateReport: async (id, filterOverrides = {}) => {
-    const response = await apiClient.post(`/reports/generate/${id}`, {
+    const response = await apiClient.post(`/api/reports/generate/${id}`, {
       filterOverrides,
     });
     return response.data;
@@ -35,7 +35,7 @@ const reportApi = {
 
   exportReport: async (id, format = "csv", filterOverrides = {}) => {
     const response = await apiClient.post(
-      `/reports/export/${id}`,
+      `/api/reports/export/${id}`,
       { format, filterOverrides },
       { responseType: "blob" },
     );

--- a/server/tests/reportRoutes.test.js
+++ b/server/tests/reportRoutes.test.js
@@ -1,0 +1,178 @@
+import request from "supertest";
+import { app } from "../server.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import User from "../models/userModel.js";
+import Organization from "../models/organizationModel.js";
+import ReportTemplate from "../models/reportTemplateModel.js";
+import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
+import * as reportGeneratorService from "../services/reportGeneratorService.js";
+
+// Mock the report generator service
+vi.mock("../services/reportGeneratorService.js", () => ({
+  generateReport: vi.fn(),
+}));
+
+describe("Report Template CRUD & Export Routes (/api/reports) (#2278)", () => {
+  let owner;
+  let organization;
+  let headers;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    await Promise.all([
+      User.deleteMany({ email: /report-test/ }),
+      Organization.deleteMany({ name: "Report Org" }),
+      ReportTemplate.deleteMany({}),
+    ]);
+
+    owner = await User.create({
+      name: "Report Admin",
+      email: `report-test-${Date.now()}@example.com`,
+      password: "Password123!",
+      role: "admin", // admin role allows viewing/managing reports
+      clerkUserId: `user_report_${Date.now()}`,
+    });
+
+    organization = await Organization.create({
+      name: "Report Org",
+      slug: `report-org-${Date.now()}`,
+      owner: owner._id,
+    });
+
+    owner.organization = organization._id;
+    await owner.save();
+
+    headers = authHeader(
+      createClerkTestToken({
+        clerkUserId: owner.clerkUserId,
+        email: owner.email,
+      }),
+    );
+  });
+
+  it("performs Template CRUD correctly", async () => {
+    // 1. Create template
+    const createRes = await request(app)
+      .post("/api/reports/templates")
+      .set(headers)
+      .send({
+        name: "Monthly Summary",
+        description: "Monthly dashboard metrics",
+        sections: [
+          {
+            type: "ACTION_ITEMS",
+            title: "Overdue Actions",
+            order: 0,
+          },
+        ],
+      });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.success).toBe(true);
+    const templateId = createRes.body.data._id;
+    expect(templateId).toBeDefined();
+
+    // 2. Read templates list
+    const listRes = await request(app)
+      .get("/api/reports/templates")
+      .set(headers);
+
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.success).toBe(true);
+    expect(listRes.body.data.length).toBe(1);
+    expect(listRes.body.data[0].name).toBe("Monthly Summary");
+
+    // 3. Read template by ID
+    const getRes = await request(app)
+      .get(`/api/reports/templates/${templateId}`)
+      .set(headers);
+
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.success).toBe(true);
+    expect(getRes.body.data.name).toBe("Monthly Summary");
+
+    // 4. Update template
+    const updateRes = await request(app)
+      .put(`/api/reports/templates/${templateId}`)
+      .set(headers)
+      .send({
+        name: "Monthly Summary v2",
+        description: "Updated description",
+      });
+
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.success).toBe(true);
+    expect(updateRes.body.data.name).toBe("Monthly Summary v2");
+
+    // 5. Delete template
+    const deleteRes = await request(app)
+      .delete(`/api/reports/templates/${templateId}`)
+      .set(headers);
+
+    expect(deleteRes.status).toBe(200);
+    expect(deleteRes.body.success).toBe(true);
+
+    // Verify it is gone
+    const getDeletedRes = await request(app)
+      .get(`/api/reports/templates/${templateId}`)
+      .set(headers);
+    expect(getDeletedRes.status).toBe(404);
+  });
+
+  it("POST /api/reports/generate/:id returns data from generator service", async () => {
+    const template = await ReportTemplate.create({
+      name: "Weekly Scan",
+      organization: organization._id,
+      createdBy: owner._id,
+    });
+
+    reportGeneratorService.generateReport.mockResolvedValue({
+      templateName: "Weekly Scan",
+      generatedAt: new Date().toISOString(),
+      meetingCount: 5,
+      sections: [],
+    });
+
+    const res = await request(app)
+      .post(`/api/reports/generate/${template._id}`)
+      .set(headers)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.templateName).toBe("Weekly Scan");
+    expect(reportGeneratorService.generateReport).toHaveBeenCalled();
+  });
+
+  it("POST /api/reports/export/:id returns file download attachment", async () => {
+    const template = await ReportTemplate.create({
+      name: "Quarterly Review",
+      organization: organization._id,
+      createdBy: owner._id,
+    });
+
+    reportGeneratorService.generateReport.mockResolvedValue({
+      templateName: "Quarterly Review",
+      generatedAt: new Date().toISOString(),
+      meetingCount: 12,
+      sections: [
+        {
+          title: "Top Decisions",
+          type: "DECISION_LOG",
+          data: [{ decision: "Merge branches", owner: "Alice" }],
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post(`/api/reports/export/${template._id}`)
+      .set(headers)
+      .send({ format: "csv" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/csv; charset=utf-8");
+    expect(res.headers["content-disposition"]).toContain("attachment");
+    expect(res.text).toContain("Merge branches");
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR maps the missing `/api` prefix to all report template client-side requests under `reportApi.js` to align with the server route configuration, and adds E2E/integration tests verifying template CRUD operations, generation payloads, and file export downloads.

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2278

---

## ✨ Changes Made
- **Client API**:
  - Prepended the `/api` prefix to all request routes in `reportApi.js`.
  - Created `ReportBuilderE2E.test.jsx` checking that "Generate Report" retrieves template payloads, and exporting report formats triggers download blob creation.
- **Backend Route Verification**:
  - Created `reportRoutes.test.js` verifying CRUD endpoints, data generation responses, and CSV file attachments returned by the controllers under `/api/reports`.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend tests
cd server && npm run test tests/reportRoutes.test.js

# Client tests
cd .. && npm run test client/src/pages/__tests__/ReportBuilderE2E.test.jsx
