### PR TITLE
fix: use selected organization in organization hub

### DIFF
--- a/client/src/pages/OrganizationHub.jsx
+++ b/client/src/pages/OrganizationHub.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { organizationApi } from "../services";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar";
@@ -7,10 +7,14 @@ import OrganizationGrid from "../components/organization/OrganizationGrid";
 import OrganizationEmptyState from "../components/organization/OrganizationEmptyState";
 import TopContributorsWidget from "../components/organization/TopContributorsWidget";
 import ParkingLotBacklog from "../components/organization/ParkingLotBacklog";
+import AppContent from "../context/AppContent";
+import { Building2 } from "lucide-react";
 
 // Organization Hub page for managing user organizations
 const OrganizationHub = () => {
+  const { userData } = useContext(AppContent) || {};
   const [organizations, setOrganizations] = useState([]);
+  const [selectedOrgId, setSelectedOrgId] = useState("");
   const [loading, setLoading] = useState(true);
 
   const fetchUserOrganizations = async () => {
@@ -18,7 +22,8 @@ const OrganizationHub = () => {
       setLoading(true);
       const { data } = await organizationApi.getUserOrganizations();
       if (data.success) {
-        setOrganizations(data.organizations || []);
+        const orgList = data.organizations || [];
+        setOrganizations(orgList);
       }
     } catch (error) {
       console.error("Failed to fetch organizations:", error);
@@ -31,6 +36,29 @@ const OrganizationHub = () => {
   useEffect(() => {
     fetchUserOrganizations();
   }, []);
+
+  // Determine active organization ID from userData or list fallback
+  useEffect(() => {
+    const userOrgId =
+      typeof userData?.organization === "object"
+        ? userData?.organization?._id
+        : userData?.organization;
+
+    if (userOrgId && organizations.some((org) => org._id === userOrgId)) {
+      setSelectedOrgId(userOrgId);
+    } else if (organizations.length > 0) {
+      // If current selectedOrgId is not valid or empty, fallback to first org
+      setSelectedOrgId((prev) =>
+        prev && organizations.some((org) => org._id === prev)
+          ? prev
+          : organizations[0]._id,
+      );
+    } else {
+      setSelectedOrgId("");
+    }
+  }, [userData, organizations]);
+
+  const activeOrg = organizations.find((o) => o._id === selectedOrgId);
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -49,12 +77,37 @@ const OrganizationHub = () => {
               <OrganizationGrid organizations={organizations} loading={false} />
             </div>
             <div className="lg:col-span-1">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-                Engagement
-              </h2>
-              <div className="sticky top-24 h-[400px] flex flex-col gap-8">
-                <TopContributorsWidget organizationId={organizations[0]?._id} />
-                <ParkingLotBacklog organizationId={organizations[0]?._id} />
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+                  Engagement
+                </h2>
+                {organizations.length > 1 && (
+                  <div className="flex items-center gap-1.5">
+                    <Building2 className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                    <select
+                      aria-label="Select organization for engagement metrics"
+                      value={selectedOrgId}
+                      onChange={(e) => setSelectedOrgId(e.target.value)}
+                      className="text-xs bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      {organizations.map((org) => (
+                        <option key={org._id} value={org._id}>
+                          {org.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+              {activeOrg && organizations.length === 1 && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-3 -mt-2">
+                  Showing metrics for{" "}
+                  <span className="font-medium">{activeOrg.name}</span>
+                </p>
+              )}
+              <div className="sticky top-24 flex flex-col gap-6">
+                <TopContributorsWidget organizationId={selectedOrgId} />
+                <ParkingLotBacklog organizationId={selectedOrgId} />
               </div>
             </div>
           </div>

--- a/client/src/pages/__tests__/OrganizationHubSelectedOrg.test.jsx
+++ b/client/src/pages/__tests__/OrganizationHubSelectedOrg.test.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import OrganizationHub from "../OrganizationHub.jsx";
+import { organizationApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+vi.mock("../../services", () => ({
+  organizationApi: {
+    getUserOrganizations: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../components/organization/TopContributorsWidget", () => ({
+  default: ({ organizationId }) => (
+    <div data-testid="top-contributors-widget" data-orgid={organizationId}>
+      TopContributors: {organizationId}
+    </div>
+  ),
+}));
+
+vi.mock("../../components/organization/ParkingLotBacklog", () => ({
+  default: ({ organizationId }) => (
+    <div data-testid="parking-lot-backlog" data-orgid={organizationId}>
+      ParkingLot: {organizationId}
+    </div>
+  ),
+}));
+
+describe("OrganizationHub Selected Org Wiring (#2008)", () => {
+  const mockOrgs = [
+    { _id: "org-1", name: "Primary Org", role: "member" },
+    { _id: "org-2", name: "Secondary Org", role: "admin" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses active userData.organization as selected organization in widgets", async () => {
+    organizationApi.getUserOrganizations.mockResolvedValue({
+      data: { success: true, organizations: mockOrgs },
+    });
+
+    const mockUserData = {
+      _id: "user-1",
+      organization: { _id: "org-2", name: "Secondary Org" },
+    };
+
+    render(
+      <MemoryRouter>
+        <AppContent.Provider value={{ userData: mockUserData }}>
+          <OrganizationHub />
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const topContributors = screen.getByTestId("top-contributors-widget");
+      expect(topContributors.getAttribute("data-orgid")).toBe("org-2");
+      const parkingLot = screen.getByTestId("parking-lot-backlog");
+      expect(parkingLot.getAttribute("data-orgid")).toBe("org-2");
+    });
+  });
+
+  it("allows switching active organization from dropdown", async () => {
+    organizationApi.getUserOrganizations.mockResolvedValue({
+      data: { success: true, organizations: mockOrgs },
+    });
+
+    const mockUserData = {
+      _id: "user-1",
+      organization: { _id: "org-1", name: "Primary Org" },
+    };
+
+    render(
+      <MemoryRouter>
+        <AppContent.Provider value={{ userData: mockUserData }}>
+          <OrganizationHub />
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/Select organization for engagement metrics/i),
+      ).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText(
+      /Select organization for engagement metrics/i,
+    );
+    fireEvent.change(select, { target: { value: "org-2" } });
+
+    await waitFor(() => {
+      const topContributors = screen.getByTestId("top-contributors-widget");
+      expect(topContributors.getAttribute("data-orgid")).toBe("org-2");
+    });
+  });
+
+  it("renders empty state when user has no organizations", async () => {
+    organizationApi.getUserOrganizations.mockResolvedValue({
+      data: { success: true, organizations: [] },
+    });
+
+    render(
+      <MemoryRouter>
+        <AppContent.Provider value={{ userData: null }}>
+          <OrganizationHub />
+        </AppContent.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/No Organizations Yet/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request: Fix Organization Hub to use selected org (not organizations[0])

## Description
Closes #2008

### Summary of Changes
- **Selected Organization Resolution (`client/src/pages/OrganizationHub.jsx`)**:
  - Resolved `selectedOrgId` dynamically from `userData.organization` (handling both populated Object and string ID representations) rather than hardcoding `organizations[0]`.
  - Added an interactive organization selector dropdown in the Hub sidebar if the user belongs to multiple organizations.
  - Automatically synchronizes when switching active organizations in `userData`.
- **Child Component Props Wiring**:
  - Propagated `selectedOrgId` to `TopContributorsWidget` and `ParkingLotBacklog` components.
- **Testing**:
  - Created unit tests in `client/src/pages/__tests__/OrganizationHubSelectedOrg.test.jsx` verifying that `selectedOrgId` defaults correctly to `userData.organization` and renders proper metrics without fallback bias.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pre-commit hooks (`eslint`, `prettier`) executed without errors
