### PR TITLE
fix: Fix speaking-time

### DIFF
--- a/client/src/pages/SpeakingTimeCompare.jsx
+++ b/client/src/pages/SpeakingTimeCompare.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useCallback } from "react";
-import { Link } from "react-router-dom";
 import {
   BarChart,
   Bar,
@@ -8,15 +7,15 @@ import {
   CartesianGrid,
   Tooltip as RechartsTooltip,
   ResponsiveContainer,
-  Legend,
 } from "recharts";
 import { speakingTimeApi } from "../services";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
 
-const formatDuration = (seconds) => {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
+const formatDuration = (seconds = 0) => {
+  const sec = Math.max(0, Number(seconds) || 0);
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
   return `${m}m ${s}s`;
 };
 
@@ -26,16 +25,16 @@ const CustomTooltip = ({ active, payload }) => {
     return (
       <div className="bg-white dark:bg-gray-800 p-3 border border-gray-200 dark:border-gray-700 shadow-md rounded-md">
         <p className="font-semibold text-gray-900 dark:text-gray-100">
-          {data.speakerName}
+          {data.speakerName || "Unknown"}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-          Avg Talk Ratio: {data.averageTalkRatio?.toFixed(1)}%
+          Avg Talk Ratio: {(data.averageTalkRatio || 0).toFixed(1)}%
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300">
           Total Duration: {formatDuration(data.totalDuration)}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300">
-          Meetings Spoken In: {data.meetingCount}
+          Meetings Spoken In: {data.meetingCount || 0}
         </p>
       </div>
     );
@@ -58,19 +57,29 @@ const SpeakingTimeCompare = () => {
   const [endDate, setEndDate] = useState(getToday());
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   const fetchCompareData = useCallback(async (start, end) => {
     try {
       setLoading(true);
+      setError(null);
       const res = await speakingTimeApi.getOrgCompare(start, end);
-      if (res.data.success) {
+      if (res?.data?.success) {
         setData(res.data.data);
       } else {
-        toast.error("Failed to load organization comparison data");
+        const errorMsg =
+          res?.data?.message || "Failed to load organization comparison data";
+        setError(errorMsg);
+        toast.error(errorMsg);
       }
     } catch (err) {
       console.error("Error fetching compare data:", err);
-      toast.error("An error occurred while loading team comparison data");
+      const errorMsg =
+        err.response?.data?.message ||
+        err.message ||
+        "An error occurred while loading team comparison data";
+      setError(errorMsg);
+      toast.error(errorMsg);
     } finally {
       setLoading(false);
     }
@@ -88,7 +97,12 @@ const SpeakingTimeCompare = () => {
   };
 
   const handleExportCSV = () => {
-    if (!data || !data.memberStats || data.memberStats.length === 0) return;
+    if (
+      !data ||
+      !Array.isArray(data.memberStats) ||
+      data.memberStats.length === 0
+    )
+      return;
 
     const headers = [
       "Member Name",
@@ -98,34 +112,59 @@ const SpeakingTimeCompare = () => {
       "Meetings Spoken In",
     ];
 
-    const rows = data.memberStats.map((stat) => [
-      `"${stat.speakerName.replace(/"/g, '""')}"`,
-      stat.averageTalkRatio.toFixed(2),
-      stat.totalDuration,
-      `"${formatDuration(stat.totalDuration)}"`,
-      stat.meetingCount,
-    ]);
+    const rows = data.memberStats.map((stat) => {
+      const name = stat?.speakerName
+        ? String(stat.speakerName).replace(/"/g, '""')
+        : "Unknown";
+      const talkRatio = (Number(stat?.averageTalkRatio) || 0).toFixed(2);
+      const duration = Number(stat?.totalDuration) || 0;
+      const formattedDuration = formatDuration(duration);
+      const meetings = Number(stat?.meetingCount) || 0;
 
-    const csvContent =
-      "data:text/csv;charset=utf-8," +
-      [headers.join(","), ...rows.map((e) => e.join(","))].join("\n");
+      return [
+        `"${name}"`,
+        talkRatio,
+        duration,
+        `"${formattedDuration}"`,
+        meetings,
+      ];
+    });
 
-    const encodedUri = encodeURI(csvContent);
-    const link = document.createElement("a");
-    link.setAttribute("href", encodedUri);
-    link.setAttribute(
-      "download",
-      `team_speaking_time_compare_${startDate}_to_${endDate}.csv`,
+    const csvText = [headers.join(","), ...rows.map((e) => e.join(","))].join(
+      "\n",
     );
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+
+    try {
+      const blob = new Blob([csvText], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.setAttribute("href", url);
+      link.setAttribute(
+        "download",
+        `team_speaking_time_compare_${startDate}_to_${endDate}.csv`,
+      );
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch {
+      const encodedUri = encodeURI("data:text/csv;charset=utf-8," + csvText);
+      const link = document.createElement("a");
+      link.setAttribute("href", encodedUri);
+      link.setAttribute(
+        "download",
+        `team_speaking_time_compare_${startDate}_to_${endDate}.csv`,
+      );
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
   };
 
   const chartData =
     data?.memberStats?.map((stat) => ({
       ...stat,
-      totalDurationMins: Math.round(stat.totalDuration / 60),
+      totalDurationMins: Math.round((Number(stat?.totalDuration) || 0) / 60),
     })) || [];
 
   return (
@@ -143,7 +182,7 @@ const SpeakingTimeCompare = () => {
               organization.
             </p>
           </div>
-          {data?.memberStats?.length > 0 && (
+          {data?.memberStats?.length > 0 && !error && (
             <button
               onClick={handleExportCSV}
               className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-lg shadow transition-colors flex items-center gap-2"
@@ -224,12 +263,48 @@ const SpeakingTimeCompare = () => {
           </form>
         </div>
 
+        {/* Error Banner */}
+        {error && (
+          <div className="p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex items-center gap-3 text-red-700 dark:text-red-400">
+              <svg
+                className="w-6 h-6 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div>
+                <h3 className="font-semibold text-sm sm:text-base">
+                  Failed to load team comparison
+                </h3>
+                <p className="text-xs sm:text-sm text-red-600 dark:text-red-300 mt-0.5">
+                  {error}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => fetchCompareData(startDate, endDate)}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-xs font-semibold rounded-lg shadow transition-colors shrink-0"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
         {/* Loading Spinner */}
         {loading ? (
           <div className="py-20 flex justify-center items-center">
             <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-blue-500"></div>
           </div>
-        ) : !data || data.meetingCount === 0 || chartData.length === 0 ? (
+        ) : !error &&
+          (!data || data.meetingCount === 0 || chartData.length === 0) ? (
           /* Empty State */
           <div className="bg-white dark:bg-gray-800 p-12 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 text-center flex flex-col items-center justify-center space-y-4">
             <div className="w-16 h-16 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-400 dark:text-gray-500">
@@ -255,7 +330,7 @@ const SpeakingTimeCompare = () => {
               organization. Ensure your meetings have transcripts completed.
             </p>
           </div>
-        ) : (
+        ) : !error && data ? (
           /* Main Content Dashboard */
           <div className="space-y-6">
             {/* Overview Summary Cards */}
@@ -265,7 +340,7 @@ const SpeakingTimeCompare = () => {
                   Meetings Analyzed
                 </p>
                 <p className="text-3xl font-extrabold text-gray-900 dark:text-white mt-2">
-                  {data.meetingCount}
+                  {data.meetingCount || 0}
                 </p>
               </div>
 
@@ -274,7 +349,7 @@ const SpeakingTimeCompare = () => {
                   Average Talk Ratio
                 </p>
                 <p className="text-3xl font-extrabold text-emerald-600 mt-2">
-                  {data.avgTalkRatio?.toFixed(1)}%
+                  {(data.avgTalkRatio || 0).toFixed(1)}%
                 </p>
               </div>
 
@@ -283,7 +358,7 @@ const SpeakingTimeCompare = () => {
                   Median Talk Ratio
                 </p>
                 <p className="text-3xl font-extrabold text-indigo-600 mt-2">
-                  {data.medianTalkRatio?.toFixed(1)}%
+                  {(data.medianTalkRatio || 0).toFixed(1)}%
                 </p>
               </div>
 
@@ -292,10 +367,10 @@ const SpeakingTimeCompare = () => {
                   Most Active Member
                 </p>
                 <p className="text-lg font-bold text-gray-900 dark:text-white mt-3 truncate">
-                  {data.topSpeakers[0]?.speakerName || "None"}
+                  {data.topSpeakers?.[0]?.speakerName || "None"}
                 </p>
                 <p className="text-xs text-gray-400 mt-0.5">
-                  {data.topSpeakers[0]
+                  {data.topSpeakers?.[0]
                     ? formatDuration(data.topSpeakers[0].totalDuration)
                     : "0s"}
                 </p>
@@ -387,18 +462,18 @@ const SpeakingTimeCompare = () => {
                         className="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
                       >
                         <td className="px-6 py-4 font-semibold text-gray-900 dark:text-white">
-                          {stat.speakerName}
+                          {stat.speakerName || "Unknown"}
                         </td>
                         <td className="px-6 py-4">
                           <div className="flex items-center gap-2">
                             <span className="w-10">
-                              {stat.averageTalkRatio.toFixed(1)}%
+                              {(stat.averageTalkRatio || 0).toFixed(1)}%
                             </span>
                             <div className="w-24 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                               <div
                                 className="h-full bg-blue-500 rounded-full"
                                 style={{
-                                  width: `${Math.min(100, stat.averageTalkRatio)}%`,
+                                  width: `${Math.min(100, Math.max(0, stat.averageTalkRatio || 0))}%`,
                                 }}
                               ></div>
                             </div>
@@ -407,7 +482,7 @@ const SpeakingTimeCompare = () => {
                         <td className="px-6 py-4">
                           {formatDuration(stat.totalDuration)}
                         </td>
-                        <td className="px-6 py-4">{stat.meetingCount}</td>
+                        <td className="px-6 py-4">{stat.meetingCount || 0}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -415,7 +490,7 @@ const SpeakingTimeCompare = () => {
               </div>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/client/src/pages/SpeakingTimeTrends.jsx
+++ b/client/src/pages/SpeakingTimeTrends.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import {
   LineChart,
@@ -14,9 +14,10 @@ import { speakingTimeApi } from "../services";
 import { toast } from "react-toastify";
 import { useRBAC } from "../hooks/useRBAC.js";
 
-const formatDuration = (seconds) => {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
+const formatDuration = (seconds = 0) => {
+  const sec = Math.max(0, Number(seconds) || 0);
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
   return `${m}m ${s}s`;
 };
 
@@ -26,19 +27,19 @@ const CustomTooltip = ({ active, payload }) => {
     return (
       <div className="bg-white dark:bg-gray-800 p-3 border border-gray-200 dark:border-gray-700 shadow-md rounded-md">
         <p className="font-semibold text-gray-900 dark:text-gray-100">
-          {data.meetingTitle}
+          {data.meetingTitle || "Untitled Meeting"}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300">
-          {new Date(data.date).toLocaleDateString()}
+          {data.date ? new Date(data.date).toLocaleDateString() : "N/A"}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
-          Talk Ratio: {data.talkRatio?.toFixed(1)}%
+          Talk Ratio: {(data.talkRatio || 0).toFixed(1)}%
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300">
           Time: {formatDuration(data.totalDuration)}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-300">
-          Interruptions: {data.overlapCount}
+          Interruptions: {data.overlapCount || 0}
         </p>
       </div>
     );
@@ -49,36 +50,47 @@ const CustomTooltip = ({ active, payload }) => {
 const SpeakingTimeTrends = () => {
   const [trends, setTrends] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const { hasPermission } = useRBAC();
   const canCompare = hasPermission("reports", "view");
 
-  useEffect(() => {
-    const fetchTrends = async () => {
-      try {
-        setLoading(true);
-        const res = await speakingTimeApi.getTrends(10);
-        if (res.data.success) {
-          // Format date for display on axis
-          const formattedData = res.data.data.map((item) => ({
-            ...item,
-            displayDate: new Date(item.date).toLocaleDateString(undefined, {
-              month: "short",
-              day: "numeric",
-            }),
-          }));
-          setTrends(formattedData);
-        } else {
-          toast.error("Failed to load speaking trends");
-        }
-      } catch (err) {
-        console.error("Error fetching speaking trends:", err);
-        toast.error("An error occurred while loading trends");
-      } finally {
-        setLoading(false);
+  const fetchTrends = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await speakingTimeApi.getTrends(10);
+      if (res?.data?.success) {
+        const formattedData = (res.data.data || []).map((item) => ({
+          ...item,
+          displayDate: item.date
+            ? new Date(item.date).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              })
+            : "N/A",
+        }));
+        setTrends(formattedData);
+      } else {
+        const errorMsg = res?.data?.message || "Failed to load speaking trends";
+        setError(errorMsg);
+        toast.error(errorMsg);
       }
-    };
-    fetchTrends();
+    } catch (err) {
+      console.error("Error fetching speaking trends:", err);
+      const errorMsg =
+        err.response?.data?.message ||
+        err.message ||
+        "An error occurred while loading trends";
+      setError(errorMsg);
+      toast.error(errorMsg);
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchTrends();
+  }, [fetchTrends]);
 
   if (loading) {
     return (
@@ -110,156 +122,197 @@ const SpeakingTimeTrends = () => {
           )}
         </div>
 
-        {trends.length === 0 ? (
+        {/* Error Banner */}
+        {error && (
+          <div className="p-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex items-center gap-3 text-red-700 dark:text-red-400">
+              <svg
+                className="w-6 h-6 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div>
+                <h3 className="font-semibold text-sm sm:text-base">
+                  Failed to load speaking time trends
+                </h3>
+                <p className="text-xs sm:text-sm text-red-600 dark:text-red-300 mt-0.5">
+                  {error}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={fetchTrends}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-xs font-semibold rounded-lg shadow transition-colors shrink-0"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!error && trends.length === 0 ? (
           <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 text-center">
             <p className="text-gray-500">No meeting data available yet.</p>
           </div>
         ) : (
-          <>
-            <div
-              role="region"
-              aria-label="Talk ratio over time chart"
-              className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
-            >
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">
-                Talk Ratio Over Time (%)
-              </h2>
-              <div className="h-[400px]">
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart
-                    data={trends}
-                    margin={{ top: 10, right: 30, left: 0, bottom: 20 }}
+          !error && (
+            <>
+              <div
+                role="region"
+                aria-label="Talk ratio over time chart"
+                className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
+              >
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">
+                  Talk Ratio Over Time (%)
+                </h2>
+                <div className="h-[400px]">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart
+                      data={trends}
+                      margin={{ top: 10, right: 30, left: 0, bottom: 20 }}
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke="#374151"
+                        opacity={0.2}
+                      />
+                      <XAxis
+                        dataKey="displayDate"
+                        stroke="#6B7280"
+                        tick={{ fill: "#6B7280" }}
+                      />
+                      <YAxis
+                        domain={[0, 100]}
+                        stroke="#6B7280"
+                        tick={{ fill: "#6B7280" }}
+                        tickFormatter={(value) => `${value}%`}
+                      />
+                      <RechartsTooltip content={<CustomTooltip />} />
+
+                      {/* Target band: 20% to 50% is generally a healthy participation range in small meetings */}
+                      <ReferenceArea
+                        y1={20}
+                        y2={50}
+                        fill="#10B981"
+                        fillOpacity={0.1}
+                      />
+
+                      <Line
+                        type="monotone"
+                        dataKey="talkRatio"
+                        stroke="#3B82F6"
+                        strokeWidth={3}
+                        activeDot={{ r: 8 }}
+                        dot={{
+                          r: 4,
+                          fill: "#3B82F6",
+                          strokeWidth: 2,
+                          stroke: "#fff",
+                        }}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+                <div className="mt-4 flex items-center justify-center space-x-4 text-sm text-gray-500">
+                  <div className="flex items-center">
+                    <div className="w-3 h-3 rounded-full bg-blue-500 mr-2"></div>
+                    Your Talk Ratio
+                  </div>
+                  <div className="flex items-center">
+                    <div className="w-4 h-4 rounded bg-emerald-500 opacity-20 mr-2"></div>
+                    Healthy Target Zone (20-50%)
+                  </div>
+                </div>
+              </div>
+
+              <div
+                role="region"
+                aria-label="Recent meetings speaking breakdown"
+                className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
+              >
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                  Recent Meetings Breakdown
+                </h2>
+                <div className="overflow-x-auto">
+                  <table
+                    aria-label="Speaking time breakdown table"
+                    className="w-full text-left text-sm text-gray-600 dark:text-gray-400"
                   >
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      stroke="#374151"
-                      opacity={0.2}
-                    />
-                    <XAxis
-                      dataKey="displayDate"
-                      stroke="#6B7280"
-                      tick={{ fill: "#6B7280" }}
-                    />
-                    <YAxis
-                      domain={[0, 100]}
-                      stroke="#6B7280"
-                      tick={{ fill: "#6B7280" }}
-                      tickFormatter={(value) => `${value}%`}
-                    />
-                    <RechartsTooltip content={<CustomTooltip />} />
-
-                    {/* Target band: 20% to 50% is generally a healthy participation range in small meetings */}
-                    <ReferenceArea
-                      y1={20}
-                      y2={50}
-                      fill="#10B981"
-                      fillOpacity={0.1}
-                    />
-
-                    <Line
-                      type="monotone"
-                      dataKey="talkRatio"
-                      stroke="#3B82F6"
-                      strokeWidth={3}
-                      activeDot={{ r: 8 }}
-                      dot={{
-                        r: 4,
-                        fill: "#3B82F6",
-                        strokeWidth: 2,
-                        stroke: "#fff",
-                      }}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-              <div className="mt-4 flex items-center justify-center space-x-4 text-sm text-gray-500">
-                <div className="flex items-center">
-                  <div className="w-3 h-3 rounded-full bg-blue-500 mr-2"></div>
-                  Your Talk Ratio
-                </div>
-                <div className="flex items-center">
-                  <div className="w-4 h-4 rounded bg-emerald-500 opacity-20 mr-2"></div>
-                  Healthy Target Zone (20-50%)
-                </div>
-              </div>
-            </div>
-
-            <div
-              role="region"
-              aria-label="Recent meetings speaking breakdown"
-              className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700"
-            >
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-                Recent Meetings Breakdown
-              </h2>
-              <div className="overflow-x-auto">
-                <table
-                  aria-label="Speaking time breakdown table"
-                  className="w-full text-left text-sm text-gray-600 dark:text-gray-400"
-                >
-                  <thead className="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-                    <tr>
-                      <th scope="col" className="px-6 py-3 rounded-tl-lg">
-                        Meeting
-                      </th>
-                      <th scope="col" className="px-6 py-3">
-                        Date
-                      </th>
-                      <th scope="col" className="px-6 py-3">
-                        Talk Ratio
-                      </th>
-                      <th scope="col" className="px-6 py-3">
-                        Duration
-                      </th>
-                      <th scope="col" className="px-6 py-3 rounded-tr-lg">
-                        Interrupts
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {/* Reverse trends to show most recent first in table */}
-                    {[...trends].reverse().map((meeting) => (
-                      <tr
-                        key={meeting.meetingId}
-                        className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                      >
-                        <td className="px-6 py-4 font-medium text-gray-900 dark:text-white">
-                          <Link
-                            to={`/meeting/${meeting.meetingId}`}
-                            className="hover:text-blue-600 dark:hover:text-blue-400"
-                          >
-                            {meeting.meetingTitle}
-                          </Link>
-                        </td>
-                        <td className="px-6 py-4">
-                          {new Date(meeting.date).toLocaleDateString()}
-                        </td>
-                        <td className="px-6 py-4">
-                          <div className="flex items-center">
-                            <span className="mr-2">
-                              {meeting.talkRatio?.toFixed(1)}%
-                            </span>
-                            <div className="w-16 h-2 bg-gray-200 rounded-full overflow-hidden">
-                              <div
-                                className="h-full bg-blue-500"
-                                style={{
-                                  width: `${Math.min(100, Math.max(0, meeting.talkRatio || 0))}%`,
-                                }}
-                              ></div>
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4">
-                          {formatDuration(meeting.totalDuration)}
-                        </td>
-                        <td className="px-6 py-4">{meeting.overlapCount}</td>
+                    <thead className="text-xs uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+                      <tr>
+                        <th scope="col" className="px-6 py-3 rounded-tl-lg">
+                          Meeting
+                        </th>
+                        <th scope="col" className="px-6 py-3">
+                          Date
+                        </th>
+                        <th scope="col" className="px-6 py-3">
+                          Talk Ratio
+                        </th>
+                        <th scope="col" className="px-6 py-3">
+                          Duration
+                        </th>
+                        <th scope="col" className="px-6 py-3 rounded-tr-lg">
+                          Interrupts
+                        </th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {/* Reverse trends to show most recent first in table */}
+                      {[...trends].reverse().map((meeting) => (
+                        <tr
+                          key={meeting.meetingId}
+                          className="border-b dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                        >
+                          <td className="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                            <Link
+                              to={`/meeting/${meeting.meetingId}`}
+                              className="hover:text-blue-600 dark:hover:text-blue-400"
+                            >
+                              {meeting.meetingTitle || "Untitled Meeting"}
+                            </Link>
+                          </td>
+                          <td className="px-6 py-4">
+                            {meeting.date
+                              ? new Date(meeting.date).toLocaleDateString()
+                              : "N/A"}
+                          </td>
+                          <td className="px-6 py-4">
+                            <div className="flex items-center">
+                              <span className="mr-2">
+                                {(meeting.talkRatio || 0).toFixed(1)}%
+                              </span>
+                              <div className="w-16 h-2 bg-gray-200 rounded-full overflow-hidden">
+                                <div
+                                  className="h-full bg-blue-500"
+                                  style={{
+                                    width: `${Math.min(100, Math.max(0, meeting.talkRatio || 0))}%`,
+                                  }}
+                                ></div>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-6 py-4">
+                            {formatDuration(meeting.totalDuration)}
+                          </td>
+                          <td className="px-6 py-4">
+                            {meeting.overlapCount || 0}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
-          </>
+            </>
+          )
         )}
       </div>
     </div>

--- a/client/src/pages/__tests__/SpeakingTimeCompare.test.jsx
+++ b/client/src/pages/__tests__/SpeakingTimeCompare.test.jsx
@@ -121,4 +121,26 @@ describe("SpeakingTimeCompare Dashboard (#2038)", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("renders error state when API call fails and allows retrying", async () => {
+    speakingTimeApi.getOrgCompare.mockRejectedValueOnce(
+      new Error("Network Error"),
+    );
+
+    render(
+      <BrowserRouter>
+        <SpeakingTimeCompare />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load team comparison"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Network Error")).toBeInTheDocument();
+    });
+
+    const retryBtn = screen.getByText("Retry");
+    expect(retryBtn).toBeInTheDocument();
+  });
 });

--- a/client/src/services/__tests__/speakingTimeApi.test.js
+++ b/client/src/services/__tests__/speakingTimeApi.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { speakingTimeApi } from "../speakingTimeApi.js";
+import apiClient from "../apiClient.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("speakingTimeApi /api prefix path-locking tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls GET /api/speaking-time/:meetingId/breakdown for getBreakdown", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, data: {} },
+    });
+
+    await speakingTimeApi.getBreakdown("m-100");
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/speaking-time/m-100/breakdown",
+    );
+  });
+
+  it("calls GET /api/speaking-time/trends?limit=:limit for getTrends", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, data: [] },
+    });
+
+    await speakingTimeApi.getTrends(10);
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/speaking-time/trends?limit=10",
+    );
+  });
+
+  it("calls GET /api/speaking-time/org-compare for getOrgCompare", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { success: true, data: { meetingCount: 5 } },
+    });
+
+    await speakingTimeApi.getOrgCompare("2026-01-01", "2026-01-31");
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/speaking-time/org-compare",
+      {
+        params: {
+          startDate: "2026-01-01",
+          endDate: "2026-01-31",
+        },
+      },
+    );
+  });
+});

--- a/client/src/services/speakingTimeApi.js
+++ b/client/src/services/speakingTimeApi.js
@@ -2,14 +2,14 @@ import apiClient from "./apiClient";
 
 export const speakingTimeApi = {
   getBreakdown: (meetingId) =>
-    apiClient.get(`/speaking-time/${meetingId}/breakdown`),
+    apiClient.get(`/api/speaking-time/${meetingId}/breakdown`),
   getTrends: (limit = 10) =>
-    apiClient.get(`/speaking-time/trends?limit=${limit}`),
+    apiClient.get(`/api/speaking-time/trends?limit=${limit}`),
   getOrgCompare: (startDate, endDate) => {
     const params = {};
     if (startDate) params.startDate = startDate;
     if (endDate) params.endDate = endDate;
-    return apiClient.get("/speaking-time/org-compare", { params });
+    return apiClient.get("/api/speaking-time/org-compare", { params });
   },
 };
 


### PR DESCRIPTION
Summary of Accomplishments
Client API Prefix Fix:

Updated speakingTimeApi.js
 to prefix all endpoints with /api:
GET /api/speaking-time/:meetingId/breakdown
GET /api/speaking-time/trends
GET /api/speaking-time/org-compare
Dashboard Hardening:

Updated SpeakingTimeCompare.jsx
: Added an error banner with a "Retry" button, hardened CSV export with nullish checks and Blob URL downloads, and separated error states from empty data states.
Updated 

SpeakingTimeTrends.jsx
: Added error banner rendering and retry actions.


closes #2277