### PR TITLE
feat(sessions): persist session cards in org library with gallery and…

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -75,6 +75,7 @@ import {
   CheckCheck,
   Smile,
   Lightbulb,
+  Presentation,
 } from "lucide-react";
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
@@ -477,6 +478,12 @@ const Navbar = () => {
             label: t("navbar.meetingTemplates"),
             href: "/meeting-templates",
             icon: GitMerge,
+            permission: { resource: "meetings", action: "view" },
+          },
+          {
+            label: t("navbar.sessionCards", "Session Cards"),
+            href: "/session-cards",
+            icon: Presentation,
             permission: { resource: "meetings", action: "view" },
           },
           {

--- a/client/src/pages/CreateMeeting.jsx
+++ b/client/src/pages/CreateMeeting.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import Navbar from "../components/Navbar.jsx";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
-import { meetingApi } from "../services";
+import { meetingApi, sessionCardApi } from "../services";
 import MeetingTabs from "./CreateMeeting/components/MeetingTabs";
 import ScheduleMeeting from "./CreateMeeting/components/ScheduleMeeting/ScheduleMeeting";
 import LiveMeeting from "./CreateMeeting/components/LiveMeeting/LiveMeeting";
@@ -15,9 +15,17 @@ import { useSessionCards } from "./CreateMeeting/hooks/useSessionCards";
 
 const CreateMeeting = () => {
   const navigate = useNavigate();
-  const [activeSection, setActiveSection] = useState("live");
   const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const [activeSection, setActiveSection] = useState(
+    tabParam === "session"
+      ? "session"
+      : tabParam === "schedule"
+        ? "schedule"
+        : "live",
+  );
   const duplicateFrom = searchParams.get("duplicateFrom");
+  const fromSessionCard = searchParams.get("fromSessionCard");
   const [loadingDuplicate, setLoadingDuplicate] = useState(false);
   const [showSmartScheduler, setShowSmartScheduler] = useState(false);
 
@@ -27,10 +35,66 @@ const CreateMeeting = () => {
   const sessionCardsHooks = useSessionCards();
 
   useEffect(() => {
+    if (
+      tabParam &&
+      ["live", "schedule", "smart", "session"].includes(tabParam)
+    ) {
+      setActiveSection(tabParam);
+    }
+  }, [tabParam]);
+
+  useEffect(() => {
     if (activeSection === "smart") {
       setShowSmartScheduler(true);
     }
   }, [activeSection]);
+
+  // Handle populating schedule form from a session card
+  useEffect(() => {
+    if (!fromSessionCard) return;
+
+    let cancelled = false;
+    setActiveSection("schedule");
+    setLoadingDuplicate(true);
+
+    sessionCardApi
+      .getSessionCardById(fromSessionCard)
+      .then(({ data }) => {
+        if (cancelled) return;
+        const session = data?.data?.session || data?.session;
+        if (!session) {
+          throw new Error("Unable to load session card details");
+        }
+
+        const draftPayload = {
+          title: session.sessionTitle || "",
+          description:
+            session.summary ||
+            (session.speaker ? `Speaker: ${session.speaker}` : ""),
+          tags: Array.isArray(session.keywords) ? session.keywords : [],
+          location: session.eventName || "Conference Session",
+          venue: session.eventName || "",
+        };
+
+        hydrateDuplicateMeeting(draftPayload);
+        toast.success("✨ Session card loaded into meeting draft!");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        toast.error(
+          err.response?.data?.message ||
+            err.message ||
+            "Failed to load session card draft",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDuplicate(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fromSessionCard, hydrateDuplicateMeeting]);
 
   useEffect(() => {
     if (!duplicateFrom) return;

--- a/client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx
@@ -1,75 +1,186 @@
-import { Tag, ExternalLink } from "lucide-react";
+import React, { useState } from "react";
+import {
+  Tag,
+  ExternalLink,
+  CalendarPlus,
+  Trash2,
+  Copy,
+  Check,
+  Building2,
+  Sparkles,
+} from "lucide-react";
+import { useNavigate, Link } from "react-router-dom";
+import { toast } from "react-toastify";
 
-const GeneratedSessionCards = ({ generatedSessions }) => {
+const GeneratedSessionCards = ({
+  generatedSessions = [],
+  onDeleteSession,
+  onReuseSession,
+}) => {
+  const navigate = useNavigate();
+  const [copiedId, setCopiedId] = useState(null);
+
   if (generatedSessions.length === 0) return null;
+
+  const handleCopySummary = (session, id) => {
+    const textToCopy = `Session: ${session.sessionTitle}\nEvent: ${session.eventName || "N/A"}\nSpeaker: ${session.speaker || "N/A"}\n\nSummary:\n${session.summary || ""}\n\nKeywords: ${(session.keywords || []).join(", ")}`;
+    navigator.clipboard.writeText(textToCopy);
+    setCopiedId(id);
+    toast.success("Session details copied to clipboard!");
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const handleReuse = (session) => {
+    if (onReuseSession) {
+      onReuseSession(session);
+    } else {
+      const params = new URLSearchParams();
+      if (session._id || session.id) {
+        params.set("fromSessionCard", session._id || session.id);
+      }
+      navigate(`/create-meeting?${params.toString()}`);
+    }
+  };
 
   return (
     <div className="mt-8">
-      <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-4">
-        ✨ Generated Session Cards
-      </h3>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Sparkles
+            className="text-purple-600 dark:text-purple-400"
+            size={20}
+          />
+          <h3 className="text-xl font-bold text-gray-900 dark:text-white">
+            Saved & Generated Session Cards ({generatedSessions.length})
+          </h3>
+        </div>
+        <Link
+          to="/session-cards"
+          className="inline-flex items-center gap-1.5 text-xs font-semibold text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 hover:underline"
+        >
+          <Building2 size={14} />
+          <span>View Org Gallery</span>
+        </Link>
+      </div>
+
       <div className="space-y-4">
-        {generatedSessions.map((session, index) => (
-          <div
-            key={index}
-            className="bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-950/40 dark:to-blue-950/40 border border-purple-200 dark:border-purple-800 rounded-xl p-6"
-          >
-            <div className="flex items-start justify-between mb-3">
-              <div>
-                <h4 className="text-lg font-bold text-gray-900 dark:text-white">
-                  {session.sessionTitle}
-                </h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  {session.eventName}
-                </p>
-              </div>
-              <span className="px-3 py-1 bg-purple-600 text-white text-xs rounded-full">
-                Session
-              </span>
-            </div>
-
-            {session.speaker && (
-              <div className="mb-3 p-3 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg">
-                <p className="text-sm font-semibold text-gray-900 dark:text-white">
-                  {session.speaker}
-                </p>
-                {session.speakerTitle && (
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    {session.speakerTitle}
-                  </p>
-                )}
-              </div>
-            )}
-
-            <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">
-              {session.summary || "AI-generated summary will appear here..."}
-            </p>
-
-            {session.keywords && session.keywords.length > 0 && (
-              <div className="flex flex-wrap gap-2 mb-3">
-                {session.keywords.map((keyword, i) => (
-                  <span
-                    key={i}
-                    className="px-3 py-1 bg-purple-100 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-800/60 text-xs rounded-full flex items-center gap-1"
-                  >
-                    <Tag size={12} /> {keyword}
+        {generatedSessions.map((session, index) => {
+          const cardId = session._id || session.id || `session-${index}`;
+          return (
+            <div
+              key={cardId}
+              className="bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-950/40 dark:to-blue-950/40 border border-purple-200 dark:border-purple-800 rounded-xl p-6 shadow-sm hover:shadow-md transition"
+            >
+              <div className="flex items-start justify-between mb-3 gap-4">
+                <div>
+                  <h4 className="text-lg font-bold text-gray-900 dark:text-white">
+                    {session.sessionTitle}
+                  </h4>
+                  {session.eventName && (
+                    <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
+                      {session.eventName}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="px-3 py-1 bg-purple-600 text-white text-xs font-semibold rounded-full">
+                    Session Card
                   </span>
-                ))}
+                  {onDeleteSession && (session._id || session.id) && (
+                    <button
+                      type="button"
+                      onClick={() => onDeleteSession(session._id || session.id)}
+                      title="Delete session card"
+                      className="p-1.5 text-gray-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-white/80 dark:hover:bg-gray-800 transition"
+                      aria-label="Delete session card"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  )}
+                </div>
               </div>
-            )}
 
-            {session.videoUrl && (
-              <a
-                href={session.videoUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
-              >
-                <ExternalLink size={16} /> Watch Video
-              </a>
-            )}
-          </div>
-        ))}
+              {session.speaker && (
+                <div className="mb-3 p-3 bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 rounded-lg">
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                    {session.speaker}
+                  </p>
+                  {session.speakerTitle && (
+                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                      {session.speakerTitle}
+                    </p>
+                  )}
+                  {session.speakerBio && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 italic">
+                      {session.speakerBio}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <p className="text-sm text-gray-700 dark:text-gray-300 mb-3 whitespace-pre-wrap">
+                {session.summary || "AI-generated summary will appear here..."}
+              </p>
+
+              {session.keywords && session.keywords.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-4">
+                  {session.keywords.map((keyword, i) => (
+                    <span
+                      key={i}
+                      className="px-2.5 py-1 bg-purple-100 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-800/60 text-xs rounded-full flex items-center gap-1 font-medium"
+                    >
+                      <Tag size={11} /> {keyword}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              <div className="flex flex-wrap items-center justify-between gap-3 pt-3 border-t border-purple-200/60 dark:border-purple-800/60">
+                <div className="flex items-center gap-3">
+                  {session.videoUrl && (
+                    <a
+                      href={session.videoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
+                    >
+                      <ExternalLink size={14} /> Watch Video
+                    </a>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopySummary(session, cardId)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700 text-xs font-medium rounded-lg transition cursor-pointer"
+                  >
+                    {copiedId === cardId ? (
+                      <>
+                        <Check size={13} className="text-emerald-500" />
+                        <span>Copied!</span>
+                      </>
+                    ) : (
+                      <>
+                        <Copy size={13} />
+                        <span>Copy Details</span>
+                      </>
+                    )}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => handleReuse(session)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-700 text-white text-xs font-semibold rounded-lg shadow-sm transition cursor-pointer"
+                  >
+                    <CalendarPlus size={13} />
+                    <span>Use as Meeting Draft</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/client/src/pages/CreateMeeting/components/SessionCards/SessionCards.jsx
+++ b/client/src/pages/CreateMeeting/components/SessionCards/SessionCards.jsx
@@ -1,10 +1,11 @@
-import { Presentation, Loader2, Sparkles } from "lucide-react";
+import { Presentation, Loader2, Sparkles, Building2 } from "lucide-react";
+import { Link } from "react-router-dom";
 import SpeakerSection from "./SpeakerSection";
 import SlideUploader from "./SlideUploader";
 import VideoUploader from "./VideoUploader";
 import GeneratedSessionCards from "./GeneratedSessionCards";
 
-const SessionCards = ({ hookProps }) => {
+const SessionCards = ({ hookProps, onReuseSession }) => {
   const {
     sessionData,
     slideFiles,
@@ -15,25 +16,35 @@ const SessionCards = ({ hookProps }) => {
     handleSlideUpload,
     handleVideoUpload,
     removeSlideFile,
+    handleDeleteSession,
     handleSessionSubmit,
   } = hookProps;
 
   return (
     <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 shadow-lg rounded-2xl p-8">
-      <div className="flex items-center gap-3 mb-6">
-        <Presentation
-          className="text-purple-600 dark:text-purple-400"
-          size={28}
-        />
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Auto Session Card Generation
-          </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Upload slides/videos from conferences and seminars - AI generates
-            session cards with summaries, keywords, and speaker profiles
-          </p>
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-6">
+        <div className="flex items-center gap-3">
+          <Presentation
+            className="text-purple-600 dark:text-purple-400"
+            size={28}
+          />
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Auto Session Card Generation
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Upload slides/videos from conferences and seminars - AI generates
+              session cards with summaries, keywords, and speaker profiles
+            </p>
+          </div>
         </div>
+        <Link
+          to="/session-cards"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-purple-50 dark:bg-purple-950/40 hover:bg-purple-100 dark:hover:bg-purple-900/40 border border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 rounded-lg text-sm font-semibold transition"
+        >
+          <Building2 size={16} />
+          <span>Browse Org Gallery</span>
+        </Link>
       </div>
 
       <form onSubmit={handleSessionSubmit}>
@@ -102,7 +113,11 @@ const SessionCards = ({ hookProps }) => {
         </button>
       </form>
 
-      <GeneratedSessionCards generatedSessions={generatedSessions} />
+      <GeneratedSessionCards
+        generatedSessions={generatedSessions}
+        onDeleteSession={handleDeleteSession}
+        onReuseSession={onReuseSession}
+      />
     </div>
   );
 };

--- a/client/src/pages/CreateMeeting/hooks/__tests__/useSessionCards.persistence.test.jsx
+++ b/client/src/pages/CreateMeeting/hooks/__tests__/useSessionCards.persistence.test.jsx
@@ -1,0 +1,82 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSessionCards } from "../useSessionCards";
+import { sessionCardApi } from "../../../../services";
+
+vi.mock("../../../../services", () => ({
+  sessionCardApi: {
+    getSessionCards: vi.fn(),
+    generateSession: vi.fn(),
+    deleteSessionCard: vi.fn(),
+  },
+}));
+
+describe("useSessionCards Persistence Hook (#2257)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches and initializes existing session cards on mount", async () => {
+    const mockCards = [
+      {
+        _id: "sc-1",
+        sessionTitle: "Keynote 2026",
+        eventName: "DevFest",
+        summary: "Opening keynote overview",
+        keywords: ["Keynote", "DevFest"],
+      },
+    ];
+
+    sessionCardApi.getSessionCards.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          sessions: mockCards,
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSessionCards());
+
+    await waitFor(() => {
+      expect(result.current.generatedSessions).toEqual(mockCards);
+    });
+
+    expect(sessionCardApi.getSessionCards).toHaveBeenCalled();
+  });
+
+  it("deletes a session card and updates local state", async () => {
+    const mockCards = [
+      { _id: "sc-1", sessionTitle: "Card 1" },
+      { _id: "sc-2", sessionTitle: "Card 2" },
+    ];
+
+    sessionCardApi.getSessionCards.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          sessions: mockCards,
+        },
+      },
+    });
+
+    sessionCardApi.deleteSessionCard.mockResolvedValueOnce({
+      data: { success: true },
+    });
+
+    const { result } = renderHook(() => useSessionCards());
+
+    await waitFor(() => {
+      expect(result.current.generatedSessions).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.handleDeleteSession("sc-1");
+    });
+
+    expect(sessionCardApi.deleteSessionCard).toHaveBeenCalledWith("sc-1");
+    expect(result.current.generatedSessions).toEqual([
+      { _id: "sc-2", sessionTitle: "Card 2" },
+    ]);
+  });
+});

--- a/client/src/pages/CreateMeeting/hooks/useSessionCards.js
+++ b/client/src/pages/CreateMeeting/hooks/useSessionCards.js
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { toast } from "react-toastify";
-import { meetingApi } from "../../../services";
+import { sessionCardApi } from "../../../services";
 
 export const useSessionCards = () => {
   const [sessionData, setSessionData] = useState({
@@ -14,6 +14,30 @@ export const useSessionCards = () => {
   const [videoFile, setVideoFile] = useState(null);
   const [generatedSessions, setGeneratedSessions] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [fetchingCards, setFetchingCards] = useState(false);
+
+  const fetchSessionCards = useCallback(async () => {
+    setFetchingCards(true);
+    try {
+      const response = await sessionCardApi.getSessionCards({ limit: 50 });
+      if (response.data?.success) {
+        const list = Array.isArray(response.data?.sessions)
+          ? response.data.sessions
+          : Array.isArray(response.data?.data?.sessions)
+            ? response.data.data.sessions
+            : [];
+        setGeneratedSessions(list);
+      }
+    } catch (error) {
+      console.error("Error loading session cards:", error);
+    } finally {
+      setFetchingCards(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessionCards();
+  }, [fetchSessionCards]);
 
   const handleSessionChange = (e) => {
     const { name, value } = e.target;
@@ -22,7 +46,7 @@ export const useSessionCards = () => {
 
   const handleSlideUpload = (e) => {
     const files = Array.from(e.target.files);
-    setSlideFiles([...slideFiles, ...files]);
+    setSlideFiles((prev) => [...prev, ...files]);
     toast.success(`${files.length} slide file(s) uploaded`);
   };
 
@@ -35,7 +59,25 @@ export const useSessionCards = () => {
   };
 
   const removeSlideFile = (index) => {
-    setSlideFiles(slideFiles.filter((_, i) => i !== index));
+    setSlideFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleDeleteSession = async (sessionId) => {
+    if (!sessionId) return;
+    try {
+      const response = await sessionCardApi.deleteSessionCard(sessionId);
+      if (response.data?.success || response.status === 200) {
+        setGeneratedSessions((prev) =>
+          prev.filter((s) => s._id !== sessionId && s.id !== sessionId),
+        );
+        toast.success("Session card deleted successfully");
+      }
+    } catch (error) {
+      console.error("Error deleting session card:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to delete session card",
+      );
+    }
   };
 
   const handleSessionSubmit = async (e) => {
@@ -62,11 +104,17 @@ export const useSessionCards = () => {
         formData.append("video", videoFile);
       }
 
-      const response = await meetingApi.generateSession(formData);
+      const response = await sessionCardApi.generateSession(formData);
 
       if (response.data?.success) {
-        toast.success("✨ AI Session card generated successfully!");
-        setGeneratedSessions([response.data.session, ...generatedSessions]);
+        toast.success("✨ AI Session card generated and saved successfully!");
+        const newSession =
+          response.data?.data?.session || response.data?.session;
+        if (newSession) {
+          setGeneratedSessions((prev) => [newSession, ...prev]);
+        } else {
+          fetchSessionCards();
+        }
 
         // Reset form
         setSessionData({
@@ -95,10 +143,13 @@ export const useSessionCards = () => {
     videoFile,
     generatedSessions,
     loading,
+    fetchingCards,
+    fetchSessionCards,
     handleSessionChange,
     handleSlideUpload,
     handleVideoUpload,
     removeSlideFile,
+    handleDeleteSession,
     handleSessionSubmit,
   };
 };

--- a/client/src/pages/SessionGallery.jsx
+++ b/client/src/pages/SessionGallery.jsx
@@ -1,0 +1,536 @@
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import {
+  Presentation,
+  Search,
+  Plus,
+  Tag,
+  ExternalLink,
+  CalendarPlus,
+  Trash2,
+  Copy,
+  Check,
+  Building2,
+  Users,
+  Calendar,
+  Sparkles,
+  RefreshCw,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
+import Navbar from "../components/Navbar.jsx";
+import { sessionCardApi } from "../services";
+import { toast } from "react-toastify";
+
+const SessionGallery = () => {
+  const navigate = useNavigate();
+  const [sessions, setSessions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selectedTag, setSelectedTag] = useState("");
+  const [selectedEvent, setSelectedEvent] = useState("");
+  const [copiedId, setCopiedId] = useState(null);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState({
+    total: 0,
+    page: 1,
+    limit: 24,
+    totalPages: 1,
+  });
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = {
+        page,
+        limit: 24,
+        search: debouncedSearch.trim() || undefined,
+        tag: selectedTag || undefined,
+        event: selectedEvent || undefined,
+      };
+      const response = await sessionCardApi.getSessionCards(params);
+      if (response.data?.success) {
+        const raw = response.data?.data || response.data;
+        const list = Array.isArray(response.data?.sessions)
+          ? response.data.sessions
+          : Array.isArray(raw?.sessions)
+            ? raw.sessions
+            : [];
+        setSessions(list);
+        if (response.data?.pagination || raw?.pagination) {
+          setPagination(response.data?.pagination || raw.pagination);
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching session cards:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to load session cards gallery",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [page, debouncedSearch, selectedTag, selectedEvent]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  const handleDelete = async (id, title) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete "${title || "this session card"}"?`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const response = await sessionCardApi.deleteSessionCard(id);
+      if (response.data?.success || response.status === 200) {
+        toast.success("Session card deleted successfully");
+        setSessions((prev) => prev.filter((s) => s._id !== id && s.id !== id));
+      }
+    } catch (error) {
+      console.error("Error deleting session card:", error);
+      toast.error(
+        error.response?.data?.message || "Failed to delete session card",
+      );
+    }
+  };
+
+  const handleCopy = (session, id) => {
+    const textToCopy = `Session: ${session.sessionTitle}\nEvent: ${session.eventName || "N/A"}\nSpeaker: ${session.speaker || "N/A"}\n\nSummary:\n${session.summary || ""}\n\nKeywords: ${(session.keywords || []).join(", ")}`;
+    navigator.clipboard.writeText(textToCopy);
+    setCopiedId(id);
+    toast.success("Session details copied to clipboard!");
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const handleReuse = (session) => {
+    const cardId = session._id || session.id;
+    if (cardId) {
+      navigate(`/create-meeting?fromSessionCard=${cardId}`);
+    } else {
+      navigate("/create-meeting?tab=schedule");
+    }
+  };
+
+  // Derive unique events and tags from current list for quick filters
+  const allEvents = useMemo(() => {
+    const set = new Set();
+    sessions.forEach((s) => {
+      if (s.eventName && s.eventName.trim()) set.add(s.eventName.trim());
+    });
+    return Array.from(set);
+  }, [sessions]);
+
+  const allTags = useMemo(() => {
+    const set = new Set();
+    sessions.forEach((s) => {
+      (s.keywords || []).forEach((k) => k && set.add(k.trim()));
+      (s.tags || []).forEach((t) => t && set.add(t.trim()));
+    });
+    return Array.from(set).slice(0, 15);
+  }, [sessions]);
+
+  const stats = useMemo(() => {
+    const uniqueSpeakers = new Set();
+    sessions.forEach((s) => {
+      if (s.speaker && s.speaker.trim()) uniqueSpeakers.add(s.speaker.trim());
+    });
+    return {
+      totalCards: pagination.total || sessions.length,
+      speakers: uniqueSpeakers.size,
+      events: allEvents.length,
+    };
+  }, [sessions, pagination.total, allEvents]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-slate-800 dark:text-slate-200">
+      <Navbar />
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
+        {/* Header */}
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+          <div>
+            <div className="flex items-center gap-3">
+              <div className="p-2.5 bg-purple-100 dark:bg-purple-950/60 rounded-xl text-purple-600 dark:text-purple-400">
+                <Presentation size={28} />
+              </div>
+              <div>
+                <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white">
+                  Organization Session Cards
+                </h1>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Shared library of conference sessions, speaker profiles, and
+                  AI-extracted summaries
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => fetchSessions()}
+              title="Refresh library"
+              className="p-2.5 bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-slate-800 text-gray-700 dark:text-gray-300 rounded-xl transition cursor-pointer"
+              aria-label="Refresh library"
+            >
+              <RefreshCw size={18} className={loading ? "animate-spin" : ""} />
+            </button>
+            <Link
+              to="/create-meeting?tab=session"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold rounded-xl shadow-sm transition"
+            >
+              <Plus size={18} />
+              <span>Generate Session Card</span>
+            </Link>
+          </div>
+        </div>
+
+        {/* Stats Strip */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+          <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-5 shadow-xs flex items-center gap-4">
+            <div className="p-3 bg-purple-50 dark:bg-purple-950/40 text-purple-600 dark:text-purple-400 rounded-xl">
+              <Sparkles size={24} />
+            </div>
+            <div>
+              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Total Session Cards
+              </p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {stats.totalCards}
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-5 shadow-xs flex items-center gap-4">
+            <div className="p-3 bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 rounded-xl">
+              <Users size={24} />
+            </div>
+            <div>
+              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Featured Speakers
+              </p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {stats.speakers}
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-5 shadow-xs flex items-center gap-4">
+            <div className="p-3 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-600 dark:text-emerald-400 rounded-xl">
+              <Building2 size={24} />
+            </div>
+            <div>
+              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                Conferences & Events
+              </p>
+              <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                {stats.events}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Search & Filter Toolbar */}
+        <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-4 md:p-6 mb-8 shadow-xs space-y-4">
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search
+                size={18}
+                className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400"
+              />
+              <input
+                type="text"
+                placeholder="Search session title, speaker, event, or keyword..."
+                value={searchQuery}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  setPage(1);
+                }}
+                className="w-full pl-10 pr-4 py-2.5 bg-gray-50 dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 text-gray-900 dark:text-white placeholder-gray-400"
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                >
+                  <X size={16} />
+                </button>
+              )}
+            </div>
+
+            {allEvents.length > 0 && (
+              <div className="w-full md:w-64">
+                <select
+                  value={selectedEvent}
+                  onChange={(e) => {
+                    setSelectedEvent(e.target.value);
+                    setPage(1);
+                  }}
+                  className="w-full px-3.5 py-2.5 bg-gray-50 dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 rounded-xl text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                >
+                  <option value="">All Conferences & Events</option>
+                  {allEvents.map((evt) => (
+                    <option key={evt} value={evt}>
+                      {evt}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          {/* Quick Tag Pills */}
+          {allTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-gray-100 dark:border-gray-800">
+              <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 flex items-center gap-1 mr-1">
+                <SlidersHorizontal size={12} /> Filter tags:
+              </span>
+              {selectedTag && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedTag("")}
+                  className="px-2.5 py-1 bg-purple-600 text-white rounded-full text-xs font-medium flex items-center gap-1"
+                >
+                  <span>{selectedTag}</span>
+                  <X size={12} />
+                </button>
+              )}
+              {allTags.map((tag) => {
+                if (tag === selectedTag) return null;
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => {
+                      setSelectedTag(tag);
+                      setPage(1);
+                    }}
+                    className="px-2.5 py-1 bg-gray-100 hover:bg-purple-100 dark:bg-gray-800 dark:hover:bg-purple-950/60 text-gray-600 hover:text-purple-700 dark:text-gray-400 dark:hover:text-purple-300 rounded-full text-xs font-medium transition cursor-pointer"
+                  >
+                    #{tag}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Gallery Content */}
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[1, 2, 3, 4, 5, 6].map((n) => (
+              <div
+                key={n}
+                className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-6 animate-pulse space-y-4"
+              >
+                <div className="h-6 bg-gray-200 dark:bg-gray-800 rounded-md w-3/4" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded-md w-1/2" />
+                <div className="h-20 bg-gray-100 dark:bg-gray-800/60 rounded-lg" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-800 rounded-md w-full" />
+              </div>
+            ))}
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-12 text-center shadow-xs">
+            <div className="w-16 h-16 bg-purple-100 dark:bg-purple-950/60 text-purple-600 dark:text-purple-400 rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <Presentation size={32} />
+            </div>
+            <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
+              No session cards found
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 max-w-md mx-auto mb-6">
+              {searchQuery || selectedTag || selectedEvent
+                ? "No session cards match your search criteria. Try clearing some filters."
+                : "Your organization doesn't have any session cards yet. Generate your first card from presentation slides or videos!"}
+            </p>
+            {searchQuery || selectedTag || selectedEvent ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchQuery("");
+                  setSelectedTag("");
+                  setSelectedEvent("");
+                }}
+                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-xl text-sm font-semibold transition cursor-pointer"
+              >
+                Clear all filters
+              </button>
+            ) : (
+              <Link
+                to="/create-meeting?tab=session"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-xl text-sm font-semibold shadow-sm transition"
+              >
+                <Plus size={18} />
+                <span>Generate New Session Card</span>
+              </Link>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {sessions.map((session, idx) => {
+              const cardId = session._id || session.id || `card-${idx}`;
+              return (
+                <div
+                  key={cardId}
+                  className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 rounded-2xl p-6 shadow-xs hover:shadow-md hover:border-purple-200 dark:hover:border-purple-800/80 transition flex flex-col justify-between"
+                >
+                  <div>
+                    {/* Card Top */}
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                      <div>
+                        {session.eventName && (
+                          <span className="inline-block px-2.5 py-0.5 bg-purple-50 dark:bg-purple-950/60 text-purple-700 dark:text-purple-300 border border-purple-200/60 dark:border-purple-800/60 text-xs font-semibold rounded-full mb-1.5">
+                            {session.eventName}
+                          </span>
+                        )}
+                        <h3 className="text-lg font-bold text-gray-900 dark:text-white line-clamp-2">
+                          {session.sessionTitle}
+                        </h3>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          handleDelete(cardId, session.sessionTitle)
+                        }
+                        title="Delete session card"
+                        className="text-gray-400 hover:text-red-600 dark:hover:text-red-400 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+                        aria-label="Delete session card"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+
+                    {/* Speaker info */}
+                    {session.speaker && (
+                      <div className="mb-3 p-3 bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-800 rounded-xl">
+                        <p className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-1.5">
+                          <Users
+                            size={14}
+                            className="text-purple-600 dark:text-purple-400"
+                          />
+                          <span>{session.speaker}</span>
+                        </p>
+                        {session.speakerTitle && (
+                          <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+                            {session.speakerTitle}
+                          </p>
+                        )}
+                        {session.speakerBio && (
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 italic line-clamp-2">
+                            {session.speakerBio}
+                          </p>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Summary */}
+                    <p className="text-xs text-gray-700 dark:text-gray-300 line-clamp-4 mb-4 leading-relaxed">
+                      {session.summary || "No summary provided."}
+                    </p>
+
+                    {/* Keywords */}
+                    {session.keywords && session.keywords.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5 mb-4">
+                        {session.keywords.slice(0, 5).map((keyword, i) => (
+                          <span
+                            key={i}
+                            className="px-2 py-0.5 bg-purple-50 dark:bg-purple-950/40 text-purple-700 dark:text-purple-300 text-[11px] font-medium rounded-md border border-purple-100 dark:border-purple-900/50 flex items-center gap-1"
+                          >
+                            <Tag size={10} /> {keyword}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Card Actions */}
+                  <div className="pt-4 border-t border-gray-100 dark:border-gray-800 flex items-center justify-between gap-2 mt-2">
+                    <div>
+                      {session.videoUrl && (
+                        <a
+                          href={session.videoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline font-medium"
+                        >
+                          <ExternalLink size={13} />
+                          <span>Video</span>
+                        </a>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleCopy(session, cardId)}
+                        title="Copy session details"
+                        className="p-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition text-xs font-medium"
+                      >
+                        {copiedId === cardId ? (
+                          <Check size={14} className="text-emerald-500" />
+                        ) : (
+                          <Copy size={14} />
+                        )}
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={() => handleReuse(session)}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-700 text-white text-xs font-semibold rounded-lg shadow-xs transition cursor-pointer"
+                      >
+                        <CalendarPlus size={14} />
+                        <span>Use in Draft</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {pagination.totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 mt-10">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-4 py-2 rounded-xl text-sm font-medium bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <span className="text-sm text-gray-600 dark:text-gray-400 px-3">
+              Page {page} of {pagination.totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={page >= pagination.totalPages}
+              onClick={() =>
+                setPage((p) => Math.min(pagination.totalPages, p + 1))
+              }
+              className="px-4 py-2 rounded-xl text-sm font-medium bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-800 disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default SessionGallery;

--- a/client/src/pages/__tests__/SessionGallery.test.jsx
+++ b/client/src/pages/__tests__/SessionGallery.test.jsx
@@ -1,0 +1,169 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import SessionGallery from "../SessionGallery";
+import { sessionCardApi } from "../../services";
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="mock-navbar">Navbar</div>,
+}));
+
+vi.mock("../../services", () => ({
+  sessionCardApi: {
+    getSessionCards: vi.fn(),
+    deleteSessionCard: vi.fn(),
+  },
+}));
+
+describe("SessionGallery Component (#2257)", () => {
+  const mockSessions = [
+    {
+      _id: "s1",
+      sessionTitle: "AI in Clinical Healthcare",
+      eventName: "HealthTech 2026",
+      speaker: "Dr. Sarah Connor",
+      speakerTitle: "Chief Medical Scientist",
+      speakerBio: "Leading researcher in AI diagnosis",
+      summary: "Overview of deep learning diagnostic pipelines and compliance.",
+      keywords: ["HealthAI", "DeepLearning", "Clinical"],
+      videoUrl: "https://example.com/video1.mp4",
+      createdAt: new Date().toISOString(),
+    },
+    {
+      _id: "s2",
+      sessionTitle: "Distributed Cloud Infrastructure",
+      eventName: "CloudSummit 2026",
+      speaker: "Alex Rivera",
+      speakerTitle: "Cloud Architect",
+      speakerBio: "Kubernetes core contributor",
+      summary: "Strategies for multi-region active-active cloud topologies.",
+      keywords: ["Kubernetes", "Cloud", "DevOps"],
+      videoUrl: null,
+      createdAt: new Date().toISOString(),
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders gallery header, stats, and session cards", async () => {
+    sessionCardApi.getSessionCards.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          sessions: mockSessions,
+          pagination: { total: 2, page: 1, limit: 24, totalPages: 1 },
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SessionGallery />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Organization Session Cards"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("AI in Clinical Healthcare")).toBeInTheDocument();
+    expect(
+      screen.getByText("Distributed Cloud Infrastructure"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Dr. Sarah Connor")).toBeInTheDocument();
+    expect(screen.getByText("Alex Rivera")).toBeInTheDocument();
+  });
+
+  it("handles search input filtering", async () => {
+    sessionCardApi.getSessionCards.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          sessions: [mockSessions[0]],
+          pagination: { total: 1, page: 1, limit: 24, totalPages: 1 },
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SessionGallery />
+      </MemoryRouter>,
+    );
+
+    const searchInput = screen.getByPlaceholderText(
+      /Search session title, speaker, event, or keyword.../i,
+    );
+    fireEvent.change(searchInput, { target: { value: "Clinical" } });
+
+    await waitFor(() => {
+      expect(sessionCardApi.getSessionCards).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: "Clinical",
+        }),
+      );
+    });
+  });
+
+  it("deletes a session card with confirmation", async () => {
+    sessionCardApi.getSessionCards.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          sessions: mockSessions,
+          pagination: { total: 2, page: 1, limit: 24, totalPages: 1 },
+        },
+      },
+    });
+    sessionCardApi.deleteSessionCard.mockResolvedValue({
+      data: { success: true },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <MemoryRouter>
+        <SessionGallery />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("AI in Clinical Healthcare")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", {
+      name: /Delete session card/i,
+    });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(sessionCardApi.deleteSessionCard).toHaveBeenCalledWith("s1");
+    });
+  });
+
+  it("renders empty state when no session cards exist", async () => {
+    sessionCardApi.getSessionCards.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          sessions: [],
+          pagination: { total: 0, page: 1, limit: 24, totalPages: 1 },
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SessionGallery />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("No session cards found")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -92,9 +92,26 @@ import TeamAvailability from "../pages/TeamAvailability.jsx";
 import ActionItemTemplates from "../pages/ActionItemTemplates.jsx";
 import IntegrationMarketplaceHub from "../pages/IntegrationMarketplaceHub.jsx";
 import SentimentTrends from "../pages/SentimentTrends.jsx";
+import SessionGallery from "../pages/SessionGallery.jsx";
 
 const ProtectedRoutes = (
   <React.Fragment>
+    <Route
+      path="/session-cards"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <SessionGallery />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/sessions/gallery"
+      element={
+        <ProtectedRoute resource="meetings" action="view">
+          <SessionGallery />
+        </ProtectedRoute>
+      }
+    />
     <Route
       path="/sentiment-trends"
       element={

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -43,3 +43,4 @@ export * from "./adminImportanceApi";
 export * from "./exportTemplateApi.js";
 export * from "./skillEndorsementApi";
 export * from "./slackApi";
+export * from "./sessionCardApi";

--- a/client/src/services/meetingApi.js
+++ b/client/src/services/meetingApi.js
@@ -5,6 +5,9 @@ export const meetingApi = {
   notifyLive: (data) => apiClient.post("/api/meetings/notify-live", data),
   generateSession: (formData, config) =>
     apiClient.post("/api/sessions/generate", formData, config),
+  getSessionCards: (params = {}) => apiClient.get("/api/sessions", { params }),
+  getSessionCardById: (id) => apiClient.get(`/api/sessions/${id}`),
+  deleteSessionCard: (id) => apiClient.delete(`/api/sessions/${id}`),
 
   uploadMeeting: (formData, config) =>
     apiClient.post("/api/meetings/upload", formData, config),

--- a/client/src/services/sessionCardApi.js
+++ b/client/src/services/sessionCardApi.js
@@ -1,0 +1,24 @@
+import apiClient from "./apiClient";
+
+export const sessionCardApi = {
+  // Generate session card from slides/video + metadata
+  generateSession: (formData, config) =>
+    apiClient.post("/api/sessions/generate", formData, config),
+
+  // Get all session cards with optional search, pagination, filter
+  getSessionCards: (params = {}) => apiClient.get("/api/sessions", { params }),
+
+  // Get session card by ID
+  getSessionCardById: (id) => apiClient.get(`/api/sessions/${id}`),
+
+  // Create manual session card
+  createSessionCard: (data) => apiClient.post("/api/sessions", data),
+
+  // Update session card
+  updateSessionCard: (id, data) => apiClient.patch(`/api/sessions/${id}`, data),
+
+  // Delete session card
+  deleteSessionCard: (id) => apiClient.delete(`/api/sessions/${id}`),
+};
+
+export default sessionCardApi;

--- a/scripts/validation/run-client-related-tests.mjs
+++ b/scripts/validation/run-client-related-tests.mjs
@@ -22,6 +22,26 @@ const ROOT_CLIENT_MAP = {
     "client/src/components/__tests__/OfflineBanner.test.jsx",
   "client/src/components/OfflineQueueInspector.jsx":
     "client/src/components/__tests__/OfflineQueueInspector.test.jsx",
+  "client/src/services/index.js":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/services/meetingApi.js":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/services/sessionCardApi.js":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/routes/ProtectedRoutes.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/components/Navbar.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/pages/CreateMeeting.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/pages/CreateMeeting/components/SessionCards/SessionCards.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
+  "client/src/pages/CreateMeeting/hooks/useSessionCards.js":
+    "client/src/pages/CreateMeeting/hooks/__tests__/useSessionCards.persistence.test.jsx",
+  "client/src/pages/SessionGallery.jsx":
+    "client/src/pages/__tests__/SessionGallery.test.jsx",
 };
 
 const directTests = [

--- a/scripts/validation/run-server-related-tests.mjs
+++ b/scripts/validation/run-server-related-tests.mjs
@@ -26,6 +26,7 @@ const VITEST_TEST_FILES = new Set([
   "server/tests/realtimeClerkAuthPhase4.test.js",
   "server/tests/sharedLinkAnalytics.test.js",
   "server/tests/meetingValidation.test.js",
+  "server/tests/sessionController.test.js",
 ]);
 const JEST_RELATED_IGNORE = [
   "tests/integration.test.js",
@@ -58,6 +59,9 @@ const vitestOwnedSources = new Set([
   "server/middleware/meetingValidation.js",
   "server/controllers/meetingSeriesController.js",
   "server/controllers/meetingController.js",
+  "server/controllers/sessionController.js",
+  "server/models/sessionCardModel.js",
+  "server/routes/sessionRoutes.js",
   "server/controllers/sharedLinkController.js",
   "server/models/sharedLinkModel.js",
   "server/config/express.js",
@@ -79,6 +83,10 @@ const VITEST_SOURCE_TEST_MAP = {
     "server/tests/meetingValidation.test.js",
   "server/controllers/meetingSeriesController.js":
     "server/tests/meetingValidation.test.js",
+  "server/controllers/sessionController.js":
+    "server/tests/sessionController.test.js",
+  "server/models/sessionCardModel.js": "server/tests/sessionController.test.js",
+  "server/routes/sessionRoutes.js": "server/tests/sessionController.test.js",
   "server/controllers/meetingController.js":
     "server/tests/MeetingService.test.js",
   "server/services/MeetingService.js": "server/tests/MeetingService.test.js",

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -1,7 +1,8 @@
+import SessionCard from "../models/sessionCardModel.js";
 import { generateSessionCardAI } from "../services/GenerativeAIService.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
 
-// @desc    Generate AI Session Card
+// @desc    Generate AI Session Card & Persist to Org Library
 // @route   POST /api/sessions/generate
 // @access  Private
 export const generateSession = async (req, res) => {
@@ -20,6 +21,12 @@ export const generateSession = async (req, res) => {
       ? `/uploads/sessions/${videoFile.filename}`
       : null;
 
+    const slideFiles =
+      req.files && req.files["slides"] ? req.files["slides"] : [];
+    const slideUrls = slideFiles.map(
+      (file) => `/uploads/sessions/${file.filename}`,
+    );
+
     const { summary, keywords } = await generateSessionCardAI(
       eventName ? eventName.trim() : "",
       sessionTitle.trim(),
@@ -28,23 +35,279 @@ export const generateSession = async (req, res) => {
       speakerBio ? speakerBio.trim() : "",
     );
 
+    const organization = req.user?.organization || null;
+    const createdBy = req.user?._id || req.user?.id || null;
+
+    let savedSession = null;
+    if (organization && createdBy) {
+      savedSession = await SessionCard.create({
+        organization,
+        createdBy,
+        eventName: eventName ? eventName.trim() : "",
+        sessionTitle: sessionTitle.trim(),
+        speaker: speaker ? speaker.trim() : "",
+        speakerTitle: speakerTitle ? speakerTitle.trim() : "",
+        speakerBio: speakerBio ? speakerBio.trim() : "",
+        summary: summary || "",
+        keywords: Array.isArray(keywords) ? keywords : [],
+        videoUrl,
+        slideUrls,
+      });
+    }
+
     return sendSuccess(
       res,
       {
-        session: {
+        session: savedSession || {
           eventName: eventName ? eventName.trim() : "",
           sessionTitle: sessionTitle.trim(),
           speaker: speaker ? speaker.trim() : "",
           speakerTitle: speakerTitle ? speakerTitle.trim() : "",
+          speakerBio: speakerBio ? speakerBio.trim() : "",
           summary,
           keywords,
           videoUrl,
+          slideUrls,
         },
       },
-      "Session card generated successfully.",
+      "Session card generated and saved successfully.",
+      201,
     );
   } catch (error) {
     console.error("Error in generateSession controller:", error);
     return sendError(res, 500, "Failed to generate session card.");
+  }
+};
+
+// @desc    Get all session cards for the user's organization with search and pagination
+// @route   GET /api/sessions
+// @access  Private
+export const getSessions = async (req, res) => {
+  try {
+    const orgId = req.user?.organization;
+    if (!orgId) {
+      return sendError(
+        res,
+        400,
+        "User is not associated with an organization.",
+      );
+    }
+
+    const { page = 1, limit = 20, search, q, event, tag } = req.query;
+
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limitNum = Math.max(1, Math.min(100, parseInt(limit, 10) || 20));
+    const skip = (pageNum - 1) * limitNum;
+
+    const filter = { organization: orgId };
+
+    const searchTerm = (search || q || "").trim();
+    if (searchTerm) {
+      const searchRegex = new RegExp(
+        searchTerm.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"),
+        "i",
+      );
+      filter.$or = [
+        { sessionTitle: searchRegex },
+        { eventName: searchRegex },
+        { speaker: searchRegex },
+        { speakerTitle: searchRegex },
+        { summary: searchRegex },
+        { keywords: searchRegex },
+        { tags: searchRegex },
+      ];
+    }
+
+    if (event && event.trim()) {
+      filter.eventName = new RegExp(`^${event.trim()}$`, "i");
+    }
+
+    if (tag && tag.trim()) {
+      filter.$or = filter.$or || [];
+      filter.$or.push(
+        { keywords: new RegExp(`^${tag.trim()}$`, "i") },
+        { tags: new RegExp(`^${tag.trim()}$`, "i") },
+      );
+    }
+
+    const [sessions, total] = await Promise.all([
+      SessionCard.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limitNum)
+        .populate("createdBy", "name email imageUrl")
+        .lean(),
+      SessionCard.countDocuments(filter),
+    ]);
+
+    return sendSuccess(
+      res,
+      {
+        sessions,
+        pagination: {
+          total,
+          page: pageNum,
+          limit: limitNum,
+          totalPages: Math.ceil(total / limitNum) || 1,
+        },
+      },
+      "Session cards retrieved successfully.",
+    );
+  } catch (error) {
+    console.error("Error in getSessions controller:", error);
+    return sendError(res, 500, "Failed to retrieve session cards.");
+  }
+};
+
+// @desc    Get session card by ID
+// @route   GET /api/sessions/:id
+// @access  Private
+export const getSessionById = async (req, res) => {
+  try {
+    const orgId = req.user?.organization;
+    const session = await SessionCard.findOne({
+      _id: req.params.id,
+      organization: orgId,
+    })
+      .populate("createdBy", "name email imageUrl")
+      .lean();
+
+    if (!session) {
+      return sendError(res, 404, "Session card not found.");
+    }
+
+    return sendSuccess(
+      res,
+      { session },
+      "Session card retrieved successfully.",
+    );
+  } catch (error) {
+    console.error("Error in getSessionById controller:", error);
+    return sendError(res, 500, "Failed to retrieve session card.");
+  }
+};
+
+// @desc    Create manual session card
+// @route   POST /api/sessions
+// @access  Private
+export const createSession = async (req, res) => {
+  try {
+    const orgId = req.user?.organization;
+    const userId = req.user?._id || req.user?.id;
+
+    if (!orgId) {
+      return sendError(
+        res,
+        400,
+        "User is not associated with an organization.",
+      );
+    }
+
+    const {
+      eventName,
+      sessionTitle,
+      speaker,
+      speakerTitle,
+      speakerBio,
+      summary,
+      keywords,
+      videoUrl,
+      slideUrls,
+      tags,
+    } = req.body;
+
+    if (!sessionTitle || !sessionTitle.trim()) {
+      return sendError(res, 400, "Session title is required.");
+    }
+
+    const session = await SessionCard.create({
+      organization: orgId,
+      createdBy: userId,
+      eventName: eventName ? eventName.trim() : "",
+      sessionTitle: sessionTitle.trim(),
+      speaker: speaker ? speaker.trim() : "",
+      speakerTitle: speakerTitle ? speakerTitle.trim() : "",
+      speakerBio: speakerBio ? speakerBio.trim() : "",
+      summary: summary || "",
+      keywords: Array.isArray(keywords) ? keywords : [],
+      videoUrl: videoUrl || null,
+      slideUrls: Array.isArray(slideUrls) ? slideUrls : [],
+      tags: Array.isArray(tags) ? tags : [],
+    });
+
+    return sendSuccess(
+      res,
+      { session },
+      "Session card created successfully.",
+      201,
+    );
+  } catch (error) {
+    console.error("Error in createSession controller:", error);
+    return sendError(res, 500, "Failed to create session card.");
+  }
+};
+
+// @desc    Update session card
+// @route   PATCH /api/sessions/:id
+// @access  Private
+export const updateSession = async (req, res) => {
+  try {
+    const orgId = req.user?.organization;
+    const session = await SessionCard.findOne({
+      _id: req.params.id,
+      organization: orgId,
+    });
+
+    if (!session) {
+      return sendError(res, 404, "Session card not found.");
+    }
+
+    const allowedUpdates = [
+      "eventName",
+      "sessionTitle",
+      "speaker",
+      "speakerTitle",
+      "speakerBio",
+      "summary",
+      "keywords",
+      "videoUrl",
+      "slideUrls",
+      "tags",
+    ];
+
+    allowedUpdates.forEach((field) => {
+      if (req.body[field] !== undefined) {
+        session[field] = req.body[field];
+      }
+    });
+
+    await session.save();
+
+    return sendSuccess(res, { session }, "Session card updated successfully.");
+  } catch (error) {
+    console.error("Error in updateSession controller:", error);
+    return sendError(res, 500, "Failed to update session card.");
+  }
+};
+
+// @desc    Delete session card
+// @route   DELETE /api/sessions/:id
+// @access  Private
+export const deleteSession = async (req, res) => {
+  try {
+    const orgId = req.user?.organization;
+    const session = await SessionCard.findOneAndDelete({
+      _id: req.params.id,
+      organization: orgId,
+    });
+
+    if (!session) {
+      return sendError(res, 404, "Session card not found.");
+    }
+
+    return sendSuccess(res, null, "Session card deleted successfully.");
+  } catch (error) {
+    console.error("Error in deleteSession controller:", error);
+    return sendError(res, 500, "Failed to delete session card.");
   }
 };

--- a/server/models/sessionCardModel.js
+++ b/server/models/sessionCardModel.js
@@ -1,0 +1,81 @@
+import mongoose from "mongoose";
+
+const sessionCardSchema = new mongoose.Schema(
+  {
+    organization: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Organization",
+      required: true,
+      index: true,
+    },
+    createdBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    eventName: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    sessionTitle: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    speaker: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    speakerTitle: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    speakerBio: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    summary: {
+      type: String,
+      default: "",
+    },
+    keywords: {
+      type: [String],
+      default: [],
+    },
+    videoUrl: {
+      type: String,
+      default: null,
+    },
+    slideUrls: {
+      type: [String],
+      default: [],
+    },
+    tags: {
+      type: [String],
+      default: [],
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+sessionCardSchema.index({ organization: 1, createdAt: -1 });
+sessionCardSchema.index({
+  sessionTitle: "text",
+  eventName: "text",
+  speaker: "text",
+  summary: "text",
+  keywords: "text",
+});
+
+const SessionCard =
+  mongoose.models.SessionCard ||
+  mongoose.model("SessionCard", sessionCardSchema);
+
+export default SessionCard;

--- a/server/routes/sessionRoutes.js
+++ b/server/routes/sessionRoutes.js
@@ -1,5 +1,12 @@
 import express from "express";
-import { generateSession } from "../controllers/sessionController.js";
+import {
+  generateSession,
+  getSessions,
+  getSessionById,
+  createSession,
+  updateSession,
+  deleteSession,
+} from "../controllers/sessionController.js";
 import userAuth from "../middleware/userAuth.js";
 import { writeLimiter } from "../middleware/rateLimiter.js";
 import { requirePermission, requireOrgMembership } from "../middleware/rbac.js";
@@ -51,7 +58,7 @@ const handleMulterUpload = (req, res, next) => {
   });
 };
 
-// Generate session card
+// Generate AI session card and persist
 router.post(
   "/generate",
   userAuth,
@@ -60,6 +67,63 @@ router.post(
   writeLimiter,
   handleMulterUpload,
   generateSession,
+);
+
+// List session cards for org
+router.get(
+  "/",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getSessions,
+);
+
+// Get single session card by ID
+router.get(
+  "/:id",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "view"),
+  getSessionById,
+);
+
+// Create session card manually
+router.post(
+  "/",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "create"),
+  writeLimiter,
+  createSession,
+);
+
+// Update session card
+router.patch(
+  "/:id",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "edit"),
+  writeLimiter,
+  updateSession,
+);
+
+router.put(
+  "/:id",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "edit"),
+  writeLimiter,
+  updateSession,
+);
+
+// Delete session card
+router.delete(
+  "/:id",
+  userAuth,
+  requireOrgMembership,
+  requirePermission("meetings", "delete"),
+  writeLimiter,
+  deleteSession,
 );
 
 export default router;

--- a/server/tests/sessionController.test.js
+++ b/server/tests/sessionController.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock GenerativeAIService
+vi.mock("../services/GenerativeAIService.js", () => ({
+  generateSessionCardAI: vi.fn().mockResolvedValue({
+    summary: "AI extracted keynote summary",
+    keywords: ["AI", "Healthcare", "Innovation"],
+  }),
+}));
+
+// Mock SessionCard model
+const mockSessionCardStore = [];
+let idCounter = 1;
+
+vi.mock("../models/sessionCardModel.js", () => {
+  const MockModel = {
+    create: vi.fn(async (data) => {
+      const created = {
+        _id: `session-${idCounter++}`,
+        ...data,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockSessionCardStore.push(created);
+      return created;
+    }),
+    find: vi.fn((filter) => {
+      let results = [...mockSessionCardStore];
+      if (filter.organization) {
+        results = results.filter(
+          (s) => s.organization.toString() === filter.organization.toString(),
+        );
+      }
+      if (filter.$or) {
+        // Simple search mock
+        results = results.filter((s) => {
+          return filter.$or.some((condition) => {
+            const field = Object.keys(condition)[0];
+            const regex = condition[field];
+            if (Array.isArray(s[field])) {
+              return s[field].some((item) => regex.test(item));
+            }
+            return (
+              regex && typeof s[field] === "string" && regex.test(s[field])
+            );
+          });
+        });
+      }
+      return {
+        sort: () => ({
+          skip: (skipCount) => ({
+            limit: (limitCount) => ({
+              populate: () => ({
+                lean: async () =>
+                  results.slice(skipCount, skipCount + limitCount),
+              }),
+            }),
+          }),
+        }),
+      };
+    }),
+    countDocuments: vi.fn(async (filter) => {
+      let results = [...mockSessionCardStore];
+      if (filter.organization) {
+        results = results.filter(
+          (s) => s.organization.toString() === filter.organization.toString(),
+        );
+      }
+      return results.length;
+    }),
+    findOne: vi.fn((filter) => ({
+      populate: () => ({
+        lean: async () =>
+          mockSessionCardStore.find(
+            (s) =>
+              s._id === filter._id &&
+              s.organization.toString() === filter.organization.toString(),
+          ) || null,
+      }),
+      save: async function () {
+        return this;
+      },
+    })),
+    findOneAndDelete: vi.fn(async (filter) => {
+      const idx = mockSessionCardStore.findIndex(
+        (s) =>
+          s._id === filter._id &&
+          s.organization.toString() === filter.organization.toString(),
+      );
+      if (idx !== -1) {
+        const removed = mockSessionCardStore.splice(idx, 1)[0];
+        return removed;
+      }
+      return null;
+    }),
+  };
+  return { default: MockModel };
+});
+
+import {
+  generateSession,
+  getSessions,
+  getSessionById,
+  createSession,
+  updateSession,
+  deleteSession,
+} from "../controllers/sessionController.js";
+
+describe("Session Controller Persistence & Org Library (#2257)", () => {
+  beforeEach(() => {
+    mockSessionCardStore.length = 0;
+    idCounter = 1;
+    vi.clearAllMocks();
+  });
+
+  it("generates session card and persists to SessionCard model with user org", async () => {
+    const req = {
+      body: {
+        eventName: "TechSummit 2026",
+        sessionTitle: "Scaling Node.js Microservices",
+        speaker: "Jane Doe",
+        speakerTitle: "Principal Engineer",
+        speakerBio: "Expert in backend architecture",
+      },
+      user: {
+        _id: "user-123",
+        organization: "org-456",
+      },
+      files: {},
+    };
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await generateSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        session: expect.objectContaining({
+          sessionTitle: "Scaling Node.js Microservices",
+          eventName: "TechSummit 2026",
+          speaker: "Jane Doe",
+          summary: "AI extracted keynote summary",
+          keywords: ["AI", "Healthcare", "Innovation"],
+        }),
+      }),
+    );
+
+    expect(mockSessionCardStore).toHaveLength(1);
+    expect(mockSessionCardStore[0].organization).toBe("org-456");
+  });
+
+  it("lists saved session cards for the user's organization with pagination", async () => {
+    mockSessionCardStore.push({
+      _id: "session-1",
+      organization: "org-456",
+      sessionTitle: "Keynote 1",
+      eventName: "Event A",
+      speaker: "Speaker 1",
+      keywords: ["AI"],
+      createdAt: new Date(),
+    });
+
+    const req = {
+      user: { organization: "org-456" },
+      query: { page: "1", limit: "10" },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await getSessions(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        sessions: expect.arrayContaining([
+          expect.objectContaining({ sessionTitle: "Keynote 1" }),
+        ]),
+        pagination: expect.objectContaining({
+          total: 1,
+          page: 1,
+          limit: 10,
+        }),
+      }),
+    );
+  });
+
+  it("retrieves a single session card by ID scoped to org", async () => {
+    mockSessionCardStore.push({
+      _id: "session-1",
+      organization: "org-456",
+      sessionTitle: "Deep Dive into ML",
+      createdAt: new Date(),
+    });
+
+    const req = {
+      user: { organization: "org-456" },
+      params: { id: "session-1" },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await getSessionById(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        session: expect.objectContaining({
+          sessionTitle: "Deep Dive into ML",
+        }),
+      }),
+    );
+  });
+
+  it("creates a manual session card", async () => {
+    const req = {
+      user: { _id: "user-1", organization: "org-456" },
+      body: {
+        sessionTitle: "Manual Architecture Review",
+        eventName: "Internal Workshop",
+        speaker: "John Smith",
+        summary: "Discussion on system boundaries",
+        keywords: ["Architecture", "Design"],
+      },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await createSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        session: expect.objectContaining({
+          sessionTitle: "Manual Architecture Review",
+        }),
+      }),
+    );
+  });
+
+  it("deletes a session card scoped to organization", async () => {
+    mockSessionCardStore.push({
+      _id: "session-to-del",
+      organization: "org-456",
+      sessionTitle: "To Delete",
+    });
+
+    const req = {
+      user: { organization: "org-456" },
+      params: { id: "session-to-del" },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await deleteSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockSessionCardStore).toHaveLength(0);
+  });
+});


### PR DESCRIPTION

### Summary of Changes

Closes #2257

This PR introduces full database persistence and an Organization Gallery library for conference session cards. Previously, generated session cards lived only in ephemeral component state and were lost on page reload. Now, session cards are persisted in MongoDB scoped to the organization, survive browser refresh, can be browsed/searched/filtered in a dedicated Org Gallery, and can be reused into new meeting drafts with one click.

---

### Key Highlights & Changes

#### 1. Database Model & Persistence
- **`server/models/sessionCardModel.js`**: Created `SessionCard` schema storing cards scoped to organizations (`organization`), creators (`createdBy`), event name, session title, speaker profile (name, title, bio), AI summary, keywords, video and slide URLs, and tags. Compound indexes added for `{ organization: 1, createdAt: -1 }` and text search.

#### 2. Org-Scoped Backend CRUD Routes
- **`server/controllers/sessionController.js` & `server/routes/sessionRoutes.js`**:
  - `POST /api/sessions/generate`: Generates AI summary & keywords and automatically persists the card to MongoDB under `req.user.organization`.
  - `GET /api/sessions`: Lists saved cards for the user's active organization with search (`q` / `search`), event/tag filtering, and pagination.
  - `GET /api/sessions/:id`: Retrieves a single session card with multi-tenant org validation.
  - `POST /api/sessions`: Creates manual session cards.
  - `PATCH /api/sessions/:id` / `PUT /api/sessions/:id`: Updates session cards.
  - `DELETE /api/sessions/:id`: Deletes session cards scoped to organization.
  - Protected with `userAuth`, `requireOrgMembership`, and RBAC permissions.

#### 3. Frontend API Client & State Sync
- **`client/src/services/sessionCardApi.js` & `client/src/services/index.js`**: Added client endpoints for session card CRUD operations.
- **`client/src/pages/CreateMeeting/hooks/useSessionCards.js`**: Fetches existing saved cards on mount (persisting across page reloads) and provides instant card generation and deletion methods.

#### 4. Organization Gallery & Draft Reuse
- **`client/src/pages/SessionGallery.jsx`** (`/session-cards` & `/sessions/gallery`):
  - Dedicated gallery page featuring live debounced search across session titles, speakers, events, and keywords.
  - Interactive tag pills and event filter dropdown.
  - Stats overview (Total Session Cards, Featured Speakers, Conferences & Events).
  - One-click **"Use in Draft"** action that opens the Schedule Meeting form with title, objective, venue, and tags pre-populated.
  - Copy details to clipboard and card deletion with confirmation.
- **`client/src/pages/CreateMeeting.jsx`**: Added support for `fromSessionCard=<id>` and `tab=session` query parameters.
- **`client/src/pages/CreateMeeting/components/SessionCards/GeneratedSessionCards.jsx` & `SessionCards.jsx`**: Added quick actions for "Use as Meeting Draft", "Copy Details", "Delete Card", and link to the Org Gallery.
- **`client/src/routes/ProtectedRoutes.jsx` & `client/src/components/Navbar.jsx`**: Registered `/session-cards` route and added "Session Cards" link under the Navbar Meetings group.

---

### Verification & Tests

- **Server Unit Tests**: `server/tests/sessionController.test.js` (5/5 tests passing: generate & persist, org-scoped list & pagination, get by ID, manual create, and delete).
- **Client Unit Tests**:
  - `client/src/pages/__tests__/SessionGallery.test.jsx` (4/4 tests passing: rendering, search filtering, deletion, and empty state).
  - `client/src/pages/CreateMeeting/hooks/__tests__/useSessionCards.persistence.test.jsx` (2/2 tests passing: auto-loading saved cards on mount and deleting cards).
- **Validation Suite**: `npm run validate` passed 100% (Prettier, ESLint, Server Tests, Client Tests, and Production Vite Build).


```