### PR TITLE
Implement local draft recovery and UI banner for Personal Notes #2270

### DIFF
--- a/client/src/components/meeting-details/PersonalNotes.jsx
+++ b/client/src/components/meeting-details/PersonalNotes.jsx
@@ -4,11 +4,15 @@ import React, {
   useRef,
   useCallback,
   useMemo,
+  useContext,
 } from "react";
 import { personalNoteApi } from "../../services";
 import { Pin, Save, CheckCircle, Highlighter, Trash2, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { normalizeTranscript } from "../../utils/normalizeTranscript.js";
+import AppContent from "../../context/AppContent";
+import { useFormDraft } from "../../hooks/useFormDraft";
+import PersonalNotesDraftRecoveryBanner from "./PersonalNotesDraftRecoveryBanner";
 
 const PersonalNotes = ({ meeting }) => {
   const [content, setContent] = useState("");
@@ -17,6 +21,10 @@ const PersonalNotes = ({ meeting }) => {
   const [annotations, setAnnotations] = useState([]);
   const [isPinning, setIsPinning] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [serverUpdatedAt, setServerUpdatedAt] = useState(null);
+
+  const context = useContext(AppContent) || {};
+  const { userData } = context;
 
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
@@ -24,6 +32,48 @@ const PersonalNotes = ({ meeting }) => {
 
   const lastSavedContentRef = useRef("");
   const containerRef = useRef(null);
+
+  const draftKey = useMemo(() => {
+    const userId = userData?._id || userData?.id || "anonymous";
+    const meetingId = meeting?._id || meeting?.id;
+    if (!meetingId) return null;
+    return `meet-on-memory:personal-notes-draft:v1:${userId}:${meetingId}`;
+  }, [userData, meeting]);
+
+  const draftValues = useMemo(() => ({ content }), [content]);
+
+  const restoreDraftValues = useCallback((draft) => {
+    if (typeof draft?.content === "string") {
+      setContent(draft.content);
+    }
+  }, []);
+
+  const {
+    recoverableDraft,
+    isCheckComplete,
+    restoreDraft,
+    discardDraft,
+    clearDraft,
+  } = useFormDraft({
+    key: draftKey,
+    values: draftValues,
+    enabled: Boolean(draftKey) && isLoaded,
+    maxAgeMs: 7 * 24 * 60 * 60 * 1000,
+    serverUpdatedAt,
+    onRestore: restoreDraftValues,
+  });
+
+  // Proactively clear draft when content matches server's synced content
+  useEffect(() => {
+    if (
+      isLoaded &&
+      isCheckComplete &&
+      !recoverableDraft &&
+      content === lastSavedContentRef.current
+    ) {
+      clearDraft();
+    }
+  }, [content, isLoaded, isCheckComplete, recoverableDraft, clearDraft]);
 
   const normalizedSegments = useMemo(() => {
     return normalizeTranscript(meeting?.transcript);
@@ -40,6 +90,9 @@ const PersonalNotes = ({ meeting }) => {
         setIsPinned(noteData.isPinned || false);
         setAnnotations(noteData.annotations || []);
         lastSavedContentRef.current = initialContent;
+        if (noteData.updatedAt) {
+          setServerUpdatedAt(noteData.updatedAt);
+        }
       }
     } catch (error) {
       console.error("Error fetching personal note", error);
@@ -57,9 +110,16 @@ const PersonalNotes = ({ meeting }) => {
       if (!meeting?._id) return;
       setSaveStatus("saving");
       try {
-        await personalNoteApi.upsertNote(meeting._id, newContent);
+        const response = await personalNoteApi.upsertNote(
+          meeting._id,
+          newContent,
+        );
+        const noteData = response?.data?.note || response?.note;
         lastSavedContentRef.current = newContent;
         setSaveStatus("saved");
+        if (noteData?.updatedAt) {
+          setServerUpdatedAt(noteData.updatedAt);
+        }
       } catch (error) {
         console.error("Error saving note", error);
         setSaveStatus("error");
@@ -299,6 +359,11 @@ const PersonalNotes = ({ meeting }) => {
 
       {/* RIGHT: Markdown Editor */}
       <div className="md:w-1/2 p-6 flex flex-col max-h-[600px]">
+        <PersonalNotesDraftRecoveryBanner
+          savedAt={recoverableDraft?.savedAt}
+          onRestore={restoreDraft}
+          onDiscard={discardDraft}
+        />
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center space-x-3">
             <h3 className="text-lg font-semibold text-slate-800 dark:text-gray-100">

--- a/client/src/components/meeting-details/PersonalNotesDraftRecoveryBanner.jsx
+++ b/client/src/components/meeting-details/PersonalNotesDraftRecoveryBanner.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Clock3, RotateCcw, Trash2 } from "lucide-react";
+
+const formatSavedTime = (savedAt) => {
+  if (!savedAt) return "recently";
+
+  const savedDate = new Date(savedAt);
+  if (Number.isNaN(savedDate.getTime())) return "recently";
+
+  const elapsedMinutes = Math.max(
+    0,
+    Math.floor((Date.now() - savedDate.getTime()) / 60000),
+  );
+
+  if (elapsedMinutes < 1) return "just now";
+  if (elapsedMinutes < 60)
+    return `${elapsedMinutes} minute${elapsedMinutes === 1 ? "" : "s"} ago`;
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return `${elapsedHours} hour${elapsedHours === 1 ? "" : "s"} ago`;
+  }
+
+  return savedDate.toLocaleString();
+};
+
+const PersonalNotesDraftRecoveryBanner = ({
+  savedAt,
+  onRestore,
+  onDiscard,
+}) => {
+  if (!savedAt) return null;
+
+  return (
+    <section
+      className="mb-4 rounded-xl border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/40 p-4 text-amber-950 dark:text-amber-100"
+      aria-labelledby="notes-draft-recovery-title"
+      aria-live="polite"
+      data-testid="notes-draft-recovery-banner"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <Clock3
+            className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+            size={20}
+            aria-hidden="true"
+          />
+          <div>
+            <h3
+              id="notes-draft-recovery-title"
+              className="font-semibold text-sm"
+            >
+              Unsaved personal notes draft found
+            </h3>
+            <p className="mt-1 text-xs text-amber-800 dark:text-amber-300">
+              This draft was saved locally {formatSavedTime(savedAt)}. Restore
+              it to continue editing or discard it.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onRestore}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-amber-700 cursor-pointer"
+            data-testid="restore-draft-btn"
+          >
+            <RotateCcw size={14} aria-hidden="true" />
+            Restore Draft
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-gray-800 px-3 py-1.5 text-xs font-semibold text-amber-900 dark:text-amber-200 transition hover:bg-amber-100 dark:hover:bg-gray-700 cursor-pointer"
+            data-testid="discard-draft-btn"
+          >
+            <Trash2 size={14} aria-hidden="true" />
+            Discard
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PersonalNotesDraftRecoveryBanner;

--- a/client/src/components/meeting-details/__tests__/PersonalNotesDraftRecovery.test.jsx
+++ b/client/src/components/meeting-details/__tests__/PersonalNotesDraftRecovery.test.jsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import PersonalNotes from "../PersonalNotes";
+import { personalNoteApi } from "../../../services";
+import AppContent from "../../../context/AppContent";
+
+vi.mock("../../../services", () => ({
+  personalNoteApi: {
+    getNoteByMeetingId: vi.fn(),
+    upsertNote: vi.fn(),
+    togglePin: vi.fn(),
+    clearNoteContent: vi.fn(),
+  },
+}));
+
+describe("PersonalNotes Draft Recovery (#2270)", () => {
+  const baseMeeting = {
+    _id: "meeting-777",
+    title: "Draft Testing Meeting",
+    transcript: [],
+  };
+
+  const contextValue = {
+    userData: { _id: "user-777" },
+  };
+
+  const draftKey =
+    "meet-on-memory:personal-notes-draft:v1:user-777:meeting-777";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders recovery banner when a local draft exists and is newer than server", async () => {
+    // Server updatedAt: 10 mins ago
+    const serverTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    // Draft savedAt: 5 mins ago (newer than server)
+    const draftTime = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    personalNoteApi.getNoteByMeetingId.mockResolvedValueOnce({
+      data: {
+        success: true,
+        note: {
+          content: "Server note content",
+          isPinned: false,
+          annotations: [],
+          updatedAt: serverTime,
+        },
+      },
+    });
+
+    const draftData = {
+      version: 1,
+      savedAt: draftTime,
+      values: { content: "Unsaved local draft content!" },
+    };
+    localStorage.setItem(draftKey, JSON.stringify(draftData));
+
+    render(
+      <AppContent.Provider value={contextValue}>
+        <PersonalNotes meeting={baseMeeting} />
+      </AppContent.Provider>,
+    );
+
+    // Verify recovery banner shows up
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("notes-draft-recovery-banner"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Unsaved personal notes draft found/),
+    ).toBeInTheDocument();
+
+    // Click Restore
+    const restoreBtn = screen.getByTestId("restore-draft-btn");
+    fireEvent.click(restoreBtn);
+
+    // Content should update to the restored draft content
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("Unsaved local draft content!"),
+      ).toBeInTheDocument();
+    });
+
+    // Banner should disappear
+    expect(
+      screen.queryByTestId("notes-draft-recovery-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("discards the draft when discard button is clicked", async () => {
+    const serverTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const draftTime = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    personalNoteApi.getNoteByMeetingId.mockResolvedValueOnce({
+      data: {
+        success: true,
+        note: {
+          content: "Server content",
+          isPinned: false,
+          annotations: [],
+          updatedAt: serverTime,
+        },
+      },
+    });
+
+    const draftData = {
+      version: 1,
+      savedAt: draftTime,
+      values: { content: "Discardable content" },
+    };
+    localStorage.setItem(draftKey, JSON.stringify(draftData));
+
+    render(
+      <AppContent.Provider value={contextValue}>
+        <PersonalNotes meeting={baseMeeting} />
+      </AppContent.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("notes-draft-recovery-banner"),
+      ).toBeInTheDocument();
+    });
+
+    const discardBtn = screen.getByTestId("discard-draft-btn");
+    fireEvent.click(discardBtn);
+
+    // Banner disappears and content remains server content
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("notes-draft-recovery-banner"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue("Server content")).toBeInTheDocument();
+    expect(localStorage.getItem(draftKey)).toBeNull();
+  });
+
+  it("discards the draft and does not render banner if server note is fresher", async () => {
+    // Server updatedAt: 5 mins ago (fresher/newer)
+    const serverTime = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    // Draft savedAt: 10 mins ago (older than server)
+    const draftTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+    personalNoteApi.getNoteByMeetingId.mockResolvedValueOnce({
+      data: {
+        success: true,
+        note: {
+          content: "Server content is fresher",
+          isPinned: false,
+          annotations: [],
+          updatedAt: serverTime,
+        },
+      },
+    });
+
+    const draftData = {
+      version: 1,
+      savedAt: draftTime,
+      values: { content: "Stale draft content" },
+    };
+    localStorage.setItem(draftKey, JSON.stringify(draftData));
+
+    render(
+      <AppContent.Provider value={contextValue}>
+        <PersonalNotes meeting={baseMeeting} />
+      </AppContent.Provider>,
+    );
+
+    // Wait for editor to load
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("Server content is fresher"),
+      ).toBeInTheDocument();
+    });
+
+    // Banner must NOT render, and draft is removed from localStorage
+    expect(
+      screen.queryByTestId("notes-draft-recovery-banner"),
+    ).not.toBeInTheDocument();
+    expect(localStorage.getItem(draftKey)).toBeNull();
+  });
+});

--- a/client/src/hooks/useFormDraft.js
+++ b/client/src/hooks/useFormDraft.js
@@ -67,6 +67,7 @@ export const useFormDraft = ({
   const [recoverableDraft, setRecoverableDraft] = useState(null);
   const [lastSavedAt, setLastSavedAt] = useState(null);
   const [status, setStatus] = useState("idle");
+  const [isCheckComplete, setIsCheckComplete] = useState(false);
   const hasInspectedStorage = useRef(false);
   const hasDraftRef = useRef(false);
   const skipNextSave = useRef(false);
@@ -112,6 +113,7 @@ export const useFormDraft = ({
     setRecoverableDraft(null);
     setLastSavedAt(null);
     setStatus("idle");
+    setIsCheckComplete(false);
 
     if (!enabled || !storageAvailable || !key) return;
 
@@ -122,6 +124,7 @@ export const useFormDraft = ({
     if (!draft) {
       if (rawDraft) window.localStorage.removeItem(key);
       skipNextSave.current = true;
+      setIsCheckComplete(true);
       return;
     }
 
@@ -132,6 +135,7 @@ export const useFormDraft = ({
       window.localStorage.removeItem(key);
       setStatus("expired");
       skipNextSave.current = true;
+      setIsCheckComplete(true);
       return;
     }
 
@@ -139,6 +143,7 @@ export const useFormDraft = ({
     setRecoverableDraft(draft);
     setLastSavedAt(draft.savedAt);
     setStatus("recovery-available");
+    setIsCheckComplete(true);
   }, [enabled, key, maxAgeMs, serverUpdatedAt, storageAvailable]);
 
   useEffect(() => {
@@ -183,6 +188,7 @@ export const useFormDraft = ({
     recoverableDraft,
     lastSavedAt,
     status,
+    isCheckComplete,
     restoreDraft,
     discardDraft,
     clearDraft,

--- a/docs/MEETING_DRAFT_RECOVERY.md
+++ b/docs/MEETING_DRAFT_RECOVERY.md
@@ -43,3 +43,23 @@ useScheduleMeeting({
 ```
 
 The current repository has a schedule/create form but no full meeting edit form. The hook and key format already support edit-mode integration when such a form is added.
+
+## Personal Notes Draft Recovery
+
+Personal notes also mirror the form draft autosave and recovery pattern:
+
+### Storage scope
+
+The draft key for personal notes is scoped by the authenticated user and the specific meeting:
+
+```text
+meet-on-memory:personal-notes-draft:v1:<userId>:<meetingId>
+```
+
+### Recovery behavior
+
+- Local changes to personal notes are autosaved to the browser's `localStorage` after editing.
+- If a browser crash or page reload occurs before the notes are successfully synced to the server, a **Personal Notes Draft Recovery Banner** is displayed above the notes editor.
+- The user can choose to **Restore Draft** (copying the local draft back into the editor) or **Discard** the draft.
+- **Server wins when fresher**: If the server note has a newer `updatedAt` timestamp than the local draft's `savedAt` timestamp, the draft is ignored and cleaned up automatically to avoid overwriting newer server data.
+- The draft is proactively cleared once the client note is fully synchronized with the server.


### PR DESCRIPTION
### Summary
This PR implements local draft recovery and a restoration banner for Personal Notes under Issue #2270.

### Key Changes
- **useFormDraft Hook**: Extended the hook with an `isCheckComplete` status variable to coordinate storage check lifecycle and prevent mount-time race conditions.
- **PersonalNotesDraftRecoveryBanner Component**: Created a note-specific recovery card display showing elapsed time and providing CTA buttons for restoring or discarding drafts.
- **PersonalNotes Component**: 
  - Integrated `useFormDraft` utilizing user-scoped and meeting-scoped keys (`meet-on-memory:personal-notes-draft:v1:${userId}:${meetingId}`).
  - Enforced "Server wins when fresher" behavior by passing server notes' `updatedAt` to the hook.
  - Cleared the local draft proactively when changes are fully synced to the database.
- **Documentation**: Extended `docs/MEETING_DRAFT_RECOVERY.md` to document the scoping, key structure, and conflict resolution rules for personal notes drafts.
- **Tests**: Created a new unit test suite `PersonalNotesDraftRecovery.test.jsx` verifying banner rendering, CTA click handling, and conflict resolution, while ensuring all existing note tests pass.

Closes #2270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personal meeting notes now recover unsaved drafts automatically.
  - Restore or discard recovered drafts using the new recovery banner.
  - Drafts are checked against the latest saved note and expire after seven days.

- **Bug Fixes**
  - Prevented outdated drafts from replacing newer server content.
  - Drafts are cleared after successfully saving matching content.

- **Documentation**
  - Added guidance on draft autosave, recovery, expiration, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->