### PR TITLE
feat: glossary pending-terms reject/edit workflow

### DIFF
--- a/client/src/pages/Glossary.jsx
+++ b/client/src/pages/Glossary.jsx
@@ -4,6 +4,7 @@ import {
   createTerm,
   deleteTerm,
   approveTerm,
+  rejectTerm,
 } from "../services/glossaryApi";
 import ConfirmModal from "../components/ConfirmModal.jsx";
 
@@ -24,6 +25,18 @@ const Glossary = () => {
   // Confirmation modal state (#1489)
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+
+  // Pending moderation (#2245)
+  const [rejectTargetId, setRejectTargetId] = useState(null);
+  const [rejectReason, setRejectReason] = useState("");
+  const [rejectLoading, setRejectLoading] = useState(false);
+  const [editTargetId, setEditTargetId] = useState(null);
+  const [editDraft, setEditDraft] = useState({
+    term: "",
+    definition: "",
+    category: "",
+  });
+  const [approveLoadingId, setApproveLoadingId] = useState(null);
 
   const loadTerms = useCallback(async () => {
     try {
@@ -92,14 +105,53 @@ const Glossary = () => {
     }
   };
 
-  const handleApprove = async (id) => {
+  const handleApprove = async (id, edits = undefined) => {
+    setApproveLoadingId(id);
     try {
-      await approveTerm(id);
+      await approveTerm(id, edits);
+      setEditTargetId(null);
       loadTerms();
     } catch (approveError) {
       console.error("Failed to approve term:", approveError);
       alert("Failed to approve term");
+    } finally {
+      setApproveLoadingId(null);
     }
+  };
+
+  const handleRejectConfirm = async (termId) => {
+    if (!rejectReason.trim()) return;
+    setRejectLoading(true);
+    try {
+      await rejectTerm(termId, rejectReason.trim());
+      setRejectTargetId(null);
+      setRejectReason("");
+      loadTerms();
+    } catch (rejectError) {
+      console.error("Failed to reject term:", rejectError);
+      alert("Failed to reject term");
+    } finally {
+      setRejectLoading(false);
+    }
+  };
+
+  const startEditAndApprove = (term) => {
+    setRejectTargetId(null);
+    setRejectReason("");
+    setEditTargetId(term._id);
+    setEditDraft({
+      term: term.term,
+      definition: term.definition,
+      category: term.category || "",
+    });
+  };
+
+  const handleEditAndApprove = async (id) => {
+    await handleApprove(id, {
+      term: editDraft.term.trim(),
+      definition: editDraft.definition.trim(),
+      category: editDraft.category.trim() || undefined,
+    });
   };
 
   const pendingTerms = terms.filter((t) => t.approvalStatus === "pending");
@@ -222,31 +274,160 @@ const Glossary = () => {
                 <div className="absolute top-2 right-2 text-xs font-bold text-amber-600 bg-amber-100 px-2 py-1 rounded">
                   AI Suggestion
                 </div>
-                <h4 className="text-lg font-bold text-gray-900 mt-2">
-                  {term.term}
-                </h4>
-                <p className="text-sm text-gray-600 mt-1">{term.definition}</p>
-                {term.category && (
-                  <span className="inline-block mt-2 text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
-                    {term.category}
-                  </span>
+                {editTargetId === term._id ? (
+                  <div className="mt-6 space-y-3">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700">
+                        Term
+                      </label>
+                      <input
+                        type="text"
+                        value={editDraft.term}
+                        onChange={(e) =>
+                          setEditDraft({ ...editDraft, term: e.target.value })
+                        }
+                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm p-2 border text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700">
+                        Definition
+                      </label>
+                      <textarea
+                        value={editDraft.definition}
+                        onChange={(e) =>
+                          setEditDraft({
+                            ...editDraft,
+                            definition: e.target.value,
+                          })
+                        }
+                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm p-2 border text-sm"
+                        rows={3}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700">
+                        Category
+                      </label>
+                      <input
+                        type="text"
+                        value={editDraft.category}
+                        onChange={(e) =>
+                          setEditDraft({
+                            ...editDraft,
+                            category: e.target.value,
+                          })
+                        }
+                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm p-2 border text-sm"
+                      />
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleEditAndApprove(term._id)}
+                        disabled={
+                          approveLoadingId === term._id ||
+                          !editDraft.term.trim() ||
+                          !editDraft.definition.trim()
+                        }
+                        className="flex-1 bg-green-600 text-white py-1 rounded text-sm hover:bg-green-700 cursor-pointer disabled:opacity-50"
+                      >
+                        {approveLoadingId === term._id
+                          ? "Saving..."
+                          : "Save & Approve"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditTargetId(null)}
+                        className="flex-1 bg-gray-100 text-gray-700 py-1 rounded text-sm hover:bg-gray-200 cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : rejectTargetId === term._id ? (
+                  <div className="mt-6 space-y-3">
+                    <p className="text-sm text-gray-700">
+                      Reject &quot;{term.term}&quot;?
+                    </p>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700">
+                        Reason for rejection
+                      </label>
+                      <textarea
+                        value={rejectReason}
+                        onChange={(e) => setRejectReason(e.target.value)}
+                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm p-2 border text-sm"
+                        rows={3}
+                        placeholder="e.g. Incorrect definition or duplicate concept"
+                      />
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleRejectConfirm(term._id)}
+                        disabled={rejectLoading || !rejectReason.trim()}
+                        className="flex-1 bg-red-600 text-white py-1 rounded text-sm hover:bg-red-700 cursor-pointer disabled:opacity-50"
+                      >
+                        {rejectLoading ? "Rejecting..." : "Confirm Reject"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRejectTargetId(null);
+                          setRejectReason("");
+                        }}
+                        className="flex-1 bg-gray-100 text-gray-700 py-1 rounded text-sm hover:bg-gray-200 cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <h4 className="text-lg font-bold text-gray-900 mt-2">
+                      {term.term}
+                    </h4>
+                    <p className="text-sm text-gray-600 mt-1">
+                      {term.definition}
+                    </p>
+                    {term.category && (
+                      <span className="inline-block mt-2 text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                        {term.category}
+                      </span>
+                    )}
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleApprove(term._id)}
+                        disabled={approveLoadingId === term._id}
+                        className="flex-1 min-w-[5rem] bg-green-600 text-white py-1 rounded text-sm hover:bg-green-700 cursor-pointer disabled:opacity-50"
+                      >
+                        {approveLoadingId === term._id
+                          ? "Approving..."
+                          : "Approve"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => startEditAndApprove(term)}
+                        className="flex-1 min-w-[5rem] bg-indigo-100 text-indigo-700 py-1 rounded text-sm hover:bg-indigo-200 cursor-pointer"
+                      >
+                        Edit & Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRejectTargetId(term._id);
+                          setRejectReason("");
+                          setEditTargetId(null);
+                        }}
+                        className="flex-1 min-w-[5rem] bg-red-100 text-red-700 py-1 rounded text-sm hover:bg-red-200 cursor-pointer"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </>
                 )}
-                <div className="mt-4 flex space-x-2">
-                  <button
-                    type="button"
-                    onClick={() => handleApprove(term._id)}
-                    className="flex-1 bg-green-600 text-white py-1 rounded text-sm hover:bg-green-700 cursor-pointer"
-                  >
-                    Approve
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setDeleteTarget(term)}
-                    className="flex-1 bg-red-100 text-red-700 py-1 rounded text-sm hover:bg-red-200 cursor-pointer"
-                  >
-                    Reject
-                  </button>
-                </div>
               </div>
             ))}
           </div>

--- a/client/src/pages/__tests__/GlossaryConfirmModal.test.jsx
+++ b/client/src/pages/__tests__/GlossaryConfirmModal.test.jsx
@@ -9,6 +9,7 @@ vi.mock("../../services/glossaryApi.js", () => ({
   createTerm: vi.fn(),
   deleteTerm: vi.fn(),
   approveTerm: vi.fn(),
+  rejectTerm: vi.fn(),
 }));
 
 describe("Glossary Confirmation Modal (#1489)", () => {

--- a/client/src/pages/__tests__/GlossaryPendingModeration.test.jsx
+++ b/client/src/pages/__tests__/GlossaryPendingModeration.test.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Glossary from "../Glossary.jsx";
+import * as api from "../../services/glossaryApi.js";
+
+vi.mock("../../services/glossaryApi.js", () => ({
+  fetchTerms: vi.fn(),
+  createTerm: vi.fn(),
+  deleteTerm: vi.fn(),
+  approveTerm: vi.fn(),
+  rejectTerm: vi.fn(),
+}));
+
+describe("Glossary pending moderation (#2245)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a pending term with a reason", async () => {
+    api.fetchTerms.mockResolvedValue([
+      {
+        _id: "pending-1",
+        term: "K8s",
+        definition: "Kubernetes",
+        approvalStatus: "pending",
+      },
+      {
+        _id: "approved-1",
+        term: "ROI",
+        definition: "Return on Investment",
+        approvalStatus: "approved",
+      },
+    ]);
+    api.rejectTerm.mockResolvedValue({
+      _id: "pending-1",
+      approvalStatus: "rejected",
+    });
+
+    render(<Glossary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("K8s")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^reject$/i }));
+    fireEvent.change(
+      screen.getByPlaceholderText(/incorrect definition or duplicate concept/i),
+      { target: { value: "Not relevant to our org" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /confirm reject/i }));
+
+    await waitFor(() => {
+      expect(api.rejectTerm).toHaveBeenCalledWith(
+        "pending-1",
+        "Not relevant to our org",
+      );
+    });
+  });
+
+  it("approves a pending term after editing", async () => {
+    api.fetchTerms.mockResolvedValue([
+      {
+        _id: "pending-1",
+        term: "K8s",
+        definition: "Bad definition",
+        category: "General",
+        approvalStatus: "pending",
+      },
+    ]);
+    api.approveTerm.mockResolvedValue({
+      _id: "pending-1",
+      approvalStatus: "approved",
+    });
+
+    render(<Glossary />);
+
+    await waitFor(() => {
+      expect(screen.getByText("K8s")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /edit & approve/i }));
+    fireEvent.change(screen.getByDisplayValue("Bad definition"), {
+      target: { value: "Kubernetes orchestration platform" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save & approve/i }));
+
+    await waitFor(() => {
+      expect(api.approveTerm).toHaveBeenCalledWith("pending-1", {
+        term: "K8s",
+        definition: "Kubernetes orchestration platform",
+        category: "General",
+      });
+    });
+  });
+});

--- a/client/src/services/__tests__/glossaryApi.test.js
+++ b/client/src/services/__tests__/glossaryApi.test.js
@@ -6,6 +6,7 @@ import {
   updateTerm,
   deleteTerm,
   approveTerm,
+  rejectTerm,
   detectTerms,
   extractTerms,
 } from "../glossaryApi.js";
@@ -55,7 +56,28 @@ describe("glossaryApi endpoint prefixes (#1878)", () => {
   it("approves terms through /api/glossary/:id/approve", async () => {
     api.post.mockResolvedValue({ data: {} });
     await approveTerm("term-123");
-    expect(api.post).toHaveBeenCalledWith("/api/glossary/term-123/approve");
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/glossary/term-123/approve",
+      undefined,
+    );
+  });
+
+  it("approves terms with edits through /api/glossary/:id/approve (#2245)", async () => {
+    api.post.mockResolvedValue({ data: {} });
+    const edits = { definition: "Updated definition" };
+    await approveTerm("term-123", edits);
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/glossary/term-123/approve",
+      edits,
+    );
+  });
+
+  it("rejects terms through /api/glossary/:id/reject (#2245)", async () => {
+    api.post.mockResolvedValue({ data: {} });
+    await rejectTerm("term-123", "Incorrect definition");
+    expect(api.post).toHaveBeenCalledWith("/api/glossary/term-123/reject", {
+      reason: "Incorrect definition",
+    });
   });
 
   it("detects glossary terms through /api/glossary/detect", async () => {

--- a/client/src/services/glossaryApi.js
+++ b/client/src/services/glossaryApi.js
@@ -38,11 +38,23 @@ export const deleteTerm = async (id) => {
 };
 
 /**
- * Approve a pending term
+ * Approve a pending term, optionally with corrected fields (#2245).
  * @param {string} id
+ * @param {Object} [edits]
  */
-export const approveTerm = async (id) => {
-  const { data } = await api.post(`/api/glossary/${id}/approve`);
+export const approveTerm = async (id, edits = undefined) => {
+  const payload = edits && Object.keys(edits).length > 0 ? edits : undefined;
+  const { data } = await api.post(`/api/glossary/${id}/approve`, payload);
+  return data;
+};
+
+/**
+ * Reject a pending term with a reason (#2245).
+ * @param {string} id
+ * @param {string} reason
+ */
+export const rejectTerm = async (id, reason) => {
+  const { data } = await api.post(`/api/glossary/${id}/reject`, { reason });
   return data;
 };
 

--- a/server/controllers/glossaryController.js
+++ b/server/controllers/glossaryController.js
@@ -73,6 +73,15 @@ const extractSchema = z.object({
   }),
 });
 
+const rejectTermSchema = z.object({
+  reason: z.string().trim().min(1).max(500),
+});
+
+/**
+ * Optional edits applied when approving a pending suggestion (#2245).
+ */
+const approveTermSchema = termFieldsSchema.partial().strict();
+
 /**
  * Looks up a term by its exact name, ignoring case (Issue #1157).
  *
@@ -292,7 +301,7 @@ export const deleteTerm = async (req, res) => {
 };
 
 /**
- * Approve a pending term
+ * Approve a pending term, optionally with corrected fields (#2245).
  */
 export const approveTerm = async (req, res) => {
   try {
@@ -303,9 +312,62 @@ export const approveTerm = async (req, res) => {
       return res.status(400).json({ message: "Invalid term ID" });
     }
 
+    const edits =
+      req.body && Object.keys(req.body).length > 0
+        ? approveTermSchema.parse(req.body)
+        : {};
+
+    if (edits.term) {
+      const existing = await findTermByName(orgId, edits.term);
+      if (existing && existing._id.toString() !== id) {
+        return res
+          .status(400)
+          .json({ message: "This term already exists in your glossary" });
+      }
+    }
+
+    const term = await GlossaryTerm.findOne({
+      _id: id,
+      organization: orgId,
+      approvalStatus: "pending",
+    });
+
+    if (!term) {
+      return res.status(404).json({ message: "Pending term not found" });
+    }
+
+    Object.assign(term, edits, {
+      approvalStatus: "approved",
+      rejectionReason: null,
+    });
+    await term.save();
+
+    res.status(200).json(term);
+  } catch (error) {
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+
+    console.error("Error approving glossary term:", error);
+    res.status(500).json({ message: "Server error approving glossary term" });
+  }
+};
+
+/**
+ * Reject a pending term with a reason (#2245).
+ */
+export const rejectTerm = async (req, res) => {
+  try {
+    const orgId = resolveOrgId(req);
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: "Invalid term ID" });
+    }
+
+    const { reason } = rejectTermSchema.parse(req.body);
+
     const term = await GlossaryTerm.findOneAndUpdate(
       { _id: id, organization: orgId, approvalStatus: "pending" },
-      { $set: { approvalStatus: "approved" } },
+      { $set: { approvalStatus: "rejected", rejectionReason: reason } },
       { new: true },
     );
 
@@ -313,10 +375,16 @@ export const approveTerm = async (req, res) => {
       return res.status(404).json({ message: "Pending term not found" });
     }
 
+    console.info(
+      `[Glossary] Pending term rejected: id=${term._id} term="${term.term}" reason="${reason}" org=${orgId}`,
+    );
+
     res.status(200).json(term);
   } catch (error) {
-    console.error("Error approving glossary term:", error);
-    res.status(500).json({ message: "Server error approving glossary term" });
+    if (error instanceof z.ZodError) return sendZodError(res, error);
+
+    console.error("Error rejecting glossary term:", error);
+    res.status(500).json({ message: "Server error rejecting glossary term" });
   }
 };
 

--- a/server/models/glossaryTermModel.js
+++ b/server/models/glossaryTermModel.js
@@ -44,6 +44,11 @@ const glossaryTermSchema = new mongoose.Schema(
       enum: ["pending", "approved", "rejected"],
       default: "approved",
     },
+    rejectionReason: {
+      type: String,
+      trim: true,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/server/routes/glossaryRoutes.js
+++ b/server/routes/glossaryRoutes.js
@@ -47,11 +47,16 @@ router.delete(
   glossaryController.deleteTerm,
 );
 
-// Approval for pending terms
+// Approval for pending terms (#2245)
 router.post(
   "/:id/approve",
   requirePermission("knowledge", "edit"),
   glossaryController.approveTerm,
+);
+router.post(
+  "/:id/reject",
+  requirePermission("knowledge", "edit"),
+  glossaryController.rejectTerm,
 );
 
 // Detection endpoint

--- a/server/tests/glossaryAuthorization.test.js
+++ b/server/tests/glossaryAuthorization.test.js
@@ -366,6 +366,76 @@ describe("role permissions", () => {
     await request(app).delete(`/api/glossary/${pending._id}`).expect(200);
   });
 
+  it("rejects a pending term with reason and removes it from pending queue (#2245)", async () => {
+    const pending = await seedTerm({
+      term: "KPI",
+      definition: "Key Performance Indicator",
+      approvalStatus: "pending",
+      isAutoSuggested: true,
+    });
+    currentUser = moderator;
+
+    const res = await request(app)
+      .post(`/api/glossary/${pending._id}/reject`)
+      .send({ reason: "Duplicate of an existing metric" })
+      .expect(200);
+
+    expect(res.body.approvalStatus).toBe("rejected");
+    expect(res.body.rejectionReason).toBe("Duplicate of an existing metric");
+
+    const pendingList = await request(app)
+      .get("/api/glossary")
+      .query({ status: "pending" })
+      .expect(200);
+    expect(pendingList.body).toHaveLength(0);
+  });
+
+  it("approves a pending term with corrected fields (#2245)", async () => {
+    const pending = await seedTerm({
+      term: "K8s",
+      definition: "Bad definition",
+      approvalStatus: "pending",
+      isAutoSuggested: true,
+    });
+    currentUser = moderator;
+
+    const res = await request(app)
+      .post(`/api/glossary/${pending._id}/approve`)
+      .send({
+        definition: "Kubernetes container orchestration platform",
+        category: "Engineering",
+      })
+      .expect(200);
+
+    expect(res.body.approvalStatus).toBe("approved");
+    expect(res.body.definition).toBe(
+      "Kubernetes container orchestration platform",
+    );
+    expect(res.body.category).toBe("Engineering");
+  });
+
+  it("refuses a viewer rejecting a pending term (#2245)", async () => {
+    const pending = await seedTerm({ approvalStatus: "pending" });
+    currentUser = viewer;
+
+    await request(app)
+      .post(`/api/glossary/${pending._id}/reject`)
+      .send({ reason: "Not relevant" })
+      .expect(403);
+
+    const stored = await GlossaryTerm.findById(pending._id);
+    expect(stored.approvalStatus).toBe("pending");
+  });
+
+  it("requires a rejection reason (#2245)", async () => {
+    const pending = await seedTerm({ approvalStatus: "pending" });
+
+    await request(app)
+      .post(`/api/glossary/${pending._id}/reject`)
+      .send({ reason: "   " })
+      .expect(400);
+  });
+
   it("rejects a caller with no organization", async () => {
     currentUser = {
       _id: new mongoose.Types.ObjectId(),


### PR DESCRIPTION
## Summary
- Add `POST /api/glossary/:id/reject` with required reason and optional edits on approve
- Extend Glossary pending UI with Reject, Edit & Approve, and Approve actions
- Rejected terms leave the pending queue; rejection reason is stored and logged
- Tests for approve/reject auth, status transitions, and pending UI workflow

Closes #2245

## Test plan
- [ ] Pending AI suggestion → Reject with reason → leaves pending list
- [ ] Pending suggestion → Edit & Approve → appears in approved list with edits
- [ ] Viewer cannot approve/reject (403)
- [ ] `npm run lint:changed --prefix client` / `server`
- [ ] `npx vitest run src/pages/__tests__/GlossaryPendingModeration.test.jsx` (client)
- [ ] `npm test -- tests/glossaryAuthorization.test.js` (server)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moderators can reject pending glossary terms with a required explanation.
  * Pending terms can be edited before approval, including the term, definition, and category.
  * Approval, editing, and rejection flows now include inline validation, cancellation, and loading states.
  * Rejection details are recorded for review.

* **Bug Fixes**
  * Improved moderation authorization and validation for glossary approvals and rejections.

* **Tests**
  * Added coverage for edited approvals, rejected terms, required reasons, and permission restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->