### PR TITLE
[Docs Update] Reconcile CONTRIBUTING and Clerk migration docs for Issue #2272

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,6 +332,8 @@ npm run server
 - Secondary **JWTs** are used only for specific features (e.g. shared links, integration tokens) — not for primary auth.
 - Legacy login/session-based auth flow has been fully removed; do not reintroduce it.
 
+For detailed setup, environment variables, local testing, and user synchronization instructions, please refer to the [Authentication Contributor Runbook](docs/AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ---
 
 ## ✨ Development

--- a/docs/AUTH_CONTRIBUTOR_RUNBOOK.md
+++ b/docs/AUTH_CONTRIBUTOR_RUNBOOK.md
@@ -1,0 +1,105 @@
+# 🔐 Authentication Contributor Runbook
+
+This document is the official guide for contributors to set up, run, and test the **Clerk authentication system** locally.
+
+---
+
+## 📚 Table of Contents
+
+1. [Architecture Overview](#-architecture-overview)
+2. [Environment Variables](#-environment-variables)
+3. [Local Clerk Setup Guide](#-local-clerk-setup-guide)
+4. [User Synchronization (`sync-clerk-user`)](#-user-synchronization-sync-clerk-user)
+5. [Testing Auth Flows Locally](#-testing-auth-flows-locally)
+
+---
+
+## 🏗️ Architecture Overview
+
+MeetOnMemory uses **Clerk** as the sole identity provider.
+
+- **Identity & Session Verification**: Managed entirely by Clerk via Bearer tokens sent in the `Authorization` header of API requests.
+- **Authorization & RBAC**: Managed internally in MongoDB. The backend resolves the Clerk user (via their Clerk `sub` ID) to a MongoDB `User` document, which holds their role (`User.role`) and organization association (`User.organization`).
+- **Legacy Auth**: Traditional email/password login, cookie-based session verification, and csurf CSRF protection have been fully retired and removed. Do not reintroduce them.
+
+---
+
+## 🔑 Environment Variables
+
+To run the application locally, you must configure the following Clerk keys in your `.env` files.
+
+### Client (`client/.env`)
+
+| Variable                     | Description                                            | Example / Value |
+| :--------------------------- | :----------------------------------------------------- | :-------------- |
+| `VITE_CLERK_PUBLISHABLE_KEY` | Clerk Publishable Key (identifies your Clerk instance) | `pk_test_...`   |
+
+### Server (`server/.env`)
+
+| Variable           | Description                                                                           | Example / Value               |
+| :----------------- | :------------------------------------------------------------------------------------ | :---------------------------- |
+| `AUTH_PROVIDER`    | Defines the identity provider for the server                                          | `clerk`                       |
+| `CLERK_SECRET_KEY` | Clerk Secret Key (used to call Clerk API/verify tokens)                               | `sk_test_...`                 |
+| `JWT_SECRET`       | Secret key used to sign secondary tokens (Slack OAuth state, exports) and test tokens | `your_development_jwt_secret` |
+
+---
+
+## 🚀 Local Clerk Setup Guide
+
+Follow these steps to set up a free Clerk instance for local development:
+
+1. **Sign Up**: Go to [Clerk.com](https://clerk.com) and create a free account.
+2. **Create Application**: In the Clerk dashboard, click **Add Application**.
+   - Name it `MeetOnMemory Dev` or similar.
+   - Under **Select authentication providers**, check **Email** and **Password** (default). Click **Create Application**.
+3. **Retrieve Keys**: Once the application is created, copy the **Publishable Key** and **Secret Key** from the home screen.
+4. **Configure Client**:
+   - Create or open `client/.env`.
+   - Set `VITE_CLERK_PUBLISHABLE_KEY=pk_test_your_copied_key`.
+5. **Configure Server**:
+   - Create or open `server/.env`.
+   - Set `AUTH_PROVIDER=clerk`.
+   - Set `CLERK_SECRET_KEY=sk_test_your_copied_secret`.
+6. **JWT Templates (Optional)**: If you need custom session claims, configure a custom JWT template in the Clerk Dashboard under **JWT Templates**, but the default template is sufficient for normal local development.
+
+---
+
+## 🔄 User Synchronization (`sync-clerk-user`)
+
+When a user signs in or registers via Clerk, the client receives a Clerk session token. It then calls the backend `/sync-clerk-user` endpoint:
+
+- **Route**: `POST /api/auth/sync-clerk-user`
+- **Auth**: Protected by the `userAuth` middleware, which expects the Clerk token as a `Bearer` token in the `Authorization` header.
+- **Workflow**:
+  1. The `userAuth` middleware parses and verifies the Clerk token.
+  2. If a MongoDB user with matching `clerkUserId` (Clerk's `sub` claim) is found, it loads that user document into `req.user`.
+  3. If no user is found, the middleware automatically triggers `provisionOrLinkClerkUser` inside `authLinkingService.js`.
+  4. The service attempts to find an existing MongoDB user by matching the primary email address. If found, it links the `clerkUserId` to the document. Otherwise, it creates a new MongoDB user document with a secure, random dummy password.
+
+---
+
+## 🧪 Testing Auth Flows Locally
+
+For automated unit and integration tests, we mock external Clerk network requests using a JWT test fallback:
+
+- **Test Auth Setup**:
+  In tests, we set the environment variable `CLERK_TEST_AUTH=jwt`.
+- **JWT Verification**:
+  When `CLERK_TEST_AUTH=jwt` is enabled, the backend resolves Clerk tokens by validating them using the local `JWT_SECRET` key.
+- **Helper Methods**:
+  Use `createClerkTestToken({ clerkUserId, email, name })` inside `server/tests/helpers/clerkTestAuth.js` to sign mock Clerk tokens for integration tests.
+
+Example usage in a test:
+
+```javascript
+import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
+
+const token = createClerkTestToken({
+  clerkUserId: "user_test_123",
+  email: "test@example.com",
+});
+
+const response = await request(app)
+  .get("/api/meetings/all")
+  .set("Authorization", authHeader(token));
+```

--- a/docs/clerk-migration/00_VERSION_FREEZE.md
+++ b/docs/clerk-migration/00_VERSION_FREEZE.md
@@ -1,5 +1,10 @@
 # Version Freeze — Last Stable JWT Release
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ## Recommended tag
 
 ```text

--- a/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
+++ b/docs/clerk-migration/01_AUTHENTICATION_ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Authentication Architecture (Current System)
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 **Status:** Verified from MeetOnMemory source.  
 **Last reviewed against:** repository `server/` and `client/src/` during Clerk migration planning.
 

--- a/docs/clerk-migration/02_CLERK_MIGRATION_PROPOSAL.md
+++ b/docs/clerk-migration/02_CLERK_MIGRATION_PROPOSAL.md
@@ -1,5 +1,10 @@
 # Clerk Migration Proposal
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ## 1. Why migrate
 
 MeetOnMemory’s identity layer is entirely custom: password hashing, OTP email verification/reset, JWT issuance, cookie session, and CSRF. That surface area is large relative to product features (meetings, AI, orgs) and competes with contributor bandwidth on security-sensitive code.

--- a/docs/clerk-migration/03_MIGRATION_STRATEGY.md
+++ b/docs/clerk-migration/03_MIGRATION_STRATEGY.md
@@ -1,5 +1,10 @@
 # Migration Strategy (Master Program)
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ## 1. Philosophy
 
 **Strangler Fig + Dual Authentication + Feature Flag.**

--- a/docs/clerk-migration/04_PHASES.md
+++ b/docs/clerk-migration/04_PHASES.md
@@ -1,5 +1,10 @@
 # Phases — Source of Truth
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 Do **not** start Phase N+1 until Phase N exit criteria are met and signed off.
 
 Issue bodies for Phase 1 live in [`phase-1/ISSUES.md`](./phase-1/ISSUES.md).  

--- a/docs/clerk-migration/05_MIGRATION_CHECKLIST.md
+++ b/docs/clerk-migration/05_MIGRATION_CHECKLIST.md
@@ -1,5 +1,10 @@
 # Migration Checklist
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 Use this at the end of **every** phase before authorizing the next.
 
 Copy into the phase tracking issue and check boxes in comments.

--- a/docs/clerk-migration/06_FILES_TO_REMOVE.md
+++ b/docs/clerk-migration/06_FILES_TO_REMOVE.md
@@ -1,5 +1,10 @@
 # Files To Remove
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 **When:** Phase 8 only (after cutover soak).  
 **Rule:** Verified identity-layer obsolescence only.  
 **Do not remove** during Phases 1–7.

--- a/docs/clerk-migration/07_FILES_TO_MODIFY.md
+++ b/docs/clerk-migration/07_FILES_TO_MODIFY.md
@@ -1,5 +1,10 @@
 # Files To Modify
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 Effort: **S** &lt; 0.5d · **M** 0.5–2d · **L** &gt; 2d  
 Risk: Low / Medium / High / Critical
 

--- a/docs/clerk-migration/08_RISKS.md
+++ b/docs/clerk-migration/08_RISKS.md
@@ -1,5 +1,10 @@
 # Risks
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 | ID  | Risk                                             | Rank         | Mitigation                                                                        | Rollback                             | Monitoring                                         | Owner                     |
 | --- | ------------------------------------------------ | ------------ | --------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------- | ------------------------- |
 | R1  | Email mismatch creates duplicate Mongo users     | **Critical** | Normalized email upsert; unique email + sparse `clerkUserId`; linking transaction | Disable Clerk signup; legacy login   | Count users with null `clerkUserId` vs Clerk total | Maintainer / Phase 6 lead |

--- a/docs/clerk-migration/09_TESTING_PLAN.md
+++ b/docs/clerk-migration/09_TESTING_PLAN.md
@@ -1,5 +1,10 @@
 # Testing Plan
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ## Principles
 
 1. Legacy path must stay green until Phase 7.

--- a/docs/clerk-migration/10_CONTRIBUTOR_GUIDE.md
+++ b/docs/clerk-migration/10_CONTRIBUTOR_GUIDE.md
@@ -1,5 +1,10 @@
 # Contributor Guide — Clerk Migration
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 ## Purpose
 
 How to contribute safely during the Clerk authentication migration.

--- a/docs/clerk-migration/11_ARCHITECTURE_VERIFICATION.md
+++ b/docs/clerk-migration/11_ARCHITECTURE_VERIFICATION.md
@@ -1,5 +1,10 @@
 # Architecture Verification Report
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 > **Historical snapshot** (pre–Clerk cutover inventory). Last reconciled for Issue #1139 on **2026-08-06**. Several rows below describe the former JWT + CSRF stack; where status has changed since planning time, that is noted in the Status / Evidence columns.
 
 Evidence-based checklist for the current auth system.

--- a/docs/clerk-migration/12_MIGRATION_PLAN_VERIFICATION.md
+++ b/docs/clerk-migration/12_MIGRATION_PLAN_VERIFICATION.md
@@ -1,5 +1,10 @@
 # Migration Plan Verification
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 Review of the previously proposed Clerk migration (conversation / planning drafts) against the repository.
 
 Legend: ✅ Verified · ⚠ Needs adjustment · ❌ Incorrect

--- a/docs/clerk-migration/README.md
+++ b/docs/clerk-migration/README.md
@@ -1,5 +1,10 @@
 # Clerk Authentication Migration — Official Guide
 
+> [!WARNING]
+> **ARCHIVED / HISTORICAL DOCUMENTATION**  
+> The Clerk authentication migration has been fully completed. Clerk is now the sole identity provider for MeetOnMemory.  
+> For current contributor setup and development instructions, please refer to [AUTH_CONTRIBUTOR_RUNBOOK.md](../AUTH_CONTRIBUTOR_RUNBOOK.md).
+
 **Status:** Production cutover complete for identity (Issue #974). Clerk is the sole identity provider.  
 **Scope:** Identity/session = Clerk Bearer tokens. Authorization = MongoDB RBAC.  
 **Preserve:** Organizations, Memberships, RBAC, Meetings, Policies, AI, Analytics, Calendar (Google API OAuth), Notifications, Tasks, Slack, shared-link/export/Slack-state JWTs.


### PR DESCRIPTION
### Summary
This PR reconciles the project contribution guidelines and historical Clerk migration documentation with the live Clerk-only authentication state, and introduces a dedicated contributor authentication runbook.

### Key Changes
- **Contributor Authentication Runbook**: Created `docs/AUTH_CONTRIBUTOR_RUNBOOK.md` detailing the modern Clerk authentication architecture, required local environment variables, Clerk development instance setup instructions, user synchronization backend flows (`/sync-clerk-user`), and local auth test mock guidelines.
- **Historical Migration Banners**: Added warning/archived banners to all markdown documents under `docs/clerk-migration/` to notify new contributors that the migration is complete and these documents are kept for historical reference only.
- **CONTRIBUTING Reconciliation**: Modified `CONTRIBUTING.md` to align with the Clerk-only auth state and added direct links pointing to the new contributor runbook.

Closes #2272