### PR TITLE
Implement resumable chunk upload and UI recovery for UploadMeeting #2268

### DIFF
--- a/client/src/hooks/__tests__/useMeetingUploadResumable.test.jsx
+++ b/client/src/hooks/__tests__/useMeetingUploadResumable.test.jsx
@@ -1,0 +1,119 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import useMeetingUpload from "../useMeetingUpload";
+import { meetingApi } from "../../services";
+
+vi.mock("../../services", () => ({
+  meetingApi: {
+    initResumableUpload: vi.fn(),
+    uploadChunk: vi.fn(),
+    getUploadStatus: vi.fn(),
+    completeResumableUpload: vi.fn(),
+    abortResumableUpload: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useMeetingUpload Resumable Upload Hook (#2268)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("slice file into chunks and executes complete upload", async () => {
+    meetingApi.initResumableUpload.mockResolvedValue({
+      data: {
+        success: true,
+        data: { uploadId: "upload-999", chunkSize: 5242880, totalChunks: 1 },
+      },
+    });
+
+    meetingApi.uploadChunk.mockResolvedValue({
+      data: {
+        success: true,
+        data: { uploadId: "upload-999", chunkIndex: 0, uploadedChunks: [0] },
+      },
+    });
+
+    meetingApi.completeResumableUpload.mockResolvedValue({
+      data: {
+        success: true,
+        data: { meetingId: "m-123", transcript: "Chunked transcript text" },
+      },
+    });
+
+    const { result } = renderHook(() => useMeetingUpload());
+
+    const fakeFile = new File(["dummy audio content"], "test.mp3", {
+      type: "audio/mpeg",
+    });
+
+    act(() => {
+      result.current.setFile(fakeFile);
+    });
+
+    await act(async () => {
+      result.current.handleUpload("Test Meeting", vi.fn(), ["tag1"]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.meetingId).toBe("m-123");
+    });
+
+    expect(meetingApi.initResumableUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "test.mp3",
+      }),
+    );
+    expect(meetingApi.uploadChunk).toHaveBeenCalled();
+    expect(meetingApi.completeResumableUpload).toHaveBeenCalledWith({
+      uploadId: "upload-999",
+    });
+  });
+
+  it("rehydrates in-progress upload session from localStorage", async () => {
+    localStorage.setItem(
+      "active_upload_session",
+      JSON.stringify({
+        uploadId: "active-session-1",
+        fileName: "saved.mp3",
+        fileSize: 1000,
+        totalChunks: 2,
+      }),
+    );
+
+    meetingApi.getUploadStatus.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          uploadId: "active-session-1",
+          fileName: "saved.mp3",
+          fileSize: 1000,
+          totalChunks: 2,
+          uploadedChunks: [0],
+          status: "in_progress",
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useMeetingUpload());
+
+    let session;
+    await act(async () => {
+      session = await result.current.checkInactivityOrRehydrate();
+    });
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        uploadId: "active-session-1",
+        uploadedChunks: [0],
+      }),
+    );
+  });
+});

--- a/client/src/hooks/useMeetingUpload.js
+++ b/client/src/hooks/useMeetingUpload.js
@@ -32,11 +32,30 @@ const useMeetingUpload = () => {
   };
 
   const { isDragging, handlers } = useDragAndDrop(handleDropCallback);
-  const { status, progress, uploadMeeting } = useUploadMeetingApi();
+
+  const {
+    status,
+    progress,
+
+    uploadId,
+    totalChunks,
+    uploadedChunks,
+    uploadMeetingResumable,
+    pauseUpload,
+
+    checkInactivityOrRehydrate,
+    abortCurrentUpload,
+  } = useUploadMeetingApi();
+
   const isUploading = status === "pending";
+  const isPaused = status === "paused";
+  const isError = status === "error";
   const uploadProgress = progress;
 
   const resetUpload = (setSummary, setTitle) => {
+    if (uploadId) {
+      abortCurrentUpload(uploadId);
+    }
     setFile(null);
     setTranscript("");
     if (setSummary) setSummary("");
@@ -47,14 +66,21 @@ const useMeetingUpload = () => {
     }
   };
 
-  const handleUpload = (title, setTitle, tags = []) => {
-    if (!file) {
+  const handleUpload = (
+    title,
+    setTitle,
+    tags = [],
+    date = "",
+    options = {},
+  ) => {
+    if (!file && !options.existingUploadId) {
       toast.error("Please select an audio file first.");
       return;
     }
     setTranscript("");
     setMeetingId(null);
-    uploadMeeting(file, title, tags, {
+    uploadMeetingResumable(file, title, tags, date, {
+      existingUploadId: options.existingUploadId,
       onSuccess: (data) => {
         toast.success("Transcription complete!");
         setTranscript(data.transcript || "");
@@ -72,6 +98,12 @@ const useMeetingUpload = () => {
     setFile,
     uploadProgress,
     isUploading,
+    isPaused,
+    isError,
+    status,
+    uploadId,
+    totalChunks,
+    uploadedChunks,
     isDragging,
     transcript,
     setTranscript,
@@ -85,6 +117,9 @@ const useMeetingUpload = () => {
     handleDrop: handlers.onDrop,
     resetUpload,
     handleUpload,
+    pauseUpload,
+    checkInactivityOrRehydrate,
+    abortCurrentUpload,
     formatFileSize,
   };
 };

--- a/client/src/hooks/useUploadMeetingApi.js
+++ b/client/src/hooks/useUploadMeetingApi.js
@@ -1,75 +1,289 @@
-import { useState, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { meetingApi } from "../services";
+
+const CHUNK_SIZE = 5 * 1024 * 1024; // 5MB
 
 const useUploadMeetingApi = () => {
   const [state, setState] = useState({
-    status: "idle", // 'idle' | 'pending' | 'success' | 'error'
+    status: "idle", // 'idle' | 'pending' | 'paused' | 'success' | 'error'
     data: null,
     error: null,
     progress: 0,
+    uploadId: null,
+    currentChunkIndex: 0,
+    totalChunks: 0,
+    uploadedChunks: [],
+    sessionMetadata: null,
   });
 
-  const uploadMeeting = useCallback(
-    async (file, title, tags = [], options = {}) => {
-      const { onSuccess, onError } = options;
+  const isPausedRef = useRef(false);
 
-      if (!file) {
+  const pauseUpload = useCallback(() => {
+    isPausedRef.current = true;
+    setState((prev) => ({ ...prev, status: "paused" }));
+  }, []);
+
+  const uploadMeetingResumable = useCallback(
+    async (file, title, tags = [], date = "", options = {}) => {
+      const { onSuccess, onError, existingUploadId } = options;
+
+      if (!file && !existingUploadId) {
         const error = new Error("Please select an audio file first.");
         setState({ status: "error", data: null, error, progress: 0 });
         if (onError) onError(error);
         return;
       }
 
+      isPausedRef.current = false;
+
       try {
-        setState({ status: "pending", data: null, error: null, progress: 0 });
+        let uploadId = existingUploadId;
+        let totalChunks = 0;
+        let uploadedChunks = [];
 
-        const formData = new FormData();
-        formData.append("file", file);
-        if (title) formData.append("title", title);
+        // 1. Initialize or Rehydrate Upload Session
+        if (!uploadId) {
+          const fileSize = file.size;
+          totalChunks = Math.ceil(fileSize / CHUNK_SIZE);
 
-        // Append tags array
-        if (tags && tags.length > 0) {
-          tags.forEach((tag) => formData.append("tags", tag));
+          const initRes = await meetingApi.initResumableUpload({
+            fileName: file.name,
+            fileSize,
+            totalChunks,
+            title,
+            tags,
+            date,
+            mimeType: file.type,
+          });
+
+          if (!initRes.data?.success) {
+            throw new Error(
+              initRes.data?.message || "Failed to initialize resumable upload",
+            );
+          }
+
+          uploadId = initRes.data.data.uploadId;
+          try {
+            localStorage.setItem(
+              "active_upload_session",
+              JSON.stringify({
+                uploadId,
+                fileName: file.name,
+                fileSize,
+                totalChunks,
+                title,
+                tags,
+                date,
+              }),
+            );
+          } catch {
+            // ignore localStorage quota errors
+          }
+        } else {
+          // Rehydrate existing upload session
+          const statusRes = await meetingApi.getUploadStatus(uploadId);
+          if (statusRes.data?.data) {
+            totalChunks = statusRes.data.data.totalChunks;
+            uploadedChunks = statusRes.data.data.uploadedChunks || [];
+          }
         }
 
-        const res = await meetingApi.uploadMeeting(formData, {
-          onUploadProgress: (progressEvent) => {
-            const percent = Math.round(
-              (progressEvent.loaded * 100) / progressEvent.total,
-            );
-            setState((prev) => ({ ...prev, progress: percent }));
-          },
+        setState({
+          status: "pending",
+          data: null,
+          error: null,
+          progress: Math.round(
+            (uploadedChunks.length / Math.max(1, totalChunks)) * 100,
+          ),
+          uploadId,
+          totalChunks,
+          uploadedChunks,
+          sessionMetadata: { title, tags, date },
         });
 
-        if (res.data?.success) {
+        // 2. Upload Chunks
+        const fileSize = file ? file.size : 0;
+        totalChunks = totalChunks || Math.ceil(fileSize / CHUNK_SIZE);
+
+        for (let i = 0; i < totalChunks; i++) {
+          if (isPausedRef.current) {
+            setState((prev) => ({ ...prev, status: "paused" }));
+            return;
+          }
+
+          if (uploadedChunks.includes(i)) {
+            continue;
+          }
+
+          if (!file) {
+            throw new Error(
+              `Please re-select the file to resume chunk ${i + 1}`,
+            );
+          }
+
+          const start = i * CHUNK_SIZE;
+          const end = Math.min(start + CHUNK_SIZE, fileSize);
+          const chunkBlob = file.slice(start, end);
+
+          const formData = new FormData();
+          formData.append("uploadId", uploadId);
+          formData.append("chunkIndex", i);
+          formData.append("totalChunks", totalChunks);
+          formData.append("chunk", chunkBlob, file.name);
+
+          // Retry logic per chunk (up to 3 attempts)
+          let attempts = 0;
+          let chunkSuccess = false;
+          let lastChunkErr = null;
+
+          while (attempts < 3 && !chunkSuccess && !isPausedRef.current) {
+            attempts++;
+            try {
+              const chunkRes = await meetingApi.uploadChunk(formData, {
+                onUploadProgress: (progressEvent) => {
+                  const chunkPercent =
+                    (progressEvent.loaded / progressEvent.total) *
+                    (1 / totalChunks);
+                  const totalPercent = Math.round(
+                    ((uploadedChunks.length + chunkPercent) / totalChunks) *
+                      100,
+                  );
+                  setState((prev) => ({
+                    ...prev,
+                    progress: Math.min(99, totalPercent),
+                  }));
+                },
+              });
+
+              if (chunkRes.data?.success) {
+                chunkSuccess = true;
+                if (!uploadedChunks.includes(i)) {
+                  uploadedChunks.push(i);
+                }
+                setState((prev) => ({
+                  ...prev,
+                  currentChunkIndex: i,
+                  uploadedChunks: [...uploadedChunks],
+                  progress: Math.round(
+                    (uploadedChunks.length / totalChunks) * 100,
+                  ),
+                }));
+              } else {
+                lastChunkErr = new Error(
+                  chunkRes.data?.message || `Chunk ${i} failed`,
+                );
+              }
+            } catch (chunkErr) {
+              lastChunkErr = chunkErr;
+              await new Promise((r) => setTimeout(r, 1000 * attempts)); // exponential backoff
+            }
+          }
+
+          if (!chunkSuccess && !isPausedRef.current) {
+            throw (
+              lastChunkErr ||
+              new Error(`Failed uploading chunk ${i + 1} after 3 retries`)
+            );
+          }
+        }
+
+        // 3. Complete and Assemble
+        setState((prev) => ({ ...prev, progress: 99 }));
+        const completeRes = await meetingApi.completeResumableUpload({
+          uploadId,
+        });
+
+        if (completeRes.data?.success) {
+          localStorage.removeItem("active_upload_session");
           setState({
             status: "success",
-            data: res.data,
+            data: completeRes.data.data,
             error: null,
             progress: 100,
+            uploadId: null,
+            currentChunkIndex: totalChunks,
+            totalChunks,
+            uploadedChunks,
+            sessionMetadata: null,
           });
-          if (onSuccess) onSuccess(res.data);
+          if (onSuccess) onSuccess(completeRes.data.data);
         } else {
-          const errorMsg = res.data?.message || "Upload failed";
-          const error = new Error(errorMsg);
-          setState({ status: "error", data: null, error, progress: 0 });
-          if (onError) onError(error);
+          throw new Error(completeRes.data?.message || "Assembly failed");
         }
       } catch (err) {
-        console.error("Upload error:", err);
+        console.error("Resumable upload error:", err);
         const errorMsg =
           err.response?.data?.message ||
           err.message ||
-          "Server error during upload";
+          "Upload failed during chunk processing";
         const error = new Error(errorMsg);
-        setState({ status: "error", data: null, error, progress: 0 });
+        setState((prev) => ({ ...prev, status: "error", error }));
         if (onError) onError(error);
       }
     },
     [],
   );
 
-  return { ...state, uploadMeeting };
+  const checkInactivityOrRehydrate = useCallback(async () => {
+    try {
+      const saved = localStorage.getItem("active_upload_session");
+      if (!saved) return null;
+      const parsed = JSON.parse(saved);
+      if (!parsed?.uploadId) return null;
+
+      const res = await meetingApi.getUploadStatus(parsed.uploadId);
+      if (res.data?.data && res.data.data.status === "in_progress") {
+        return {
+          ...parsed,
+          ...res.data.data,
+        };
+      } else {
+        localStorage.removeItem("active_upload_session");
+        return null;
+      }
+    } catch (e) {
+      console.warn("Failed rehydrating upload session:", e);
+      return null;
+    }
+  }, []);
+
+  const abortCurrentUpload = useCallback(async (uploadIdToAbort) => {
+    try {
+      if (uploadIdToAbort) {
+        await meetingApi.abortResumableUpload({ uploadId: uploadIdToAbort });
+      }
+      localStorage.removeItem("active_upload_session");
+      setState({
+        status: "idle",
+        data: null,
+        error: null,
+        progress: 0,
+        uploadId: null,
+        currentChunkIndex: 0,
+        totalChunks: 0,
+        uploadedChunks: [],
+        sessionMetadata: null,
+      });
+    } catch (e) {
+      console.error("Error aborting upload session:", e);
+    }
+  }, []);
+
+  const uploadMeeting = useCallback(
+    (file, title, tags = [], options = {}) => {
+      return uploadMeetingResumable(file, title, tags, "", options);
+    },
+    [uploadMeetingResumable],
+  );
+
+  return {
+    ...state,
+    uploadMeeting,
+    uploadMeetingResumable,
+    pauseUpload,
+    checkInactivityOrRehydrate,
+    abortCurrentUpload,
+  };
 };
 
 export default useUploadMeetingApi;

--- a/client/src/pages/UploadMeeting.jsx
+++ b/client/src/pages/UploadMeeting.jsx
@@ -16,6 +16,10 @@ import {
   CheckCircle2,
   Clock,
   Mic,
+  Pause,
+  Play,
+  RotateCcw,
+  RefreshCw,
 } from "lucide-react";
 import { io } from "socket.io-client";
 import Navbar from "../components/Navbar.jsx";
@@ -43,6 +47,11 @@ const UploadMeeting = () => {
     setFile,
     uploadProgress,
     isUploading,
+    isPaused,
+    isError,
+    uploadId,
+    totalChunks,
+    uploadedChunks,
     isDragging,
     transcript,
     meetingId,
@@ -54,8 +63,24 @@ const UploadMeeting = () => {
     handleFileChange,
     resetUpload,
     handleUpload,
+    pauseUpload,
+    checkInactivityOrRehydrate,
+    abortCurrentUpload,
     formatFileSize,
   } = useMeetingUpload();
+
+  const [rehydratedSession, setRehydratedSession] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      if (checkInactivityOrRehydrate) {
+        const session = await checkInactivityOrRehydrate();
+        if (session) {
+          setRehydratedSession(session);
+        }
+      }
+    })();
+  }, [checkInactivityOrRehydrate]);
 
   const [isSummarizing, setIsSummarizing] = useState(false);
   const [summary, setSummary] = useState("");
@@ -314,6 +339,50 @@ const UploadMeeting = () => {
             </div>
           )}
 
+          {/* Rehydrated Session Banner */}
+          {rehydratedSession && (
+            <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-xl flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 shadow-sm">
+              <div>
+                <h4 className="text-sm font-bold text-amber-800 dark:text-amber-200 flex items-center gap-1.5">
+                  <Clock className="w-4 h-4 text-amber-600" />
+                  Unfinished Resumable Upload Session Found
+                </h4>
+                <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                  File: <strong>{rehydratedSession.fileName}</strong> (
+                  {rehydratedSession.uploadedChunks?.length || 0} of{" "}
+                  {rehydratedSession.totalChunks} chunks stored on server)
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => {
+                    setProcessingStep(1);
+                    handleUpload(
+                      rehydratedSession.metadata?.title || title,
+                      setTitle,
+                      rehydratedSession.metadata?.tags || tags,
+                      rehydratedSession.metadata?.date || meetingDate,
+                      { existingUploadId: rehydratedSession.uploadId },
+                    );
+                    setRehydratedSession(null);
+                  }}
+                  className="px-3 py-1.5 text-xs font-bold bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors flex items-center gap-1 cursor-pointer"
+                >
+                  <Play className="w-3.5 h-3.5" /> Resume Upload
+                </button>
+                <button
+                  onClick={() => {
+                    abortCurrentUpload(rehydratedSession.uploadId);
+                    setRehydratedSession(null);
+                  }}
+                  className="px-3 py-1.5 text-xs font-bold text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-800/40 rounded-lg transition-colors cursor-pointer"
+                >
+                  Discard
+                </button>
+              </div>
+            </div>
+          )}
+
           {/* Toggle Tabs */}
           <div className="flex justify-center mb-8 fade-in-up stagger-1">
             <div className="inline-flex bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
@@ -457,30 +526,57 @@ const UploadMeeting = () => {
               {activeTab === "upload" && (
                 <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700 flex flex-col sm:flex-row items-center justify-between gap-4">
                   <div className="flex items-center gap-3 w-full sm:w-auto justify-start order-2 sm:order-1">
-                    <button
-                      onClick={() => {
-                        setProcessingStep(1);
-                        handleUpload(title, setTitle, tags);
-                      }}
-                      disabled={isUploading || !file}
-                      className={`w-full sm:w-auto px-6 py-3 rounded-xl font-bold shadow-lg flex items-center justify-center gap-2 transition-all duration-200 cursor-pointer ${
-                        isUploading || !file
-                          ? "bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed shadow-none border border-gray-200 dark:border-gray-600"
-                          : "bg-blue-600 text-white hover:bg-blue-700 shadow-blue-500/10 hover:shadow-blue-500/25 hover:-translate-y-0.5 active:translate-y-0"
-                      }`}
-                    >
-                      {isUploading ? (
-                        <>
-                          <Loader2 className="w-4 h-4 animate-spin text-white" />
-                          <span>Uploading ({uploadProgress}%)</span>
-                        </>
-                      ) : (
-                        <>
-                          <UploadCloud className="w-4 h-4" />
-                          <span>Upload & Transcribe</span>
-                        </>
-                      )}
-                    </button>
+                    {isUploading ? (
+                      <button
+                        onClick={() => pauseUpload()}
+                        className="w-full sm:w-auto px-5 py-3 rounded-xl font-bold bg-amber-500 hover:bg-amber-600 text-white shadow-md flex items-center justify-center gap-2 transition-all cursor-pointer"
+                      >
+                        <Pause className="w-4 h-4" />
+                        <span>Pause Upload ({uploadProgress}%)</span>
+                      </button>
+                    ) : isPaused ? (
+                      <button
+                        onClick={() => {
+                          setProcessingStep(1);
+                          handleUpload(title, setTitle, tags, meetingDate, {
+                            existingUploadId: uploadId,
+                          });
+                        }}
+                        className="w-full sm:w-auto px-5 py-3 rounded-xl font-bold bg-blue-600 hover:bg-blue-700 text-white shadow-md flex items-center justify-center gap-2 transition-all cursor-pointer"
+                      >
+                        <Play className="w-4 h-4" />
+                        <span>Resume Upload ({uploadProgress}%)</span>
+                      </button>
+                    ) : isError ? (
+                      <button
+                        onClick={() => {
+                          setProcessingStep(1);
+                          handleUpload(title, setTitle, tags, meetingDate, {
+                            existingUploadId: uploadId,
+                          });
+                        }}
+                        className="w-full sm:w-auto px-5 py-3 rounded-xl font-bold bg-red-600 hover:bg-red-700 text-white shadow-md flex items-center justify-center gap-2 transition-all cursor-pointer"
+                      >
+                        <RotateCcw className="w-4 h-4" />
+                        <span>Retry Failed Chunk</span>
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          setProcessingStep(1);
+                          handleUpload(title, setTitle, tags, meetingDate);
+                        }}
+                        disabled={!file}
+                        className={`w-full sm:w-auto px-6 py-3 rounded-xl font-bold shadow-lg flex items-center justify-center gap-2 transition-all duration-200 cursor-pointer ${
+                          !file
+                            ? "bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed shadow-none border border-gray-200 dark:border-gray-600"
+                            : "bg-blue-600 text-white hover:bg-blue-700 shadow-blue-500/10 hover:shadow-blue-500/25 hover:-translate-y-0.5 active:translate-y-0"
+                        }`}
+                      >
+                        <UploadCloud className="w-4 h-4" />
+                        <span>Upload & Transcribe (Resumable)</span>
+                      </button>
+                    )}
 
                     <button
                       onClick={() => {
@@ -496,10 +592,17 @@ const UploadMeeting = () => {
 
                   <div className="text-sm font-semibold text-gray-500 dark:text-gray-400 flex items-center gap-2 order-1 sm:order-2 w-full sm:w-auto justify-center sm:justify-start">
                     {file ? (
-                      <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-100 dark:border-emerald-800 px-3 py-1 rounded-full text-xs font-bold animate-pulse">
-                        <CheckCircle2 className="w-3.5 h-3.5" /> Ready to
-                        transcribe
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-100 dark:border-emerald-800 px-3 py-1 rounded-full text-xs font-bold animate-pulse">
+                          <CheckCircle2 className="w-3.5 h-3.5" /> Ready for
+                          resumable chunk upload
+                        </span>
+                        {totalChunks > 0 && (
+                          <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+                            ({uploadedChunks?.length || 0}/{totalChunks} chunks)
+                          </span>
+                        )}
+                      </div>
                     ) : (
                       <span className="text-gray-400 text-xs font-medium">
                         No file selected

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -9,6 +9,18 @@ export const meetingApi = {
   uploadMeeting: (formData, config) =>
     apiClient.post("/api/meetings/upload", formData, config),
 
+  // Resumable Chunk Upload Endpoints (#2268)
+  initResumableUpload: (data) =>
+    apiClient.post("/api/meetings/upload/init", data),
+  uploadChunk: (formData, config) =>
+    apiClient.post("/api/meetings/upload/chunk", formData, config),
+  getUploadStatus: (uploadId) =>
+    apiClient.get(`/api/meetings/upload/status/${uploadId}`),
+  completeResumableUpload: (data) =>
+    apiClient.post("/api/meetings/upload/complete", data),
+  abortResumableUpload: (data) =>
+    apiClient.post("/api/meetings/upload/abort", data),
+
   summarizeMeeting: (data) => apiClient.post("/api/meetings/summarize", data),
 
   getAllMeetings: (params = {}, config = {}) =>

--- a/server/controllers/resumableUploadController.js
+++ b/server/controllers/resumableUploadController.js
@@ -1,0 +1,375 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import UploadSession from "../models/uploadSessionModel.js";
+import MeetingService from "../services/meetingService.js";
+import {
+  ValidationError,
+  NotFoundError,
+  ForbiddenError,
+} from "../utils/errors.js";
+import { sendSuccess } from "../utils/responseHandler.js";
+
+const ALLOWED_RECORDING_MIME_TYPES = [
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/x-wav",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+  "audio/webm",
+  "audio/flac",
+  "audio/aac",
+  "audio/mp4",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-msvideo",
+  "video/x-matroska",
+  "application/octet-stream",
+];
+
+const ALLOWED_RECORDING_EXTENSIONS = [
+  ".mp3",
+  ".wav",
+  ".m4a",
+  ".ogg",
+  ".webm",
+  ".flac",
+  ".aac",
+  ".mp4",
+  ".mov",
+  ".avi",
+  ".mkv",
+];
+
+const validateFileNameAndType = (fileName, mimeType) => {
+  if (!fileName) throw new ValidationError("File name is required");
+  const ext = path.extname(fileName || "").toLowerCase();
+  const isExtAllowed = ALLOWED_RECORDING_EXTENSIONS.includes(ext);
+  const isMimeAllowed =
+    !mimeType || ALLOWED_RECORDING_MIME_TYPES.includes(mimeType);
+
+  if (!isExtAllowed || !isMimeAllowed) {
+    throw new ValidationError(
+      `Invalid meeting recording file format: ${fileName}. Supported formats: MP3, WAV, M4A, OGG, WEBM, FLAC, AAC, MP4, MOV, AVI, MKV`,
+    );
+  }
+};
+
+const getChunksDir = (uploadId) => {
+  const chunksDir = path.resolve("uploads", "chunks", uploadId);
+  if (!chunksDir.startsWith(path.resolve("uploads"))) {
+    throw new ValidationError("Directory traversal detected");
+  }
+  return chunksDir;
+};
+
+/**
+ * 1. Initialize Resumable Chunk Upload Session
+ */
+export const initResumableUpload = async (req, res, next) => {
+  try {
+    const { fileName, fileSize, totalChunks, title, tags, date, mimeType } =
+      req.body;
+
+    if (!fileName || !fileSize || !totalChunks) {
+      throw new ValidationError(
+        "fileName, fileSize, and totalChunks are required",
+      );
+    }
+
+    validateFileNameAndType(fileName, mimeType);
+
+    const userId = req.user.id || req.user._id;
+    const orgId = req.user.organization || null;
+
+    const uploadId = `upload_${Date.now()}_${crypto.randomBytes(4).toString("hex")}`;
+
+    const session = await UploadSession.create({
+      uploadId,
+      user: userId,
+      organization: orgId,
+      fileName,
+      fileSize: Number(fileSize),
+      totalChunks: Number(totalChunks),
+      uploadedChunks: [],
+      status: "in_progress",
+      metadata: {
+        title: title || "",
+        tags: Array.isArray(tags) ? tags : tags ? [tags] : [],
+        date: date || "",
+      },
+    });
+
+    const chunksDir = getChunksDir(uploadId);
+    fs.mkdirSync(chunksDir, { recursive: true });
+
+    return sendSuccess(
+      res,
+      {
+        uploadId: session.uploadId,
+        chunkSize: 5 * 1024 * 1024,
+        totalChunks: session.totalChunks,
+        uploadedChunks: [],
+      },
+      "Resumable upload session initialized",
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 2. Upload Single Chunk
+ */
+export const uploadChunk = async (req, res, next) => {
+  try {
+    const { uploadId, chunkIndex: rawChunkIndex } = req.body;
+
+    if (!uploadId || rawChunkIndex === undefined) {
+      throw new ValidationError("uploadId and chunkIndex are required");
+    }
+
+    const chunkIndex = Number(rawChunkIndex);
+
+    const session = await UploadSession.findOne({ uploadId });
+    if (!session) {
+      throw new NotFoundError("Upload session not found");
+    }
+
+    if (session.status !== "in_progress") {
+      throw new ValidationError(
+        `Upload session is no longer active (status: ${session.status})`,
+      );
+    }
+
+    if (chunkIndex < 0 || chunkIndex >= session.totalChunks) {
+      throw new ValidationError(`Invalid chunkIndex ${chunkIndex}`);
+    }
+
+    const chunkBuffer =
+      req.file?.buffer ||
+      (req.file?.path ? fs.readFileSync(req.file.path) : null);
+    if (!chunkBuffer) {
+      throw new ValidationError("No chunk data provided");
+    }
+
+    const chunksDir = getChunksDir(uploadId);
+    if (!fs.existsSync(chunksDir)) {
+      fs.mkdirSync(chunksDir, { recursive: true });
+    }
+
+    const chunkFilePath = path.join(chunksDir, `chunk_${chunkIndex}.tmp`);
+    fs.writeFileSync(chunkFilePath, chunkBuffer);
+
+    // Clean up multer file path if temporary
+    if (req.file?.path && fs.existsSync(req.file.path)) {
+      try {
+        fs.unlinkSync(req.file.path);
+      } catch (_e) {
+        // ignore
+      }
+    }
+
+    if (!session.uploadedChunks.includes(chunkIndex)) {
+      session.uploadedChunks.push(chunkIndex);
+      session.uploadedChunks.sort((a, b) => a - b);
+    }
+    session.lastActiveAt = new Date();
+    await session.save();
+
+    return sendSuccess(
+      res,
+      {
+        uploadId: session.uploadId,
+        chunkIndex,
+        uploadedChunks: session.uploadedChunks,
+        totalChunks: session.totalChunks,
+      },
+      `Chunk ${chunkIndex} received`,
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 3. Get Upload Session Status (Rehydrate in-progress upload on refresh)
+ */
+export const getUploadStatus = async (req, res, next) => {
+  try {
+    const { uploadId } = req.params;
+    const userId = req.user.id || req.user._id;
+
+    const session = await UploadSession.findOne({ uploadId });
+    if (!session) {
+      throw new NotFoundError("Upload session not found");
+    }
+
+    if (session.user.toString() !== userId.toString()) {
+      throw new ForbiddenError("You don't have access to this upload session");
+    }
+
+    return sendSuccess(res, {
+      uploadId: session.uploadId,
+      fileName: session.fileName,
+      fileSize: session.fileSize,
+      totalChunks: session.totalChunks,
+      uploadedChunks: session.uploadedChunks,
+      status: session.status,
+      metadata: session.metadata,
+      lastActiveAt: session.lastActiveAt,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 4. Complete & Assemble Chunks with Integrity Verification
+ */
+export const completeResumableUpload = async (req, res, next) => {
+  let assembledFilePath = null;
+  try {
+    const { uploadId } = req.body;
+    if (!uploadId) {
+      throw new ValidationError("uploadId is required");
+    }
+
+    const session = await UploadSession.findOne({ uploadId });
+    if (!session) {
+      throw new NotFoundError("Upload session not found");
+    }
+
+    const userId = req.user.id || req.user._id;
+    const orgId = req.user.organization || null;
+
+    const chunksDir = getChunksDir(uploadId);
+
+    // Verify all chunks 0..totalChunks-1 are uploaded
+    const missingChunks = [];
+    for (let i = 0; i < session.totalChunks; i++) {
+      const chunkPath = path.join(chunksDir, `chunk_${i}.tmp`);
+      if (!session.uploadedChunks.includes(i) || !fs.existsSync(chunkPath)) {
+        missingChunks.push(i);
+      }
+    }
+
+    if (missingChunks.length > 0) {
+      throw new ValidationError(
+        `Upload incomplete. Missing chunk indices: ${missingChunks.join(", ")}`,
+      );
+    }
+
+    // Assemble file
+    assembledFilePath = path.resolve(
+      "uploads",
+      `assembled_${uploadId}_${session.fileName}`,
+    );
+    const writeStream = fs.createWriteStream(assembledFilePath);
+
+    for (let i = 0; i < session.totalChunks; i++) {
+      const chunkPath = path.join(chunksDir, `chunk_${i}.tmp`);
+      const chunkBuffer = fs.readFileSync(chunkPath);
+      writeStream.write(chunkBuffer);
+    }
+    writeStream.end();
+
+    await new Promise((resolve, reject) => {
+      writeStream.on("finish", resolve);
+      writeStream.on("error", reject);
+    });
+
+    // Integrity Check: Assembled size must match expected fileSize
+    const assembledStat = fs.statSync(assembledFilePath);
+    if (assembledStat.size !== session.fileSize) {
+      throw new ValidationError(
+        `File integrity check failed: expected size ${session.fileSize} bytes, got ${assembledStat.size} bytes`,
+      );
+    }
+
+    // Call MeetingService uploadAndTranscribeMeeting
+    const fakeFileObject = {
+      path: assembledFilePath,
+      originalname: session.fileName,
+      size: assembledStat.size,
+      mimetype: "audio/mpeg",
+    };
+
+    const validatedInput = {
+      title: session.metadata?.title || undefined,
+      tags: session.metadata?.tags || undefined,
+      date: session.metadata?.date || undefined,
+    };
+
+    const { meeting, transcript } =
+      await MeetingService.uploadAndTranscribeMeeting(
+        userId,
+        orgId,
+        fakeFileObject,
+        validatedInput,
+      );
+
+    session.status = "completed";
+    await session.save();
+
+    // Clean up chunk files and directory
+    try {
+      fs.rmSync(chunksDir, { recursive: true, force: true });
+    } catch (_e) {
+      // ignore
+    }
+
+    return sendSuccess(
+      res,
+      {
+        meetingId: meeting._id,
+        transcript,
+        autoTitle: meeting.title,
+      },
+      "Resumable upload assembled and transcribed successfully",
+    );
+  } catch (err) {
+    if (assembledFilePath && fs.existsSync(assembledFilePath)) {
+      try {
+        fs.unlinkSync(assembledFilePath);
+      } catch (_e) {
+        // ignore
+      }
+    }
+    next(err);
+  }
+};
+
+/**
+ * 5. Abort Resumable Upload
+ */
+export const abortResumableUpload = async (req, res, next) => {
+  try {
+    const { uploadId } = req.body;
+    if (!uploadId) {
+      throw new ValidationError("uploadId is required");
+    }
+
+    const session = await UploadSession.findOne({ uploadId });
+    if (session) {
+      session.status = "aborted";
+      await session.save();
+    }
+
+    const chunksDir = getChunksDir(uploadId);
+    if (fs.existsSync(chunksDir)) {
+      fs.rmSync(chunksDir, { recursive: true, force: true });
+    }
+
+    return sendSuccess(
+      res,
+      { uploadId },
+      "Upload session aborted successfully",
+    );
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/models/uploadSessionModel.js
+++ b/server/models/uploadSessionModel.js
@@ -1,0 +1,64 @@
+import mongoose from "mongoose";
+
+const uploadSessionSchema = new mongoose.Schema(
+  {
+    uploadId: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      default: null,
+      index: true,
+    },
+    fileName: {
+      type: String,
+      required: true,
+    },
+    fileSize: {
+      type: Number,
+      required: true,
+    },
+    totalChunks: {
+      type: Number,
+      required: true,
+    },
+    uploadedChunks: {
+      type: [Number],
+      default: [],
+    },
+    status: {
+      type: String,
+      enum: ["in_progress", "completed", "failed", "aborted"],
+      default: "in_progress",
+      index: true,
+    },
+    lastActiveAt: {
+      type: Date,
+      default: Date.now,
+    },
+    metadata: {
+      title: { type: String, default: "" },
+      date: { type: String, default: "" },
+      tags: { type: [String], default: [] },
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const UploadSession =
+  mongoose.models.UploadSession ||
+  mongoose.model("UploadSession", uploadSessionSchema);
+
+export default UploadSession;

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -228,7 +228,16 @@ router.get(
 
 // ========== EXISTING ROUTES (Working) ==========
 
+import {
+  initResumableUpload,
+  uploadChunk,
+  getUploadStatus,
+  completeResumableUpload,
+  abortResumableUpload,
+} from "../controllers/resumableUploadController.js";
+
 // ✅ Upload & Transcribe Meeting (from UploadMeetings page) - admin only
+
 router.post(
   "/upload",
   userAuth,
@@ -238,6 +247,52 @@ router.post(
   requirePermission("meetings", "create"),
   upload.single("file"),
   uploadMeeting,
+);
+
+// Resumable Chunk Upload Routes (#2268)
+router.post(
+  "/upload/init",
+  userAuth,
+  uploadLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  initResumableUpload,
+);
+
+router.post(
+  "/upload/chunk",
+  userAuth,
+  uploadLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  upload.single("chunk"),
+  uploadChunk,
+);
+
+router.get(
+  "/upload/status/:uploadId",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  getUploadStatus,
+);
+
+router.post(
+  "/upload/complete",
+  userAuth,
+  uploadLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  completeResumableUpload,
+);
+
+router.post(
+  "/upload/abort",
+  userAuth,
+  uploadLimiter,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  abortResumableUpload,
 );
 
 // ✅ Summarize Transcript (send meetingId or transcript)

--- a/server/tests/resumableUpload.test.js
+++ b/server/tests/resumableUpload.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+
+vi.mock("../models/uploadSessionModel.js", () => {
+  let mockDoc = null;
+
+  return {
+    default: {
+      create: vi.fn().mockImplementation((data) => {
+        mockDoc = {
+          ...data,
+          save: vi.fn().mockResolvedValue(true),
+        };
+        return Promise.resolve(mockDoc);
+      }),
+      findOne: vi.fn().mockImplementation(({ uploadId }) => {
+        if (mockDoc && mockDoc.uploadId === uploadId) {
+          return Promise.resolve(mockDoc);
+        }
+        return Promise.resolve(null);
+      }),
+    },
+  };
+});
+
+vi.mock("../services/meetingService.js", () => ({
+  default: {
+    uploadAndTranscribeMeeting: vi.fn().mockResolvedValue({
+      meeting: { _id: "meeting-123", title: "Resumable Meeting" },
+      transcript: "Transcribed meeting text",
+    }),
+  },
+}));
+
+import {
+  initResumableUpload,
+  uploadChunk,
+  getUploadStatus,
+  completeResumableUpload,
+  abortResumableUpload,
+} from "../controllers/resumableUploadController.js";
+import UploadSession from "../models/uploadSessionModel.js";
+
+describe("Resumable Upload Controller (#2268)", () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    req = {
+      user: { id: "user-1", organization: "org-1" },
+      body: {},
+      params: {},
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    next = vi.fn();
+  });
+
+  afterEach(() => {
+    // Cleanup temporary chunks directory if created
+    const chunksRootDir = path.resolve("uploads", "chunks");
+    if (fs.existsSync(chunksRootDir)) {
+      try {
+        fs.rmSync(chunksRootDir, { recursive: true, force: true });
+      } catch (_e) {
+        // ignore
+      }
+    }
+  });
+
+  it("initResumableUpload creates session and chunk directory", async () => {
+    req.body = {
+      fileName: "recording.mp3",
+      fileSize: 10485760,
+      totalChunks: 2,
+      title: "Quarterly Review",
+      date: "2026-08-25",
+    };
+
+    await initResumableUpload(req, res, next);
+
+    expect(UploadSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "recording.mp3",
+        fileSize: 10485760,
+        totalChunks: 2,
+        status: "in_progress",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        totalChunks: 2,
+      }),
+    );
+  });
+
+  it("uploadChunk saves chunk buffer and updates uploadedChunks array", async () => {
+    // Init session first
+    req.body = {
+      fileName: "test.wav",
+      fileSize: 100,
+      totalChunks: 2,
+    };
+    await initResumableUpload(req, res, next);
+    const uploadId = res.json.mock.calls[0][0].uploadId;
+
+    // Reset mocks for uploadChunk
+    res.status.mockClear();
+    res.json.mockClear();
+
+    req.body = {
+      uploadId,
+      chunkIndex: 0,
+      totalChunks: 2,
+    };
+    req.file = {
+      buffer: Buffer.from("Chunk 0 data "),
+    };
+
+    await uploadChunk(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        chunkIndex: 0,
+        uploadedChunks: [0],
+      }),
+    );
+  });
+
+  it("getUploadStatus rehydrates upload session state for client", async () => {
+    req.body = {
+      fileName: "meeting.m4a",
+      fileSize: 200,
+      totalChunks: 2,
+    };
+    await initResumableUpload(req, res, next);
+    const uploadId = res.json.mock.calls[0][0].uploadId;
+
+    res.status.mockClear();
+    res.json.mockClear();
+
+    req.params = { uploadId };
+    await getUploadStatus(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        uploadId,
+        fileName: "meeting.m4a",
+        status: "in_progress",
+      }),
+    );
+  });
+
+  it("completeResumableUpload assembles chunks and verifies size integrity", async () => {
+    // Init session
+    const chunk0 = Buffer.from("Hello ");
+    const chunk1 = Buffer.from("World!");
+    const totalSize = chunk0.length + chunk1.length;
+
+    req.body = {
+      fileName: "test_assemble.mp3",
+      fileSize: totalSize,
+      totalChunks: 2,
+    };
+    await initResumableUpload(req, res, next);
+    const uploadId = res.json.mock.calls[0][0].uploadId;
+
+    // Upload chunk 0
+    req.body = { uploadId, chunkIndex: 0, totalChunks: 2 };
+    req.file = { buffer: chunk0 };
+    await uploadChunk(req, res, next);
+
+    // Upload chunk 1
+    req.body = { uploadId, chunkIndex: 1, totalChunks: 2 };
+    req.file = { buffer: chunk1 };
+    await uploadChunk(req, res, next);
+
+    res.status.mockClear();
+    res.json.mockClear();
+
+    // Complete upload
+    req.body = { uploadId };
+    await completeResumableUpload(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        meetingId: "meeting-123",
+        transcript: "Transcribed meeting text",
+      }),
+    );
+  });
+
+  it("abortResumableUpload sets status to aborted and clears temp files", async () => {
+    req.body = { uploadId: "upload-abort-123" };
+    await abortResumableUpload(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Summary
This PR implements client-side audio file chunking, pause/resume/retry error recovery, page reload recovery/rehydration, server-side assembly, and file size integrity validation for Issue #2268.

### Key Changes
- **UploadSession Model**: Created a new Mongoose schema tracking `uploadId`, file metrics, completed chunk list, session status, and meeting metadata.
- **API & Assembly Controllers**: Implemented routes for session initialization, chunk upload, session status checks, assembly completion with byte integrity validation, and abortion cleanup.
- **Client & Hook Upgrades**: Extended `useUploadMeetingApi` to slice recordings into 5MB chunks, perform exponential backoff per chunk (up to 3 retries), and track overall progress.
- **UI Enhancements**: Added an "Unfinished Session Found" recovery banner on mount, and introduced Pause, Resume, and Retry buttons within the upload action panel.
- **Tests**: Wrote server unit tests for controller/assembly validation and client unit tests for chunk sequence and rehydration.

Closes #2268