### PR TITLE
feat: speaker timeline scrubber in TranscriptViewer (#2252)

### DIFF
--- a/client/src/components/meeting-details/TimelinePlayer.jsx
+++ b/client/src/components/meeting-details/TimelinePlayer.jsx
@@ -9,11 +9,12 @@ const TimelinePlayer = ({
   handleDurationChange,
   setIsPlaying,
 }) => {
-  // If there's an audioFilePath, use it; else, placeholder
-  const audioUrl = meeting?.audioFilePath
-    ? meeting.audioFilePath.startsWith("http")
-      ? meeting.audioFilePath
-      : `/api/media/${meeting.audioFilePath}`
+  // If there's an audioFilePath or fileUrl, use it; else, placeholder
+  const mediaPath = meeting?.audioFilePath || meeting?.fileUrl || null;
+  const audioUrl = mediaPath
+    ? mediaPath.startsWith("http")
+      ? mediaPath
+      : `/api/media/${mediaPath}`
     : null;
 
   if (!audioUrl) {

--- a/client/src/components/meeting-details/TranscriptTimelineScrubber.jsx
+++ b/client/src/components/meeting-details/TranscriptTimelineScrubber.jsx
@@ -1,0 +1,220 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { meetingTimelineApi } from "../../services/meetingTimelineApi";
+import { useTimelineSync } from "../../hooks/useTimelineSync";
+import TimelinePlayer from "./TimelinePlayer";
+
+const formatTime = (seconds) => {
+  if (!seconds || isNaN(seconds)) return "00:00";
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
+  const s = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${m}:${s}`;
+};
+
+/**
+ * Resolve playable media path from meeting and/or transcript records.
+ */
+const resolveTranscriptMediaPath = (meeting, transcript) =>
+  meeting?.audioFilePath ||
+  meeting?.fileUrl ||
+  transcript?.audioFilePath ||
+  null;
+
+/**
+ * Speaker / event scrubber synced with TimelinePlayer for TranscriptViewer (#2252).
+ */
+const TranscriptTimelineScrubber = ({
+  meetingId,
+  meeting,
+  transcript,
+  onCurrentTimeChange,
+  seekRef,
+}) => {
+  const timelineRef = useRef(null);
+  const [timelineEvents, setTimelineEvents] = useState([]);
+  const {
+    currentTime,
+    duration,
+    isPlaying,
+    playerRef,
+    seekTo,
+    togglePlayPause,
+    handleTimeUpdate,
+    handleDurationChange,
+    setIsPlaying,
+  } = useTimelineSync();
+
+  const mediaPath = resolveTranscriptMediaPath(meeting, transcript);
+  const mediaMeeting = useMemo(
+    () => ({
+      ...(meeting || {}),
+      audioFilePath: mediaPath,
+    }),
+    [meeting, mediaPath],
+  );
+
+  const segments = transcript?.segments || [];
+
+  useEffect(() => {
+    onCurrentTimeChange?.(currentTime);
+  }, [currentTime, onCurrentTimeChange]);
+
+  useEffect(() => {
+    if (seekRef) {
+      seekRef.current = seekTo;
+    }
+    return () => {
+      if (seekRef) seekRef.current = null;
+    };
+  }, [seekRef, seekTo]);
+
+  useEffect(() => {
+    if (!meetingId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await meetingTimelineApi.getMeetingTimeline(meetingId);
+        if (!cancelled && data?.success) {
+          setTimelineEvents(data.timeline || []);
+        }
+      } catch (err) {
+        console.error("Failed to load meeting timeline for scrubber:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [meetingId]);
+
+  const maxSegmentTime = segments.reduce(
+    (max, seg) => Math.max(max, seg.endTime || seg.startTime || 0),
+    0,
+  );
+  const maxEventTime = timelineEvents.reduce(
+    (max, ev) => Math.max(max, ev.endTime || ev.startTime || 0),
+    0,
+  );
+  const totalDuration =
+    duration || transcript?.duration || maxSegmentTime || maxEventTime || 1;
+
+  const handleTimelineClick = (e) => {
+    if (!mediaPath || !timelineRef.current) return;
+    const rect = timelineRef.current.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
+    const percentage = Math.max(0, Math.min(1, clickX / rect.width));
+    seekTo(percentage * totalDuration);
+  };
+
+  if (!mediaPath) {
+    return (
+      <div
+        className="mb-6 rounded-lg border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-slate-800/50 p-4 text-center text-sm text-gray-500 dark:text-gray-400"
+        data-testid="transcript-scrubber-empty"
+      >
+        No audio or video available to scrub. Segment review still works without
+        media playback.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mb-6 bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 flex flex-col gap-4"
+      data-testid="transcript-timeline-scrubber"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Speaker Timeline
+        </h3>
+        <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
+          {formatTime(currentTime)} / {formatTime(totalDuration)}
+        </span>
+      </div>
+
+      <div
+        ref={timelineRef}
+        className="relative h-10 bg-gray-100 dark:bg-gray-900 rounded-lg overflow-hidden cursor-pointer border border-gray-200 dark:border-gray-700"
+        onClick={handleTimelineClick}
+        role="slider"
+        aria-label="Seek transcript media"
+        aria-valuemin={0}
+        aria-valuemax={Math.floor(totalDuration)}
+        aria-valuenow={Math.floor(currentTime)}
+      >
+        <div
+          className="absolute top-0 bottom-0 left-0 bg-indigo-100 dark:bg-indigo-900/40 border-r border-indigo-400"
+          style={{
+            width: `${Math.min(100, (currentTime / totalDuration) * 100)}%`,
+          }}
+        />
+
+        {segments.map((segment, index) => {
+          const start = segment.startTime || 0;
+          const end = segment.endTime ?? start;
+          const leftPercent = (start / totalDuration) * 100;
+          const widthPercent = Math.max(
+            0.4,
+            ((end - start) / totalDuration) * 100,
+          );
+          const isActive =
+            currentTime >= start && currentTime < (end || start + 0.25);
+          return (
+            <button
+              key={`seg-${index}`}
+              type="button"
+              title={`${segment.speaker || "Speaker"} @ ${formatTime(start)}`}
+              className={`absolute top-1/2 -translate-y-1/2 h-3 rounded-full transition-all ${
+                isActive
+                  ? "bg-indigo-600 h-5 z-10"
+                  : "bg-blue-400/80 hover:bg-blue-500 hover:h-4"
+              }`}
+              style={{
+                left: `${leftPercent}%`,
+                width: `${widthPercent}%`,
+                minWidth: "4px",
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                seekTo(start);
+              }}
+            />
+          );
+        })}
+
+        {timelineEvents
+          .filter((ev) => ev.type === "key_moment")
+          .map((event, index) => {
+            const leftPercent = (event.startTime / totalDuration) * 100;
+            return (
+              <button
+                key={`km-${index}`}
+                type="button"
+                title={event.data?.snippet || "Key moment"}
+                className="absolute top-0 bottom-0 w-0.5 bg-purple-500 z-20 hover:w-1"
+                style={{ left: `${leftPercent}%` }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  seekTo(event.startTime);
+                }}
+              />
+            );
+          })}
+      </div>
+
+      <TimelinePlayer
+        meeting={mediaMeeting}
+        playerRef={playerRef}
+        isPlaying={isPlaying}
+        togglePlayPause={togglePlayPause}
+        handleTimeUpdate={handleTimeUpdate}
+        handleDurationChange={handleDurationChange}
+        setIsPlaying={setIsPlaying}
+      />
+    </div>
+  );
+};
+
+export default TranscriptTimelineScrubber;

--- a/client/src/components/meeting-details/__tests__/TranscriptTimelineScrubber.test.jsx
+++ b/client/src/components/meeting-details/__tests__/TranscriptTimelineScrubber.test.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TranscriptTimelineScrubber from "../TranscriptTimelineScrubber.jsx";
+
+vi.mock("../../../services/meetingTimelineApi", () => ({
+  meetingTimelineApi: {
+    getMeetingTimeline: vi.fn().mockResolvedValue({
+      data: {
+        success: true,
+        timeline: [
+          {
+            type: "key_moment",
+            startTime: 5,
+            endTime: 8,
+            data: { snippet: "Decision point" },
+          },
+        ],
+      },
+    }),
+  },
+}));
+
+vi.mock("../../../hooks/useTimelineSync", () => ({
+  useTimelineSync: () => ({
+    currentTime: 0,
+    duration: 60,
+    isPlaying: false,
+    playerRef: { current: null },
+    seekTo: vi.fn(),
+    togglePlayPause: vi.fn(),
+    handleTimeUpdate: vi.fn(),
+    handleDurationChange: vi.fn(),
+    setIsPlaying: vi.fn(),
+  }),
+}));
+
+vi.mock("../TimelinePlayer", () => ({
+  default: ({ meeting }) => (
+    <div
+      data-testid="timeline-player"
+      data-audio={meeting?.audioFilePath || ""}
+    >
+      Player
+    </div>
+  ),
+}));
+
+describe("TranscriptTimelineScrubber (#2252)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows graceful empty state when media is missing", () => {
+    render(
+      <TranscriptTimelineScrubber
+        meetingId="m1"
+        meeting={{ title: "No media" }}
+        transcript={{ segments: [{ startTime: 0, endTime: 5, speaker: "A" }] }}
+      />,
+    );
+
+    expect(screen.getByTestId("transcript-scrubber-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("timeline-player")).not.toBeInTheDocument();
+  });
+
+  it("renders scrubber and player when media exists", async () => {
+    render(
+      <TranscriptTimelineScrubber
+        meetingId="m1"
+        meeting={{ fileUrl: "recordings/meet.mp3" }}
+        transcript={{
+          duration: 60,
+          segments: [
+            { startTime: 0, endTime: 10, speaker: "Alice", text: "Hi" },
+            { startTime: 10, endTime: 20, speaker: "Bob", text: "Hello" },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByTestId("transcript-timeline-scrubber"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-player")).toHaveAttribute(
+      "data-audio",
+      "recordings/meet.mp3",
+    );
+    expect(screen.getByText("Speaker Timeline")).toBeInTheDocument();
+  });
+
+  it("uses transcript audioFilePath when meeting has no media", async () => {
+    render(
+      <TranscriptTimelineScrubber
+        meetingId="m1"
+        meeting={{ title: "Sync" }}
+        transcript={{
+          audioFilePath: "uploads/b.wav",
+          segments: [{ startTime: 0, endTime: 4, speaker: "A", text: "Hi" }],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByTestId("transcript-timeline-scrubber"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-player")).toHaveAttribute(
+      "data-audio",
+      "uploads/b.wav",
+    );
+  });
+});

--- a/client/src/pages/TranscriptViewer.jsx
+++ b/client/src/pages/TranscriptViewer.jsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useCallback, useContext } from "react";
+import React, {
+  useEffect,
+  useState,
+  useCallback,
+  useContext,
+  useRef,
+} from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar.jsx";
 import api from "../services/apiClient.js";
@@ -21,6 +27,7 @@ import {
 import { toast } from "react-toastify";
 import MeetingSentimentChart from "../components/MeetingSentimentChart";
 import SpeakerAttribution from "../components/meeting-details/SpeakerAttribution";
+import TranscriptTimelineScrubber from "../components/meeting-details/TranscriptTimelineScrubber";
 import AppContent from "../context/AppContent.js";
 
 const HighlightedText = ({ text, query }) => {
@@ -50,6 +57,8 @@ const TranscriptViewer = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [highlightedSegment, setHighlightedSegment] = useState(null);
+  const [playbackTime, setPlaybackTime] = useState(0);
+  const mediaSeekRef = useRef(null);
 
   const { userData } = useContext(AppContent) || {};
   const [editingSpeakerIndex, setEditingSpeakerIndex] = useState(null);
@@ -338,12 +347,16 @@ const TranscriptViewer = () => {
     return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
   };
 
-  const scrollToSegment = (index) => {
+  const scrollToSegment = (index, { seek = false } = {}) => {
+    if (index == null || index < 0) return;
     setHighlightedSegment(index);
     const element = document.getElementById(`segment-${index}`);
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "center" });
       setTimeout(() => setHighlightedSegment(null), 3000);
+    }
+    if (seek && transcript?.segments?.[index]) {
+      mediaSeekRef.current?.(transcript.segments[index].startTime || 0);
     }
   };
 
@@ -389,6 +402,17 @@ const TranscriptViewer = () => {
   }
 
   const meeting = transcript.meeting;
+
+  const activePlaybackSegment = (() => {
+    const segs = transcript.segments || [];
+    if (!segs.length) return null;
+    const idx = segs.findIndex((s) => {
+      const start = s.startTime || 0;
+      const end = s.endTime ?? start + 0.25;
+      return playbackTime >= start && playbackTime < end;
+    });
+    return idx >= 0 ? idx : null;
+  })();
 
   const canEdit =
     userData &&
@@ -547,6 +571,15 @@ const TranscriptViewer = () => {
               onMappingChange={fetchTranscript}
             />
           </div>
+
+          <TranscriptTimelineScrubber
+            meetingId={meetingId}
+            meeting={meeting}
+            transcript={transcript}
+            onCurrentTimeChange={setPlaybackTime}
+            seekRef={mediaSeekRef}
+          />
+
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Transcript Content */}
             <div className="lg:col-span-2 space-y-4">
@@ -602,12 +635,28 @@ const TranscriptViewer = () => {
                   <div
                     key={index}
                     id={`segment-${index}`}
+                    role={editingSegmentIndex === index ? undefined : "button"}
+                    tabIndex={editingSegmentIndex === index ? undefined : 0}
+                    onClick={() => {
+                      if (editingSegmentIndex === index) return;
+                      scrollToSegment(index, { seek: true });
+                    }}
+                    onKeyDown={(e) => {
+                      if (editingSegmentIndex === index) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        scrollToSegment(index, { seek: true });
+                      }
+                    }}
                     className={`bg-white dark:bg-slate-800 rounded-lg p-4 border ${
                       editingSegmentIndex === index
                         ? "border-indigo-500 ring-2 ring-indigo-200 dark:ring-indigo-800"
-                        : highlightedSegment === index
-                          ? "border-indigo-500 ring-2 ring-indigo-200 dark:ring-indigo-800"
-                          : "border-gray-200 dark:border-gray-700"
+                        : `cursor-pointer ${
+                            highlightedSegment === index ||
+                            activePlaybackSegment === index
+                              ? "border-indigo-500 ring-2 ring-indigo-200 dark:ring-indigo-800 bg-indigo-50/40 dark:bg-indigo-950/20"
+                              : "border-gray-200 dark:border-gray-700"
+                          }`
                     } transition-all`}
                   >
                     {editingSegmentIndex === index ? (
@@ -762,7 +811,8 @@ const TranscriptViewer = () => {
                               </div>
                             ) : (
                               <span
-                                onClick={() => {
+                                onClick={(e) => {
+                                  e.stopPropagation();
                                   if (canEdit) {
                                     setEditingSpeakerIndex(index);
                                     setNewSpeakerName(segment.speaker);
@@ -804,7 +854,10 @@ const TranscriptViewer = () => {
                           {canEdit && (
                             <button
                               type="button"
-                              onClick={() => startEditSegment(index, segment)}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                startEditSegment(index, segment);
+                              }}
                               className="px-2 py-1 hover:bg-gray-100 dark:hover:bg-slate-700 rounded text-gray-500 hover:text-indigo-600 dark:hover:text-indigo-400 text-xs flex items-center gap-1 transition-colors"
                               title="Edit segment text and timestamps"
                               aria-label="Edit segment"

--- a/client/src/pages/__tests__/TranscriptViewer.test.jsx
+++ b/client/src/pages/__tests__/TranscriptViewer.test.jsx
@@ -12,6 +12,25 @@ vi.mock("../../components/MeetingSentimentChart", () => ({
   default: () => <div data-testid="mock-sentiment-chart">Sentiment Chart</div>,
 }));
 
+vi.mock("../../components/meeting-details/SpeakerAttribution", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meeting-details/TranscriptTimelineScrubber", () => ({
+  default: ({ meeting, transcript }) => (
+    <div
+      data-testid="mock-transcript-scrubber"
+      data-has-media={
+        meeting?.fileUrl || meeting?.audioFilePath || transcript?.audioFilePath
+          ? "yes"
+          : "no"
+      }
+    >
+      Scrubber
+    </div>
+  ),
+}));
+
 vi.mock("../../services/apiClient.js", () => ({
   default: {
     get: vi.fn(),
@@ -100,6 +119,22 @@ describe("TranscriptViewer Page (#1805)", () => {
     expect(
       screen.getAllByText("Welcome everyone to the meeting.")[0],
     ).toBeInTheDocument();
+  });
+
+  it("mounts transcript timeline scrubber (#2252)", async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        ...sampleTranscriptData,
+        meeting: {
+          ...sampleTranscriptData.meeting,
+          fileUrl: "recordings/design.mp3",
+        },
+      },
+    });
+    render(<TranscriptViewer />);
+
+    const scrubber = await screen.findByTestId("mock-transcript-scrubber");
+    expect(scrubber).toHaveAttribute("data-has-media", "yes");
   });
 
   it("searches transcript using /api/transcripts/meeting/:meetingId/search route prefix", async () => {

--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -832,7 +832,7 @@ export const getTranscriptByMeeting = async (req, res) => {
       meeting: meetingId,
     }).populate(
       "meeting",
-      "title date participants uploadedBy organization transcript encryptedTranscript isTranscriptEncrypted",
+      "title date participants uploadedBy organization transcript encryptedTranscript isTranscriptEncrypted fileUrl",
     );
 
     if (!transcript) {


### PR DESCRIPTION
## Summary
- Embed speaker timeline scrubber + TimelinePlayer in TranscriptViewer
- Segment click seeks media; active segment highlights during playback
- Graceful empty state without media; reuse meeting timeline API for key-moment markers

## Test plan
- [x] TranscriptTimelineScrubber unit tests
- [x] TranscriptViewer mount test
- [ ] Open transcript with audio → scrubber/player visible
- [ ] Click a segment → audio seeks and segment highlights while playing
- [ ] Transcript without media → empty state, no broken player

Closes #2252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronized transcript and media playback with timeline markers and clickable seeking.
  * Transcript segments now highlight during playback and support keyboard interaction.
  * Added support for remote media URLs and local media paths.
  * Transcript pages now receive and use meeting media links.

* **Bug Fixes**
  * Improved media fallback handling when one audio source is unavailable.
  * Added clear empty-state messaging when no media is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->