### PR TITLE
feat: per-route ErrorBoundary wrappers for major app shells

### DIFF
--- a/client/src/components/RouteErrorBoundary.jsx
+++ b/client/src/components/RouteErrorBoundary.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { AlertCircle, Home, RefreshCw } from "lucide-react";
+import { reportRouteError } from "../hooks/useRouteErrorReporter.js";
+
+/**
+ * Fallback UI with section reload + go-home recovery actions (#2248).
+ */
+function RouteErrorFallback({
+  section,
+  error,
+  onReloadSection,
+  homePath = "/dashboard",
+}) {
+  return (
+    <div
+      className="min-h-[50vh] flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4"
+      data-testid="route-error-fallback"
+      data-section={section}
+      role="alert"
+    >
+      <div className="flex flex-col items-center text-center max-w-md p-8 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-100 dark:border-red-800">
+        <AlertCircle className="w-12 h-12 text-red-500 dark:text-red-400 mb-4" />
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          {section ? `${section} unavailable` : "This section unavailable"}
+        </h3>
+        <p className="text-gray-600 dark:text-gray-300 mb-6">
+          {error?.message || "Something went wrong in this part of the app."}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={onReloadSection}
+            className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+            data-testid="route-error-reload"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Reload section
+          </button>
+          <Link
+            to={homePath}
+            className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            data-testid="route-error-home"
+          >
+            <Home className="w-4 h-4" />
+            Go home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Per-route error boundary so one shell crash does not blank the whole SPA (#2248).
+ */
+class RouteErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    const { section, onError } = this.props;
+    reportRouteError(error, errorInfo, { section });
+    onError?.(error, errorInfo, { section });
+  }
+
+  handleReloadSection = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    const {
+      children,
+      section = "Section",
+      homePath = "/dashboard",
+    } = this.props;
+
+    if (this.state.hasError) {
+      return (
+        <RouteErrorFallback
+          section={section}
+          error={this.state.error}
+          onReloadSection={this.handleReloadSection}
+          homePath={homePath}
+        />
+      );
+    }
+
+    return children;
+  }
+}
+
+export default RouteErrorBoundary;

--- a/client/src/components/__tests__/RouteErrorBoundary.test.jsx
+++ b/client/src/components/__tests__/RouteErrorBoundary.test.jsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import RouteErrorBoundary from "../RouteErrorBoundary.jsx";
+import {
+  reportRouteError,
+  useRouteErrorReporter,
+} from "../../hooks/useRouteErrorReporter.js";
+
+const Boom = ({ label = "boom" }) => {
+  throw new Error(label);
+};
+
+const Safe = ({ text }) => <div>{text}</div>;
+
+describe("RouteErrorBoundary (#2248)", () => {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("renders children when no error occurs", () => {
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary section="Dashboard">
+          <Safe text="Dashboard OK" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Dashboard OK")).toBeInTheDocument();
+  });
+
+  it("shows fallback with reload section and go home actions", () => {
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary section="Meeting Room">
+          <Boom label="Room crashed" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("route-error-fallback")).toHaveAttribute(
+      "data-section",
+      "Meeting Room",
+    );
+    expect(screen.getByText(/Meeting Room unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText("Room crashed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reload section/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("route-error-home")).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+
+  it("reloads the section without keeping the fallback", () => {
+    let shouldThrow = true;
+    const Flaky = () => {
+      if (shouldThrow) throw new Error("transient");
+      return <div>Recovered</div>;
+    };
+
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary section="Dashboard">
+          <Flaky />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("route-error-fallback")).toBeInTheDocument();
+    shouldThrow = false;
+    fireEvent.click(screen.getByTestId("route-error-reload"));
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+  });
+
+  it("does not unmount a sibling route shell when a child throws", () => {
+    render(
+      <MemoryRouter initialEntries={["/meeting-room/1"]}>
+        <Routes>
+          <Route
+            path="/meeting-room/:id"
+            element={
+              <RouteErrorBoundary section="Meeting Room">
+                <Boom label="room fail" />
+              </RouteErrorBoundary>
+            }
+          />
+          <Route
+            path="/dashboard"
+            element={
+              <RouteErrorBoundary section="Dashboard">
+                <Safe text="Dashboard still mounted" />
+              </RouteErrorBoundary>
+            }
+          />
+        </Routes>
+        {/* Sibling outside the active route — still in the tree */}
+        <RouteErrorBoundary section="Dashboard">
+          <Safe text="Sibling shell OK" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("route-error-fallback")).toBeInTheDocument();
+    expect(screen.getByText("Sibling shell OK")).toBeInTheDocument();
+    expect(screen.getByText("room fail")).toBeInTheDocument();
+  });
+
+  it("invokes onError / reportRouteError when a child throws", () => {
+    const onError = vi.fn();
+    render(
+      <MemoryRouter>
+        <RouteErrorBoundary section="Admin" onError={onError}>
+          <Boom label="admin fail" />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(onError).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(() =>
+      reportRouteError(
+        new Error("manual"),
+        { componentStack: "" },
+        {
+          section: "test",
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  it("useRouteErrorReporter reports through the shared channel", () => {
+    const Probe = () => {
+      const report = useRouteErrorReporter("Org Settings");
+      return (
+        <button type="button" onClick={() => report(new Error("hook report"))}>
+          Report
+        </button>
+      );
+    };
+
+    render(
+      <MemoryRouter>
+        <Probe />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Report/i }));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[RouteErrorBoundary]",
+      "Org Settings",
+      expect.any(Error),
+      expect.anything(),
+    );
+  });
+});

--- a/client/src/hooks/useRouteErrorReporter.js
+++ b/client/src/hooks/useRouteErrorReporter.js
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+
+/**
+ * Extension point for route-level error reporting (#2248).
+ * Wire a monitoring service here later without changing boundary call sites.
+ */
+export function reportRouteError(error, errorInfo, context = {}) {
+  console.error(
+    "[RouteErrorBoundary]",
+    context.section || "route",
+    error,
+    errorInfo,
+  );
+}
+
+/**
+ * Hook so feature code can report non-render failures through the same channel.
+ */
+export function useRouteErrorReporter(section = "route") {
+  return useCallback(
+    (error, errorInfo = {}) => {
+      reportRouteError(error, errorInfo, { section });
+    },
+    [section],
+  );
+}

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Route } from "react-router-dom";
 
 import ProtectedRoute from "../components/ProtectedRoute.jsx";
+import RouteErrorBoundary from "../components/RouteErrorBoundary.jsx";
 import AccessDenied from "../pages/AccessDenied.jsx";
 
 // --- Protected Pages ---
@@ -224,7 +225,9 @@ const ProtectedRoutes = (
       path="/admin/members"
       element={
         <ProtectedRoute resource="team_members" action="view">
-          <MembersManagement />
+          <RouteErrorBoundary section="Admin">
+            <MembersManagement />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -232,7 +235,9 @@ const ProtectedRoutes = (
       path="/admin/audit-logs"
       element={
         <ProtectedRoute resource="audit_logs" action="view">
-          <AuditLogViewer />
+          <RouteErrorBoundary section="Admin">
+            <AuditLogViewer />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -244,7 +249,9 @@ const ProtectedRoutes = (
           action="view"
           forbiddenFallback={<AccessDenied />}
         >
-          <AdminHealth />
+          <RouteErrorBoundary section="Admin">
+            <AdminHealth />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -256,7 +263,9 @@ const ProtectedRoutes = (
           action="view"
           forbiddenFallback={<AccessDenied />}
         >
-          <ResourceManagement />
+          <RouteErrorBoundary section="Admin">
+            <ResourceManagement />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -304,7 +313,9 @@ const ProtectedRoutes = (
       path="/organization/settings"
       element={
         <ProtectedRoute resource="organizations" action="view">
-          <OrganizationSettings />
+          <RouteErrorBoundary section="Org Settings">
+            <OrganizationSettings />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -312,7 +323,9 @@ const ProtectedRoutes = (
       path="/organizations/settings"
       element={
         <ProtectedRoute resource="organizations" action="view">
-          <OrganizationSettings />
+          <RouteErrorBoundary section="Org Settings">
+            <OrganizationSettings />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -320,7 +333,9 @@ const ProtectedRoutes = (
       path="/organization-settings"
       element={
         <ProtectedRoute resource="organizations" action="view">
-          <OrganizationSettings />
+          <RouteErrorBoundary section="Org Settings">
+            <OrganizationSettings />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -336,7 +351,9 @@ const ProtectedRoutes = (
       path="/dashboard"
       element={
         <ProtectedRoute>
-          <Dashboard />
+          <RouteErrorBoundary section="Dashboard">
+            <Dashboard />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -482,7 +499,9 @@ const ProtectedRoutes = (
       path="/meeting/:id"
       element={
         <ProtectedRoute resource="meetings" action="view">
-          <MeetingDetails />
+          <RouteErrorBoundary section="Meeting Details">
+            <MeetingDetails />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -514,7 +533,9 @@ const ProtectedRoutes = (
       path="/meeting-room/:roomId"
       element={
         <ProtectedRoute resource="meetings" action="view">
-          <MeetingRoom />
+          <RouteErrorBoundary section="Meeting Room">
+            <MeetingRoom />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />
@@ -804,7 +825,9 @@ const ProtectedRoutes = (
           action="view"
           forbiddenFallback={<AccessDenied />}
         >
-          <AdminPanel />
+          <RouteErrorBoundary section="Admin">
+            <AdminPanel />
+          </RouteErrorBoundary>
         </ProtectedRoute>
       }
     />

--- a/client/src/routes/__tests__/RouteErrorBoundaryWiring.test.jsx
+++ b/client/src/routes/__tests__/RouteErrorBoundaryWiring.test.jsx
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Ensures primary protected shells stay wrapped for #2248.
+ * Source assertion avoids mounting the full ProtectedRoutes tree.
+ */
+describe("ProtectedRoutes RouteErrorBoundary wiring (#2248)", () => {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../ProtectedRoutes.jsx"),
+    "utf8",
+  );
+
+  it("imports RouteErrorBoundary", () => {
+    expect(source).toMatch(/import RouteErrorBoundary from/);
+  });
+
+  it.each([
+    ["Dashboard", "/dashboard"],
+    ["Meeting Details", "/meeting/:id"],
+    ["Meeting Room", "/meeting-room/:roomId"],
+    ["Admin", "/admin-panel"],
+    ["Org Settings", "/organization/settings"],
+  ])("wraps %s shell (%s)", (section) => {
+    expect(source).toContain(`section="${section}"`);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `RouteErrorBoundary` with Reload section / Go home recovery CTAs and a shared error reporting hook
- Wrap primary protected shells (Dashboard, Meeting Details, Meeting Room, Admin, Org Settings)
- Unit tests for fallback UI, section reload, and sibling isolation

Closes #2248

## Test plan
- [ ] Force a throw in Meeting Room → fallback shows; navigate to Dashboard → Dashboard still works
- [ ] Fallback offers Reload section and Go home
- [ ] `npm run lint:changed --prefix client`
- [ ] `npx vitest run src/components/__tests__/RouteErrorBoundary.test.jsx src/routes/__tests__/RouteErrorBoundaryWiring.test.jsx` (client)