### PR TITLE
fix(attachments): fix missing /api prefix and add inline preview modal

### DIFF
--- a/client/src/components/meeting-details/AttachmentPanel.jsx
+++ b/client/src/components/meeting-details/AttachmentPanel.jsx
@@ -9,6 +9,9 @@ import {
   Trash2,
   FileText,
   Image as ImageIcon,
+  Eye,
+  X,
+  Loader2,
 } from "lucide-react";
 
 const AttachmentPanel = ({ meetingId }) => {
@@ -16,6 +19,9 @@ const AttachmentPanel = ({ meetingId }) => {
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [previewAttachment, setPreviewAttachment] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const fileInputRef = useRef(null);
 
   const fetchAttachments = useCallback(async () => {
@@ -36,6 +42,61 @@ const AttachmentPanel = ({ meetingId }) => {
   useEffect(() => {
     fetchAttachments();
   }, [fetchAttachments]);
+
+  // Clean up object URLs on preview close or unmount
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  // Handle escape key to close preview modal
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape" && previewAttachment) {
+        handleClosePreview();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [previewAttachment, previewUrl]);
+
+  const handleOpenPreview = async (attachment) => {
+    setPreviewAttachment(attachment);
+    setPreviewLoading(true);
+
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+
+    try {
+      const response = await attachmentApi.previewAttachment(
+        meetingId,
+        attachment._id,
+      );
+      const blob = new Blob([response.data], {
+        type: attachment.mimeType || "application/octet-stream",
+      });
+      const url = URL.createObjectURL(blob);
+      setPreviewUrl(url);
+    } catch (error) {
+      console.error("Preview error:", error);
+      toast.error("Failed to load preview for this attachment");
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
+  const handleClosePreview = () => {
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+    setPreviewAttachment(null);
+  };
 
   const handleFileChange = async (e) => {
     const files = Array.from(e.target.files);
@@ -99,6 +160,7 @@ const AttachmentPanel = ({ meetingId }) => {
       document.body.appendChild(link);
       link.click();
       link.remove();
+      window.URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Download error:", error);
       toast.error("Failed to download file");
@@ -112,6 +174,9 @@ const AttachmentPanel = ({ meetingId }) => {
     try {
       await attachmentApi.deleteAttachment(meetingId, attachmentId);
       toast.success("Attachment deleted");
+      if (previewAttachment && previewAttachment._id === attachmentId) {
+        handleClosePreview();
+      }
       fetchAttachments();
     } catch (error) {
       console.error("Delete error:", error);
@@ -121,7 +186,7 @@ const AttachmentPanel = ({ meetingId }) => {
     }
   };
 
-  const getFileIcon = (mimeType) => {
+  const getFileIcon = (mimeType = "") => {
     if (mimeType.includes("pdf"))
       return <FileText className="w-6 h-6 text-red-500 dark:text-red-400" />;
     if (mimeType.includes("image"))
@@ -136,12 +201,15 @@ const AttachmentPanel = ({ meetingId }) => {
   };
 
   const formatFileSize = (bytes) => {
-    if (bytes === 0) return "0 Bytes";
+    if (!bytes || bytes === 0) return "0 Bytes";
     const k = 1024;
     const sizes = ["Bytes", "KB", "MB", "GB"];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
   };
+
+  const isImageFile = (mimeType = "") => mimeType.startsWith("image/");
+  const isPdfFile = (mimeType = "") => mimeType === "application/pdf";
 
   return (
     <div className="bg-white dark:bg-slate-900 rounded-lg shadow-sm border border-gray-200 dark:border-slate-800 p-6 mb-6">
@@ -207,11 +275,14 @@ const AttachmentPanel = ({ meetingId }) => {
               key={file._id}
               className="flex items-center justify-between p-3 hover:bg-gray-50 dark:hover:bg-slate-800/50 transition-colors"
             >
-              <div className="flex items-center gap-3 overflow-hidden">
+              <div
+                className="flex items-center gap-3 overflow-hidden cursor-pointer"
+                onClick={() => handleOpenPreview(file)}
+              >
                 {getFileIcon(file.mimeType)}
                 <div className="min-w-0">
                   <p
-                    className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate"
+                    className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate hover:text-blue-600 dark:hover:text-blue-400"
                     title={file.fileName}
                   >
                     {file.fileName}
@@ -228,10 +299,19 @@ const AttachmentPanel = ({ meetingId }) => {
               <div className="flex items-center gap-2 flex-shrink-0 ml-4">
                 <button
                   type="button"
+                  onClick={() => handleOpenPreview(file)}
+                  className="p-1.5 text-gray-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-950/50 rounded-md transition-colors cursor-pointer"
+                  title="Preview"
+                  aria-label={`Preview attachment ${file.fileName}`}
+                >
+                  <Eye className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
                   onClick={() => handleDownload(file)}
                   className="p-1.5 text-gray-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-950/50 rounded-md transition-colors cursor-pointer"
                   title="Download"
-                  aria-label="Download attachment"
+                  aria-label={`Download attachment ${file.fileName}`}
                 >
                   <Download className="w-4 h-4" />
                 </button>
@@ -240,7 +320,7 @@ const AttachmentPanel = ({ meetingId }) => {
                   onClick={() => handleDelete(file._id)}
                   className="p-1.5 text-gray-500 dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/50 rounded-md transition-colors cursor-pointer"
                   title="Delete"
-                  aria-label="Delete attachment"
+                  aria-label={`Delete attachment ${file.fileName}`}
                 >
                   <Trash2 className="w-4 h-4" />
                 </button>
@@ -248,6 +328,99 @@ const AttachmentPanel = ({ meetingId }) => {
             </li>
           ))}
         </ul>
+      )}
+
+      {/* Inline Preview Modal Dialog */}
+      {previewAttachment && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Attachment Preview Dialog"
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-xs flex items-center justify-center p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleClosePreview();
+          }}
+        >
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl overflow-hidden">
+            {/* Header */}
+            <div className="p-4 border-b border-gray-200 dark:border-slate-800 flex items-center justify-between">
+              <div className="flex items-center gap-2 overflow-hidden">
+                {getFileIcon(previewAttachment.mimeType)}
+                <div className="min-w-0">
+                  <h3 className="text-base font-bold text-gray-900 dark:text-white truncate">
+                    {previewAttachment.fileName}
+                  </h3>
+                  <span className="text-xs text-gray-500 dark:text-slate-400">
+                    {formatFileSize(previewAttachment.fileSize)}
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleDownload(previewAttachment)}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-xs font-semibold cursor-pointer shadow-xs"
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Download
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClosePreview}
+                  className="p-1.5 rounded-lg text-gray-500 hover:text-gray-700 dark:text-slate-400 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-slate-800 cursor-pointer"
+                  aria-label="Close preview"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+
+            {/* Content Body */}
+            <div className="flex-1 overflow-auto p-4 flex items-center justify-center bg-gray-50 dark:bg-slate-950 min-h-[300px]">
+              {previewLoading ? (
+                <div className="flex flex-col items-center gap-3 text-gray-500 dark:text-slate-400">
+                  <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
+                  <span className="text-sm">Loading preview...</span>
+                </div>
+              ) : isImageFile(previewAttachment.mimeType) && previewUrl ? (
+                <img
+                  src={previewUrl}
+                  alt={previewAttachment.fileName}
+                  className="max-h-[70vh] max-w-full object-contain rounded-lg shadow-sm"
+                />
+              ) : isPdfFile(previewAttachment.mimeType) && previewUrl ? (
+                <iframe
+                  src={previewUrl}
+                  title={`Preview of ${previewAttachment.fileName}`}
+                  className="w-full h-[70vh] rounded-lg border border-gray-200 dark:border-slate-800"
+                />
+              ) : (
+                <div className="text-center py-12 space-y-4 max-w-md">
+                  <div className="mx-auto w-16 h-16 rounded-full bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center text-blue-600 dark:text-blue-400">
+                    {getFileIcon(previewAttachment.mimeType)}
+                  </div>
+                  <h4 className="text-base font-semibold text-gray-900 dark:text-white">
+                    Preview not directly available for this format
+                  </h4>
+                  <p className="text-xs text-gray-500 dark:text-slate-400">
+                    You can download{" "}
+                    <span className="font-semibold text-gray-700 dark:text-slate-300">
+                      {previewAttachment.fileName}
+                    </span>{" "}
+                    to view it in your default application.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => handleDownload(previewAttachment)}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl text-xs font-semibold cursor-pointer shadow-md"
+                  >
+                    <Download className="w-4 h-4" /> Download File
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/client/src/components/meeting-details/__tests__/AttachmentPanel.test.jsx
+++ b/client/src/components/meeting-details/__tests__/AttachmentPanel.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import AttachmentPanel from "../AttachmentPanel";
 
@@ -15,6 +15,7 @@ vi.mock("../../../services", () => ({
     getAttachments: vi.fn(),
     uploadAttachment: vi.fn(),
     downloadAttachment: vi.fn(),
+    previewAttachment: vi.fn(),
     deleteAttachment: vi.fn(),
   },
 
@@ -27,12 +28,12 @@ vi.mock("../../../services", () => ({
 
 import { attachmentApi } from "../../../services";
 
-describe("AttachmentPanel accessibility & Dark Mode (#1227)", () => {
+describe("AttachmentPanel accessibility & Inline Preview (#2253)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("exposes accessible names for icon-only attachment actions", async () => {
+  it("exposes accessible names for icon-only attachment actions including preview", async () => {
     attachmentApi.getAttachments.mockResolvedValue({
       data: {
         success: true,
@@ -56,11 +57,61 @@ describe("AttachmentPanel accessibility & Dark Mode (#1227)", () => {
     });
 
     expect(
-      screen.getByRole("button", { name: "Download attachment" }),
+      screen.getByRole("button", { name: "Preview attachment agenda.pdf" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Delete attachment" }),
+      screen.getByRole("button", { name: "Download attachment agenda.pdf" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete attachment agenda.pdf" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens inline preview modal when preview is clicked and closes on close button", async () => {
+    attachmentApi.getAttachments.mockResolvedValue({
+      data: {
+        success: true,
+        attachments: [
+          {
+            _id: "att-img",
+            fileName: "architecture.png",
+            mimeType: "image/png",
+            fileSize: 2048,
+            uploadedBy: { name: "Bob" },
+            createdAt: "2024-01-16T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+    attachmentApi.previewAttachment.mockResolvedValue({
+      data: new ArrayBuffer(8),
+    });
+
+    render(<AttachmentPanel meetingId="meeting-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("architecture.png")).toBeInTheDocument();
+    });
+
+    // Click preview
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Preview attachment architecture.png",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Attachment Preview Dialog" }),
+      ).toBeInTheDocument();
+    });
+
+    // Close preview
+    fireEvent.click(screen.getByRole("button", { name: "Close preview" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Attachment Preview Dialog" }),
+    ).not.toBeInTheDocument();
   });
 
   it("applies dark mode CSS classes for complete theme support", async () => {

--- a/client/src/services/attachmentApi.js
+++ b/client/src/services/attachmentApi.js
@@ -2,7 +2,7 @@ import apiClient from "./apiClient";
 
 export const attachmentApi = {
   uploadAttachment: (meetingId, formData, onUploadProgress) => {
-    return apiClient.post(`/meetings/${meetingId}/attachments`, formData, {
+    return apiClient.post(`/api/meetings/${meetingId}/attachments`, formData, {
       headers: {
         "Content-Type": "multipart/form-data",
       },
@@ -12,22 +12,31 @@ export const attachmentApi = {
 
   getAttachments: (meetingId, page = 1, limit = 20) => {
     return apiClient.get(
-      `/meetings/${meetingId}/attachments?page=${page}&limit=${limit}`,
+      `/api/meetings/${meetingId}/attachments?page=${page}&limit=${limit}`,
     );
   },
 
   downloadAttachment: (meetingId, attachmentId) => {
     return apiClient.get(
-      `/meetings/${meetingId}/attachments/${attachmentId}/download`,
+      `/api/meetings/${meetingId}/attachments/${attachmentId}/download`,
       {
         responseType: "blob", // Important for downloading files
       },
     );
   },
 
+  previewAttachment: (meetingId, attachmentId) => {
+    return apiClient.get(
+      `/api/meetings/${meetingId}/attachments/${attachmentId}/download?inline=true`,
+      {
+        responseType: "blob",
+      },
+    );
+  },
+
   deleteAttachment: (meetingId, attachmentId) => {
     return apiClient.delete(
-      `/meetings/${meetingId}/attachments/${attachmentId}`,
+      `/api/meetings/${meetingId}/attachments/${attachmentId}`,
     );
   },
 };

--- a/server/controllers/attachmentController.js
+++ b/server/controllers/attachmentController.js
@@ -265,9 +265,12 @@ export const downloadAttachment = async (req, res) => {
     // early and left CRLF unfiltered, and there was no `filename*` parameter,
     // so non-ASCII names arrived as mojibake. `getContentDispositionHeader`
     // is what the transcript and policy exporters already use (Issue #1454).
+    const isInline = req.query.inline === "true";
     res.setHeader(
       "Content-Disposition",
-      getContentDispositionHeader(attachment.fileName),
+      getContentDispositionHeader(attachment.fileName, {
+        dispositionType: isInline ? "inline" : "attachment",
+      }),
     );
     res.setHeader(
       "Content-Type",

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -81,11 +81,14 @@ export const FALLBACK_DOWNLOAD_FILENAME = "download";
  */
 export const getContentDispositionHeader = (
   filename,
-  { fallback = FALLBACK_DOWNLOAD_FILENAME } = {},
+  {
+    fallback = FALLBACK_DOWNLOAD_FILENAME,
+    dispositionType = "attachment",
+  } = {},
 ) => {
   const raw = typeof filename === "string" ? filename : "";
   const safeAscii = sanitizeFilenameForHeader(raw).trim() || fallback;
   const encoded = encodeURIComponent(raw || fallback);
 
-  return `attachment; filename="${safeAscii}"; filename*=UTF-8''${encoded}`;
+  return `${dispositionType}; filename="${safeAscii}"; filename*=UTF-8''${encoded}`;
 };


### PR DESCRIPTION
Fixes #2253

## Description
This PR fixes the missing `/api` prefix across all attachment API routes on the client, supports `inline` Content-Disposition in the server download controller, and builds an accessible inline preview modal in `AttachmentPanel.jsx` for viewing documents and images directly within the meeting details page.

## Proposed Changes
- **Client API Endpoints**: Added missing `/api` prefix across `uploadAttachment`, `getAttachments`, `downloadAttachment`, and `deleteAttachment` in `client/src/services/attachmentApi.js`.
- **Inline Preview API**: Added `previewAttachment` with `?inline=true` query parameter.
- **Server Header Handling**: Supported `dispositionType: 'inline' | 'attachment'` in `getContentDispositionHeader` in `server/utils/fileUtils.js` and `server/controllers/attachmentController.js`.
- **Frontend Inline Preview Modal**: Added interactive preview triggers (`Eye` icon and title clicks) in `AttachmentPanel.jsx`, rendering image previews, PDF iframes, and document details with download actions and WAI-ARIA modal accessibility.
- **Unit Tests**: Updated and expanded `AttachmentPanel.test.jsx` to test preview triggers, modal dialog opening/closing, and accessibility.

## Checklist
- [x] Related Issue is linked (Fixes #2253).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline previews for image and PDF attachments.
  - Added loading indicators, accessible preview/download/delete controls, and fallback messaging for unsupported file types.
  - Preview dialogs can be dismissed with Escape or standard close controls.

- **Bug Fixes**
  - Improved attachment cleanup and download handling.
  - Deleting an attachment currently being previewed now closes the preview.
  - Improved file-size display for missing or empty files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->