### PR TITLE
feat: add field-level duplicate merge preview

### DIFF
--- a/client/src/api/meetingDuplicateApi.js
+++ b/client/src/api/meetingDuplicateApi.js
@@ -4,9 +4,10 @@ const detectDuplicates = async (meetingId) => {
   return apiClient.get(`/api/meetings/${meetingId}/duplicates`);
 };
 
-const mergeMeetings = async (primaryId, secondaryId) => {
+const mergeMeetings = async (primaryId, secondaryId, fieldSelections = {}) => {
   return apiClient.post(`/api/meetings/${primaryId}/duplicates/merge`, {
     secondaryId,
+    fieldSelections,
   });
 };
 

--- a/client/src/components/meeting-details/DuplicateDetectionPanel.jsx
+++ b/client/src/components/meeting-details/DuplicateDetectionPanel.jsx
@@ -1,8 +1,57 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useMeetingDuplicates } from "../../hooks/useMeetingDuplicates";
 import { format } from "date-fns";
 
-const DuplicateDetectionPanel = ({ meetingId }) => {
+const FIELD_DEFINITIONS = [
+  { key: "title", label: "Title" },
+  { key: "time", label: "Date & time" },
+  { key: "participants", label: "Participants" },
+  { key: "summary", label: "Summary" },
+  { key: "tags", label: "Tags" },
+];
+
+const getFieldValue = (meeting, field) => {
+  if (!meeting) return "—";
+
+  switch (field) {
+    case "title":
+      return meeting.title || "—";
+    case "time":
+      if (!meeting.date && !meeting.time) return "Unknown";
+      return [
+        meeting.date ? format(new Date(meeting.date), "PPP p") : "Unknown date",
+        meeting.time || null,
+      ]
+        .filter(Boolean)
+        .join(" • ");
+    case "participants":
+      return meeting.participants?.length
+        ? meeting.participants
+            .map((participant) => participant.name || participant.email)
+            .filter(Boolean)
+            .join(", ")
+        : "None";
+    case "summary":
+      return meeting.summary || "No summary";
+    case "tags":
+      return meeting.tags?.length ? meeting.tags.join(", ") : "No tags";
+    default:
+      return "—";
+  }
+};
+
+const getRawFieldValue = (meeting, field) => {
+  if (!meeting) return null;
+  if (field === "time") {
+    return { date: meeting.date ?? null, time: meeting.time ?? "" };
+  }
+  return meeting[field] ?? null;
+};
+
+const valuesEqual = (left, right) =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const DuplicateDetectionPanel = ({ meetingId, meeting, onMergeSuccess }) => {
   const {
     duplicates,
     isLoading,
@@ -15,6 +64,22 @@ const DuplicateDetectionPanel = ({ meetingId }) => {
 
   const [selectedSecondary, setSelectedSecondary] = useState(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [fieldSelections, setFieldSelections] = useState({});
+
+  const diffFields = useMemo(
+    () =>
+      selectedSecondary
+        ? FIELD_DEFINITIONS.map((field) => ({
+            ...field,
+            primaryValue: getFieldValue(
+              meeting || { title: "Current meeting" },
+              field.key,
+            ),
+            secondaryValue: getFieldValue(selectedSecondary, field.key),
+          }))
+        : [],
+    [selectedSecondary],
+  );
 
   if (isLoading || isError || !duplicates || duplicates.length === 0) {
     return null;
@@ -22,20 +87,41 @@ const DuplicateDetectionPanel = ({ meetingId }) => {
 
   const handleMergeClick = (duplicate) => {
     setSelectedSecondary(duplicate);
+    setFieldSelections(
+      FIELD_DEFINITIONS.reduce(
+        (acc, field) => ({ ...acc, [field.key]: "primary" }),
+        {},
+      ),
+    );
     setShowConfirm(true);
   };
 
   const confirmMerge = async () => {
     if (!selectedSecondary) return;
+
     try {
       await mergeMeetings({
         primaryId: meetingId,
         secondaryId: selectedSecondary._id,
+        fieldSelections,
       });
+
       setShowConfirm(false);
       setSelectedSecondary(null);
+      if (onMergeSuccess) {
+        await onMergeSuccess();
+      } else {
+        window.dispatchEvent(
+          new CustomEvent("meetingMerged", {
+            detail: {
+              primaryId: meetingId,
+              secondaryId: selectedSecondary._id,
+            },
+          }),
+        );
+      }
     } catch {
-      // Error handled by hook
+      // Error handled by hook.
     }
   };
 
@@ -46,7 +132,7 @@ const DuplicateDetectionPanel = ({ meetingId }) => {
         secondaryId,
       });
     } catch {
-      // Error handled by hook
+      // Error handled by hook.
     }
   };
 
@@ -84,7 +170,11 @@ const DuplicateDetectionPanel = ({ meetingId }) => {
                       {dup.date
                         ? format(new Date(dup.date), "PPP p")
                         : "Unknown Date"}{" "}
-                      • Similarity: {Math.round(dup.similarity * 100)}%
+                      • Similarity:{" "}
+                      {Math.round(
+                        (dup.scores?.composite ?? dup.similarity ?? 0) * 100,
+                      )}
+                      %
                     </div>
                   </div>
                   <div className="flex gap-2">
@@ -111,31 +201,120 @@ const DuplicateDetectionPanel = ({ meetingId }) => {
       </div>
 
       {showConfirm && selectedSecondary && (
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded-lg shadow-xl max-w-md w-full">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">
-              Confirm Merge
+        <div
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="duplicate-merge-title"
+        >
+          <div className="bg-white p-6 rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+            <h3
+              id="duplicate-merge-title"
+              className="text-lg font-semibold text-gray-900 mb-2"
+            >
+              Review merge before confirming
             </h3>
-            <p className="text-sm text-gray-500 mb-4">
-              Are you sure you want to merge "
-              <strong>{selectedSecondary.title}</strong>" into this meeting? The
-              secondary meeting's transcript and participants will be appended
-              to this one, and the secondary meeting will be archived. This
-              action cannot be easily undone.
+            <p className="text-sm text-gray-500 mb-5">
+              Choose which meeting wins for each field. Related transcript,
+              comments, action items, attachments, decisions, and key moments
+              are still merged into the primary meeting.
             </p>
+
+            <div className="overflow-x-auto border border-gray-200 rounded-lg">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-700">
+                      Field
+                    </th>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-700">
+                      Current meeting
+                    </th>
+                    <th className="text-left px-4 py-3 font-semibold text-gray-700">
+                      Duplicate
+                    </th>
+                    <th className="text-center px-4 py-3 font-semibold text-gray-700">
+                      Survivor
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {diffFields.map((field) => {
+                    const primaryRaw = getRawFieldValue(
+                      meeting || { title: "Current meeting" },
+                      field.key,
+                    );
+                    const secondaryRaw = getRawFieldValue(
+                      selectedSecondary,
+                      field.key,
+                    );
+                    const isDifferent = !valuesEqual(primaryRaw, secondaryRaw);
+
+                    return (
+                      <tr key={field.key}>
+                        <td className="px-4 py-3 font-medium text-gray-900 align-top">
+                          {field.label}
+                        </td>
+                        <td className="px-4 py-3 text-gray-600 align-top max-w-[260px] break-words">
+                          {field.primaryValue}
+                        </td>
+                        <td className="px-4 py-3 text-gray-600 align-top max-w-[260px] break-words">
+                          {field.secondaryValue}
+                        </td>
+                        <td className="px-4 py-3 align-top">
+                          <div className="flex flex-col gap-2">
+                            {["primary", "secondary"].map((winner) => (
+                              <label
+                                key={winner}
+                                className="flex items-center gap-2 whitespace-nowrap"
+                              >
+                                <input
+                                  type="radio"
+                                  name={`merge-field-${field.key}`}
+                                  value={winner}
+                                  checked={
+                                    fieldSelections[field.key] === winner
+                                  }
+                                  onChange={() =>
+                                    setFieldSelections((current) => ({
+                                      ...current,
+                                      [field.key]: winner,
+                                    }))
+                                  }
+                                />
+                                {winner === "primary" ? "Current" : "Duplicate"}
+                              </label>
+                            ))}
+                            {!isDifferent && (
+                              <span className="text-xs text-gray-400">
+                                Identical
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
             <div className="flex justify-end gap-3 mt-6">
               <button
-                onClick={() => setShowConfirm(false)}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                onClick={() => {
+                  setShowConfirm(false);
+                  setSelectedSecondary(null);
+                }}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
               >
                 Cancel
               </button>
               <button
                 onClick={confirmMerge}
                 disabled={isMerging}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 flex items-center gap-2 disabled:opacity-50"
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md hover:bg-red-700 flex items-center gap-2 disabled:opacity-50"
               >
-                {isMerging ? "Merging..." : "Yes, Merge Meetings"}
+                {isMerging ? "Merging..." : "Confirm Merge"}
               </button>
             </div>
           </div>

--- a/client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx
+++ b/client/src/components/meeting-details/__tests__/DuplicateDetectionPanel.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import DuplicateDetectionPanel from "../DuplicateDetectionPanel.jsx";
 import { meetingDuplicateApi } from "../../../api/meetingDuplicateApi.js";
 import apiClient from "../../../services/apiClient.js";
@@ -19,53 +19,84 @@ vi.mock("react-toastify", () => ({
   },
 }));
 
-describe("DuplicateDetectionPanel & useMeetingDuplicates (#1895)", () => {
-  let originalReload;
-  let reloadMock;
-
+describe("DuplicateDetectionPanel & useMeetingDuplicates (#2260)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    originalReload = window.location.reload;
-    reloadMock = vi.fn();
-    Object.defineProperty(window.location, "reload", {
-      configurable: true,
-      value: reloadMock,
-    });
   });
 
-  afterEach(() => {
-    Object.defineProperty(window.location, "reload", {
-      configurable: true,
-      value: originalReload,
+  it("sends field selections through the duplicate merge API", async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        duplicates: [
+          {
+            _id: "dup-1",
+            title: "Duplicate Meeting",
+            date: "2026-08-01T10:00:00.000Z",
+            time: "10:00",
+            participants: [{ name: "Duplicate Person" }],
+            summary: "Secondary summary",
+            tags: ["secondary"],
+            similarity: 0.85,
+          },
+        ],
+      },
     });
-  });
-
-  it("meetingDuplicateApi uses apiClient", async () => {
-    apiClient.get.mockResolvedValue({ data: { duplicates: [] } });
-    await meetingDuplicateApi.detectDuplicates("meeting-123");
-    expect(apiClient.get).toHaveBeenCalledWith(
-      "/api/meetings/meeting-123/duplicates",
-    );
-
     apiClient.post.mockResolvedValue({ data: { success: true } });
-    await meetingDuplicateApi.mergeMeetings("meeting-123", "meeting-456");
-    expect(apiClient.post).toHaveBeenCalledWith(
-      "/api/meetings/meeting-123/duplicates/merge",
-      {
-        secondaryId: "meeting-456",
-      },
+
+    render(
+      <DuplicateDetectionPanel
+        meetingId="meeting-123"
+        meeting={{
+          _id: "meeting-123",
+          title: "Primary Meeting",
+          date: "2026-08-01T09:00:00.000Z",
+          time: "09:00",
+          participants: [{ name: "Primary Person" }],
+          summary: "Primary summary",
+          tags: ["primary"],
+        }}
+      />,
     );
 
-    await meetingDuplicateApi.dismissDuplicate("meeting-123", "meeting-456");
-    expect(apiClient.post).toHaveBeenCalledWith(
-      "/api/meetings/meeting-123/duplicates",
-      {
-        secondaryId: "meeting-456",
-      },
+    await waitFor(() => {
+      expect(screen.getByText("Duplicate Meeting")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Merge Data"));
+
+    expect(
+      screen.getByRole("heading", { name: "Review merge before confirming" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Primary summary")).toBeInTheDocument();
+    expect(screen.getByText("Secondary summary")).toBeInTheDocument();
+
+    const duplicateRadios = screen.getAllByRole("radio");
+    const secondaryTitleRadio = duplicateRadios.find(
+      (radio) => radio.value === "secondary",
     );
+    expect(secondaryTitleRadio).toBeDefined();
+    fireEvent.click(secondaryTitleRadio);
+
+    fireEvent.click(screen.getByText("Confirm Merge"));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/meetings/meeting-123/duplicates/merge",
+        {
+          secondaryId: "dup-1",
+          fieldSelections: {
+            title: "secondary",
+            time: "primary",
+            participants: "primary",
+            summary: "primary",
+            tags: "primary",
+          },
+        },
+      );
+    });
   });
 
-  it("renders duplicates list and handles merge in-place without page reload", async () => {
+  it("updates the panel without reloading the page after a successful merge", async () => {
     const mockDuplicates = [
       {
         _id: "dup-1",
@@ -78,31 +109,46 @@ describe("DuplicateDetectionPanel & useMeetingDuplicates (#1895)", () => {
     apiClient.get.mockResolvedValue({ data: { duplicates: mockDuplicates } });
     apiClient.post.mockResolvedValue({ data: { success: true } });
 
-    render(<DuplicateDetectionPanel meetingId="meeting-123" />);
+    const reloadSpy = vi
+      .spyOn(window.location, "reload")
+      .mockImplementation(() => {});
 
-    // Wait for render
+    render(
+      <DuplicateDetectionPanel
+        meetingId="meeting-123"
+        meeting={{ _id: "meeting-123", title: "Primary Meeting" }}
+      />,
+    );
+
     await waitFor(() => {
       expect(screen.getByText("Duplicate Meeting")).toBeInTheDocument();
-      expect(screen.getByText("Similarity: 85%")).toBeInTheDocument();
     });
 
-    // Click Merge Data
     fireEvent.click(screen.getByText("Merge Data"));
+    fireEvent.click(screen.getByText("Confirm Merge"));
 
-    // Click Confirm Merge
-    fireEvent.click(screen.getByText("Yes, Merge Meetings"));
-
-    // Verify API called
     await waitFor(() => {
-      expect(apiClient.post).toHaveBeenCalledWith(
-        "/api/meetings/meeting-123/duplicates/merge",
-        {
-          secondaryId: "dup-1",
-        },
-      );
+      expect(screen.queryByText("Duplicate Meeting")).not.toBeInTheDocument();
     });
 
-    // Verify window.location.reload was NOT called
-    expect(reloadMock).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    reloadSpy.mockRestore();
+  });
+
+  it("uses apiClient for duplicate detection and dismissal", async () => {
+    apiClient.get.mockResolvedValue({ data: { duplicates: [] } });
+    await meetingDuplicateApi.detectDuplicates("meeting-123");
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/meetings/meeting-123/duplicates",
+    );
+
+    apiClient.post.mockResolvedValue({ data: { success: true } });
+    await meetingDuplicateApi.dismissDuplicate("meeting-123", "meeting-456");
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/meetings/meeting-123/duplicates",
+      {
+        secondaryId: "meeting-456",
+      },
+    );
   });
 });

--- a/client/src/hooks/useMeetingDuplicates.js
+++ b/client/src/hooks/useMeetingDuplicates.js
@@ -28,12 +28,21 @@ export const useMeetingDuplicates = (meetingId) => {
     fetchDuplicates();
   }, [fetchDuplicates]);
 
-  const mergeMeetings = async ({ primaryId, secondaryId }) => {
+  const mergeMeetings = async ({
+    primaryId,
+    secondaryId,
+    fieldSelections = {},
+  }) => {
     setIsMerging(true);
     try {
-      await meetingDuplicateApi.mergeMeetings(primaryId, secondaryId);
+      const response = await meetingDuplicateApi.mergeMeetings(
+        primaryId,
+        secondaryId,
+        fieldSelections,
+      );
       toast.success("Meetings merged successfully");
       setDuplicates((prev) => prev.filter((d) => d._id !== secondaryId));
+      return response;
     } catch (error) {
       toast.error(error.response?.data?.message || "Failed to merge meetings");
       throw error;
@@ -65,5 +74,6 @@ export const useMeetingDuplicates = (meetingId) => {
     isMerging,
     dismissDuplicate,
     isDismissing,
+    refreshDuplicates: fetchDuplicates,
   };
 };

--- a/server/controllers/meetingDuplicateController.js
+++ b/server/controllers/meetingDuplicateController.js
@@ -4,6 +4,63 @@ import MergeAudit from "../models/mergeAuditModel.js";
 import { sendError, sendSuccess } from "../utils/responseHandler.js";
 import logger from "../utils/logger.js";
 
+const MERGE_FIELDS = ["title", "time", "participants", "summary", "tags"];
+
+export const normalizeFieldSelections = (selections = {}) => {
+  if (!selections || typeof selections !== "object") return {};
+
+  return MERGE_FIELDS.reduce((normalized, field) => {
+    if (selections[field] === "primary" || selections[field] === "secondary") {
+      normalized[field] = selections[field];
+    }
+    return normalized;
+  }, {});
+};
+
+const cloneValue = (value) => {
+  if (value === undefined || value === null) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      item && typeof item.toObject === "function" ? item.toObject() : item,
+    );
+  }
+  return value && typeof value.toObject === "function"
+    ? value.toObject()
+    : value;
+};
+
+export const buildFieldPatch = (primary, secondary, selections = {}) => {
+  const patch = {};
+
+  for (const field of MERGE_FIELDS) {
+    if (!selections[field]) continue;
+    const source = selections[field] === "secondary" ? secondary : primary;
+
+    if (field === "time") {
+      patch.date = source.date;
+      patch.time = source.time || "";
+    } else {
+      patch[field] = cloneValue(source[field]);
+    }
+  }
+
+  return patch;
+};
+
+const buildFieldSnapshot = (meeting, selections) => {
+  const snapshot = {};
+
+  for (const field of MERGE_FIELDS) {
+    if (!selections[field]) continue;
+    snapshot[field] =
+      field === "time"
+        ? { date: meeting.date, time: meeting.time || "" }
+        : cloneValue(meeting[field]);
+  }
+
+  return snapshot;
+};
+
 export const detectDuplicates = async (req, res) => {
   try {
     const { id } = req.params;
@@ -16,7 +73,35 @@ export const detectDuplicates = async (req, res) => {
     }
 
     const duplicates = await duplicateService.findDuplicates(id);
-    return sendSuccess(res, { duplicates }, "Duplicates fetched successfully");
+    if (duplicates.length === 0) {
+      return sendSuccess(
+        res,
+        { duplicates: [] },
+        "Duplicates fetched successfully",
+      );
+    }
+
+    const detailMeetings = await Meeting.find({
+      _id: { $in: duplicates.map((duplicate) => duplicate._id) },
+      organization: userOrgId,
+    })
+      .select("date time participants summary tags")
+      .lean();
+
+    const detailMap = new Map(
+      detailMeetings.map((candidate) => [candidate._id.toString(), candidate]),
+    );
+
+    const enrichedDuplicates = duplicates.map((duplicate) => ({
+      ...duplicate,
+      ...(detailMap.get(duplicate._id.toString()) || {}),
+    }));
+
+    return sendSuccess(
+      res,
+      { duplicates: enrichedDuplicates },
+      "Duplicates fetched successfully",
+    );
   } catch (error) {
     logger.error("Error detecting duplicates:", error);
     return sendError(res, 500, error.message);
@@ -26,23 +111,29 @@ export const detectDuplicates = async (req, res) => {
 export const mergeMeetings = async (req, res) => {
   try {
     const { id: primaryId } = req.params;
-    const { secondaryId } = req.body;
+    const { secondaryId, fieldSelections: rawFieldSelections = {} } = req.body;
 
     if (!secondaryId) {
       return sendError(res, 400, "Secondary meeting ID is required");
     }
 
+    const fieldSelections = normalizeFieldSelections(rawFieldSelections);
     const userOrgId = req.user?.organization?.toString();
     const userId = req.user._id;
 
     const [primary, secondary] = await Promise.all([
-      Meeting.findById(primaryId).select("organization").lean(),
-      Meeting.findById(secondaryId).select("organization").lean(),
+      Meeting.findById(primaryId)
+        .select("organization title date time participants summary tags")
+        .lean(),
+      Meeting.findById(secondaryId)
+        .select("organization title date time participants summary tags")
+        .lean(),
     ]);
 
     if (!primary || !secondary) {
       return sendError(res, 404, "One or both meetings not found");
     }
+
     if (
       primary.organization?.toString() !== userOrgId ||
       secondary.organization?.toString() !== userOrgId
@@ -50,12 +141,44 @@ export const mergeMeetings = async (req, res) => {
       return sendError(res, 403, "Access denied");
     }
 
+    const primaryFieldSnapshot = buildFieldSnapshot(primary, fieldSelections);
+
     const result = await duplicateService.mergeMeetings(
       primaryId,
       secondaryId,
       userId,
     );
-    return sendSuccess(res, result, "Meetings merged successfully");
+
+    let updatedFields = [];
+    if (Object.keys(fieldSelections).length > 0) {
+      const fieldPatch = buildFieldPatch(primary, secondary, fieldSelections);
+
+      if (Object.keys(fieldPatch).length > 0) {
+        await Meeting.findByIdAndUpdate(
+          primaryId,
+          { $set: fieldPatch },
+          { new: false, runValidators: true },
+        );
+        updatedFields = Object.keys(fieldSelections);
+      }
+
+      await MergeAudit.findByIdAndUpdate(result.mergeAuditId, {
+        $set: {
+          "snapshot.primaryFieldValues": primaryFieldSnapshot,
+          "snapshot.fieldSelections": fieldSelections,
+        },
+      });
+    }
+
+    return sendSuccess(
+      res,
+      {
+        ...result,
+        fieldSelections,
+        updatedFields,
+      },
+      "Meetings merged successfully",
+    );
   } catch (error) {
     logger.error("Error merging meetings:", error);
     return sendError(res, 500, error.message);
@@ -93,6 +216,29 @@ export const rollbackMerge = async (req, res) => {
     }
 
     const result = await duplicateService.rollbackMerge(mergeAuditId, userId);
+
+    if (audit.snapshot?.primaryFieldValues) {
+      const restore = {};
+      for (const [field, value] of Object.entries(
+        audit.snapshot.primaryFieldValues,
+      )) {
+        if (field === "time" && value) {
+          restore.date = value.date;
+          restore.time = value.time || "";
+        } else {
+          restore[field] = value;
+        }
+      }
+
+      if (Object.keys(restore).length > 0) {
+        await Meeting.findByIdAndUpdate(
+          audit.primaryMeeting,
+          { $set: restore },
+          { runValidators: true },
+        );
+      }
+    }
+
     return sendSuccess(res, result, "Merge rolled back successfully");
   } catch (error) {
     logger.error("Error rolling back merge:", error);

--- a/server/models/mergeAuditModel.js
+++ b/server/models/mergeAuditModel.js
@@ -49,6 +49,21 @@ const mergeAuditSchema = new mongoose.Schema(
       reparentedDecisions: { type: Number, default: 0 },
       reparentedFollowUpTasks: { type: Number, default: 0 },
       mergedTranscriptSegmentIds: [mongoose.Schema.Types.ObjectId],
+
+      // Issue #2260: preserve primary values that were replaced by a
+      // field-level merge choice so rollback can restore them.
+      primaryFieldValues: {
+        title: { type: String, default: null },
+        time: { type: String, default: null },
+        date: { type: Date, default: null },
+        participants: [mongoose.Schema.Types.Mixed],
+        summary: { type: String, default: null },
+        tags: [String],
+      },
+      fieldSelections: {
+        type: mongoose.Schema.Types.Mixed,
+        default: {},
+      },
     },
     rolledBack: {
       type: Boolean,


### PR DESCRIPTION
# Pull Request

## Summary

Implements #2260 by upgrading duplicate meeting merges from a basic confirmation modal to a field-level merge review.

Closes #2260 

## Changes

- Added field-level duplicate comparison for:
  - Title
  - Date & time
  - Participants
  - Summary
  - Tags
- Added per-field survivor selection between the current and duplicate meeting.
- Extended the duplicate API request to submit field selections.
- Enriched duplicate detection responses with the fields required for the preview.
- Applied selected field values during the merge.
- Added merge audit snapshots for replaced primary field values.
- Restores replaced primary fields when a merge is rolled back.
- Added soft refresh of `MeetingDetails` after a successful merge.
- Preserved the existing related-data merge pipeline.
- Added/updated frontend tests for field selection and merge behavior.
- Confirmed the implementation does not use `window.location.reload()` for duplicate merging.

## Acceptance Criteria

- [x] Diff preview shown before merge
- [x] Admin/user can select winning values per supported field
- [x] Selected values are persisted during merge
- [x] Meeting details refresh without a hard page reload
- [x] Existing duplicate dismissal and merge behavior preserved
- [x] Tests cover field preview and merge payload

## Testing

- `git diff --check`
- Existing duplicate detection/merge tests updated for the new payload and UI.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
