### PR TITLE
feat(notifications): integrate Keyword Watchlist scanner tab in Notifications Center

### DIFF
--- a/client/src/pages/Notifications.jsx
+++ b/client/src/pages/Notifications.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import AppContent from "../context/AppContent";
 import { toast } from "react-toastify";
 import Navbar from "../components/Navbar.jsx";
@@ -24,12 +24,14 @@ import {
   ChevronRight,
   CheckSquare,
   Layers,
+  Radio,
 } from "lucide-react";
 import {
   groupNotifications,
   notificationId,
 } from "../utils/groupNotifications.js";
 import NudgeInbox from "../components/NudgeInbox";
+import KeywordWatchlistPanel from "../components/notifications/KeywordWatchlistPanel.jsx";
 
 /**
  * Issue #977 & #1214: Category icons mapping for all notification types.
@@ -119,6 +121,29 @@ const Notifications = () => {
   const [notifications, setNotifications] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState(
+    searchParams.get("tab") === "keywords" ? "keywords" : "all",
+  );
+
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (tabParam === "keywords") {
+      setActiveTab("keywords");
+    } else {
+      setActiveTab("all");
+    }
+  }, [searchParams]);
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+    if (tab === "keywords") {
+      setSearchParams({ tab: "keywords" });
+    } else {
+      setSearchParams({});
+    }
+  };
 
   // Filter states
   const [filter, setFilter] = useState("all"); // all, read, unread
@@ -369,359 +394,419 @@ const Notifications = () => {
             )}
           </div>
 
-          <NudgeInbox organizationId={userData?.currentOrganization} />
-
-          {/* Filters Section - Issue #1214: Tasks filter added; #2064 grouping + digest */}
-          <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
-            <div className="flex items-center gap-2 mb-3">
-              <Filter className="w-4 h-4 text-slate-500 dark:text-slate-400" />
-              <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
-                Filters
-              </span>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {/* Status Filter (Read/Unread) */}
-              <div>
-                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
-                  Status
-                </label>
-                <select
-                  value={filter}
-                  onChange={(e) => setFilter(e.target.value)}
-                  className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
-                >
-                  <option value="all">All Notifications</option>
-                  <option value="unread">Unread Only</option>
-                  <option value="read">Read Only</option>
-                </select>
-              </div>
-
-              {/* Category Filter - Issue #1214: Added Tasks option */}
-              <div>
-                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
-                  Category
-                </label>
-                <select
-                  value={categoryFilter}
-                  onChange={(e) => setCategoryFilter(e.target.value)}
-                  className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
-                >
-                  <option value="all">All Categories</option>
-                  <option value="meetings">Meetings</option>
-                  <option value="tasks">Tasks</option>
-                  <option value="ai_processing">AI Processing</option>
-                  <option value="organizations">Organizations</option>
-                  <option value="policies">Policies</option>
-                  <option value="reports">Reports</option>
-                  <option value="system">System</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
-                  Group by
-                </label>
-                <select
-                  value={groupBy}
-                  onChange={(e) => setGroupBy(e.target.value)}
-                  className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
-                >
-                  <option value="day">Day</option>
-                  <option value="meeting">Meeting</option>
-                  <option value="type">Type</option>
-                  <option value="none">None</option>
-                </select>
-              </div>
-            </div>
-
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={dailyDigest}
-                  disabled={digestSaving}
-                  onChange={handleDailyDigestToggle}
-                  className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                />
-                Daily notification digest
-              </label>
-            </div>
-
-            {/* Active Filter Indicators */}
-            {(filter !== "all" || categoryFilter !== "all") && (
-              <div className="mt-3 pt-3 border-t border-slate-200 dark:border-slate-700 flex flex-wrap gap-2">
-                <span className="text-xs text-slate-500 dark:text-slate-400">
-                  Active filters:
+          {/* Navigation Tabs (Issue #2424) */}
+          <div
+            role="tablist"
+            aria-label="Notification Views"
+            className="flex items-center gap-2 border-b border-slate-200 dark:border-slate-800 mb-6"
+          >
+            <button
+              role="tab"
+              aria-selected={activeTab === "all"}
+              aria-controls="notifications-panel"
+              onClick={() => handleTabChange("all")}
+              className={`flex items-center gap-2 px-4 py-2.5 text-xs font-bold border-b-2 transition-all cursor-pointer ${
+                activeTab === "all"
+                  ? "border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400"
+                  : "border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+              }`}
+            >
+              <Bell className="w-4 h-4" />
+              All Notifications
+              {unreadCount > 0 && (
+                <span className="px-2 py-0.5 text-[10px] bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded-full font-bold">
+                  {unreadCount}
                 </span>
-                {filter !== "all" && (
-                  <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-md text-xs font-medium">
-                    Status: {filter === "unread" ? "Unread" : "Read"}
-                    <button
-                      onClick={() => setFilter("all")}
-                      className="hover:text-blue-900 dark:hover:text-blue-100"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </span>
-                )}
-                {categoryFilter !== "all" && (
-                  <span className="inline-flex items-center gap-1 px-2 py-1 bg-teal-100 dark:bg-teal-950/30 text-teal-700 dark:text-teal-300 rounded-md text-xs font-medium">
-                    Category: {CATEGORY_LABELS[categoryFilter]}
-                    <button
-                      onClick={() => setCategoryFilter("all")}
-                      className="hover:text-teal-900 dark:hover:text-teal-100"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </span>
-                )}
-                <button
-                  onClick={() => {
-                    setFilter("all");
-                    setCategoryFilter("all");
-                  }}
-                  className="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 underline"
-                >
-                  Clear all
-                </button>
-              </div>
-            )}
+              )}
+            </button>
+
+            <button
+              role="tab"
+              aria-selected={activeTab === "keywords"}
+              aria-controls="keyword-watchlist-panel"
+              data-testid="tab-keyword-watchlist"
+              onClick={() => handleTabChange("keywords")}
+              className={`flex items-center gap-2 px-4 py-2.5 text-xs font-bold border-b-2 transition-all cursor-pointer ${
+                activeTab === "keywords"
+                  ? "border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400"
+                  : "border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+              }`}
+            >
+              <Radio className="w-4 h-4" />
+              Keyword Watchlist
+            </button>
           </div>
         </div>
 
-        {/* Loading State */}
-        {loading && (
-          <div className="flex items-center justify-center py-20">
-            <div className="flex flex-col items-center gap-3">
-              <div className="w-12 h-12 border-4 border-blue-200 dark:border-blue-800 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin"></div>
-              <p className="text-slate-600 dark:text-slate-400">
-                Loading notifications...
-              </p>
-            </div>
+        {activeTab === "keywords" ? (
+          <div id="keyword-watchlist-panel" role="tabpanel">
+            <KeywordWatchlistPanel />
           </div>
-        )}
+        ) : (
+          <div id="notifications-panel" role="tabpanel" className="space-y-6">
+            <NudgeInbox organizationId={userData?.currentOrganization} />
 
-        {/* Error State */}
-        {error && !loading && (
-          <div className="bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-2xl p-8 text-center">
-            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-3" />
-            <h3 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-2">
-              Error Loading Notifications
-            </h3>
-            <p className="text-red-700 dark:text-red-300 mb-4">{error}</p>
-            <button
-              onClick={fetchNotifications}
-              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
-            >
-              Try Again
-            </button>
-          </div>
-        )}
+            {/* Filters Section - Issue #1214: Tasks filter added; #2064 grouping + digest */}
+            <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 p-4 shadow-sm">
+              <div className="flex items-center gap-2 mb-3">
+                <Filter className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                  Filters
+                </span>
+              </div>
 
-        {/* Empty State */}
-        {!loading && !error && notifications.length === 0 && (
-          <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 p-12 text-center">
-            <Bell className="w-16 h-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
-            <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">
-              No Notifications
-            </h3>
-            <p className="text-slate-600 dark:text-slate-400 mb-4">
-              {filter !== "all" || categoryFilter !== "all"
-                ? "No notifications match your current filters. Try adjusting them."
-                : "You're all caught up! No new notifications to display."}
-            </p>
-            {(filter !== "all" || categoryFilter !== "all") && (
-              <button
-                onClick={() => {
-                  setFilter("all");
-                  setCategoryFilter("all");
-                }}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
-              >
-                Clear Filters
-              </button>
-            )}
-          </div>
-        )}
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {/* Status Filter (Read/Unread) */}
+                <div>
+                  <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
+                    Status
+                  </label>
+                  <select
+                    value={filter}
+                    onChange={(e) => setFilter(e.target.value)}
+                    className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                  >
+                    <option value="all">All Notifications</option>
+                    <option value="unread">Unread Only</option>
+                    <option value="read">Read Only</option>
+                  </select>
+                </div>
 
-        {/* Notifications List (grouped — Issue #2064) */}
-        {!loading && !error && notifications.length > 0 && (
-          <div className="space-y-6">
-            {groupedNotifications.map((group) => {
-              const unreadInGroup = group.items.filter((n) => !n.isRead).length;
-              const typeLabel =
-                groupBy === "type"
-                  ? CATEGORY_LABELS[group.label] || group.label
-                  : group.label;
+                {/* Category Filter - Issue #1214: Added Tasks option */}
+                <div>
+                  <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
+                    Category
+                  </label>
+                  <select
+                    value={categoryFilter}
+                    onChange={(e) => setCategoryFilter(e.target.value)}
+                    className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                  >
+                    <option value="all">All Categories</option>
+                    <option value="meetings">Meetings</option>
+                    <option value="tasks">Tasks</option>
+                    <option value="ai_processing">AI Processing</option>
+                    <option value="organizations">Organizations</option>
+                    <option value="policies">Policies</option>
+                    <option value="reports">Reports</option>
+                    <option value="system">System</option>
+                  </select>
+                </div>
 
-              return (
-                <section key={group.key} className="space-y-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                      <Layers className="w-4 h-4 text-slate-400" />
-                      {typeLabel}
-                      <span className="text-xs font-medium text-slate-500">
-                        ({group.items.length})
-                      </span>
-                    </h2>
-                    {unreadInGroup > 0 && (
+                <div>
+                  <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1.5">
+                    Group by
+                  </label>
+                  <select
+                    value={groupBy}
+                    onChange={(e) => setGroupBy(e.target.value)}
+                    className="w-full px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                  >
+                    <option value="day">Day</option>
+                    <option value="meeting">Meeting</option>
+                    <option value="type">Type</option>
+                    <option value="none">None</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={dailyDigest}
+                    disabled={digestSaving}
+                    onChange={handleDailyDigestToggle}
+                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  Daily notification digest
+                </label>
+              </div>
+
+              {/* Active Filter Indicators */}
+              {(filter !== "all" || categoryFilter !== "all") && (
+                <div className="mt-3 pt-3 border-t border-slate-200 dark:border-slate-700 flex flex-wrap gap-2">
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    Active filters:
+                  </span>
+                  {filter !== "all" && (
+                    <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-md text-xs font-medium">
+                      Status: {filter === "unread" ? "Unread" : "Read"}
                       <button
-                        type="button"
-                        onClick={() => handleMarkGroupAsRead(group.items)}
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-100 dark:hover:bg-blue-950/50 rounded-lg transition-colors"
+                        onClick={() => setFilter("all")}
+                        className="hover:text-blue-900 dark:hover:text-blue-100"
                       >
-                        <CheckSquare className="w-3.5 h-3.5" />
-                        Mark group as read
+                        <X className="w-3 h-3" />
                       </button>
-                    )}
-                  </div>
+                    </span>
+                  )}
+                  {categoryFilter !== "all" && (
+                    <span className="inline-flex items-center gap-1 px-2 py-1 bg-teal-100 dark:bg-teal-950/30 text-teal-700 dark:text-teal-300 rounded-md text-xs font-medium">
+                      Category: {CATEGORY_LABELS[categoryFilter]}
+                      <button
+                        onClick={() => setCategoryFilter("all")}
+                        className="hover:text-teal-900 dark:hover:text-teal-100"
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    </span>
+                  )}
+                  <button
+                    onClick={() => {
+                      setFilter("all");
+                      setCategoryFilter("all");
+                    }}
+                    className="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 underline"
+                  >
+                    Clear all
+                  </button>
+                </div>
+              )}
+            </div>
 
-                  <div className="space-y-3">
-                    {group.items.map((notification) => {
-                      const id = notificationId(notification);
-                      const IconComponent =
-                        CATEGORY_ICONS[notification.category] || AlertCircle;
-                      const colorClass =
-                        CATEGORY_COLORS[notification.category] ||
-                        CATEGORY_COLORS.system;
+            {/* Loading State */}
+            {loading && (
+              <div className="flex items-center justify-center py-20">
+                <div className="flex flex-col items-center gap-3">
+                  <div className="w-12 h-12 border-4 border-blue-200 dark:border-blue-800 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin"></div>
+                  <p className="text-slate-600 dark:text-slate-400">
+                    Loading notifications...
+                  </p>
+                </div>
+              </div>
+            )}
 
-                      return (
-                        <div
-                          key={id}
-                          onClick={() => handleNotificationClick(notification)}
-                          className={`group relative bg-white dark:bg-slate-800 rounded-2xl border transition-all cursor-pointer hover:shadow-lg ${
-                            notification.isRead
-                              ? "border-slate-200 dark:border-slate-700"
-                              : "border-blue-300 dark:border-blue-700 shadow-md"
-                          }`}
-                        >
-                          <div className="p-5">
-                            <div className="flex items-start gap-4">
-                              <div
-                                className={`flex-shrink-0 w-12 h-12 rounded-xl border-2 flex items-center justify-center ${colorClass}`}
-                              >
-                                <IconComponent className="w-6 h-6" />
-                              </div>
+            {/* Error State */}
+            {error && !loading && (
+              <div className="bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-2xl p-8 text-center">
+                <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-3" />
+                <h3 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-2">
+                  Error Loading Notifications
+                </h3>
+                <p className="text-red-700 dark:text-red-300 mb-4">{error}</p>
+                <button
+                  onClick={fetchNotifications}
+                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors"
+                >
+                  Try Again
+                </button>
+              </div>
+            )}
 
-                              <div className="flex-1 min-w-0">
-                                <div className="flex items-start justify-between gap-2 mb-1">
-                                  <h3
-                                    className={`text-base font-semibold ${
-                                      notification.isRead
-                                        ? "text-slate-700 dark:text-slate-300"
-                                        : "text-slate-900 dark:text-white"
-                                    }`}
+            {/* Empty State */}
+            {!loading && !error && notifications.length === 0 && (
+              <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 p-12 text-center">
+                <Bell className="w-16 h-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+                <h3 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">
+                  No Notifications
+                </h3>
+                <p className="text-slate-600 dark:text-slate-400 mb-4">
+                  {filter !== "all" || categoryFilter !== "all"
+                    ? "No notifications match your current filters. Try adjusting them."
+                    : "You're all caught up! No new notifications to display."}
+                </p>
+                {(filter !== "all" || categoryFilter !== "all") && (
+                  <button
+                    onClick={() => {
+                      setFilter("all");
+                      setCategoryFilter("all");
+                    }}
+                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+                  >
+                    Clear Filters
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Notifications List (grouped — Issue #2064) */}
+            {!loading && !error && notifications.length > 0 && (
+              <div className="space-y-6">
+                {groupedNotifications.map((group) => {
+                  const unreadInGroup = group.items.filter(
+                    (n) => !n.isRead,
+                  ).length;
+                  const typeLabel =
+                    groupBy === "type"
+                      ? CATEGORY_LABELS[group.label] || group.label
+                      : group.label;
+
+                  return (
+                    <section key={group.key} className="space-y-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                          <Layers className="w-4 h-4 text-slate-400" />
+                          {typeLabel}
+                          <span className="text-xs font-medium text-slate-500">
+                            ({group.items.length})
+                          </span>
+                        </h2>
+                        {unreadInGroup > 0 && (
+                          <button
+                            type="button"
+                            onClick={() => handleMarkGroupAsRead(group.items)}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-100 dark:hover:bg-blue-950/50 rounded-lg transition-colors"
+                          >
+                            <CheckSquare className="w-3.5 h-3.5" />
+                            Mark group as read
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="space-y-3">
+                        {group.items.map((notification) => {
+                          const id = notificationId(notification);
+                          const IconComponent =
+                            CATEGORY_ICONS[notification.category] ||
+                            AlertCircle;
+                          const colorClass =
+                            CATEGORY_COLORS[notification.category] ||
+                            CATEGORY_COLORS.system;
+
+                          return (
+                            <div
+                              key={id}
+                              onClick={() =>
+                                handleNotificationClick(notification)
+                              }
+                              className={`group relative bg-white dark:bg-slate-800 rounded-2xl border transition-all cursor-pointer hover:shadow-lg ${
+                                notification.isRead
+                                  ? "border-slate-200 dark:border-slate-700"
+                                  : "border-blue-300 dark:border-blue-700 shadow-md"
+                              }`}
+                            >
+                              <div className="p-5">
+                                <div className="flex items-start gap-4">
+                                  <div
+                                    className={`flex-shrink-0 w-12 h-12 rounded-xl border-2 flex items-center justify-center ${colorClass}`}
                                   >
-                                    {notification.title}
-                                  </h3>
-                                  <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
-                                    {formatTimeAgo(notification.createdAt)}
-                                  </span>
+                                    <IconComponent className="w-6 h-6" />
+                                  </div>
+
+                                  <div className="flex-1 min-w-0">
+                                    <div className="flex items-start justify-between gap-2 mb-1">
+                                      <h3
+                                        className={`text-base font-semibold ${
+                                          notification.isRead
+                                            ? "text-slate-700 dark:text-slate-300"
+                                            : "text-slate-900 dark:text-white"
+                                        }`}
+                                      >
+                                        {notification.title}
+                                      </h3>
+                                      <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                                        {formatTimeAgo(notification.createdAt)}
+                                      </span>
+                                    </div>
+
+                                    <p className="text-sm text-slate-600 dark:text-slate-400 line-clamp-2 mb-2">
+                                      {notification.description}
+                                    </p>
+
+                                    <div className="flex items-center gap-2">
+                                      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300">
+                                        {CATEGORY_LABELS[
+                                          notification.category
+                                        ] || "System"}
+                                      </span>
+                                      {!notification.isRead && (
+                                        <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300">
+                                          New
+                                        </span>
+                                      )}
+                                    </div>
+                                  </div>
+
+                                  <div className="flex-shrink-0 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
+                                    {!notification.isRead && (
+                                      <button
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          handleMarkAsRead(id);
+                                        }}
+                                        aria-label={`Mark "${notification.title}" as read`}
+                                        className="p-3 sm:p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                                        title="Mark as read"
+                                      >
+                                        <Check className="w-4 h-4" />
+                                      </button>
+                                    )}
+                                    <button
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleDelete(id);
+                                      }}
+                                      aria-label={`Delete notification "${notification.title}"`}
+                                      className="p-3 sm:p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
+                                      title="Delete"
+                                    >
+                                      <Trash2 className="w-4 h-4" />
+                                    </button>
+                                  </div>
                                 </div>
 
-                                <p className="text-sm text-slate-600 dark:text-slate-400 line-clamp-2 mb-2">
-                                  {notification.description}
-                                </p>
-
-                                <div className="flex items-center gap-2">
-                                  <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300">
-                                    {CATEGORY_LABELS[notification.category] ||
-                                      "System"}
-                                  </span>
-                                  {!notification.isRead && (
-                                    <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium bg-blue-100 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300">
-                                      New
-                                    </span>
-                                  )}
-                                </div>
-                              </div>
-
-                              <div className="flex-shrink-0 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200">
-                                {!notification.isRead && (
+                                {notification.actionUrl && (
                                   <button
                                     onClick={(e) => {
                                       e.stopPropagation();
-                                      handleMarkAsRead(id);
+                                      handleNotificationClick(notification);
                                     }}
-                                    aria-label={`Mark "${notification.title}" as read`}
-                                    className="p-3 sm:p-2 text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-                                    title="Mark as read"
+                                    className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                                   >
-                                    <Check className="w-4 h-4" />
+                                    {notification.actionLabel || "View Details"}
+                                    <ArrowRight className="w-4 h-4" />
                                   </button>
                                 )}
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleDelete(id);
-                                  }}
-                                  aria-label={`Delete notification "${notification.title}"`}
-                                  className="p-3 sm:p-2 text-slate-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
-                                  title="Delete"
-                                >
-                                  <Trash2 className="w-4 h-4" />
-                                </button>
                               </div>
                             </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  );
+                })}
+              </div>
+            )}
 
-                            {notification.actionUrl && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleNotificationClick(notification);
-                                }}
-                                className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
-                              >
-                                {notification.actionLabel || "View Details"}
-                                <ArrowRight className="w-4 h-4" />
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </section>
-              );
-            })}
-          </div>
-        )}
+            {/* Pagination */}
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-between pt-6 mt-6 border-t border-slate-200 dark:border-slate-700">
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                  Showing {(pagination.page - 1) * pagination.limit + 1}
+                  {" - "}
+                  {Math.min(
+                    pagination.page * pagination.limit,
+                    pagination.total,
+                  )}
+                  {" of "}
+                  {pagination.total} notifications
+                </p>
 
-        {/* Pagination */}
-        {pagination.totalPages > 1 && (
-          <div className="flex items-center justify-between pt-6 mt-6 border-t border-slate-200 dark:border-slate-700">
-            <p className="text-sm text-slate-600 dark:text-slate-400">
-              Showing {(pagination.page - 1) * pagination.limit + 1}
-              {" - "}
-              {Math.min(pagination.page * pagination.limit, pagination.total)}
-              {" of "}
-              {pagination.total} notifications
-            </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="p-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <ChevronLeft className="w-5 h-5" />
+                  </button>
 
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page === 1}
-                className="p-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-5 h-5" />
-              </button>
+                  <span className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300">
+                    Page {pagination.page} of {pagination.totalPages}
+                  </span>
 
-              <span className="px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-300">
-                Page {pagination.page} of {pagination.totalPages}
-              </span>
-
-              <button
-                onClick={() =>
-                  setPage((p) => Math.min(pagination.totalPages, p + 1))
-                }
-                disabled={page === pagination.totalPages}
-                className="p-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronRight className="w-5 h-5" />
-              </button>
-            </div>
+                  <button
+                    onClick={() =>
+                      setPage((p) => Math.min(pagination.totalPages, p + 1))
+                    }
+                    disabled={page === pagination.totalPages}
+                    className="p-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <ChevronRight className="w-5 h-5" />
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/client/src/pages/__tests__/NotificationsKeywordWatchlist.test.jsx
+++ b/client/src/pages/__tests__/NotificationsKeywordWatchlist.test.jsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import Notifications from "../Notifications";
+import AppContent from "../../context/AppContent";
+import * as useKeywordAlertsHook from "../../hooks/useKeywordAlerts";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../components/Navbar", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../components/NudgeInbox", () => ({
+  default: () => <div data-testid="nudge-inbox">NudgeInbox</div>,
+}));
+
+describe("Notifications Keyword Watchlist Tab Integration (#2424)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(useKeywordAlertsHook, "useKeywordAlerts").mockReturnValue({
+      watchlist: {
+        keywords: ["Sprint", "Budget"],
+        notifyViaEmail: true,
+        notifyViaApp: true,
+        isActive: true,
+      },
+      history: [],
+      loading: false,
+      historyLoading: false,
+      error: null,
+      updateWatchlist: vi.fn(),
+      toggleAlerts: vi.fn(),
+      testSendAlert: vi.fn(),
+      clearHistory: vi.fn(),
+      refreshHistory: vi.fn(),
+    });
+  });
+
+  const renderComponent = () => {
+    const mockContext = {
+      userData: {
+        _id: "u_1",
+        email: "user@example.com",
+        currentOrganization: "org_1",
+      },
+    };
+
+    return render(
+      <BrowserRouter>
+        <AppContent.Provider value={mockContext}>
+          <Notifications />
+        </AppContent.Provider>
+      </BrowserRouter>,
+    );
+  };
+
+  it("renders both All Notifications and Keyword Watchlist tabs", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("tab", { name: /All Notifications/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: /Keyword Watchlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches to Keyword Watchlist tab when clicked", () => {
+    renderComponent();
+
+    const keywordTab = screen.getByTestId("tab-keyword-watchlist");
+    fireEvent.click(keywordTab);
+
+    expect(keywordTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getAllByText("Keyword Watchlist").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Monitored Keywords & Phrases/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #2424

## Description
This PR integrates the `KeywordWatchlistPanel` into `Notifications.jsx` via a dedicated tab bar with live scanner controls, delivery channel configurations, simulator testing, delivery logs, URL query synchronization (`?tab=keywords`), and WAI-ARIA tab semantics.

## Proposed Changes
- **Notifications Center Tab Integration**:
  - Added accessible tab bar in `Notifications.jsx` supporting switching between "All Notifications" and "Keyword Watchlist".
  - Synchronized active tab state with URL query parameters (`?tab=keywords`).
  - Mounted `KeywordWatchlistPanel` under the Keyword Watchlist tab.
  - Added unread badge indicator to the "All Notifications" tab button.
- **Unit Tests**:
  - Added unit test suite `client/src/pages/__tests__/NotificationsKeywordWatchlist.test.jsx` (2/2 passing).

## Checklist
- [x] Related Issue is linked (Fixes #2424).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.