### PR TITLE
feat(taxonomy): add tag merge, bulk retag, and stats export admin workflow

### DIFF
--- a/client/src/pages/TagBrowser.jsx
+++ b/client/src/pages/TagBrowser.jsx
@@ -8,6 +8,12 @@ import {
   ArrowLeft,
   Loader2,
   Search,
+  GitMerge,
+  Download,
+  CheckSquare,
+  Square,
+  Layers,
+  Check,
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { tagApi } from "../services";
@@ -22,13 +28,15 @@ const TagBrowser = () => {
 
   const [tags, setTags] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Drill-down state
   const [selectedTag, setSelectedTag] = useState(null);
   const [meetings, setMeetings] = useState([]);
   const [meetingsLoading, setMeetingsLoading] = useState(false);
+  const [selectedMeetingIds, setSelectedMeetingIds] = useState([]);
 
-  // Modal state
+  // Create/Edit Modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingTag, setEditingTag] = useState(null);
   const [formData, setFormData] = useState({
@@ -36,6 +44,18 @@ const TagBrowser = () => {
     color: "#3B82F6",
     description: "",
   });
+
+  // Merge Tags Modal state
+  const [isMergeModalOpen, setIsMergeModalOpen] = useState(false);
+  const [mergeSourceId, setMergeSourceId] = useState("");
+  const [mergeTargetId, setMergeTargetId] = useState("");
+  const [isMerging, setIsMerging] = useState(false);
+
+  // Bulk Retag Modal state
+  const [isBulkRetagModalOpen, setIsBulkRetagModalOpen] = useState(false);
+  const [bulkTagsToAdd, setBulkTagsToAdd] = useState("");
+  const [bulkTagsToRemove, setBulkTagsToRemove] = useState("");
+  const [isBulkRetagging, setIsBulkRetagging] = useState(false);
 
   const fetchTags = async () => {
     try {
@@ -76,19 +96,19 @@ const TagBrowser = () => {
     setEditingTag(null);
   };
 
-  // Escape dismisses the create/edit modal while it is open (#845)
+  // Escape key handler for all modals
   useEffect(() => {
-    if (!isModalOpen) return;
-
     const handleKeyDown = (e) => {
       if (e.key === "Escape") {
-        handleCloseModal();
+        if (isModalOpen) handleCloseModal();
+        if (isMergeModalOpen) setIsMergeModalOpen(false);
+        if (isBulkRetagModalOpen) setIsBulkRetagModalOpen(false);
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isModalOpen]);
+  }, [isModalOpen, isMergeModalOpen, isBulkRetagModalOpen]);
 
   const handleSaveTag = async (e) => {
     e.preventDefault();
@@ -102,7 +122,6 @@ const TagBrowser = () => {
       }
       handleCloseModal();
       fetchTags();
-      // If we are looking at this tag's meetings, update the selected tag
       if (selectedTag && selectedTag._id === editingTag?._id) {
         setSelectedTag({ ...selectedTag, ...formData });
       }
@@ -134,6 +153,7 @@ const TagBrowser = () => {
 
   const handleTagClick = async (tag) => {
     setSelectedTag(tag);
+    setSelectedMeetingIds([]);
     try {
       setMeetingsLoading(true);
       const res = await tagApi.getMeetingsByTag(tag.name);
@@ -148,46 +168,233 @@ const TagBrowser = () => {
     }
   };
 
+  // Export Stats Handler
+  const handleExportTaxonomy = async () => {
+    try {
+      const response = await tagApi.exportTags();
+      const blob = new Blob([response.data], {
+        type: "text/csv;charset=utf-8;",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "tags-taxonomy-export.csv");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success("Taxonomy stats exported successfully");
+    } catch (err) {
+      console.error("Export error:", err);
+      toast.error("Failed to export taxonomy");
+    }
+  };
+
+  // Merge Tags Handler
+  const handleExecuteMerge = async (e) => {
+    e.preventDefault();
+    if (!mergeSourceId || !mergeTargetId) {
+      toast.error("Please select both a source and target tag.");
+      return;
+    }
+    if (mergeSourceId === mergeTargetId) {
+      toast.error("Source and target tags must be different.");
+      return;
+    }
+
+    try {
+      setIsMerging(true);
+      const { data } = await tagApi.mergeTags({
+        sourceTagId: mergeSourceId,
+        targetTagId: mergeTargetId,
+      });
+      toast.success(data?.message || "Tags merged successfully!");
+      setIsMergeModalOpen(false);
+      setMergeSourceId("");
+      setMergeTargetId("");
+      fetchTags();
+      if (selectedTag && selectedTag._id === mergeSourceId) {
+        setSelectedTag(null);
+      }
+    } catch (err) {
+      console.error("Merge error:", err);
+      toast.error(err.response?.data?.message || "Failed to merge tags");
+    } finally {
+      setIsMerging(false);
+    }
+  };
+
+  // Bulk Retag Handler
+  const handleExecuteBulkRetag = async (e) => {
+    e.preventDefault();
+    if (selectedMeetingIds.length === 0) {
+      toast.error("No meetings selected for bulk retagging.");
+      return;
+    }
+
+    const tagsToAdd = bulkTagsToAdd
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const tagsToRemove = bulkTagsToRemove
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    if (tagsToAdd.length === 0 && tagsToRemove.length === 0) {
+      toast.error("Specify at least one tag to add or remove.");
+      return;
+    }
+
+    try {
+      setIsBulkRetagging(true);
+      const { data } = await tagApi.bulkRetag({
+        meetingIds: selectedMeetingIds,
+        tagsToAdd,
+        tagsToRemove,
+      });
+      toast.success(data?.message || "Meetings retagged successfully!");
+      setIsBulkRetagModalOpen(false);
+      setBulkTagsToAdd("");
+      setBulkTagsToRemove("");
+      setSelectedMeetingIds([]);
+      fetchTags();
+      if (selectedTag) {
+        handleTagClick(selectedTag);
+      }
+    } catch (err) {
+      console.error("Bulk retag error:", err);
+      toast.error(
+        err.response?.data?.message || "Failed to bulk retag meetings",
+      );
+    } finally {
+      setIsBulkRetagging(false);
+    }
+  };
+
+  const toggleSelectMeeting = (id) => {
+    setSelectedMeetingIds((prev) =>
+      prev.includes(id) ? prev.filter((mId) => mId !== id) : [...prev, id],
+    );
+  };
+
+  const toggleSelectAllMeetings = () => {
+    if (selectedMeetingIds.length === meetings.length) {
+      setSelectedMeetingIds([]);
+    } else {
+      setSelectedMeetingIds(meetings.map((m) => m._id));
+    }
+  };
+
+  const filteredTags = tags.filter(
+    (tag) =>
+      tag.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (tag.description &&
+        tag.description.toLowerCase().includes(searchQuery.toLowerCase())),
+  );
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <Navbar />
       <div className="flex-grow pt-28 pb-16 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto w-full">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
               <Tag className="w-8 h-8 text-blue-500" />
-              Tag Management
+              Tag Management & Taxonomy
             </h1>
             <p className="text-gray-500 dark:text-gray-400 mt-2">
-              Manage your organization's taxonomy
+              Manage, merge, and audit your organization's meeting taxonomy
             </p>
           </div>
-          {isAdmin && !selectedTag && (
+
+          <div className="flex flex-wrap items-center gap-2">
             <button
-              onClick={() => handleOpenModal()}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2 font-medium transition-colors"
+              onClick={handleExportTaxonomy}
+              className="px-3.5 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/80 flex items-center gap-1.5 text-sm font-medium transition-colors cursor-pointer shadow-xs"
+              title="Export tag taxonomy stats as CSV"
+              aria-label="Export tag taxonomy stats"
             >
-              <Plus className="w-4 h-4" />
-              New Tag
+              <Download className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
+              Export CSV
             </button>
-          )}
+
+            {isAdmin && !selectedTag && (
+              <>
+                <button
+                  onClick={() => {
+                    setMergeSourceId("");
+                    setMergeTargetId("");
+                    setIsMergeModalOpen(true);
+                  }}
+                  className="px-3.5 py-2 bg-indigo-50 dark:bg-indigo-950/50 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800/80 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/60 flex items-center gap-1.5 text-sm font-medium transition-colors cursor-pointer shadow-xs"
+                  aria-label="Merge taxonomy tags"
+                >
+                  <GitMerge className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+                  Merge Tags
+                </button>
+
+                <button
+                  onClick={() => handleOpenModal()}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2 text-sm font-semibold transition-colors cursor-pointer shadow-sm"
+                  aria-label="Create new tag"
+                >
+                  <Plus className="w-4 h-4" />
+                  New Tag
+                </button>
+              </>
+            )}
+          </div>
         </div>
 
         {selectedTag ? (
           /* Drill-down View */
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-            <button
-              onClick={() => setSelectedTag(null)}
-              className="mb-6 flex items-center gap-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Back to all tags
-            </button>
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+              <button
+                onClick={() => {
+                  setSelectedTag(null);
+                  setSelectedMeetingIds([]);
+                }}
+                className="flex items-center gap-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 cursor-pointer"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Back to all tags
+              </button>
+
+              {isAdmin && meetings.length > 0 && (
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={toggleSelectAllMeetings}
+                    className="text-xs font-semibold text-gray-600 dark:text-gray-300 flex items-center gap-1.5 cursor-pointer"
+                  >
+                    {selectedMeetingIds.length === meetings.length ? (
+                      <CheckSquare className="w-4 h-4 text-blue-600" />
+                    ) : (
+                      <Square className="w-4 h-4" />
+                    )}
+                    {selectedMeetingIds.length === meetings.length
+                      ? "Deselect All"
+                      : "Select All"}
+                  </button>
+
+                  <button
+                    onClick={() => setIsBulkRetagModalOpen(true)}
+                    disabled={selectedMeetingIds.length === 0}
+                    className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-lg text-xs font-bold flex items-center gap-1.5 transition-colors cursor-pointer disabled:cursor-not-allowed shadow-xs"
+                    aria-label="Bulk retag selected meetings"
+                  >
+                    <Layers className="w-3.5 h-3.5" />
+                    Bulk Retag ({selectedMeetingIds.length})
+                  </button>
+                </div>
+              )}
+            </div>
 
             <div className="flex items-center gap-4 mb-8 pb-6 border-b border-gray-100 dark:border-gray-700">
               <div
-                className="w-12 h-12 rounded-xl flex items-center justify-center text-white text-xl font-bold"
+                className="w-12 h-12 rounded-xl flex items-center justify-center text-white text-xl font-bold shrink-0 shadow-sm"
                 style={{ backgroundColor: selectedTag.color || "#3B82F6" }}
               >
                 #
@@ -196,14 +403,14 @@ const TagBrowser = () => {
                 <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
                   {selectedTag.name}
                 </h2>
-                <p className="text-gray-500 dark:text-gray-400">
+                <p className="text-gray-500 dark:text-gray-400 text-sm">
                   {selectedTag.description || "No description provided"}
                 </p>
               </div>
             </div>
 
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-              Meetings with this tag
+              Meetings with this tag ({meetings.length})
             </h3>
 
             {meetingsLoading ? (
@@ -215,127 +422,194 @@ const TagBrowser = () => {
                 No meetings found with this tag.
               </div>
             ) : (
-              <div className="space-y-4">
-                {meetings.map((m) => (
-                  <div
-                    key={m._id}
-                    onClick={() => navigate(`/meeting/${m._id}`)}
-                    className="p-4 rounded-xl border border-gray-100 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-500 hover:shadow-md transition-all cursor-pointer bg-gray-50/50 dark:bg-gray-800/50"
-                  >
-                    <h4 className="font-semibold text-gray-900 dark:text-white">
-                      {m.title}
-                    </h4>
-                    <p className="text-sm text-gray-500 mt-1">
-                      {new Date(m.date).toLocaleDateString()} •{" "}
-                      {m.uploadedBy?.name}
-                    </p>
-                  </div>
-                ))}
+              <div className="space-y-3">
+                {meetings.map((m) => {
+                  const isChecked = selectedMeetingIds.includes(m._id);
+                  return (
+                    <div
+                      key={m._id}
+                      className={`p-4 rounded-xl border transition-all flex items-center justify-between gap-4 ${
+                        isChecked
+                          ? "border-blue-500 bg-blue-50/40 dark:bg-blue-950/20"
+                          : "border-gray-100 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-500 bg-gray-50/50 dark:bg-gray-800/50"
+                      }`}
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        {isAdmin && (
+                          <button
+                            type="button"
+                            onClick={() => toggleSelectMeeting(m._id)}
+                            className="text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 cursor-pointer"
+                            aria-label={`Select meeting ${m.title}`}
+                          >
+                            {isChecked ? (
+                              <CheckSquare className="w-5 h-5 text-blue-600" />
+                            ) : (
+                              <Square className="w-5 h-5" />
+                            )}
+                          </button>
+                        )}
+                        <div
+                          onClick={() => navigate(`/meeting/${m._id}`)}
+                          className="min-w-0 cursor-pointer"
+                        >
+                          <h4 className="font-semibold text-gray-900 dark:text-white truncate hover:text-blue-600">
+                            {m.title}
+                          </h4>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            {new Date(m.date).toLocaleDateString()} •{" "}
+                            {m.uploadedBy?.name || "Organizer"}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-1.5 shrink-0">
+                        {m.tags &&
+                          m.tags.map((t, idx) => (
+                            <span
+                              key={idx}
+                              className="px-2 py-0.5 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-[11px] font-medium"
+                            >
+                              #{t}
+                            </span>
+                          ))}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
         ) : (
           /* Tag List/Cloud View */
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+            {/* Search Bar */}
+            <div className="p-4 border-b border-gray-100 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-900/30 flex items-center gap-3">
+              <Search className="w-4 h-4 text-gray-400" />
+              <input
+                type="text"
+                placeholder="Search tags by name or description..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 outline-none"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+
             {loading ? (
               <div className="flex justify-center py-20">
                 <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
               </div>
-            ) : tags.length === 0 ? (
+            ) : filteredTags.length === 0 ? (
               <div className="text-center py-20 text-gray-500 dark:text-gray-400">
                 <Tag className="w-12 h-12 mx-auto mb-4 opacity-50" />
                 <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">
                   No tags found
                 </p>
-                <p>Create your first tag to start organizing meetings.</p>
+                <p className="text-sm">
+                  {searchQuery
+                    ? "No tags matching your search query."
+                    : "Create your first tag to start organizing meetings."}
+                </p>
               </div>
             ) : (
-              <table className="w-full text-left border-collapse">
-                <thead>
-                  <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
-                      Name
-                    </th>
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
-                      Description
-                    </th>
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
-                      Usage
-                    </th>
-                    {isAdmin && (
-                      <th className="px-6 py-4 text-right text-sm font-semibold text-gray-600 dark:text-gray-300">
-                        Actions
+              <div className="overflow-x-auto">
+                <table className="w-full text-left border-collapse">
+                  <thead>
+                    <tr className="bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+                      <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                        Name
                       </th>
-                    )}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                  {tags.map((tag) => (
-                    <tr
-                      key={tag._id}
-                      className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-                    >
-                      <td className="px-6 py-4">
-                        <button
-                          onClick={() => handleTagClick(tag)}
-                          className="flex items-center gap-3 hover:opacity-80 transition-opacity text-left"
-                        >
-                          <div
-                            className="w-8 h-8 rounded-lg flex items-center justify-center text-white text-sm font-bold shadow-sm"
-                            style={{ backgroundColor: tag.color || "#3B82F6" }}
-                          >
-                            #
-                          </div>
-                          <span className="font-semibold text-gray-900 dark:text-white">
-                            {tag.name}
-                          </span>
-                        </button>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
-                        {tag.description || "-"}
-                      </td>
-                      <td className="px-6 py-4 text-sm font-medium text-gray-700 dark:text-gray-300">
-                        {tag.usageCount} meetings
-                      </td>
+                      <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                        Description
+                      </th>
+                      <th className="px-6 py-4 text-sm font-semibold text-gray-600 dark:text-gray-300">
+                        Usage
+                      </th>
                       {isAdmin && (
-                        <td className="px-6 py-4 text-right">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleOpenModal(tag);
-                            }}
-                            className="p-2 text-gray-400 hover:text-blue-600 transition-colors"
-                          >
-                            <Edit2 className="w-4 h-4" />
-                          </button>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleDeleteTag(tag._id);
-                            }}
-                            className="p-2 text-gray-400 hover:text-red-600 transition-colors"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </td>
+                        <th className="px-6 py-4 text-right text-sm font-semibold text-gray-600 dark:text-gray-300">
+                          Actions
+                        </th>
                       )}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                    {filteredTags.map((tag) => (
+                      <tr
+                        key={tag._id}
+                        className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                      >
+                        <td className="px-6 py-4">
+                          <button
+                            onClick={() => handleTagClick(tag)}
+                            className="flex items-center gap-3 hover:opacity-80 transition-opacity text-left cursor-pointer"
+                          >
+                            <div
+                              className="w-8 h-8 rounded-lg flex items-center justify-center text-white text-sm font-bold shadow-sm"
+                              style={{
+                                backgroundColor: tag.color || "#3B82F6",
+                              }}
+                            >
+                              #
+                            </div>
+                            <span className="font-semibold text-gray-900 dark:text-white">
+                              {tag.name}
+                            </span>
+                          </button>
+                        </td>
+                        <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs truncate">
+                          {tag.description || "-"}
+                        </td>
+                        <td className="px-6 py-4 text-sm font-medium text-gray-700 dark:text-gray-300">
+                          {tag.usageCount || 0} meetings
+                        </td>
+                        {isAdmin && (
+                          <td className="px-6 py-4 text-right">
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleOpenModal(tag);
+                              }}
+                              className="p-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors cursor-pointer"
+                              aria-label={`Edit tag ${tag.name}`}
+                            >
+                              <Edit2 className="w-4 h-4" />
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteTag(tag._id);
+                              }}
+                              className="p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors cursor-pointer"
+                              aria-label={`Delete tag ${tag.name}`}
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             )}
           </div>
         )}
       </div>
 
-      {/* Modal */}
+      {/* Create / Edit Tag Modal */}
       {isModalOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-xs"
           onClick={(e) => {
-            if (e.target === e.currentTarget) {
-              handleCloseModal();
-            }
+            if (e.target === e.currentTarget) handleCloseModal();
           }}
           role="dialog"
           aria-modal="true"
@@ -352,10 +626,10 @@ const TagBrowser = () => {
               <button
                 type="button"
                 onClick={handleCloseModal}
-                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
                 aria-label="Close"
               >
-                <X className="w-5 h-5" aria-hidden="true" />
+                <X className="w-5 h-5" />
               </button>
             </div>
             <form onSubmit={handleSaveTag} className="p-6 space-y-4">
@@ -412,15 +686,215 @@ const TagBrowser = () => {
                 <button
                   type="button"
                   onClick={handleCloseModal}
-                  className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors font-medium"
+                  className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors font-medium cursor-pointer"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
-                  className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium shadow-sm"
+                  className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium shadow-sm cursor-pointer"
                 >
                   Save Tag
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Merge Tags Modal */}
+      {isMergeModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-xs"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setIsMergeModalOpen(false);
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Merge Taxonomy Tags Dialog"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg overflow-hidden animate-fade-in-up">
+            <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+              <h3 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+                <GitMerge className="w-5 h-5 text-indigo-500" />
+                Merge Taxonomy Tags
+              </h3>
+              <button
+                type="button"
+                onClick={() => setIsMergeModalOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
+                aria-label="Close merge dialog"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <form onSubmit={handleExecuteMerge} className="p-6 space-y-4">
+              <div className="bg-indigo-50 dark:bg-indigo-950/40 p-3 rounded-xl border border-indigo-100 dark:border-indigo-800 text-xs text-indigo-800 dark:text-indigo-200 leading-relaxed">
+                Merging replaces the <strong>Source Tag</strong> across all
+                meetings with the <strong>Target Tag</strong> and deletes the
+                source tag from your taxonomy.
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold uppercase text-gray-600 dark:text-gray-300 mb-1">
+                  Source Tag (Will be removed) *
+                </label>
+                <select
+                  data-testid="merge-source-select"
+                  value={mergeSourceId}
+                  onChange={(e) => setMergeSourceId(e.target.value)}
+                  required
+                  className="w-full px-3.5 py-2.5 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white outline-none"
+                >
+                  <option value="">Select source tag...</option>
+                  {tags.map((t) => (
+                    <option key={t._id} value={t._id}>
+                      #{t.name} ({t.usageCount || 0} meetings)
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold uppercase text-gray-600 dark:text-gray-300 mb-1">
+                  Target Tag (Will be retained) *
+                </label>
+                <select
+                  data-testid="merge-target-select"
+                  value={mergeTargetId}
+                  onChange={(e) => setMergeTargetId(e.target.value)}
+                  required
+                  className="w-full px-3.5 py-2.5 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white outline-none"
+                >
+                  <option value="">Select target tag...</option>
+                  {tags
+                    .filter((t) => t._id !== mergeSourceId)
+                    .map((t) => (
+                      <option key={t._id} value={t._id}>
+                        #{t.name} ({t.usageCount || 0} meetings)
+                      </option>
+                    ))}
+                </select>
+              </div>
+
+              <div className="pt-4 flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsMergeModalOpen(false)}
+                  className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl text-xs font-semibold cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  data-testid="confirm-merge-tags-button"
+                  disabled={isMerging || !mergeSourceId || !mergeTargetId}
+                  className="px-5 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl text-xs font-bold flex items-center gap-1.5 shadow-sm cursor-pointer"
+                >
+                  {isMerging ? (
+                    <>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      Merging...
+                    </>
+                  ) : (
+                    <>
+                      <GitMerge className="w-3.5 h-3.5" />
+                      Confirm Merge
+                    </>
+                  )}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Bulk Retag Modal */}
+      {isBulkRetagModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-xs"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setIsBulkRetagModalOpen(false);
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Bulk Retag Meetings Dialog"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-md overflow-hidden animate-fade-in-up">
+            <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+              <h3 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+                <Layers className="w-5 h-5 text-indigo-500" />
+                Bulk Retag Meetings
+              </h3>
+              <button
+                type="button"
+                onClick={() => setIsBulkRetagModalOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
+                aria-label="Close bulk retag dialog"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <form onSubmit={handleExecuteBulkRetag} className="p-6 space-y-4">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Applying updates across{" "}
+                <span className="font-bold text-gray-800 dark:text-white">
+                  {selectedMeetingIds.length}
+                </span>{" "}
+                selected meeting(s).
+              </p>
+
+              <div>
+                <label className="block text-xs font-bold uppercase text-gray-600 dark:text-gray-300 mb-1">
+                  Tags to Add (comma-separated)
+                </label>
+                <input
+                  type="text"
+                  placeholder="e.g. Q3, Engineering, HighPriority"
+                  value={bulkTagsToAdd}
+                  onChange={(e) => setBulkTagsToAdd(e.target.value)}
+                  className="w-full px-3.5 py-2.5 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-xs text-gray-900 dark:text-white outline-none"
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-bold uppercase text-gray-600 dark:text-gray-300 mb-1">
+                  Tags to Remove (comma-separated)
+                </label>
+                <input
+                  type="text"
+                  placeholder="e.g. Deprecated, ReviewNeeded"
+                  value={bulkTagsToRemove}
+                  onChange={(e) => setBulkTagsToRemove(e.target.value)}
+                  className="w-full px-3.5 py-2.5 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-xs text-gray-900 dark:text-white outline-none"
+                />
+              </div>
+
+              <div className="pt-4 flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsBulkRetagModalOpen(false)}
+                  className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-xl text-xs font-semibold cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  data-testid="confirm-bulk-retag-button"
+                  disabled={isBulkRetagging}
+                  className="px-5 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded-xl text-xs font-bold flex items-center gap-1.5 shadow-sm cursor-pointer"
+                >
+                  {isBulkRetagging ? (
+                    <>
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      Retagging...
+                    </>
+                  ) : (
+                    <>
+                      <Check className="w-3.5 h-3.5" />
+                      Apply Bulk Retag
+                    </>
+                  )}
                 </button>
               </div>
             </form>

--- a/client/src/pages/__tests__/TagBrowserTaxonomyAdmin.test.jsx
+++ b/client/src/pages/__tests__/TagBrowserTaxonomyAdmin.test.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import TagBrowser from "../TagBrowser";
+import { tagApi } from "../../services";
+import AppContent from "../../context/AppContent";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("../../services", () => ({
+  tagApi: {
+    getOrgTags: vi.fn(),
+    createTag: vi.fn(),
+    updateTag: vi.fn(),
+    deleteTag: vi.fn(),
+    mergeTags: vi.fn(),
+    bulkRetag: vi.fn(),
+    exportTags: vi.fn(),
+    getMeetingsByTag: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar">Navbar</div>,
+}));
+
+describe("TagBrowser Taxonomy Administration (#2244)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockAdminContext = {
+    userData: { _id: "user-1", name: "Admin", role: "admin" },
+  };
+
+  const mockTags = [
+    { _id: "tag-1", name: "Architecture", color: "#3B82F6", usageCount: 5 },
+    { _id: "tag-2", name: "SystemDesign", color: "#10B981", usageCount: 3 },
+  ];
+
+  it("renders export CSV button and triggers exportTags API", async () => {
+    tagApi.getOrgTags.mockResolvedValue({
+      data: { success: true, data: mockTags },
+    });
+    tagApi.exportTags.mockResolvedValue({
+      data: "Name,Color,UsageCount\nArchitecture,#3B82F6,5",
+    });
+
+    render(
+      <AppContent.Provider value={mockAdminContext}>
+        <BrowserRouter>
+          <TagBrowser />
+        </BrowserRouter>
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Architecture")).toBeInTheDocument();
+    });
+
+    const exportBtn = screen.getByRole("button", {
+      name: "Export tag taxonomy stats",
+    });
+    expect(exportBtn).toBeInTheDocument();
+    fireEvent.click(exportBtn);
+
+    await waitFor(() => {
+      expect(tagApi.exportTags).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("opens Merge Tags modal and calls mergeTags API on submit", async () => {
+    tagApi.getOrgTags.mockResolvedValue({
+      data: { success: true, data: mockTags },
+    });
+    tagApi.mergeTags.mockResolvedValue({
+      data: { success: true, message: "Tags merged successfully!" },
+    });
+
+    render(
+      <AppContent.Provider value={mockAdminContext}>
+        <BrowserRouter>
+          <TagBrowser />
+        </BrowserRouter>
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Architecture")).toBeInTheDocument();
+    });
+
+    const mergeBtn = screen.getByRole("button", {
+      name: "Merge taxonomy tags",
+    });
+    fireEvent.click(mergeBtn);
+
+    expect(
+      screen.getByRole("dialog", { name: "Merge Taxonomy Tags Dialog" }),
+    ).toBeInTheDocument();
+
+    const sourceSelect = screen.getByTestId("merge-source-select");
+    const targetSelect = screen.getByTestId("merge-target-select");
+
+    fireEvent.change(sourceSelect, { target: { value: "tag-1" } });
+    fireEvent.change(targetSelect, { target: { value: "tag-2" } });
+
+    const confirmBtn = screen.getByTestId("confirm-merge-tags-button");
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(tagApi.mergeTags).toHaveBeenCalledWith({
+        sourceTagId: "tag-1",
+        targetTagId: "tag-2",
+      });
+    });
+  });
+});

--- a/client/src/services/tagApi.js
+++ b/client/src/services/tagApi.js
@@ -21,6 +21,23 @@ export const tagApi = {
     return await apiClient.delete(`/api/tags/${id}`);
   },
 
+  // Merge tags (admin only)
+  mergeTags: async (mergeData) => {
+    return await apiClient.post("/api/tags/merge", mergeData);
+  },
+
+  // Bulk retag meetings (admin only)
+  bulkRetag: async (retagData) => {
+    return await apiClient.post("/api/tags/bulk-retag", retagData);
+  },
+
+  // Export tags taxonomy CSV
+  exportTags: async () => {
+    return await apiClient.get("/api/tags/export", {
+      responseType: "blob",
+    });
+  },
+
   // Autocomplete tags based on query prefix
   autocomplete: async (query) => {
     return await apiClient.get(

--- a/server/controllers/tagController.js
+++ b/server/controllers/tagController.js
@@ -320,3 +320,167 @@ export const getTagStats = async (req, res, next) => {
     next(err);
   }
 };
+
+const mergeTagsSchema = z.object({
+  sourceTagId: z.string().min(1).optional(),
+  sourceName: z.string().min(1).optional(),
+  targetTagId: z.string().min(1).optional(),
+  targetName: z.string().min(1).optional(),
+});
+
+export const mergeTags = async (req, res, next) => {
+  try {
+    const { sourceTagId, sourceName, targetTagId, targetName } =
+      mergeTagsSchema.parse(req.body);
+    const orgId = req.user.organization;
+
+    const source = sourceTagId
+      ? await Tag.findOne({ _id: sourceTagId, organization: orgId })
+      : await findTagByName(orgId, sourceName);
+
+    const target = targetTagId
+      ? await Tag.findOne({ _id: targetTagId, organization: orgId })
+      : await findTagByName(orgId, targetName);
+
+    if (!source || !target) {
+      throw new NotFoundError(
+        "Both source and target tags must exist in your organization.",
+      );
+    }
+
+    if (source._id.equals(target._id)) {
+      throw new ValidationError("Source and target tags cannot be the same.");
+    }
+
+    const sName = source.name;
+    const tName = target.name;
+
+    const meetings = await Meeting.find({ organization: orgId, tags: sName });
+    for (const m of meetings) {
+      const filtered = (m.tags || []).filter((t) => t !== sName);
+      if (!filtered.includes(tName)) {
+        filtered.push(tName);
+      }
+      m.tags = filtered;
+      await m.save();
+    }
+
+    const targetUsage = await Meeting.countDocuments({
+      organization: orgId,
+      tags: tName,
+    });
+    target.usageCount = targetUsage;
+    await target.save();
+
+    await Tag.deleteOne({ _id: source._id, organization: orgId });
+
+    return sendSuccess(
+      res,
+      { targetTag: target, affectedMeetingsCount: meetings.length },
+      `Successfully merged '${sName}' into '${tName}' across ${meetings.length} meeting(s).`,
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const bulkRetagSchema = z.object({
+  meetingIds: z.array(z.string().min(1)).min(1),
+  tagsToAdd: z.array(z.string().min(1)).optional().default([]),
+  tagsToRemove: z.array(z.string().min(1)).optional().default([]),
+});
+
+export const bulkRetag = async (req, res, next) => {
+  try {
+    const { meetingIds, tagsToAdd, tagsToRemove } = bulkRetagSchema.parse(
+      req.body,
+    );
+    const orgId = req.user.organization;
+
+    const meetings = await Meeting.find({
+      _id: { $in: meetingIds },
+      organization: orgId,
+    });
+
+    if (!meetings.length) {
+      throw new NotFoundError(
+        "No matching meetings found in your organization.",
+      );
+    }
+
+    for (const tagName of tagsToAdd) {
+      const exists = await findTagByName(orgId, tagName);
+      if (!exists) {
+        await Tag.create({
+          name: tagName,
+          organization: orgId,
+          createdBy: req.user._id,
+        });
+      }
+    }
+
+    for (const m of meetings) {
+      let currentTags = m.tags || [];
+      if (tagsToRemove.length > 0) {
+        currentTags = currentTags.filter((t) => !tagsToRemove.includes(t));
+      }
+      for (const toAdd of tagsToAdd) {
+        if (!currentTags.includes(toAdd)) {
+          currentTags.push(toAdd);
+        }
+      }
+      m.tags = currentTags;
+      await m.save();
+    }
+
+    const allOrgTags = await Tag.find({ organization: orgId });
+    for (const t of allOrgTags) {
+      t.usageCount = await Meeting.countDocuments({
+        organization: orgId,
+        tags: t.name,
+      });
+      await t.save();
+    }
+
+    return sendSuccess(
+      res,
+      { updatedMeetingsCount: meetings.length },
+      `Successfully retagged ${meetings.length} meeting(s).`,
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const exportTags = async (req, res, next) => {
+  try {
+    const orgId = req.user.organization;
+    const tags = await Tag.find({ organization: orgId }).sort({
+      usageCount: -1,
+      name: 1,
+    });
+
+    const headers = ["Name", "Color", "UsageCount", "Description", "CreatedAt"];
+    const rows = tags.map((t) => [
+      `"${(t.name || "").replace(/"/g, '""')}"`,
+      `"${(t.color || "").replace(/"/g, '""')}"`,
+      t.usageCount || 0,
+      `"${(t.description || "").replace(/"/g, '""')}"`,
+      `"${t.createdAt ? new Date(t.createdAt).toISOString() : ""}"`,
+    ]);
+
+    const csvContent = [
+      headers.join(","),
+      ...rows.map((r) => r.join(",")),
+    ].join("\n");
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      'attachment; filename="tags-taxonomy-export.csv"',
+    );
+    return res.status(200).send(csvContent);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/routes/tagRoutes.js
+++ b/server/routes/tagRoutes.js
@@ -13,6 +13,9 @@ import {
   autocomplete,
   getMeetingsByTag,
   getTagStats,
+  mergeTags,
+  bulkRetag,
+  exportTags,
 } from "../controllers/tagController.js";
 
 const router = express.Router();
@@ -22,14 +25,23 @@ router.use(userAuth);
 router.use(apiLimiter);
 
 // ==========================================
-// TAG MANAGEMENT ROUTES
+// TAG MANAGEMENT & TAXONOMY ADMIN ROUTES
 // ==========================================
 
 // Autocomplete tags (used during meeting creation)
 router.get("/autocomplete", requireOrgMembership, autocomplete);
 
+// Export tag taxonomy stats (CSV)
+router.get("/export", requireOrgMembership, exportTags);
+
 // Get tag statistics (top tags)
 router.get("/stats", requireOrgMembership, getTagStats);
+
+// Merge tags (admin only)
+router.post("/merge", requireAdminOrOwner, mergeTags);
+
+// Bulk retag meetings (admin only)
+router.post("/bulk-retag", requireAdminOrOwner, bulkRetag);
 
 // Get all tags for the organization
 router.get("/", requireOrgMembership, getOrgTags);

--- a/server/tests/tagMergeAndExport.test.js
+++ b/server/tests/tagMergeAndExport.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// Mock models and utils
+const mockTagFindOne = jest.fn();
+const mockTagFind = jest.fn();
+const mockTagCreate = jest.fn();
+const mockTagDeleteOne = jest.fn();
+const mockMeetingFind = jest.fn();
+const mockMeetingCount = jest.fn();
+
+jest.unstable_mockModule("../models/tagModel.js", () => ({
+  default: {
+    findOne: (...args) => mockTagFindOne(...args),
+    find: (...args) => mockTagFind(...args),
+    create: (...args) => mockTagCreate(...args),
+    deleteOne: (...args) => mockTagDeleteOne(...args),
+  },
+}));
+
+jest.unstable_mockModule("../models/meetingModel.js", () => ({
+  default: {
+    find: (...args) => mockMeetingFind(...args),
+    countDocuments: (...args) => mockMeetingCount(...args),
+  },
+}));
+
+const { mergeTags, bulkRetag, exportTags } =
+  await import("../controllers/tagController.js");
+
+describe("Tag Taxonomy Administration Controllers (#2244)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("merges source tag into target tag and cleans up source tag", async () => {
+    const sourceTag = {
+      _id: { equals: () => false, toString: () => "src_1" },
+      name: "OldArch",
+      organization: "org_1",
+    };
+    const targetTag = {
+      _id: { equals: () => false, toString: () => "tgt_1" },
+      name: "NewArch",
+      organization: "org_1",
+      usageCount: 0,
+      save: jest.fn(),
+    };
+
+    mockTagFindOne
+      .mockImplementationOnce(() => ({
+        collation: () => Promise.resolve(sourceTag),
+      }))
+      .mockImplementationOnce(() => ({
+        collation: () => Promise.resolve(targetTag),
+      }));
+
+    const mockMeeting = {
+      tags: ["OldArch", "Design"],
+      save: jest.fn(),
+    };
+    mockMeetingFind.mockResolvedValue([mockMeeting]);
+    mockMeetingCount.mockResolvedValue(1);
+
+    const req = {
+      user: { organization: "org_1", _id: "user_1" },
+      body: { sourceName: "OldArch", targetName: "NewArch" },
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await mergeTags(req, res, next);
+
+    expect(mockMeeting.tags).toEqual(["Design", "NewArch"]);
+    expect(mockMeeting.save).toHaveBeenCalled();
+    expect(mockTagDeleteOne).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("exports taxonomy as CSV format with proper headers", async () => {
+    mockTagFind.mockReturnValue({
+      sort: jest.fn().mockResolvedValue([
+        {
+          name: "Backend",
+          color: "#3B82F6",
+          usageCount: 4,
+          description: "Server code",
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      ]),
+    });
+
+    const req = { user: { organization: "org_1" } };
+    const res = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+
+    await exportTags(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Type",
+      "text/csv; charset=utf-8",
+    );
+    expect(res.send).toHaveBeenCalledWith(
+      expect.stringContaining('"Backend","#3B82F6",4,"Server code"'),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2244

## Description
This PR implements a complete taxonomy administration suite in `TagBrowser.jsx` and backend tag routes, enabling organization admins to merge synonymous tags, bulk retag meetings, and export tag taxonomy metrics to CSV.

## Proposed Changes
- **Backend Endpoints**:
  - Added `POST /api/tags/merge` to merge a source tag into a target tag, update all meeting tag associations, recalculate usage counts, and delete the source tag.
  - Added `POST /api/tags/bulk-retag` to batch add and remove tags across multiple meetings.
  - Added `GET /api/tags/export` generating a formatted CSV export of organization taxonomy metrics.
- **Frontend Taxonomy Admin UI**:
  - Added an interactive **Merge Tags** modal dialog in `TagBrowser.jsx` with source/target pickers and safety warnings.
  - Added multi-meeting selection checkboxes and **Bulk Retag** toolbar modal.
  - Added **Export CSV** download trigger.
  - Enhanced tag list view with quick search filtering and WAI-ARIA modal accessibility.
- **Unit Tests**:
  - Added frontend test suite `client/src/pages/__tests__/TagBrowserTaxonomyAdmin.test.jsx`.
  - Added backend test suite `server/tests/tagMergeAndExport.test.js`.

## Checklist
- [x] Related Issue is linked (Fixes #2244).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.