### PR TITLE
feat: TagAutocomplete on Schedule Meeting

### DIFF
--- a/client/src/pages/CreateMeeting/components/ScheduleMeeting/MeetingInformationForm.jsx
+++ b/client/src/pages/CreateMeeting/components/ScheduleMeeting/MeetingInformationForm.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import RecurrenceSelector from "../../../../components/meetings/RecurrenceSelector";
+import TagAutocomplete from "../../../../components/meetings/TagAutocomplete.jsx";
 
 const MeetingInformationForm = ({
   scheduleData,
@@ -61,6 +62,22 @@ const MeetingInformationForm = ({
           rows="3"
           className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-400 outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
         ></textarea>
+      </div>
+
+      {/* Meeting Tags */}
+      <div className="mb-6">
+        <label className="block mb-2 font-semibold text-gray-700 dark:text-gray-300">
+          Meeting Tags
+        </label>
+        <TagAutocomplete
+          selectedTags={scheduleData.tags || []}
+          setSelectedTags={(tags) =>
+            setScheduleData((prev) => ({
+              ...prev,
+              tags: typeof tags === "function" ? tags(prev.tags || []) : tags,
+            }))
+          }
+        />
       </div>
 
       {/* Date & Time */}

--- a/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.tags.test.jsx
+++ b/client/src/pages/CreateMeeting/hooks/__tests__/useScheduleMeeting.tags.test.jsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AppContent from "../../../../context/AppContent";
+import { useScheduleMeeting } from "../useScheduleMeeting";
+import { meetingApi } from "../../../../services";
+
+vi.mock("../../../../services", () => ({
+  meetingApi: {
+    scheduleMeeting: vi.fn(),
+  },
+  meetingSeriesApi: {
+    createSeries: vi.fn(),
+  },
+  meetingTemplateApi: {
+    getTemplates: vi
+      .fn()
+      .mockResolvedValue({ data: { success: true, templates: [] } }),
+  },
+  aiSummaryTemplateApi: {
+    getTemplates: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock("../../../../api/focusTimeApi", () => ({
+  focusTimeApi: {
+    getBlocks: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../../../../api/customFieldApi", () => ({
+  customFieldApi: {
+    setMeetingFields: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../services/resourceBookingApi", () => ({
+  default: {
+    createBooking: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useScheduleMeeting tags persistence", () => {
+  const mockUserData = {
+    _id: "user-123",
+    organization: { _id: "org-456" },
+  };
+
+  const wrapper = ({ children }) => (
+    <AppContent.Provider value={{ userData: mockUserData }}>
+      {children}
+    </AppContent.Provider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists tags through schedule create payload to meeting metadata", async () => {
+    meetingApi.scheduleMeeting.mockResolvedValue({
+      data: { success: true, meeting: { _id: "m-100" } },
+    });
+
+    const { result } = renderHook(() => useScheduleMeeting(), { wrapper });
+
+    act(() => {
+      result.current.setScheduleData((prev) => ({
+        ...prev,
+        title: "Q4 Strategy Sync",
+        date: "2026-10-15",
+        time: "14:00",
+        tags: ["strategy", "quarterly", "executive"],
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleScheduleSubmit({ preventDefault: vi.fn() });
+    });
+
+    expect(meetingApi.scheduleMeeting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Q4 Strategy Sync",
+        tags: ["strategy", "quarterly", "executive"],
+        metadata: {
+          tags: ["strategy", "quarterly", "executive"],
+        },
+      }),
+    );
+  });
+});

--- a/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
+++ b/client/src/pages/CreateMeeting/hooks/useScheduleMeeting.js
@@ -52,6 +52,7 @@ export const buildDuplicateScheduleState = (duplicateData = {}) => ({
     syncToCalendar: true,
     reminderEnabled: duplicateData.reminderEnabled || false,
     reminderMinutesBefore: duplicateData.reminderMinutesBefore || 30,
+    tags: duplicateData.tags || [],
   },
   participants: (duplicateData.participants || []).map(
     (participant, index) => ({
@@ -90,6 +91,7 @@ export const useScheduleMeeting = ({
     reminderMinutesBefore: 30,
     recurrencePattern: "none",
     endDate: "",
+    tags: [],
   });
   const [participants, setParticipants] = useState([]);
   const [newParticipant, setNewParticipant] = useState({ name: "", email: "" });
@@ -497,10 +499,18 @@ export const useScheduleMeeting = ({
 
     setLoading(true);
     try {
+      const selectedTags =
+        Array.isArray(scheduleData.tags) && scheduleData.tags.length > 0
+          ? scheduleData.tags
+          : duplicateMetadata.tags || [];
+
       const payload = {
         ...scheduleData,
         participants,
-        tags: duplicateMetadata.tags,
+        tags: selectedTags,
+        metadata: {
+          tags: selectedTags,
+        },
         policyDetails: duplicateMetadata.policyDetails,
         recordingType: duplicateMetadata.recordingType,
         agendaItems: normalizeAgendaItems(agendaItems),

--- a/server/middleware/meetingValidation.js
+++ b/server/middleware/meetingValidation.js
@@ -113,6 +113,7 @@ export const createMeetingSchema = z
     recordingType: z.enum(["upload", "live"]).optional().default("upload"),
     syncToCalendar: z.boolean().optional().default(false),
     auditNote: z.string().optional().default(""),
+    tags: z.array(z.string().trim().max(100)).optional().default([]),
   })
   .strict();
 

--- a/server/services/MeetingService.js
+++ b/server/services/MeetingService.js
@@ -212,6 +212,7 @@ export const createMeeting = async (uploaderId, orgId, data) => {
     agendaItems: normalizeAgendaItems(data.agendaItems),
     policyDetails: data.policyDetails || null,
     recordingType: data.recordingType || "upload",
+    tags: data.tags || (data.metadata && data.metadata.tags) || [],
     transcript: "",
     summary: "",
     structuredMoM: null,

--- a/server/tests/scheduleMeetingTags.test.js
+++ b/server/tests/scheduleMeetingTags.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/userModel.js", () => ({ default: {} }));
+vi.mock("../models/membershipModel.js", () => ({
+  default: {
+    find: vi.fn().mockReturnValue({
+      populate: vi.fn().mockResolvedValue([]),
+    }),
+  },
+}));
+vi.mock("../models/tagModel.js", () => ({ default: {} }));
+vi.mock("../services/graphSnapshotService.js", () => ({
+  captureSnapshot: vi.fn(),
+}));
+vi.mock("../services/eventBus.js", () => ({
+  default: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock("../services/MeetingStorageService.js", () => ({
+  createMeetingRecord: vi.fn(),
+  findMeetingById: vi.fn(),
+  findMeetingByQuery: vi.fn(),
+  getMeetingsQuery: vi.fn(),
+  countMeetingsQuery: vi.fn(),
+  deleteMeetingById: vi.fn(),
+  searchMeetingsRecords: vi.fn(),
+}));
+
+import { createMeetingSchema } from "../middleware/meetingValidation.js";
+import * as MeetingStorageService from "../services/MeetingStorageService.js";
+import { createMeeting } from "../services/MeetingService.js";
+
+describe("Schedule meeting metadata.tags wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("validates tags in createMeetingSchema without throwing strict errors", () => {
+    const rawData = {
+      title: "Product Roadmap Sync",
+      description: "H2 Planning",
+      meetingType: "internal",
+      date: "2026-11-01",
+      time: "10:00",
+      tags: ["product", "roadmap", "h2"],
+    };
+
+    const parsed = createMeetingSchema.parse(rawData);
+    expect(parsed.tags).toEqual(["product", "roadmap", "h2"]);
+  });
+
+  it("persists tags through MeetingService.createMeeting to MeetingStorageService", async () => {
+    MeetingStorageService.createMeetingRecord.mockResolvedValue({
+      _id: "m-789",
+      title: "Product Roadmap Sync",
+      tags: ["product", "roadmap"],
+    });
+
+    const data = {
+      title: "Product Roadmap Sync",
+      meetingType: "internal",
+      date: "2026-11-01",
+      time: "10:00",
+      tags: ["product", "roadmap"],
+    };
+
+    await createMeeting("user-1", "org-1", data);
+
+    expect(MeetingStorageService.createMeetingRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Product Roadmap Sync",
+        tags: ["product", "roadmap"],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
I have completed the task TagAutocomplete on Schedule Meeting + metadata.tags wiring.

Summary of Accomplishments
Mounted TagAutocomplete on Schedule Meeting Form:

Added TagAutocomplete.jsx into MeetingInformationForm.jsx
 so users can select tags when scheduling a new meeting.
Frontend State & Payload Wiring:

Updated scheduleData in 

useScheduleMeeting.js
 to manage tags state.
Wired tags and metadata.tags into the payload sent to meetingApi.scheduleMeeting.
Backend Schema & Storage Persistence:

Updated createMeetingSchema in meetingValidation.js
 to allow tags array validation.
Updated createMeeting in MeetingService.js
 to save tags to the created Meeting document.
Testing & Verification:

Added useScheduleMeeting.tags.test.jsx
 for frontend schedule payload testing.
Added scheduleMeetingTags.test.js
 for backend validation and storage test (Passed 2/2 tests).


closes #2243