### PR TITLE
Testimonials moderation bulk actions + homepage spotlight curation (#2266)

### DIFF
--- a/client/src/components/TestimonialsSection.jsx
+++ b/client/src/components/TestimonialsSection.jsx
@@ -38,8 +38,8 @@ export default function TestimonialsSection() {
       try {
         setLoading(true);
         setError(null);
-        const { data } = await apiClient.get("/api/testimonials", {
-          params: { limit: 12, page: 1 },
+        const { data } = await apiClient.get("/api/testimonials/spotlight", {
+          params: { limit: 12 },
         });
         if (!cancelled) {
           setTestimonials(data.testimonials || []);

--- a/client/src/components/admin/TestimonialsModeration.jsx
+++ b/client/src/components/admin/TestimonialsModeration.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import apiClient from "../../services/apiClient.js";
 import StarRating from "../testimonials/StarRating.jsx";
@@ -11,6 +11,8 @@ export default function TestimonialsModeration() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [busyId, setBusyId] = useState(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [selectedIds, setSelectedIds] = useState([]);
 
   const load = useCallback(async () => {
     try {
@@ -22,6 +24,7 @@ export default function TestimonialsModeration() {
         params,
       });
       setItems(data.testimonials || []);
+      setSelectedIds([]);
     } catch {
       setError("Unable to load testimonials for moderation.");
       setItems([]);
@@ -33,6 +36,25 @@ export default function TestimonialsModeration() {
   useEffect(() => {
     load();
   }, [load]);
+
+  const allSelected = useMemo(
+    () => items.length > 0 && selectedIds.length === items.length,
+    [items, selectedIds],
+  );
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id],
+    );
+  };
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds([]);
+      return;
+    }
+    setSelectedIds(items.map((item) => item.id));
+  };
 
   const updateStatus = async (id, nextStatus) => {
     setBusyId(id);
@@ -67,6 +89,59 @@ export default function TestimonialsModeration() {
     }
   };
 
+  const runBulk = async (action) => {
+    if (!selectedIds.length) {
+      toast.info("Select at least one testimonial");
+      return;
+    }
+    if (
+      action === "delete" &&
+      !window.confirm(
+        `Remove ${selectedIds.length} selected testimonial(s) permanently?`,
+      )
+    ) {
+      return;
+    }
+
+    setBulkBusy(true);
+    try {
+      const { data } = await apiClient.post("/api/admin/testimonials/bulk", {
+        ids: selectedIds,
+        action,
+      });
+      toast.success(data.message || "Bulk action applied");
+      await load();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to apply bulk action",
+      );
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  const updateSpotlight = async (item, next) => {
+    setBusyId(item.id);
+    try {
+      await apiClient.patch(
+        `/api/admin/testimonials/${item.id}/spotlight`,
+        next,
+      );
+      toast.success(
+        next.featuredOnHomepage
+          ? "Featured on homepage"
+          : "Removed from homepage spotlight",
+      );
+      await load();
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.message || "Failed to update homepage spotlight",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div
@@ -89,6 +164,44 @@ export default function TestimonialsModeration() {
           </button>
         ))}
       </div>
+
+      {!loading && !error && items.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/60 px-3 py-2">
+          <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleSelectAll}
+              aria-label="Select all testimonials"
+            />
+            Select all ({selectedIds.length})
+          </label>
+          <button
+            type="button"
+            disabled={bulkBusy || !selectedIds.length}
+            onClick={() => runBulk("approve")}
+            className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-emerald-600 text-white disabled:opacity-50 cursor-pointer"
+          >
+            Bulk approve
+          </button>
+          <button
+            type="button"
+            disabled={bulkBusy || !selectedIds.length}
+            onClick={() => runBulk("reject")}
+            className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-amber-500 text-white disabled:opacity-50 cursor-pointer"
+          >
+            Bulk reject
+          </button>
+          <button
+            type="button"
+            disabled={bulkBusy || !selectedIds.length}
+            onClick={() => runBulk("delete")}
+            className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-rose-600 text-white disabled:opacity-50 cursor-pointer"
+          >
+            Bulk delete
+          </button>
+        </div>
+      ) : null}
 
       {loading ? (
         <div className="space-y-3" aria-busy="true">
@@ -117,10 +230,21 @@ export default function TestimonialsModeration() {
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2 mb-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.includes(item.id)}
+                      onChange={() => toggleSelect(item.id)}
+                      aria-label={`Select testimonial by ${item.user?.name || "user"}`}
+                    />
                     <StarRating value={item.rating} readOnly size="sm" />
                     <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                       {item.status}
                     </span>
+                    {item.featuredOnHomepage ? (
+                      <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-400">
+                        Spotlight #{item.spotlightOrder ?? 0}
+                      </span>
+                    ) : null}
                   </div>
                   <p className="text-sm text-slate-800 dark:text-slate-200">
                     &ldquo;{item.comment}&rdquo;
@@ -156,6 +280,55 @@ export default function TestimonialsModeration() {
                     >
                       Reject
                     </button>
+                  ) : null}
+                  {item.status === "approved" ? (
+                    <>
+                      <button
+                        type="button"
+                        disabled={busyId === item.id}
+                        onClick={() =>
+                          updateSpotlight(item, {
+                            featuredOnHomepage: !item.featuredOnHomepage,
+                            spotlightOrder: item.spotlightOrder || 0,
+                          })
+                        }
+                        className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-indigo-600 text-white disabled:opacity-50 cursor-pointer"
+                      >
+                        {item.featuredOnHomepage
+                          ? "Unfeature"
+                          : "Feature on homepage"}
+                      </button>
+                      {item.featuredOnHomepage ? (
+                        <label className="inline-flex items-center gap-1 text-xs text-slate-600 dark:text-slate-300">
+                          Order
+                          <input
+                            type="number"
+                            min={0}
+                            max={9999}
+                            defaultValue={item.spotlightOrder || 0}
+                            disabled={busyId === item.id}
+                            onBlur={(e) => {
+                              const nextOrder = Number(e.target.value);
+                              if (
+                                !Number.isFinite(nextOrder) ||
+                                nextOrder === (item.spotlightOrder || 0)
+                              ) {
+                                return;
+                              }
+                              updateSpotlight(item, {
+                                featuredOnHomepage: true,
+                                spotlightOrder: Math.max(
+                                  0,
+                                  Math.floor(nextOrder),
+                                ),
+                              });
+                            }}
+                            className="w-16 rounded-md border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1"
+                            aria-label="Homepage spotlight order"
+                          />
+                        </label>
+                      ) : null}
+                    </>
                   ) : null}
                   <button
                     type="button"

--- a/client/src/components/admin/__tests__/TestimonialsModeration.test.jsx
+++ b/client/src/components/admin/__tests__/TestimonialsModeration.test.jsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import TestimonialsModeration from "../TestimonialsModeration.jsx";
+import apiClient from "../../../services/apiClient.js";
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+describe("TestimonialsModeration (#2266)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({
+      data: {
+        testimonials: [
+          {
+            id: "t1",
+            rating: 5,
+            comment: "Pending review content here",
+            status: "pending",
+            user: { name: "Ada" },
+            organization: null,
+            createdAt: "2026-08-01T00:00:00.000Z",
+            featuredOnHomepage: false,
+            spotlightOrder: 0,
+          },
+          {
+            id: "t2",
+            rating: 4,
+            comment: "Another pending review content",
+            status: "pending",
+            user: { name: "Grace" },
+            organization: null,
+            createdAt: "2026-08-02T00:00:00.000Z",
+            featuredOnHomepage: false,
+            spotlightOrder: 0,
+          },
+        ],
+      },
+    });
+    apiClient.post.mockResolvedValue({
+      data: { success: true, message: "Marked 2 testimonial(s) as approved" },
+    });
+  });
+
+  it("sends bulk approve for selected rows", async () => {
+    render(<TestimonialsModeration />);
+
+    expect(
+      await screen.findByText(/Pending review content here/i),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Select all testimonials"));
+    fireEvent.click(screen.getByRole("button", { name: /Bulk approve/i }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/admin/testimonials/bulk",
+        {
+          ids: ["t1", "t2"],
+          action: "approve",
+        },
+      );
+    });
+  });
+});

--- a/client/src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx
+++ b/client/src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx
@@ -105,9 +105,12 @@ describe("TestimonialsSection", () => {
     );
 
     await waitFor(() => {
-      expect(apiClient.get).toHaveBeenCalledWith("/api/testimonials", {
-        params: { limit: 12, page: 1 },
-      });
+      expect(apiClient.get).toHaveBeenCalledWith(
+        "/api/testimonials/spotlight",
+        {
+          params: { limit: 12 },
+        },
+      );
     });
 
     expect(await screen.findByText("Share Your Experience")).toBeTruthy();

--- a/server/controllers/testimonialController.js
+++ b/server/controllers/testimonialController.js
@@ -54,6 +54,24 @@ const toAdminTestimonial = (doc) => ({
   userId: doc.user?._id || doc.user,
   moderatedAt: doc.moderatedAt,
   moderatedBy: doc.moderatedBy,
+  featuredOnHomepage: Boolean(doc.featuredOnHomepage),
+  spotlightOrder: Number.isFinite(doc.spotlightOrder) ? doc.spotlightOrder : 0,
+});
+
+const idsSchema = z.object({
+  ids: z
+    .array(z.string().refine((id) => mongoose.isValidObjectId(id)))
+    .min(1, "Select at least one testimonial")
+    .max(100),
+});
+
+const bulkActionSchema = idsSchema.extend({
+  action: z.enum(["approve", "reject", "delete"]),
+});
+
+const spotlightSchema = z.object({
+  featuredOnHomepage: z.boolean(),
+  spotlightOrder: z.coerce.number().int().min(0).max(9999).optional(),
 });
 
 const populatePublic = (query) =>
@@ -100,6 +118,50 @@ export const listApprovedTestimonials = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to load testimonials",
+    });
+  }
+};
+
+/**
+ * GET /api/testimonials/spotlight
+ * Approved testimonials curated for the marketing homepage.
+ * Falls back to recent approved items when no spotlight is set.
+ */
+export const listSpotlightTestimonials = async (req, res) => {
+  try {
+    const limit = Math.min(
+      24,
+      Math.max(1, parseInt(req.query.limit, 10) || 12),
+    );
+
+    const spotlightFilter = {
+      status: "approved",
+      featuredOnHomepage: true,
+    };
+
+    let items = await populatePublic(
+      Testimonial.find(spotlightFilter)
+        .sort({ spotlightOrder: 1, createdAt: -1 })
+        .limit(limit),
+    ).lean();
+
+    if (!items.length) {
+      items = await populatePublic(
+        Testimonial.find({ status: "approved" })
+          .sort({ createdAt: -1 })
+          .limit(limit),
+      ).lean();
+    }
+
+    return res.status(200).json({
+      success: true,
+      testimonials: items.map(toPublicTestimonial),
+    });
+  } catch (error) {
+    console.error("Error listing spotlight testimonials:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load homepage testimonials",
     });
   }
 };
@@ -274,6 +336,8 @@ export const updateTestimonial = async (req, res) => {
     existing.status = "pending";
     existing.moderatedAt = null;
     existing.moderatedBy = null;
+    existing.featuredOnHomepage = false;
+    existing.spotlightOrder = 0;
     await existing.save();
 
     const doc = await populatePublic(Testimonial.findById(existing._id)).lean();
@@ -415,6 +479,10 @@ export const updateTestimonialStatus = async (req, res) => {
     existing.status = parsed.data.status;
     existing.moderatedBy = req.user._id || req.user.id;
     existing.moderatedAt = new Date();
+    if (parsed.data.status !== "approved") {
+      existing.featuredOnHomepage = false;
+      existing.spotlightOrder = 0;
+    }
     await existing.save();
 
     const doc = await populatePublic(Testimonial.findById(existing._id)).lean();
@@ -429,6 +497,128 @@ export const updateTestimonialStatus = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to update moderation status",
+    });
+  }
+};
+
+/**
+ * POST /api/admin/testimonials/bulk
+ * Bulk approve, reject, or delete testimonials.
+ */
+export const bulkModerateTestimonials = async (req, res) => {
+  try {
+    const parsed = bulkActionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message: parsed.error.issues[0]?.message || "Invalid bulk action",
+      });
+    }
+
+    const { ids, action } = parsed.data;
+    const moderatorId = req.user._id || req.user.id;
+    const now = new Date();
+
+    if (action === "delete") {
+      const result = await Testimonial.deleteMany({ _id: { $in: ids } });
+      return res.status(200).json({
+        success: true,
+        message: `Removed ${result.deletedCount} testimonial(s)`,
+        modifiedCount: result.deletedCount,
+      });
+    }
+
+    const nextStatus = action === "approve" ? "approved" : "rejected";
+    const update = {
+      status: nextStatus,
+      moderatedBy: moderatorId,
+      moderatedAt: now,
+    };
+    if (nextStatus !== "approved") {
+      update.featuredOnHomepage = false;
+      update.spotlightOrder = 0;
+    }
+
+    const result = await Testimonial.updateMany(
+      { _id: { $in: ids } },
+      { $set: update },
+    );
+
+    return res.status(200).json({
+      success: true,
+      message: `Marked ${result.modifiedCount} testimonial(s) as ${nextStatus}`,
+      modifiedCount: result.modifiedCount,
+    });
+  } catch (error) {
+    console.error("Error bulk-moderating testimonials:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to apply bulk moderation action",
+    });
+  }
+};
+
+/**
+ * PATCH /api/admin/testimonials/:id/spotlight
+ * Feature an approved testimonial on the homepage and set order.
+ */
+export const updateTestimonialSpotlight = async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid testimonial id",
+      });
+    }
+
+    const parsed = spotlightSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        success: false,
+        message:
+          parsed.error.issues[0]?.message || "Invalid spotlight settings",
+      });
+    }
+
+    const existing = await Testimonial.findById(id);
+    if (!existing) {
+      return res.status(404).json({
+        success: false,
+        message: "Testimonial not found",
+      });
+    }
+
+    if (parsed.data.featuredOnHomepage && existing.status !== "approved") {
+      return res.status(400).json({
+        success: false,
+        message: "Only approved testimonials can be featured on the homepage",
+      });
+    }
+
+    existing.featuredOnHomepage = parsed.data.featuredOnHomepage;
+    if (parsed.data.spotlightOrder !== undefined) {
+      existing.spotlightOrder = parsed.data.spotlightOrder;
+    }
+    if (!existing.featuredOnHomepage) {
+      existing.spotlightOrder = 0;
+    }
+    await existing.save();
+
+    const doc = await populatePublic(Testimonial.findById(existing._id)).lean();
+
+    return res.status(200).json({
+      success: true,
+      message: existing.featuredOnHomepage
+        ? "Testimonial featured on homepage"
+        : "Testimonial removed from homepage spotlight",
+      testimonial: toAdminTestimonial(doc),
+    });
+  } catch (error) {
+    console.error("Error updating testimonial spotlight:", error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update homepage spotlight",
     });
   }
 };

--- a/server/models/testimonialModel.js
+++ b/server/models/testimonialModel.js
@@ -41,6 +41,16 @@ const testimonialSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    featuredOnHomepage: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    spotlightOrder: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
   },
   { timestamps: true },
 );
@@ -48,6 +58,11 @@ const testimonialSchema = new mongoose.Schema(
 // One active review per user
 testimonialSchema.index({ user: 1 }, { unique: true });
 testimonialSchema.index({ status: 1, createdAt: -1 });
+testimonialSchema.index({
+  featuredOnHomepage: 1,
+  spotlightOrder: 1,
+  createdAt: -1,
+});
 
 export const TESTIMONIAL_COMMENT_MAX_LENGTH = COMMENT_MAX_LENGTH;
 

--- a/server/routes/testimonialRoutes.js
+++ b/server/routes/testimonialRoutes.js
@@ -4,6 +4,7 @@ import { requireAdminOrOwner } from "../middleware/rbac.js";
 import { testimonialSubmitLimiter } from "../middleware/rateLimiter.js";
 import {
   listApprovedTestimonials,
+  listSpotlightTestimonials,
   getTestimonialStats,
   getMyTestimonial,
   createTestimonial,
@@ -11,6 +12,8 @@ import {
   deleteOwnTestimonial,
   listAdminTestimonials,
   updateTestimonialStatus,
+  bulkModerateTestimonials,
+  updateTestimonialSpotlight,
   adminDeleteTestimonial,
 } from "../controllers/testimonialController.js";
 
@@ -18,6 +21,7 @@ const router = express.Router();
 
 // Public
 router.get("/", listApprovedTestimonials);
+router.get("/spotlight", listSpotlightTestimonials);
 router.get("/stats", getTestimonialStats);
 
 // Authenticated user
@@ -32,5 +36,7 @@ export const adminTestimonialRouter = express.Router();
 
 adminTestimonialRouter.use(userAuth, requireAdminOrOwner);
 adminTestimonialRouter.get("/", listAdminTestimonials);
+adminTestimonialRouter.post("/bulk", bulkModerateTestimonials);
 adminTestimonialRouter.patch("/:id/status", updateTestimonialStatus);
+adminTestimonialRouter.patch("/:id/spotlight", updateTestimonialSpotlight);
 adminTestimonialRouter.delete("/:id", adminDeleteTestimonial);

--- a/server/tests/testimonialController.test.js
+++ b/server/tests/testimonialController.test.js
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   listApprovedTestimonials,
+  listSpotlightTestimonials,
   getTestimonialStats,
   createTestimonial,
   updateTestimonial,
   deleteOwnTestimonial,
   updateTestimonialStatus,
+  bulkModerateTestimonials,
+  updateTestimonialSpotlight,
 } from "../controllers/testimonialController.js";
 import Testimonial from "../models/testimonialModel.js";
 
@@ -17,6 +20,8 @@ vi.mock("../models/testimonialModel.js", () => {
     countDocuments: vi.fn(),
     create: vi.fn(),
     aggregate: vi.fn(),
+    updateMany: vi.fn(),
+    deleteMany: vi.fn(),
   };
   return {
     default: Model,
@@ -329,5 +334,147 @@ describe("testimonialController", () => {
 
     expect(existing.status).toBe("approved");
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("bulk approves selected testimonials", async () => {
+    Testimonial.updateMany.mockResolvedValue({ modifiedCount: 2 });
+
+    const req = {
+      user: { _id: "admin1" },
+      body: {
+        ids: ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"],
+        action: "approve",
+      },
+    };
+    const res = mockRes();
+    await bulkModerateTestimonials(req, res);
+
+    expect(Testimonial.updateMany).toHaveBeenCalledWith(
+      {
+        _id: {
+          $in: ["507f1f77bcf86cd799439011", "507f1f77bcf86cd799439012"],
+        },
+      },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: "approved" }),
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("bulk deletes selected testimonials", async () => {
+    Testimonial.deleteMany.mockResolvedValue({ deletedCount: 1 });
+
+    const req = {
+      user: { _id: "admin1" },
+      body: {
+        ids: ["507f1f77bcf86cd799439011"],
+        action: "delete",
+      },
+    };
+    const res = mockRes();
+    await bulkModerateTestimonials(req, res);
+
+    expect(Testimonial.deleteMany).toHaveBeenCalledWith({
+      _id: { $in: ["507f1f77bcf86cd799439011"] },
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("lists curated spotlight testimonials for homepage", async () => {
+    const docs = [
+      {
+        _id: "t1",
+        rating: 5,
+        comment: "Featured review for homepage spotlight",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        featuredOnHomepage: true,
+        spotlightOrder: 1,
+        user: { name: "Ada", profilePic: "", role: "member" },
+        organization: null,
+      },
+    ];
+    Testimonial.find.mockReturnValue(chainFind(docs));
+
+    const req = { query: { limit: "6" } };
+    const res = mockRes();
+    await listSpotlightTestimonials(req, res);
+
+    expect(Testimonial.find).toHaveBeenCalledWith({
+      status: "approved",
+      featuredOnHomepage: true,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        testimonials: [
+          expect.objectContaining({
+            comment: "Featured review for homepage spotlight",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("features an approved testimonial on the homepage", async () => {
+    const existing = {
+      _id: "507f1f77bcf86cd799439011",
+      status: "approved",
+      featuredOnHomepage: false,
+      spotlightOrder: 0,
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    Testimonial.findById.mockResolvedValueOnce(existing).mockReturnValueOnce(
+      (() => {
+        const chain = {
+          populate: vi.fn().mockReturnThis(),
+          lean: vi.fn().mockResolvedValue({
+            _id: existing._id,
+            rating: 5,
+            comment: "Approved review content here",
+            status: "approved",
+            featuredOnHomepage: true,
+            spotlightOrder: 2,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            user: { _id: "u1", name: "Ada", profilePic: "", role: "member" },
+            organization: null,
+          }),
+        };
+        chain.populate.mockReturnValue(chain);
+        return chain;
+      })(),
+    );
+
+    const req = {
+      user: { _id: "admin1" },
+      params: { id: "507f1f77bcf86cd799439011" },
+      body: { featuredOnHomepage: true, spotlightOrder: 2 },
+    };
+    const res = mockRes();
+    await updateTestimonialSpotlight(req, res);
+
+    expect(existing.featuredOnHomepage).toBe(true);
+    expect(existing.spotlightOrder).toBe(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("rejects featuring non-approved testimonials", async () => {
+    Testimonial.findById.mockResolvedValue({
+      status: "pending",
+      save: vi.fn(),
+    });
+
+    const req = {
+      user: { _id: "admin1" },
+      params: { id: "507f1f77bcf86cd799439011" },
+      body: { featuredOnHomepage: true },
+    };
+    const res = mockRes();
+    await updateTestimonialSpotlight(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 });


### PR DESCRIPTION
## Summary
- Add admin bulk approve/reject/delete for testimonials
- Add homepage spotlight flag + controllable order (approved only)
- Marketing homepage reads curated spotlight set (fallback to recent approved)

## Test plan
- [ ] Admin panel: select multiple pending rows → Bulk approve/reject/delete
- [ ] Feature an approved testimonial and set order; confirm homepage order
- [ ] Unfeature / reject clears spotlight
- [ ] Non-admin cannot hit `/api/admin/testimonials/bulk` or `/spotlight` PATCH
- [ ] `npx vitest run tests/testimonialController.test.js` (server)
- [ ] `npx vitest run src/components/admin/__tests__/TestimonialsModeration.test.jsx src/components/testimonials/__tests__/TestimonialsCarousel.test.jsx` (client)

Closes #2266