### PR TITLE
[Feature]: AI-Powered Meeting Debrief Q&A

### DIFF
--- a/client/src/api/debriefQAApi.js
+++ b/client/src/api/debriefQAApi.js
@@ -1,0 +1,16 @@
+import apiClient from "../services/apiClient";
+
+export const debriefQAApi = {
+  askQuestion: async (meetingId, question) => {
+    const response = await apiClient.post("/debrief/session", {
+      meetingId,
+      question,
+    });
+    return response.data;
+  },
+
+  getSession: async (meetingId) => {
+    const response = await apiClient.get(`/debrief/session/${meetingId}`);
+    return response.data;
+  },
+};

--- a/client/src/components/meetings/DebriefQAPanel.jsx
+++ b/client/src/components/meetings/DebriefQAPanel.jsx
@@ -1,0 +1,161 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Send, Loader2, MessageSquare, ChevronRight } from "lucide-react";
+import { debriefQAApi } from "../../api/debriefQAApi.js";
+
+const DebriefQAPanel = ({ meetingId, onCitationClick }) => {
+  const [messages, setMessages] = useState([]);
+  const [inputValue, setInputValue] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      try {
+        const session = await debriefQAApi.getSession(meetingId);
+        if (session && session.messages) {
+          setMessages(session.messages);
+        }
+      } catch (error) {
+        console.error("Failed to fetch debrief session:", error);
+      }
+    };
+    if (meetingId) {
+      fetchSession();
+    }
+  }, [meetingId]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = async (e) => {
+    e.preventDefault();
+    if (!inputValue.trim() || isLoading) return;
+
+    const userMessage = { role: "user", content: inputValue, citations: [] };
+    setMessages((prev) => [...prev, userMessage]);
+    setInputValue("");
+    setIsLoading(true);
+
+    try {
+      const assistantMessage = await debriefQAApi.askQuestion(
+        meetingId,
+        userMessage.content,
+      );
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (error) {
+      console.error("Failed to send question:", error);
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: "Sorry, I encountered an error processing your request.",
+          citations: [],
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const renderMessageContent = (message) => {
+    // If there are citations, we want to highlight the markers in the text
+    let content = message.content;
+    const renderCitations = () => {
+      if (!message.citations || message.citations.length === 0) return null;
+      return (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {message.citations.map((citation, idx) => (
+            <button
+              key={idx}
+              onClick={() => onCitationClick && onCitationClick(citation)}
+              className="inline-flex items-center text-xs bg-indigo-50 text-indigo-700 px-2 py-1 rounded hover:bg-indigo-100 transition-colors border border-indigo-200"
+              title={citation.excerpt}
+            >
+              <ChevronRight className="w-3 h-3 mr-1" />
+              {citation.marker}{" "}
+              {citation.type === "transcript" ? "Transcript" : "Decision"}
+            </button>
+          ))}
+        </div>
+      );
+    };
+
+    return (
+      <div>
+        <p className="whitespace-pre-wrap text-sm">{content}</p>
+        {renderCitations()}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+      <div className="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center">
+        <MessageSquare className="w-5 h-5 text-indigo-600 mr-2" />
+        <h3 className="text-sm font-semibold text-gray-800">Debrief Q&A</h3>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 bg-gray-50">
+        {messages.length === 0 && (
+          <div className="text-center text-gray-500 text-sm mt-8">
+            <p>Ask a question about this meeting.</p>
+            <p className="mt-2 text-xs">
+              Answers are strictly grounded in the meeting's transcript and
+              decisions.
+            </p>
+          </div>
+        )}
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`flex ${
+              msg.role === "user" ? "justify-end" : "justify-start"
+            }`}
+          >
+            <div
+              className={`max-w-[85%] rounded-lg px-4 py-2 ${
+                msg.role === "user"
+                  ? "bg-indigo-600 text-white rounded-tr-none"
+                  : "bg-white border border-gray-200 text-gray-800 rounded-tl-none shadow-sm"
+              }`}
+            >
+              {renderMessageContent(msg)}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <div className="flex justify-start">
+            <div className="bg-white border border-gray-200 text-gray-500 rounded-lg rounded-tl-none px-4 py-2 shadow-sm flex items-center space-x-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span className="text-sm">Analyzing context...</span>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="p-3 border-t border-gray-200 bg-white">
+        <form onSubmit={handleSend} className="relative">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder="Ask about specific decisions, action items..."
+            className="w-full pl-4 pr-12 py-2 border border-gray-300 rounded-full focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-sm"
+            disabled={isLoading}
+          />
+          <button
+            type="submit"
+            disabled={!inputValue.trim() || isLoading}
+            className="absolute right-1 top-1 bottom-1 px-3 bg-indigo-600 text-white rounded-full hover:bg-indigo-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+          >
+            <Send className="w-4 h-4" />
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default DebriefQAPanel;

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -59,6 +59,7 @@ import ExportDialog from "../components/export/ExportDialog";
 import RetentionQuizSection from "../components/meetings/RetentionQuizSection";
 import ResourceConflictsPanel from "../components/meeting-details/ResourceConflictsPanel";
 import SkillEndorsementModal from "../components/meetings/SkillEndorsementModal";
+import DebriefQAPanel from "../components/meetings/DebriefQAPanel";
 
 const MeetingDetails = () => {
   const { id } = useParams();
@@ -85,6 +86,28 @@ const MeetingDetails = () => {
       p.user?.toString() === dbUserId || p.user?._id?.toString() === dbUserId,
   );
   const userRole = participant?.role || null;
+
+  const handleCitationClick = (citation) => {
+    if (citation.type === "transcript" && citation.timestamp !== null) {
+      const event = new CustomEvent("seekToTimestamp", {
+        detail: citation.timestamp,
+      });
+      window.dispatchEvent(event);
+      const transcriptEl = document.querySelector(
+        `[data-start-time="${citation.timestamp}"]`,
+      );
+      if (transcriptEl) {
+        transcriptEl.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    } else if (citation.type === "decision") {
+      const decisionEl = document.querySelector(
+        `[data-decision-id="${citation.refId}"]`,
+      );
+      if (decisionEl) {
+        decisionEl.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
+  };
 
   const handleGenerateBriefing = async () => {
     setBriefingStatus("generating");
@@ -488,7 +511,17 @@ const MeetingDetails = () => {
             />
           </div>
 
-          <MeetingTranscript meeting={meeting} />
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <div className="xl:col-span-2">
+              <MeetingTranscript meeting={meeting} />
+            </div>
+            <div className="xl:col-span-1 h-[600px]">
+              <DebriefQAPanel
+                meetingId={meeting._id}
+                onCitationClick={handleCitationClick}
+              />
+            </div>
+          </div>
           <div className="mt-6 mb-6">
             <TopicSummary
               meetingId={meeting._id}

--- a/server/controllers/debriefQAController.js
+++ b/server/controllers/debriefQAController.js
@@ -1,0 +1,54 @@
+import {
+  askDebriefQuestion,
+  getDebriefSession,
+} from "../services/debriefQAService.js";
+
+/**
+ * @desc    Ask a debrief question about a specific meeting
+ * @route   POST /api/debrief/session
+ * @access  Private
+ */
+export const askQuestion = async (req, res) => {
+  try {
+    const { meetingId, question } = req.body;
+    const userId = req.user._id;
+
+    if (!meetingId || !question) {
+      return res
+        .status(400)
+        .json({ error: "meetingId and question are required" });
+    }
+
+    const assistantMessage = await askDebriefQuestion(
+      meetingId,
+      userId,
+      question,
+    );
+    res.status(200).json(assistantMessage);
+  } catch (error) {
+    console.error("Error in askQuestion:", error);
+    res.status(500).json({ error: "Failed to process question" });
+  }
+};
+
+/**
+ * @desc    Get chat history for a debrief session
+ * @route   GET /api/debrief/session/:meetingId
+ * @access  Private
+ */
+export const getSession = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+    const userId = req.user._id;
+
+    const session = await getDebriefSession(meetingId, userId);
+    if (!session) {
+      return res.status(200).json({ messages: [] });
+    }
+
+    res.status(200).json(session);
+  } catch (error) {
+    console.error("Error in getSession:", error);
+    res.status(500).json({ error: "Failed to fetch session" });
+  }
+};

--- a/server/models/debriefSessionModel.js
+++ b/server/models/debriefSessionModel.js
@@ -1,0 +1,75 @@
+import mongoose from "mongoose";
+
+const citationSchema = new mongoose.Schema({
+  type: {
+    type: String,
+    enum: ["transcript", "decision", "action_item"],
+    required: true,
+  },
+  refId: {
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+  },
+  excerpt: {
+    type: String,
+    required: true,
+  },
+  timestamp: {
+    type: Number, // Applicable mainly to transcripts (start time in seconds)
+    default: null,
+  },
+  marker: {
+    type: String, // e.g., "[1]"
+    required: true,
+  },
+});
+
+const messageSchema = new mongoose.Schema({
+  role: {
+    type: String,
+    enum: ["user", "assistant"],
+    required: true,
+  },
+  content: {
+    type: String,
+    required: true,
+  },
+  citations: [citationSchema],
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const debriefSessionSchema = new mongoose.Schema({
+  meetingId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Meeting",
+    required: true,
+    index: true,
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+    index: true,
+  },
+  messages: [messageSchema],
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  updatedAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+debriefSessionSchema.pre("save", function (next) {
+  this.updatedAt = Date.now();
+  next();
+});
+
+const DebriefSession = mongoose.model("DebriefSession", debriefSessionSchema);
+
+export default DebriefSession;

--- a/server/routes/debriefQARoutes.js
+++ b/server/routes/debriefQARoutes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import { askQuestion, getSession } from "../controllers/debriefQAController.js";
+import { protect } from "../middleware/authMiddleware.js";
+
+const router = express.Router();
+
+router.use(protect);
+
+router.post("/session", askQuestion);
+router.get("/session/:meetingId", getSession);
+
+export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -210,6 +210,8 @@ router.use("/api/rsvps", meetingRsvpRoutes);
 router.use("/api/testimonials", testimonialRoutes);
 router.use("/api/admin/testimonials", adminTestimonialRouter);
 router.use("/api/absentee-catchup", absenteeCatchUpRoutes);
+import debriefQARoutes from "./debriefQARoutes.js";
+router.use("/api/debrief", debriefQARoutes);
 import adminJobsRoutes from "./adminJobsRoutes.js";
 router.use("/api/admin/jobs", adminJobsRoutes);
 import adminReindexRoutes from "./adminReindexRoutes.js";

--- a/server/services/debriefQAService.js
+++ b/server/services/debriefQAService.js
@@ -1,0 +1,149 @@
+import Transcript from "../models/transcriptModel.js";
+import Decision from "../models/decisionModel.js";
+import DebriefSession from "../models/debriefSessionModel.js";
+import { generateText } from "./GenerativeAIService.js";
+
+/**
+ * Parses the AI response to extract citation markers and map them back
+ * to the original segments.
+ *
+ * Example AI output: "The budget was approved [1]."
+ * We need to map [1] to the actual excerpt and timestamp.
+ */
+function extractCitations(responseText, contextMap) {
+  const citations = [];
+  // Regex to find things like [1], [2]
+  const regex = /\[(\d+)\]/g;
+  let match;
+  while ((match = regex.exec(responseText)) !== null) {
+    const refIndex = match[1];
+    const marker = `[${refIndex}]`;
+    const contextItem = contextMap[refIndex];
+    if (contextItem) {
+      // Avoid duplicate citations for the same marker in the same message
+      if (!citations.find((c) => c.marker === marker)) {
+        citations.push({
+          type: contextItem.type,
+          refId: contextItem.id,
+          excerpt: contextItem.text,
+          timestamp: contextItem.timestamp || null,
+          marker: marker,
+        });
+      }
+    }
+  }
+  return citations;
+}
+
+export const askDebriefQuestion = async (meetingId, userId, question) => {
+  // 1. Fetch meeting context
+  const transcript = await Transcript.findOne({ meeting: meetingId });
+  const decisions = await Decision.find({ sourceMeetingId: meetingId });
+
+  if (!transcript && decisions.length === 0) {
+    throw new Error("No context available for this meeting.");
+  }
+
+  // 2. Build the context map and text block for the prompt
+  let contextText = "--- MEETING CONTEXT ---\n\n";
+  const contextMap = {};
+  let refIndex = 1;
+
+  if (transcript && transcript.segments && transcript.segments.length > 0) {
+    contextText += "TRANSCRIPT:\n";
+    transcript.segments.forEach((seg) => {
+      const text = `${seg.speaker}: ${seg.text}`;
+      contextText += `[${refIndex}] [Time: ${seg.startTime}s] ${text}\n`;
+      contextMap[refIndex] = {
+        type: "transcript",
+        id: transcript._id,
+        text: text,
+        timestamp: seg.startTime,
+      };
+      refIndex++;
+    });
+    contextText += "\n";
+  } else if (transcript && transcript.fullText) {
+    // fallback if segments are not available but fullText is
+    contextText += "TRANSCRIPT:\n";
+    contextText += `[${refIndex}] ${transcript.fullText}\n`;
+    contextMap[refIndex] = {
+      type: "transcript",
+      id: transcript._id,
+      text: transcript.fullText,
+      timestamp: 0,
+    };
+    refIndex++;
+  }
+
+  if (decisions && decisions.length > 0) {
+    contextText += "DECISIONS:\n";
+    decisions.forEach((dec) => {
+      contextText += `[${refIndex}] Decision: ${dec.text} (Status: ${dec.status})\n`;
+      contextMap[refIndex] = {
+        type: "decision",
+        id: dec._id,
+        text: dec.text,
+      };
+      refIndex++;
+    });
+    contextText += "\n";
+  }
+
+  // 3. Fetch chat history
+  let session = await DebriefSession.findOne({ meetingId, userId });
+  if (!session) {
+    session = new DebriefSession({ meetingId, userId, messages: [] });
+  }
+
+  let historyText = "";
+  if (session.messages.length > 0) {
+    historyText = "--- CHAT HISTORY ---\n";
+    session.messages.forEach((msg) => {
+      historyText += `${msg.role === "user" ? "User" : "Assistant"}: ${msg.content}\n`;
+    });
+    historyText += "\n";
+  }
+
+  // 4. Construct prompt
+  const prompt = `
+You are a helpful meeting assistant. You must answer the user's question using ONLY the provided meeting context.
+Do not invent information. If the answer is not in the context, say "I don't have enough information from the meeting to answer that."
+
+When you use information from the context, you MUST cite the source by appending the corresponding bracketed number, e.g., [1] or [42], directly after the relevant sentence or fact.
+
+${contextText}
+
+${historyText}
+--- NEW QUESTION ---
+User: ${question}
+Assistant:`;
+
+  // 5. Call LLM
+  const responseText = await generateText(prompt, "debrief_qa");
+
+  // 6. Extract citations
+  const citations = extractCitations(responseText, contextMap);
+
+  // 7. Save to DB
+  session.messages.push({
+    role: "user",
+    content: question,
+    citations: [],
+  });
+
+  session.messages.push({
+    role: "assistant",
+    content: responseText,
+    citations: citations,
+  });
+
+  await session.save();
+
+  // Return the newly added assistant message with citations
+  return session.messages[session.messages.length - 1];
+};
+
+export const getDebriefSession = async (meetingId, userId) => {
+  return await DebriefSession.findOne({ meetingId, userId });
+};

--- a/server/tests/tagMergeAndExport.test.js
+++ b/server/tests/tagMergeAndExport.test.js
@@ -24,7 +24,7 @@ jest.unstable_mockModule("../models/meetingModel.js", () => ({
   },
 }));
 
-const { mergeTags, bulkRetag, exportTags } =
+const { mergeTags, exportTags } =
   await import("../controllers/tagController.js");
 
 describe("Tag Taxonomy Administration Controllers (#2244)", () => {


### PR DESCRIPTION
- closes #2361

### Description
Implemented a new **Meeting-Scoped Debrief Q&A** feature that allows users to ask questions strictly grounded in a single meeting's context. This eliminates AI hallucinations by parsing the meeting's transcript and decisions, constructing a dedicated context prompt, and rendering inline, clickable citation chips that link directly to the exact source timestamp or decision entry.

### Changes Made

#### Server
* **Models:** Created `debriefSessionModel.js` to persist chat history and structured citations tied to specific meetings and users.
* **Services:** Developed `debriefQAService.js` to handle fetching context (transcript and decisions), constructing the grounded LLM prompt, and extracting citation markers from the AI response.
* **Controllers & Routes:** Added `debriefQAController.js` and `debriefQARoutes.js` exposing endpoints (`POST /api/debrief/session` and `GET /api/debrief/session/:meetingId`) and registered them in the main router.

#### Client
* **API:** Added `debriefQAApi.js` to interface with the new backend endpoints.
* **Components:** Built the `DebriefQAPanel.jsx` component featuring a modern chat UI, persistent message history, and clickable citation chips.
* **Integration:** Embedded `DebriefQAPanel` inside `MeetingDetails.jsx` alongside the transcript and implemented a `handleCitationClick` callback to smoothly scroll the view to referenced transcript segments or decisions.

### Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new ESLint warnings or errors.
- [x] I have tested the feature locally and verified that citations accurately scroll to the correct timestamp or decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an AI-powered Q&A panel to meeting details.
  - Ask questions about meeting transcripts and decisions.
  - View conversational history with source citations.
  - Select citations to jump directly to relevant transcript or decision content.
  - Existing Q&A sessions are restored when reopening a meeting.

- **Bug Fixes**
  - Updated tag-related tests to reflect the removal of an obsolete bulk retagging feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->