### PR TITLE
[Feature] Translation export/history UI on LanguagePreferences for Issue #2271

### DIFF
--- a/client/src/pages/LanguagePreferences.jsx
+++ b/client/src/pages/LanguagePreferences.jsx
@@ -10,6 +10,9 @@ import {
   Settings,
   AlertCircle,
   RefreshCw,
+  Download,
+  History,
+  Award,
 } from "lucide-react";
 import { toast } from "react-toastify";
 
@@ -24,6 +27,17 @@ const LanguagePreferences = () => {
     target: "",
     language: "en",
   });
+
+  const [meetings, setMeetings] = useState([]);
+  const [selectedMeetingId, setSelectedMeetingId] = useState("");
+  const [cacheHistory, setCacheHistory] = useState([]);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [selectedSegmentId, setSelectedSegmentId] = useState("");
+  const [segmentQuality, setSegmentQuality] = useState(null);
+  const [loadingQuality, setLoadingQuality] = useState(false);
+  const [exportFormat, setExportFormat] = useState("json");
+  const [selectedExportLanguages, setSelectedExportLanguages] = useState([]);
+  const [exporting, setExporting] = useState(false);
 
   const fetchPreferences = useCallback(async () => {
     try {
@@ -49,10 +63,101 @@ const LanguagePreferences = () => {
     }
   }, []);
 
+  const fetchMeetings = useCallback(async () => {
+    try {
+      const { data } = await apiClient.get("/api/meetings");
+      const meetingsList = Array.isArray(data?.meetings)
+        ? data.meetings
+        : Array.isArray(data)
+          ? data
+          : [];
+      setMeetings(meetingsList);
+    } catch (err) {
+      console.error("Error fetching meetings:", err);
+    }
+  }, []);
+
+  const fetchCacheHistory = useCallback(async (meetingId) => {
+    if (!meetingId) return;
+    try {
+      setLoadingHistory(true);
+      const { data } = await apiClient.get(
+        `/api/translation/cache/${meetingId}`,
+      );
+      setCacheHistory(data?.translations || []);
+    } catch (err) {
+      console.error("Error fetching translation cache history:", err);
+      toast.error("Failed to load translation history");
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, []);
+
+  const fetchSegmentQuality = useCallback(
+    async (segmentId) => {
+      if (!segmentId || !selectedMeetingId) return;
+      try {
+        setLoadingQuality(true);
+        const { data } = await apiClient.get(
+          `/api/translation/quality/${segmentId}?meetingId=${selectedMeetingId}`,
+        );
+        setSegmentQuality(data || null);
+      } catch (err) {
+        console.error("Error fetching segment quality:", err);
+      } finally {
+        setLoadingQuality(false);
+      }
+    },
+    [selectedMeetingId],
+  );
+
+  const handleExport = async () => {
+    if (!selectedMeetingId) return;
+    try {
+      setExporting(true);
+      const { data } = await apiClient.post(
+        `/api/translation/export/${selectedMeetingId}`,
+        { format: exportFormat, languages: selectedExportLanguages },
+      );
+
+      const isJson = exportFormat === "json";
+      const blob = new Blob(
+        [isJson ? JSON.stringify(data, null, 2) : data.content || data],
+        { type: isJson ? "application/json" : "text/plain" },
+      );
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute(
+        "download",
+        `transcript-${selectedMeetingId}.${exportFormat}`,
+      );
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+      toast.success("Transcript exported successfully");
+    } catch (err) {
+      console.error("Export failed:", err);
+      toast.error("Failed to export transcript");
+    } finally {
+      setExporting(false);
+    }
+  };
+
   useEffect(() => {
     fetchPreferences();
     fetchLanguages();
-  }, [fetchPreferences, fetchLanguages]);
+    fetchMeetings();
+  }, [fetchPreferences, fetchLanguages, fetchMeetings]);
+
+  useEffect(() => {
+    if (selectedMeetingId) {
+      fetchCacheHistory(selectedMeetingId);
+    } else {
+      setCacheHistory([]);
+    }
+  }, [selectedMeetingId, fetchCacheHistory]);
 
   const savePreferences = async () => {
     try {
@@ -405,6 +510,348 @@ const LanguagePreferences = () => {
             <p className="text-center py-8 text-slate-500 dark:text-slate-400">
               No glossary entries yet
             </p>
+          )}
+        </div>
+
+        {/* Translation Audit & Management Section */}
+        <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-lg p-6 mb-6">
+          <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+            <History className="w-5 h-5 text-blue-600" />
+            Translation Audit & Management
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mb-6">
+            Export transcripts, audit cached translations, and monitor
+            translation quality scores across meetings.
+          </p>
+
+          {/* Meeting Selection */}
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+              Select Meeting to Audit
+            </label>
+            <div className="flex gap-2">
+              <select
+                value={selectedMeetingId}
+                onChange={(e) => {
+                  setSelectedMeetingId(e.target.value);
+                  setSelectedSegmentId("");
+                  setSegmentQuality(null);
+                }}
+                className="flex-1 px-3 py-2 border border-slate-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-800 text-slate-900 dark:text-white text-sm"
+                data-testid="audit-meeting-select"
+              >
+                <option value="">-- Choose a Meeting --</option>
+                {meetings.map((m) => (
+                  <option key={m._id} value={m._id}>
+                    {m.title} (
+                    {new Date(
+                      m.createdAt || m.date || Date.now(),
+                    ).toLocaleDateString()}
+                    )
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={fetchMeetings}
+                className="px-3 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 text-slate-750 dark:text-slate-200 rounded-lg text-sm transition-colors cursor-pointer"
+                title="Refresh meetings list"
+                data-testid="refresh-meetings-btn"
+              >
+                <RefreshCw className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          {selectedMeetingId ? (
+            <div className="space-y-6">
+              {/* Export Panel */}
+              <div className="border-t border-slate-100 dark:border-slate-800 pt-6">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                  <Download className="w-4 h-4 text-blue-600" />
+                  Export Transcript Translations
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label className="block text-xs font-semibold text-slate-500 uppercase mb-2">
+                      Format
+                    </label>
+                    <div className="flex gap-2">
+                      {["json", "srt"].map((fmt) => (
+                        <button
+                          key={fmt}
+                          type="button"
+                          onClick={() => setExportFormat(fmt)}
+                          className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                            exportFormat === fmt
+                              ? "bg-blue-600 text-white"
+                              : "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-755"
+                          }`}
+                          data-testid={`export-format-${fmt}-btn`}
+                        >
+                          {fmt.toUpperCase()}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-xs font-semibold text-slate-500 uppercase mb-2">
+                      Target Languages to Include
+                    </label>
+                    <div className="flex flex-wrap gap-2 max-h-28 overflow-y-auto p-2 border border-slate-200 dark:border-slate-700 rounded-lg">
+                      {languages.map((lang) => {
+                        const isChecked = selectedExportLanguages.includes(
+                          lang.code,
+                        );
+                        return (
+                          <label
+                            key={lang.code}
+                            className="flex items-center gap-1.5 bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded text-xs text-slate-700 dark:text-slate-300 cursor-pointer hover:bg-slate-200 dark:hover:bg-slate-700"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isChecked}
+                              onChange={() => {
+                                if (isChecked) {
+                                  setSelectedExportLanguages((prev) =>
+                                    prev.filter((l) => l !== lang.code),
+                                  );
+                                } else {
+                                  setSelectedExportLanguages((prev) => [
+                                    ...prev,
+                                    lang.code,
+                                  ]);
+                                }
+                              }}
+                              className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                              data-testid={`export-lang-checkbox-${lang.code}`}
+                            />
+                            <span>{lang.name}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleExport}
+                    disabled={exporting || selectedExportLanguages.length === 0}
+                    className="px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-sm font-semibold transition-colors disabled:opacity-50 inline-flex items-center gap-2 cursor-pointer"
+                    data-testid="export-download-btn"
+                  >
+                    <Download className="w-4 h-4" />
+                    {exporting ? "Exporting..." : "Export & Download"}
+                  </button>
+                </div>
+              </div>
+
+              {/* Cache History List */}
+              <div className="border-t border-slate-100 dark:border-slate-800 pt-6">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                  <History className="w-4 h-4 text-blue-600" />
+                  Translation Cache History
+                </h3>
+                {loadingHistory ? (
+                  <div className="text-center py-8">
+                    <RefreshCw className="w-6 h-6 animate-spin text-blue-600 mx-auto mb-2" />
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                      Loading translation memory...
+                    </p>
+                  </div>
+                ) : cacheHistory.length > 0 ? (
+                  <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    {/* Left: History list */}
+                    <div className="lg:col-span-2 space-y-3 max-h-[400px] overflow-y-auto pr-2">
+                      {cacheHistory.map((item) => (
+                        <button
+                          key={item._id || item.segmentId}
+                          type="button"
+                          onClick={() => {
+                            setSelectedSegmentId(item.segmentId);
+                            fetchSegmentQuality(item.segmentId);
+                          }}
+                          className={`w-full text-left p-4 rounded-xl border transition-all ${
+                            selectedSegmentId === item.segmentId
+                              ? "border-blue-500 bg-blue-50/30 dark:bg-blue-950/20"
+                              : "border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/50 hover:border-slate-350 dark:hover:border-slate-700"
+                          }`}
+                          data-testid={`cache-history-item-${item.segmentId}`}
+                        >
+                          <div className="flex items-center justify-between mb-2">
+                            <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+                              Segment: {item.segmentId} •{" "}
+                              {item.context?.speakerName || "Unknown Speaker"}
+                            </span>
+                            <span className="px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded text-[10px] font-bold">
+                              Score: {item.qualityScore ?? 100}%
+                            </span>
+                          </div>
+                          <p className="text-sm font-semibold text-slate-900 dark:text-white mb-2 line-clamp-2">
+                            {item.sourceText}
+                          </p>
+                          <div className="space-y-1 pl-3 border-l-2 border-slate-200 dark:border-slate-880">
+                            {item.translations?.slice(0, 3).map((trans, i) => (
+                              <p
+                                key={i}
+                                className="text-xs text-slate-600 dark:text-slate-400 truncate"
+                              >
+                                <span className="font-bold text-slate-500 dark:text-slate-500 uppercase mr-1">
+                                  {trans.language}:
+                                </span>
+                                {trans.text}
+                                {trans.provider === "manual" && (
+                                  <span className="ml-1.5 px-1 bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 rounded text-[9px] font-semibold">
+                                    manual
+                                  </span>
+                                )}
+                              </p>
+                            ))}
+                            {item.translations?.length > 3 && (
+                              <p className="text-[10px] text-slate-500 italic">
+                                +{item.translations.length - 3} more
+                                translations
+                              </p>
+                            )}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+
+                    {/* Right: Quality Details Panel */}
+                    <div className="bg-slate-50 dark:bg-slate-950 p-4 rounded-xl border border-slate-200 dark:border-slate-800">
+                      {selectedSegmentId ? (
+                        loadingQuality ? (
+                          <div className="text-center py-8">
+                            <RefreshCw className="w-5 h-5 animate-spin text-blue-600 mx-auto mb-2" />
+                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                              Loading metrics...
+                            </p>
+                          </div>
+                        ) : segmentQuality ? (
+                          <div className="space-y-4">
+                            <div>
+                              <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                                Segment Quality Details
+                              </h4>
+                              <div className="flex items-center gap-3">
+                                <div
+                                  className={`w-12 h-12 rounded-xl flex items-center justify-center font-bold text-lg text-white ${
+                                    segmentQuality.qualityScore >= 80
+                                      ? "bg-emerald-500"
+                                      : segmentQuality.qualityScore >= 50
+                                        ? "bg-amber-500"
+                                        : "bg-red-500"
+                                  }`}
+                                  data-testid="segment-quality-score-badge"
+                                >
+                                  {segmentQuality.qualityScore}%
+                                </div>
+                                <div>
+                                  <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                                    Quality Index
+                                  </p>
+                                  <p className="text-xs text-slate-400 dark:text-slate-500">
+                                    Based on translation confidence & length
+                                    ratios
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-2 text-center border-y border-slate-200 dark:border-slate-800 py-3 my-2">
+                              <div>
+                                <p className="text-[10px] font-bold text-slate-400 uppercase">
+                                  Access Count
+                                </p>
+                                <p className="text-sm font-bold text-slate-800 dark:text-slate-100">
+                                  {segmentQuality.accessCount ?? 0}
+                                </p>
+                              </div>
+                              <div>
+                                <p className="text-[10px] font-bold text-slate-400 uppercase">
+                                  Last Accessed
+                                </p>
+                                <p className="text-[10px] text-slate-700 dark:text-slate-300">
+                                  {segmentQuality.lastAccessedAt
+                                    ? new Date(
+                                        segmentQuality.lastAccessedAt,
+                                      ).toLocaleTimeString()
+                                    : "Never"}
+                                </p>
+                              </div>
+                            </div>
+
+                            <div>
+                              <h5 className="text-xs font-semibold text-slate-500 dark:text-slate-400 mb-2">
+                                Target Translation Audits
+                              </h5>
+                              <div className="space-y-2 max-h-40 overflow-y-auto pr-1">
+                                {segmentQuality.translations?.map(
+                                  (trans, i) => (
+                                    <div
+                                      key={i}
+                                      className="flex flex-col p-2 bg-white dark:bg-slate-900 rounded border border-slate-150 dark:border-slate-800 text-xs"
+                                    >
+                                      <div className="flex items-center justify-between mb-1">
+                                        <span className="font-bold text-slate-500 dark:text-slate-400 uppercase">
+                                          {trans.language}
+                                        </span>
+                                        <span className="text-[10px] font-medium text-slate-400">
+                                          Conf:{" "}
+                                          {Math.round(trans.confidence * 100)}%
+                                        </span>
+                                      </div>
+                                      <div className="flex items-center justify-between">
+                                        <span className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">
+                                          Provider: {trans.provider}
+                                        </span>
+                                        {trans.corrected && (
+                                          <span className="px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 rounded text-[8px] font-bold">
+                                            corrected
+                                          </span>
+                                        )}
+                                      </div>
+                                    </div>
+                                  ),
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-red-500 italic">
+                            Failed to load quality details.
+                          </p>
+                        )
+                      ) : (
+                        <div className="text-center py-12 text-slate-400 dark:text-slate-600">
+                          <Award className="w-8 h-8 mx-auto mb-2 text-slate-300 dark:text-slate-700" />
+                          <p className="text-xs">
+                            Select a history segment to audit translation
+                            metrics
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-center py-8 text-slate-500 dark:text-slate-400 italic">
+                    No translation history segments cached for this meeting.
+                  </p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="text-center py-12 text-slate-400 dark:text-slate-600 border-2 border-dashed border-slate-200 dark:border-slate-805 rounded-xl">
+              <History className="w-10 h-10 mx-auto mb-2 text-slate-300 dark:text-slate-700" />
+              <p className="text-sm">
+                Choose a meeting from the list to audit translations and export
+                artifacts
+              </p>
+            </div>
           )}
         </div>
 

--- a/client/src/pages/__tests__/TranslationAuditWiring.test.jsx
+++ b/client/src/pages/__tests__/TranslationAuditWiring.test.jsx
@@ -1,0 +1,347 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LanguagePreferences from "../LanguagePreferences.jsx";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar" />,
+}));
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: (...args) => mockGet(...args),
+    post: (...args) => mockPost(...args),
+    put: (...args) => mockPut(...args),
+  },
+}));
+
+describe("LanguagePreferences Translation Audit (#2271)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock global window URL methods for file download
+    window.URL.createObjectURL = vi.fn(() => "blob:http://localhost/mock-blob");
+    window.URL.revokeObjectURL = vi.fn();
+
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: {
+            autoTranslate: true,
+            showConfidenceScores: true,
+            preferredProvider: "google",
+            defaultSourceLanguage: "en",
+            defaultTargetLanguages: ["es", "fr"],
+            customGlossary: [],
+          },
+        });
+      }
+      if (url === "/api/translations/languages") {
+        return Promise.resolve({
+          data: {
+            languages: [
+              { code: "en", name: "English" },
+              { code: "es", name: "Spanish" },
+              { code: "fr", name: "French" },
+            ],
+          },
+        });
+      }
+      if (url === "/api/meetings") {
+        return Promise.resolve({
+          data: {
+            meetings: [
+              { _id: "meeting-1", title: "Project Sync" },
+              { _id: "meeting-2", title: "Design Discussion" },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  it("loads and displays the meetings list in the audit select element", async () => {
+    render(<LanguagePreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Language Preferences")).toBeInTheDocument();
+    });
+
+    // Verify meetings are fetched
+    expect(mockGet).toHaveBeenCalledWith("/api/meetings");
+
+    const select = screen.getByTestId("audit-meeting-select");
+    expect(select).toBeInTheDocument();
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(3);
+    expect(options[1]).toHaveTextContent("Project Sync");
+    expect(options[2]).toHaveTextContent("Design Discussion");
+  });
+
+  it("fetches and displays translation cache history when a meeting is selected", async () => {
+    const mockCacheData = {
+      translations: [
+        {
+          _id: "cache-1",
+          segmentId: "seg-1",
+          sourceText: "Hello world",
+          sourceLanguage: "en",
+          qualityScore: 90,
+          context: { speakerName: "Alice" },
+          translations: [
+            {
+              language: "es",
+              text: "Hola mundo",
+              provider: "google",
+              confidence: 0.95,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: { defaultTargetLanguages: [], customGlossary: [] },
+        });
+      }
+      if (url === "/api/translations/languages") {
+        return Promise.resolve({
+          data: {
+            languages: [
+              { code: "en", name: "English" },
+              { code: "es", name: "Spanish" },
+            ],
+          },
+        });
+      }
+      if (url === "/api/meetings") {
+        return Promise.resolve({
+          data: [{ _id: "meeting-1", title: "Project Sync" }],
+        });
+      }
+      if (url === "/api/translation/cache/meeting-1") {
+        return Promise.resolve({ data: mockCacheData });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    render(<LanguagePreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("audit-meeting-select")).toBeInTheDocument();
+    });
+
+    const select = screen.getByTestId("audit-meeting-select");
+    fireEvent.change(select, { target: { value: "meeting-1" } });
+
+    // Verify cache endpoint is hit
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/api/translation/cache/meeting-1");
+    });
+
+    // Check segment info rendered
+    await waitFor(() => {
+      expect(screen.getByText("Hello world")).toBeInTheDocument();
+      expect(screen.getByText("Segment: seg-1 • Alice")).toBeInTheDocument();
+      expect(screen.getByText("Score: 90%")).toBeInTheDocument();
+      expect(screen.getByText("es:")).toBeInTheDocument();
+      expect(screen.getByText("Hola mundo")).toBeInTheDocument();
+    });
+  });
+
+  it("fetches and renders segment quality metrics when a segment item is clicked", async () => {
+    const mockCacheData = {
+      translations: [
+        {
+          _id: "cache-1",
+          segmentId: "seg-1",
+          sourceText: "Hello world",
+          sourceLanguage: "en",
+          qualityScore: 90,
+          context: { speakerName: "Alice" },
+          translations: [
+            {
+              language: "es",
+              text: "Hola mundo",
+              provider: "google",
+              confidence: 0.95,
+            },
+          ],
+        },
+      ],
+    };
+
+    const mockQualityData = {
+      segmentId: "seg-1",
+      sourceLanguage: "en",
+      qualityScore: 90,
+      accessCount: 5,
+      lastAccessedAt: "2026-08-26T05:00:00.000Z",
+      translations: [
+        {
+          language: "es",
+          confidence: 0.95,
+          provider: "google",
+          corrected: false,
+        },
+      ],
+    };
+
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: { defaultTargetLanguages: [], customGlossary: [] },
+        });
+      }
+      if (url === "/api/translations/languages") {
+        return Promise.resolve({
+          data: {
+            languages: [
+              { code: "en", name: "English" },
+              { code: "es", name: "Spanish" },
+            ],
+          },
+        });
+      }
+      if (url === "/api/meetings") {
+        return Promise.resolve({
+          data: [{ _id: "meeting-1", title: "Project Sync" }],
+        });
+      }
+      if (url === "/api/translation/cache/meeting-1") {
+        return Promise.resolve({ data: mockCacheData });
+      }
+      if (url === "/api/translation/quality/seg-1?meetingId=meeting-1") {
+        return Promise.resolve({ data: mockQualityData });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    render(<LanguagePreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("audit-meeting-select")).toBeInTheDocument();
+    });
+
+    const select = screen.getByTestId("audit-meeting-select");
+    fireEvent.change(select, { target: { value: "meeting-1" } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("cache-history-item-seg-1"),
+      ).toBeInTheDocument();
+    });
+
+    const item = screen.getByTestId("cache-history-item-seg-1");
+    fireEvent.click(item);
+
+    // Verify quality endpoint hit
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "/api/translation/quality/seg-1?meetingId=meeting-1",
+      );
+    });
+
+    // Check quality metrics panel content
+    await waitFor(() => {
+      expect(screen.getByText("Segment Quality Details")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("segment-quality-score-badge"),
+      ).toHaveTextContent("90%");
+      expect(screen.getByText("Access Count")).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
+      expect(screen.getByText("Conf: 95%")).toBeInTheDocument();
+      expect(screen.getByText("Provider: google")).toBeInTheDocument();
+    });
+  });
+
+  it("calls export API and triggers file download when export is submitted", async () => {
+    const mockExportResponse = {
+      meetingId: "meeting-1",
+      languages: ["es"],
+      segments: [],
+    };
+
+    mockGet.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: { defaultTargetLanguages: [], customGlossary: [] },
+        });
+      }
+      if (url === "/api/translations/languages") {
+        return Promise.resolve({
+          data: {
+            languages: [
+              { code: "en", name: "English" },
+              { code: "es", name: "Spanish" },
+            ],
+          },
+        });
+      }
+      if (url === "/api/meetings") {
+        return Promise.resolve({
+          data: [{ _id: "meeting-1", title: "Project Sync" }],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    mockPost.mockResolvedValueOnce({
+      data: mockExportResponse,
+    });
+
+    render(<LanguagePreferences />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("audit-meeting-select")).toBeInTheDocument();
+    });
+
+    // Select meeting
+    const select = screen.getByTestId("audit-meeting-select");
+    fireEvent.change(select, { target: { value: "meeting-1" } });
+
+    // Wait for export options to render
+    await waitFor(() => {
+      expect(
+        screen.getByText("Export Transcript Translations"),
+      ).toBeInTheDocument();
+    });
+
+    // Click Spanish checkbox
+    const esCheckbox = screen.getByTestId("export-lang-checkbox-es");
+    fireEvent.click(esCheckbox);
+
+    // Click Export
+    const exportBtn = screen.getByTestId("export-download-btn");
+    fireEvent.click(exportBtn);
+
+    // Verify post data
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        "/api/translation/export/meeting-1",
+        {
+          format: "json",
+          languages: ["es"],
+        },
+      );
+    });
+
+    // Verify blob URL and download trigger
+    expect(window.URL.createObjectURL).toHaveBeenCalled();
+  });
+});

--- a/server/services/realtimeTranslationService.js
+++ b/server/services/realtimeTranslationService.js
@@ -319,6 +319,8 @@ export const submitCorrection = async (
       throw new Error("Translation cache entry not found");
     }
 
+    cache.qualityScore = 100;
+
     await cache.addTranslation({
       language,
       text: correctedText,


### PR DESCRIPTION
### Summary
This PR adds translation export options, a cache history log, and segment quality metrics panels to the LanguagePreferences view, wired directly to the translation service API endpoints for Issue #2271. It also updates the manual correction workflow to reset the quality score of translated segments to 100.

### Key Changes
- **Translation Services**: Updated `submitCorrection` in `realtimeTranslationService.js` to set the cached segment's `qualityScore` to `100` when a manual translation correction is saved.
- **LanguagePreferences UI**:
  - Implemented a **Meeting Selector** dropdown to select a meeting to audit.
  - Implemented an **Export Panel** to allow format selection (`json`/`srt`) and target language checkboxes to download translated transcripts using the `/api/translation/export/:meetingId` endpoint.
  - Added a **Cache History List** detailing cached segments, speakers, source text, and target translations.
  - Added a **Quality Details Panel** visualizing quality score, access metrics, and confidence breakdowns from `/api/translation/quality/:segmentId?meetingId=...`.
- **Tests**: Created a comprehensive suite of unit tests in `TranslationAuditWiring.test.jsx` covering dropdown mounting, cache history fetching, quality metrics auditing, and export download generation.

Closes #2271