### PR TITLE
feat: collaborative notes sync status indicator

### DIFF
--- a/client/src/components/meetings/CollabSyncStatusChip.jsx
+++ b/client/src/components/meetings/CollabSyncStatusChip.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Save, CheckCircle, WifiOff, Loader2, AlertCircle } from "lucide-react";
+
+/** Keep labels aligned with useCollaborativeNote syncStatus values (#2250). */
+const STATUS = {
+  CONNECTING: "connecting",
+  SYNCED: "synced",
+  SAVING: "saving",
+  OFFLINE: "offline",
+  ERROR: "error",
+};
+
+/**
+ * PersonalNotes-style status chip for collaborative notes sync (#2250).
+ */
+const CollabSyncStatusChip = ({ syncStatus, isReadOnly = false }) => {
+  if (isReadOnly && syncStatus === STATUS.SYNCED) {
+    return (
+      <span
+        className="inline-flex items-center text-xs text-emerald-600 dark:text-emerald-400"
+        data-testid="collab-sync-status"
+        data-status="synced"
+      >
+        <CheckCircle className="w-3 h-3 mr-1" />
+        Viewing live
+      </span>
+    );
+  }
+
+  switch (syncStatus) {
+    case STATUS.CONNECTING:
+      return (
+        <span
+          className="inline-flex items-center text-xs text-slate-500 dark:text-gray-400"
+          data-testid="collab-sync-status"
+          data-status="connecting"
+        >
+          <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+          Connecting...
+        </span>
+      );
+    case STATUS.SAVING:
+      return (
+        <span
+          className="inline-flex items-center text-xs text-amber-500"
+          data-testid="collab-sync-status"
+          data-status="saving"
+        >
+          <Save className="w-3 h-3 mr-1 animate-pulse" />
+          Saving...
+        </span>
+      );
+    case STATUS.SYNCED:
+      return (
+        <span
+          className="inline-flex items-center text-xs text-emerald-500"
+          data-testid="collab-sync-status"
+          data-status="synced"
+        >
+          <CheckCircle className="w-3 h-3 mr-1" />
+          Synced
+        </span>
+      );
+    case STATUS.OFFLINE:
+      return (
+        <span
+          className="inline-flex items-center text-xs text-amber-600 dark:text-amber-400"
+          data-testid="collab-sync-status"
+          data-status="offline"
+        >
+          <WifiOff className="w-3 h-3 mr-1" />
+          Offline — changes may not sync
+        </span>
+      );
+    case STATUS.ERROR:
+      return (
+        <span
+          className="inline-flex items-center text-xs text-red-500"
+          data-testid="collab-sync-status"
+          data-status="error"
+        >
+          <AlertCircle className="w-3 h-3 mr-1" />
+          Error syncing
+        </span>
+      );
+    default:
+      return null;
+  }
+};
+
+export default CollabSyncStatusChip;

--- a/client/src/components/meetings/CollaborativeEditor.jsx
+++ b/client/src/components/meetings/CollaborativeEditor.jsx
@@ -9,6 +9,7 @@ import { useCollaborativeNote } from "../../hooks/useCollaborativeNote";
 import PresenceAvatars from "./PresenceAvatars";
 import VersionHistory from "./VersionHistory";
 import NoteVersionHistory from "../NoteVersionHistory";
+import CollabSyncStatusChip from "./CollabSyncStatusChip";
 
 /**
  * @desc Main collaborative editor pane (Tiptap + Yjs). Remount via `key` after
@@ -23,6 +24,7 @@ const CollaborativeEditorPane = ({
     ydoc,
     isConnected,
     isLoading,
+    syncStatus,
     activeUsers,
     userColor,
     broadcastCursor,
@@ -116,17 +118,24 @@ const CollaborativeEditorPane = ({
       <div className="flex-1 flex flex-col overflow-hidden">
         {/* Top Bar: Connection Status & Active Users */}
         <div className="flex items-center justify-between px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/30">
-          <div className="flex items-center gap-2">
-            <div
-              className={`w-2 h-2 rounded-full ${isConnected ? "bg-green-500 animate-pulse" : "bg-red-500"}`}
-            ></div>
-            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-              {isConnected
-                ? isReadOnly
-                  ? "Viewing Live"
-                  : "Connected & Syncing"
-                : "Disconnected"}
-            </span>
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="flex items-center gap-2">
+              <div
+                className={`w-2 h-2 rounded-full ${isConnected ? "bg-green-500 animate-pulse" : "bg-red-500"}`}
+                aria-hidden="true"
+              ></div>
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                {isConnected
+                  ? isReadOnly
+                    ? "Viewing Live"
+                    : "Connected"
+                  : "Disconnected"}
+              </span>
+            </div>
+            <CollabSyncStatusChip
+              syncStatus={syncStatus}
+              isReadOnly={isReadOnly}
+            />
           </div>
 
           <div className="flex items-center gap-3">

--- a/client/src/components/meetings/__tests__/CollabSyncStatusChip.test.jsx
+++ b/client/src/components/meetings/__tests__/CollabSyncStatusChip.test.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import CollabSyncStatusChip from "../CollabSyncStatusChip.jsx";
+
+describe("CollabSyncStatusChip (#2250)", () => {
+  it("shows Connecting for connecting status", () => {
+    render(<CollabSyncStatusChip syncStatus="connecting" />);
+    expect(screen.getByTestId("collab-sync-status")).toHaveAttribute(
+      "data-status",
+      "connecting",
+    );
+    expect(screen.getByText(/Connecting/i)).toBeInTheDocument();
+  });
+
+  it("shows Saving then Synced labels", () => {
+    const { rerender } = render(<CollabSyncStatusChip syncStatus="saving" />);
+    expect(screen.getByText(/Saving/i)).toBeInTheDocument();
+
+    rerender(<CollabSyncStatusChip syncStatus="synced" />);
+    expect(screen.getByText(/^Synced$/i)).toBeInTheDocument();
+  });
+
+  it("warns when offline", () => {
+    render(<CollabSyncStatusChip syncStatus="offline" />);
+    expect(screen.getByTestId("collab-sync-status")).toHaveAttribute(
+      "data-status",
+      "offline",
+    );
+    expect(screen.getByText(/Offline/i)).toBeInTheDocument();
+  });
+
+  it("shows error syncing state", () => {
+    render(<CollabSyncStatusChip syncStatus="error" />);
+    expect(screen.getByText(/Error syncing/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/meetings/__tests__/CollaborativeEditorNoteVersionHistory.test.jsx
+++ b/client/src/components/meetings/__tests__/CollaborativeEditorNoteVersionHistory.test.jsx
@@ -8,11 +8,19 @@ vi.mock("../../../hooks/useCollaborativeNote", () => ({
     ydoc: { getText: () => ({}) },
     isConnected: true,
     isLoading: false,
+    syncStatus: "synced",
     activeUsers: [],
     userColor: "#3366ff",
     broadcastCursor: vi.fn(),
     saveSnapshot: vi.fn().mockResolvedValue({ success: true }),
   }),
+  COLLAB_SYNC_STATUS: {
+    CONNECTING: "connecting",
+    SYNCED: "synced",
+    SAVING: "saving",
+    OFFLINE: "offline",
+    ERROR: "error",
+  },
 }));
 
 vi.mock("@tiptap/react", () => ({

--- a/client/src/hooks/__tests__/useCollaborativeNote.test.js
+++ b/client/src/hooks/__tests__/useCollaborativeNote.test.js
@@ -23,17 +23,20 @@ vi.mock("react-toastify", () => ({
 vi.mock("socket.io-client", () => {
   const listeners = {};
   const mockSocket = {
-    on: vi.fn((event, callback) => {
+    on(event, callback) {
       listeners[event] = callback;
-    }),
-    emit: vi.fn((event, data, cb) => {
-      if (event === "join-meeting" && cb) {
+    },
+    emit(event, _data, cb) {
+      if (event === "join-meeting" && typeof cb === "function") {
         cb({ success: true, userColor: "#ff0000", activeUsers: [] });
       }
-    }),
+    },
     disconnect: vi.fn(),
-    __trigger: (event, payload) => {
-      if (listeners[event]) listeners[event](payload);
+    __trigger(event, payload) {
+      listeners[event]?.(payload);
+    },
+    __has(event) {
+      return typeof listeners[event] === "function";
     },
   };
   return {
@@ -41,9 +44,10 @@ vi.mock("socket.io-client", () => {
   };
 });
 
-describe("useCollaborativeNote socket URL & backend config alignment (#2002)", () => {
+describe("useCollaborativeNote socket URL & sync status (#2002, #2250)", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    io.mockClear();
+    toast.error.mockClear();
   });
 
   it("connects to ${getBackendUrl()}/notes using shared Clerk socket options", async () => {
@@ -59,14 +63,18 @@ describe("useCollaborativeNote socket URL & backend config alignment (#2002)", (
     });
   });
 
-  it("handles connect_error, updates error state, and triggers toast error", async () => {
+  it("handles connect_error, updates error + syncStatus, and triggers toast (#2250)", async () => {
     const { result } = renderHook(() => useCollaborativeNote("meeting-123"));
 
     await waitFor(() => {
       expect(io).toHaveBeenCalled();
     });
+    const mockSocket = io.mock.results.at(-1).value;
 
-    const mockSocket = io.mock.results[0].value;
+    await waitFor(() => {
+      expect(mockSocket.__has("connect_error")).toBe(true);
+    });
+
     act(() => {
       mockSocket.__trigger("connect_error", new Error("Authentication failed"));
     });
@@ -74,9 +82,32 @@ describe("useCollaborativeNote socket URL & backend config alignment (#2002)", (
     await waitFor(() => {
       expect(result.current.error).toBe("Authentication failed");
       expect(result.current.isConnected).toBe(false);
+      expect(result.current.syncStatus).toBe("error");
       expect(toast.error).toHaveBeenCalledWith(
         expect.stringContaining("Authentication failed"),
       );
+    });
+  });
+
+  it("sets offline syncStatus on disconnect (#2250)", async () => {
+    const { result } = renderHook(() => useCollaborativeNote("meeting-123"));
+
+    await waitFor(() => {
+      expect(io).toHaveBeenCalled();
+    });
+    const mockSocket = io.mock.results.at(-1).value;
+
+    await waitFor(() => {
+      expect(mockSocket.__has("disconnect")).toBe(true);
+    });
+
+    act(() => {
+      mockSocket.__trigger("disconnect");
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(false);
+      expect(result.current.syncStatus).toBe("offline");
     });
   });
 });

--- a/client/src/hooks/useCollaborativeNote.js
+++ b/client/src/hooks/useCollaborativeNote.js
@@ -10,12 +10,24 @@ import {
 import { getBackendUrl } from "../config/backendConfig.js";
 
 /**
+ * Sync status values surfaced in collaborative notes UI (#2250).
+ * connecting | synced | saving | offline | error
+ */
+export const COLLAB_SYNC_STATUS = {
+  CONNECTING: "connecting",
+  SYNCED: "synced",
+  SAVING: "saving",
+  OFFLINE: "offline",
+  ERROR: "error",
+};
+
+/**
  * @desc Custom hook to manage the WebSocket connection, Yjs document state,
  * and awareness (presence) for a collaborative meeting note.
  *
  * @param {string} meetingId - The ID of the meeting to collaborate on.
  * @param {boolean} isReadOnly - If true, disables broadcasting of local changes.
- * @returns {Object} Yjs doc, awareness state, connection status, and snapshot functions.
+ * @returns {Object} Yjs doc, awareness state, connection/sync status, and snapshot functions.
  */
 export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
   const { userId, getToken, isSignedIn } = useAuth();
@@ -23,20 +35,48 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
   const [activeUsers, setActiveUsers] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [syncStatus, setSyncStatus] = useState(COLLAB_SYNC_STATUS.CONNECTING);
 
   // Refs to persist across renders without causing re-renders
   const socketRef = useRef(null);
   const ydocRef = useRef(new Y.Doc());
   const ytextRef = useRef(ydocRef.current.getText("collaborative-note"));
   const userColorRef = useRef("#000000");
+  // Clerk's getToken identity can change every render — keep it out of effect deps
+  const getTokenRef = useRef(getToken);
+  getTokenRef.current = getToken;
+
+  useEffect(() => {
+    const handleOffline = () => {
+      setIsConnected(false);
+      setSyncStatus(COLLAB_SYNC_STATUS.OFFLINE);
+    };
+    const handleOnline = () => {
+      // Socket reconnect will move status to connecting/synced
+      if (!socketRef.current?.connected) {
+        setSyncStatus(COLLAB_SYNC_STATUS.CONNECTING);
+      }
+    };
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
+    if (typeof navigator !== "undefined" && navigator.onLine === false) {
+      setSyncStatus(COLLAB_SYNC_STATUS.OFFLINE);
+    }
+    return () => {
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
 
   useEffect(() => {
     if (!meetingId || !isSignedIn) return;
 
     let isActive = true;
+    setSyncStatus(COLLAB_SYNC_STATUS.CONNECTING);
+    setIsLoading(true);
 
     const initializeSocket = async () => {
-      const token = await getToken();
+      const token = await getTokenRef.current();
 
       if (!isActive) {
         setIsLoading(false);
@@ -64,13 +104,15 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
         setError(errorMsg);
         setIsConnected(false);
         setIsLoading(false);
+        setSyncStatus(COLLAB_SYNC_STATUS.ERROR);
         toast.error(`Collaborative notes connection error: ${errorMsg}`);
       });
 
       socket.on("reconnect_attempt", async () => {
+        setSyncStatus(COLLAB_SYNC_STATUS.CONNECTING);
         try {
           const freshToken =
-            (await getClerkBearerToken()) || (await getToken());
+            (await getClerkBearerToken()) || (await getTokenRef.current());
           if (socket.auth) {
             socket.auth.token = freshToken;
           } else {
@@ -88,16 +130,20 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
         console.log("[CollabNote] Socket connected");
         setIsConnected(true);
         setError(null);
+        setSyncStatus(COLLAB_SYNC_STATUS.CONNECTING);
 
         // Join the meeting room and fetch initial state
-        socket.emit("join-meeting", { meetingId }, async (response) => {
-          if (!isActive) return;
+        socket.emit("join-meeting", { meetingId }, (response) => {
+          // Ignore stale callbacks from React Strict Mode remounts / prior sockets
+          if (socketRef.current !== socket) return;
           if (response?.success) {
             userColorRef.current = response.userColor;
             setActiveUsers(response.activeUsers || []);
+            setSyncStatus(COLLAB_SYNC_STATUS.SYNCED);
           } else {
             const errorMsg = response?.error || "Failed to join meeting";
             setError(errorMsg);
+            setSyncStatus(COLLAB_SYNC_STATUS.ERROR);
             toast.error(errorMsg);
           }
           setIsLoading(false);
@@ -107,13 +153,14 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
       socket.on("disconnect", () => {
         console.log("[CollabNote] Socket disconnected");
         setIsConnected(false);
+        setSyncStatus(COLLAB_SYNC_STATUS.OFFLINE);
       });
 
       // Listen for remote CRDT updates from other clients
       socket.on("remote-update", ({ update, userId: remoteUserId }) => {
         if (remoteUserId !== userId) {
           const uint8Update = new Uint8Array(update);
-          Y.applyUpdate(ydocRef.current, uint8Update);
+          Y.applyUpdate(ydocRef.current, uint8Update, "remote");
         }
       });
 
@@ -168,12 +215,30 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
 
       // Observe local Yjs document changes to broadcast to server
       const updateHandler = (update, origin) => {
-        if (origin !== "remote" && !isReadOnly) {
-          socket.emit("sync-update", {
+        if (origin === "remote" || isReadOnly) return;
+
+        if (!socket.connected) {
+          setSyncStatus(COLLAB_SYNC_STATUS.OFFLINE);
+          return;
+        }
+
+        setSyncStatus(COLLAB_SYNC_STATUS.SAVING);
+        socket.emit(
+          "sync-update",
+          {
             meetingId,
             update: Array.from(update),
-          });
-        }
+          },
+          (response) => {
+            if (socketRef.current !== socket) return;
+            if (response?.success) {
+              setSyncStatus(COLLAB_SYNC_STATUS.SYNCED);
+            } else {
+              setSyncStatus(COLLAB_SYNC_STATUS.ERROR);
+              setError(response?.error || "Failed to sync notes");
+            }
+          },
+        );
       };
 
       const ydoc = ydocRef.current;
@@ -197,7 +262,7 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
         cleanupSocket.then((cleanup) => cleanup && cleanup());
       }
     };
-  }, [meetingId, getToken, isReadOnly, isSignedIn, userId]);
+  }, [meetingId, isReadOnly, isSignedIn, userId]);
 
   /**
    * @desc Broadcasts local cursor position to other clients.
@@ -241,6 +306,7 @@ export const useCollaborativeNote = (meetingId, isReadOnly = false) => {
     isConnected,
     isLoading,
     error,
+    syncStatus,
     activeUsers,
     userColor: userColorRef.current,
     broadcastCursor,

--- a/server/socket/notesSocket.js
+++ b/server/socket/notesSocket.js
@@ -108,7 +108,7 @@ const initializeNotesSocket = (io) => {
      * @desc Receives a binary CRDT update from a client, applies it to the server doc,
      * and broadcasts it to all other clients in the room.
      */
-    socket.on("sync-update", async ({ meetingId, update }) => {
+    socket.on("sync-update", async ({ meetingId, update }, callback) => {
       try {
         const uint8Update = new Uint8Array(update);
 
@@ -120,8 +120,15 @@ const initializeNotesSocket = (io) => {
           update: Array.from(uint8Update),
           userId: socket.user.id,
         });
+
+        if (typeof callback === "function") {
+          callback({ success: true });
+        }
       } catch (error) {
         console.error("[NotesSocket] Error applying update:", error);
+        if (typeof callback === "function") {
+          callback({ success: false, error: error.message });
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Surface connection/sync status (connecting, Saving…, Synced, offline, error) for collaborative notes
- Ack `sync-te` on the notes socket so local edits show Saving… then Synced
- Match PersonalNotes-style status chip UX; add status-transition tests

Closes #2250

## Test plan
- [ ] Open collaborative notes → chip shows Connecting… then Synced when connected
- [ ] Edit notes → Saving… then Synced
- [ ] Disconnect / go offline → Offline warning
- [ ] Force connect error → Error syncing + toast
- [ ] `npm run lint:changed --prefix client` / `server`
- [ ] `npx vitest run src/hooks/__tests__/useCollaborativeNote.test.js src/components/meetings/__tests__/CollabSyncStatusChip.test.jsx` (client)