### PR TITLE
feat: make the Decision Graph editable — create / link / supersede (#2027)

### DIFF
--- a/client/src/components/decision-graph/DecisionGraphEditor.jsx
+++ b/client/src/components/decision-graph/DecisionGraphEditor.jsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Plus, GitBranch, Archive, ChevronDown, ChevronUp, Lock } from "lucide-react";
+import { toast } from "react-toastify";
+import { useRBAC } from "../../hooks/useRBAC";
+import { meetingApi } from "../../services/meetingApi";
+import {
+  createDecision,
+  linkDecisions,
+  supersedeDecision,
+} from "../../services/decisionGraphApi";
+
+const STATUSES = ["open", "in-progress", "resolved", "superseded"];
+
+/**
+ * Issue #2027 — create / link / supersede editor for the Decision Graph.
+ * Gated by RBAC: only knowledge:create sees the create form and knowledge:edit
+ * sees the relationship tools; everyone else stays view-only (the server also
+ * enforces this).
+ */
+const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
+  const { hasPermission } = useRBAC();
+  const canCreate = hasPermission("knowledge", "create");
+  const canEdit = hasPermission("knowledge", "edit");
+
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [meetings, setMeetings] = useState([]);
+
+  // Create form
+  const [text, setText] = useState("");
+  const [owner, setOwner] = useState("");
+  const [status, setStatus] = useState("open");
+  const [sourceMeetingId, setSourceMeetingId] = useState("");
+
+  // Edge form
+  const [edgeSource, setEdgeSource] = useState("");
+  const [edgeTarget, setEdgeTarget] = useState("");
+  const [confidence, setConfidence] = useState(100);
+
+  useEffect(() => {
+    if (!open || !canCreate) return;
+    let active = true;
+    meetingApi
+      .getAllMeetings({ limit: 100 })
+      .then((res) => {
+        const list = res?.data?.meetings || res?.data?.data || res?.data || [];
+        if (active && Array.isArray(list)) setMeetings(list);
+      })
+      .catch(() => {
+        /* meeting list is a convenience; a manual id still works */
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, canCreate]);
+
+  const nodeOptions = useMemo(
+    () => nodes.map((n) => ({ id: n.id, label: n.label })),
+    [nodes],
+  );
+
+  if (!canCreate && !canEdit) {
+    return (
+      <div className="mb-3 inline-flex items-center gap-1 rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-900/50 dark:text-gray-400">
+        <Lock size={12} /> View-only — you don’t have permission to edit the decision graph.
+      </div>
+    );
+  }
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    if (!text.trim()) return toast.error("Decision text is required.");
+    if (!sourceMeetingId) return toast.error("Choose a source meeting.");
+    try {
+      setBusy(true);
+      await createDecision({ text: text.trim(), owner, status, sourceMeetingId });
+      toast.success("Decision created.");
+      setText("");
+      setOwner("");
+      setStatus("open");
+      onChanged?.();
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to create decision.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runEdge = async (kind) => {
+    if (!edgeSource || !edgeTarget) return toast.error("Pick both decisions.");
+    if (edgeSource === edgeTarget) return toast.error("A decision can’t link to itself.");
+    try {
+      setBusy(true);
+      if (kind === "link") {
+        await linkDecisions(edgeSource, { targetId: edgeTarget, confidence: Number(confidence) });
+        toast.success("Decisions linked.");
+      } else {
+        await supersedeDecision(edgeSource, { targetId: edgeTarget });
+        toast.success("Decision superseded.");
+      }
+      onChanged?.();
+    } catch (err) {
+      toast.error(err?.response?.data?.message || `Failed to ${kind}.`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const inputCls =
+    "rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-800";
+
+  return (
+    <div className="mb-4 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium text-gray-800 dark:text-gray-100"
+      >
+        <span className="flex items-center gap-2">
+          <GitBranch size={16} /> Edit decision graph
+        </span>
+        {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+      </button>
+
+      {open && (
+        <div className="grid gap-4 border-t border-gray-100 p-4 dark:border-gray-700 md:grid-cols-2">
+          {canCreate && (
+            <form onSubmit={handleCreate} className="space-y-2">
+              <h3 className="flex items-center gap-1 text-sm font-semibold text-gray-700 dark:text-gray-200">
+                <Plus size={14} /> New decision
+              </h3>
+              <input
+                className={`${inputCls} w-full`}
+                placeholder="Decision text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+              />
+              <div className="flex gap-2">
+                <input
+                  className={`${inputCls} flex-1`}
+                  placeholder="Owner (optional)"
+                  value={owner}
+                  onChange={(e) => setOwner(e.target.value)}
+                />
+                <select className={inputCls} value={status} onChange={(e) => setStatus(e.target.value)}>
+                  {STATUSES.map((s) => (
+                    <option key={s} value={s}>{s}</option>
+                  ))}
+                </select>
+              </div>
+              <select
+                className={`${inputCls} w-full`}
+                value={sourceMeetingId}
+                onChange={(e) => setSourceMeetingId(e.target.value)}
+              >
+                <option value="">Source meeting…</option>
+                {meetings.map((m) => (
+                  <option key={m._id} value={m._id}>
+                    {m.title || m.name || m._id}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                disabled={busy}
+                className="rounded-md bg-indigo-600 px-3 py-1 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+              >
+                {busy ? "Creating…" : "Create decision"}
+              </button>
+            </form>
+          )}
+
+          {canEdit && (
+            <div className="space-y-2">
+              <h3 className="flex items-center gap-1 text-sm font-semibold text-gray-700 dark:text-gray-200">
+                <GitBranch size={14} /> Link / supersede
+              </h3>
+              <select
+                className={`${inputCls} w-full`}
+                value={edgeSource}
+                onChange={(e) => setEdgeSource(e.target.value)}
+              >
+                <option value="">From decision…</option>
+                {nodeOptions.map((n) => (
+                  <option key={n.id} value={n.id}>{n.label?.slice(0, 60)}</option>
+                ))}
+              </select>
+              <select
+                className={`${inputCls} w-full`}
+                value={edgeTarget}
+                onChange={(e) => setEdgeTarget(e.target.value)}
+              >
+                <option value="">To decision…</option>
+                {nodeOptions.map((n) => (
+                  <option key={n.id} value={n.id}>{n.label?.slice(0, 60)}</option>
+                ))}
+              </select>
+              <div className="flex items-center gap-2">
+                <label className="text-xs text-gray-500 dark:text-gray-400">Confidence</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  className={`${inputCls} w-20`}
+                  value={confidence}
+                  onChange={(e) => setConfidence(e.target.value)}
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => runEdge("link")}
+                  disabled={busy}
+                  className="flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+                >
+                  <GitBranch size={14} /> Link (relatesTo)
+                </button>
+                <button
+                  type="button"
+                  onClick={() => runEdge("supersede")}
+                  disabled={busy}
+                  className="flex items-center gap-1 rounded-md bg-amber-600 px-3 py-1 text-sm font-medium text-white hover:bg-amber-500 disabled:opacity-50"
+                >
+                  <Archive size={14} /> Supersede
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DecisionGraphEditor;

--- a/client/src/components/decision-graph/DecisionGraphEditor.jsx
+++ b/client/src/components/decision-graph/DecisionGraphEditor.jsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Plus, GitBranch, Archive, ChevronDown, ChevronUp, Lock } from "lucide-react";
+import {
+  Plus,
+  GitBranch,
+  Archive,
+  ChevronDown,
+  ChevronUp,
+  Lock,
+} from "lucide-react";
 import { toast } from "react-toastify";
 import { useRBAC } from "../../hooks/useRBAC";
 import { meetingApi } from "../../services/meetingApi";
@@ -62,7 +69,8 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
   if (!canCreate && !canEdit) {
     return (
       <div className="mb-3 inline-flex items-center gap-1 rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-900/50 dark:text-gray-400">
-        <Lock size={12} /> View-only — you don’t have permission to edit the decision graph.
+        <Lock size={12} /> View-only — you don’t have permission to edit the
+        decision graph.
       </div>
     );
   }
@@ -73,7 +81,12 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
     if (!sourceMeetingId) return toast.error("Choose a source meeting.");
     try {
       setBusy(true);
-      await createDecision({ text: text.trim(), owner, status, sourceMeetingId });
+      await createDecision({
+        text: text.trim(),
+        owner,
+        status,
+        sourceMeetingId,
+      });
       toast.success("Decision created.");
       setText("");
       setOwner("");
@@ -88,11 +101,15 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
 
   const runEdge = async (kind) => {
     if (!edgeSource || !edgeTarget) return toast.error("Pick both decisions.");
-    if (edgeSource === edgeTarget) return toast.error("A decision can’t link to itself.");
+    if (edgeSource === edgeTarget)
+      return toast.error("A decision can’t link to itself.");
     try {
       setBusy(true);
       if (kind === "link") {
-        await linkDecisions(edgeSource, { targetId: edgeTarget, confidence: Number(confidence) });
+        await linkDecisions(edgeSource, {
+          targetId: edgeTarget,
+          confidence: Number(confidence),
+        });
         toast.success("Decisions linked.");
       } else {
         await supersedeDecision(edgeSource, { targetId: edgeTarget });
@@ -142,9 +159,15 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
                   value={owner}
                   onChange={(e) => setOwner(e.target.value)}
                 />
-                <select className={inputCls} value={status} onChange={(e) => setStatus(e.target.value)}>
+                <select
+                  className={inputCls}
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value)}
+                >
                   {STATUSES.map((s) => (
-                    <option key={s} value={s}>{s}</option>
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -182,7 +205,9 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
               >
                 <option value="">From decision…</option>
                 {nodeOptions.map((n) => (
-                  <option key={n.id} value={n.id}>{n.label?.slice(0, 60)}</option>
+                  <option key={n.id} value={n.id}>
+                    {n.label?.slice(0, 60)}
+                  </option>
                 ))}
               </select>
               <select
@@ -192,11 +217,15 @@ const DecisionGraphEditor = ({ nodes = [], onChanged }) => {
               >
                 <option value="">To decision…</option>
                 {nodeOptions.map((n) => (
-                  <option key={n.id} value={n.id}>{n.label?.slice(0, 60)}</option>
+                  <option key={n.id} value={n.id}>
+                    {n.label?.slice(0, 60)}
+                  </option>
                 ))}
               </select>
               <div className="flex items-center gap-2">
-                <label className="text-xs text-gray-500 dark:text-gray-400">Confidence</label>
+                <label className="text-xs text-gray-500 dark:text-gray-400">
+                  Confidence
+                </label>
                 <input
                   type="number"
                   min={0}

--- a/client/src/hooks/useDecisionGraph.js
+++ b/client/src/hooks/useDecisionGraph.js
@@ -8,6 +8,10 @@ const useDecisionGraph = () => {
 
   const [keywordFilter, setKeywordFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Let callers reload the graph after a mutation (create/link/supersede, #2027).
+  const refetch = () => setRefreshKey((k) => k + 1);
 
   useEffect(() => {
     let isCurrent = true;
@@ -35,7 +39,7 @@ const useDecisionGraph = () => {
     return () => {
       isCurrent = false;
     };
-  }, []);
+  }, [refreshKey]);
 
   // Filter logic: when filters change, we compute the visible subset of nodes and edges
   const filteredData = useMemo(() => {
@@ -73,6 +77,7 @@ const useDecisionGraph = () => {
     setKeywordFilter,
     statusFilter,
     setStatusFilter,
+    refetch,
   };
 };
 

--- a/client/src/pages/DecisionGraph.jsx
+++ b/client/src/pages/DecisionGraph.jsx
@@ -11,9 +11,11 @@ import {
   Loader2,
 } from "lucide-react";
 import useDecisionGraph from "../hooks/useDecisionGraph";
+import DecisionGraphEditor from "../components/decision-graph/DecisionGraphEditor";
 
 const DecisionGraph = () => {
   const {
+    data,
     filteredData,
     loading,
     error,
@@ -21,6 +23,7 @@ const DecisionGraph = () => {
     setKeywordFilter,
     statusFilter,
     setStatusFilter,
+    refetch,
   } = useDecisionGraph();
 
   const canvasRef = useRef(null);
@@ -263,6 +266,11 @@ const DecisionGraph = () => {
             </select>
           </div>
         </div>
+      </div>
+
+      {/* Decision editor (create / link / supersede) — RBAC-gated (#2027) */}
+      <div className="px-6 pt-4">
+        <DecisionGraphEditor nodes={data?.nodes || []} onChanged={refetch} />
       </div>
 
       {/* Main Content */}

--- a/client/src/services/decisionGraphApi.js
+++ b/client/src/services/decisionGraphApi.js
@@ -50,7 +50,12 @@ export const getDecisionNeighbors = async (id) => {
 
 // --- Mutations (Issue #2027) ---
 
-export const createDecision = async ({ text, owner, status, sourceMeetingId }) => {
+export const createDecision = async ({
+  text,
+  owner,
+  status,
+  sourceMeetingId,
+}) => {
   const response = await apiClient.post("/api/decision-graph", {
     text,
     owner,

--- a/client/src/services/decisionGraphApi.js
+++ b/client/src/services/decisionGraphApi.js
@@ -47,3 +47,30 @@ export const getDecisionNeighbors = async (id) => {
   const response = await apiClient.get(`/api/decision-graph/${id}/neighbors`);
   return response.data;
 };
+
+// --- Mutations (Issue #2027) ---
+
+export const createDecision = async ({ text, owner, status, sourceMeetingId }) => {
+  const response = await apiClient.post("/api/decision-graph", {
+    text,
+    owner,
+    status,
+    sourceMeetingId,
+  });
+  return response.data;
+};
+
+export const linkDecisions = async (id, { targetId, confidence } = {}) => {
+  const response = await apiClient.post(`/api/decision-graph/${id}/relations`, {
+    targetId,
+    confidence,
+  });
+  return response.data;
+};
+
+export const supersedeDecision = async (id, { targetId } = {}) => {
+  const response = await apiClient.post(`/api/decision-graph/${id}/supersede`, {
+    targetId,
+  });
+  return response.data;
+};

--- a/client/src/services/decisionGraphApi.test.js
+++ b/client/src/services/decisionGraphApi.test.js
@@ -122,20 +122,28 @@ describe("decision graph mutations (Issue #2027)", () => {
   });
 
   it("linkDecisions posts a relatesTo edge to the right id", async () => {
-    apiClient.post.mockResolvedValueOnce({ data: { edge: { type: "relatesTo" } } });
-    await linkDecisions("d1", { targetId: "d2", confidence: 80 });
-    expect(apiClient.post).toHaveBeenCalledWith("/api/decision-graph/d1/relations", {
-      targetId: "d2",
-      confidence: 80,
+    apiClient.post.mockResolvedValueOnce({
+      data: { edge: { type: "relatesTo" } },
     });
+    await linkDecisions("d1", { targetId: "d2", confidence: 80 });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/decision-graph/d1/relations",
+      {
+        targetId: "d2",
+        confidence: 80,
+      },
+    );
   });
 
   it("supersedeDecision posts to the supersede endpoint", async () => {
     apiClient.post.mockResolvedValueOnce({ data: { status: "superseded" } });
     const out = await supersedeDecision("d1", { targetId: "d2" });
-    expect(apiClient.post).toHaveBeenCalledWith("/api/decision-graph/d1/supersede", {
-      targetId: "d2",
-    });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/decision-graph/d1/supersede",
+      {
+        targetId: "d2",
+      },
+    );
     expect(out.status).toBe("superseded");
   });
 });

--- a/client/src/services/decisionGraphApi.test.js
+++ b/client/src/services/decisionGraphApi.test.js
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import apiClient from "./apiClient";
-import { getAllDecisionGraphPages } from "./decisionGraphApi";
+import {
+  getAllDecisionGraphPages,
+  createDecision,
+  linkDecisions,
+  supersedeDecision,
+} from "./decisionGraphApi";
 
 vi.mock("./apiClient", () => ({
   default: {
     get: vi.fn(),
+    post: vi.fn(),
   },
 }));
 
@@ -90,5 +96,46 @@ describe("getAllDecisionGraphPages", () => {
     const graph = await getAllDecisionGraphPages();
 
     expect(graph.edges).toHaveLength(2);
+  });
+});
+
+describe("decision graph mutations (Issue #2027)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("createDecision posts the decision payload", async () => {
+    apiClient.post.mockResolvedValueOnce({ data: { decision: { id: "d1" } } });
+    const out = await createDecision({
+      text: "Adopt Rust for the parser",
+      owner: "alice",
+      status: "open",
+      sourceMeetingId: "m1",
+    });
+    expect(apiClient.post).toHaveBeenCalledWith("/api/decision-graph", {
+      text: "Adopt Rust for the parser",
+      owner: "alice",
+      status: "open",
+      sourceMeetingId: "m1",
+    });
+    expect(out.decision.id).toBe("d1");
+  });
+
+  it("linkDecisions posts a relatesTo edge to the right id", async () => {
+    apiClient.post.mockResolvedValueOnce({ data: { edge: { type: "relatesTo" } } });
+    await linkDecisions("d1", { targetId: "d2", confidence: 80 });
+    expect(apiClient.post).toHaveBeenCalledWith("/api/decision-graph/d1/relations", {
+      targetId: "d2",
+      confidence: 80,
+    });
+  });
+
+  it("supersedeDecision posts to the supersede endpoint", async () => {
+    apiClient.post.mockResolvedValueOnce({ data: { status: "superseded" } });
+    const out = await supersedeDecision("d1", { targetId: "d2" });
+    expect(apiClient.post).toHaveBeenCalledWith("/api/decision-graph/d1/supersede", {
+      targetId: "d2",
+    });
+    expect(out.status).toBe("superseded");
   });
 });

--- a/server/controllers/decisionGraphController.js
+++ b/server/controllers/decisionGraphController.js
@@ -1,6 +1,9 @@
 import Decision from "../models/decisionModel.js";
+import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
 import { escapeRegex } from "../utils/regex.js";
+
+const DECISION_STATUSES = ["open", "in-progress", "resolved", "superseded"];
 
 /**
  * @desc    Get the decision dependency graph for the current organization
@@ -160,5 +163,147 @@ export const getDecisionNeighbors = async (req, res) => {
     res
       .status(500)
       .json({ message: "Server error fetching decision neighbors" });
+  }
+};
+
+/**
+ * @desc    Create a new decision node in the current organization
+ * @route   POST /api/decision-graph
+ * @access  Private (knowledge:create)
+ */
+export const createDecision = async (req, res) => {
+  try {
+    const orgId = req.user.organization;
+    const { text, owner = "", status = "open", sourceMeetingId } = req.body || {};
+
+    if (!text || typeof text !== "string" || !text.trim()) {
+      return res.status(400).json({ message: "Decision text is required" });
+    }
+    if (status && !DECISION_STATUSES.includes(status)) {
+      return res.status(400).json({ message: "Invalid decision status" });
+    }
+    if (!sourceMeetingId || !mongoose.isValidObjectId(sourceMeetingId)) {
+      return res
+        .status(400)
+        .json({ message: "A valid sourceMeetingId is required" });
+    }
+
+    // The meeting must belong to the caller's organization — prevents attaching
+    // a decision to another org's meeting.
+    const meeting = await Meeting.findOne({
+      _id: sourceMeetingId,
+      organization: orgId,
+    }).select("_id");
+    if (!meeting) {
+      return res
+        .status(404)
+        .json({ message: "Source meeting not found in your organization" });
+    }
+
+    const decision = await Decision.create({
+      text: text.trim(),
+      owner: typeof owner === "string" ? owner : "",
+      status,
+      sourceMeetingId,
+      organization: orgId,
+    });
+
+    return res.status(201).json({
+      decision: {
+        id: decision._id.toString(),
+        label: decision.text,
+        owner: decision.owner,
+        status: decision.status,
+      },
+    });
+  } catch (error) {
+    console.error("Error creating decision:", error);
+    return res.status(500).json({ message: "Server error creating decision" });
+  }
+};
+
+/**
+ * Load two decisions in the caller's org, or return the HTTP error to send.
+ * Guards ownership + existence + self-reference for both link and supersede.
+ */
+const loadEdgePair = async (orgId, sourceId, targetId) => {
+  if (!mongoose.isValidObjectId(sourceId) || !mongoose.isValidObjectId(targetId)) {
+    return { error: { status: 400, message: "Invalid decision ID" } };
+  }
+  if (String(sourceId) === String(targetId)) {
+    return { error: { status: 400, message: "A decision cannot link to itself" } };
+  }
+  const [source, target] = await Promise.all([
+    Decision.findOne({ _id: sourceId, organization: orgId }),
+    Decision.findOne({ _id: targetId, organization: orgId }).select("_id"),
+  ]);
+  if (!source || !target) {
+    return { error: { status: 404, message: "Decision not found in your organization" } };
+  }
+  return { source, target };
+};
+
+/**
+ * @desc    Add a relatesTo edge from :id to a target decision
+ * @route   POST /api/decision-graph/:id/relations
+ * @access  Private (knowledge:edit)
+ */
+export const linkDecisions = async (req, res) => {
+  try {
+    const orgId = req.user.organization;
+    const { id } = req.params;
+    const { targetId, confidence } = req.body || {};
+
+    const { source, error } = await loadEdgePair(orgId, id, targetId);
+    if (error) return res.status(error.status).json({ message: error.message });
+
+    const alreadyLinked = (source.relatesTo || []).some(
+      (rel) => rel.target?.toString() === String(targetId),
+    );
+    if (alreadyLinked) {
+      return res.status(409).json({ message: "These decisions are already linked" });
+    }
+
+    const conf =
+      typeof confidence === "number" && confidence >= 0 && confidence <= 100
+        ? confidence
+        : 100;
+    source.relatesTo.push({ target: targetId, confidence: conf });
+    await source.save();
+
+    return res.status(200).json({
+      edge: { source: String(id), target: String(targetId), type: "relatesTo", confidence: conf },
+    });
+  } catch (error) {
+    console.error("Error linking decisions:", error);
+    return res.status(500).json({ message: "Server error linking decisions" });
+  }
+};
+
+/**
+ * @desc    Mark :id as superseded by a target decision
+ * @route   POST /api/decision-graph/:id/supersede
+ * @access  Private (knowledge:edit)
+ */
+export const supersedeDecision = async (req, res) => {
+  try {
+    const orgId = req.user.organization;
+    const { id } = req.params;
+    const { targetId } = req.body || {};
+
+    const { source, error } = await loadEdgePair(orgId, id, targetId);
+    if (error) return res.status(error.status).json({ message: error.message });
+
+    source.supersededByMemory = targetId;
+    source.status = "superseded";
+    await source.save();
+
+    return res.status(200).json({
+      edge: { source: String(id), target: String(targetId), type: "supersededBy" },
+      status: "superseded",
+    });
+  } catch (error) {
+    console.error("Error superseding decision:", error);
+    return res.status(500).json({ message: "Server error superseding decision" });
   }
 };

--- a/server/controllers/decisionGraphController.js
+++ b/server/controllers/decisionGraphController.js
@@ -174,7 +174,12 @@ export const getDecisionNeighbors = async (req, res) => {
 export const createDecision = async (req, res) => {
   try {
     const orgId = req.user.organization;
-    const { text, owner = "", status = "open", sourceMeetingId } = req.body || {};
+    const {
+      text,
+      owner = "",
+      status = "open",
+      sourceMeetingId,
+    } = req.body || {};
 
     if (!text || typeof text !== "string" || !text.trim()) {
       return res.status(400).json({ message: "Decision text is required" });
@@ -227,18 +232,28 @@ export const createDecision = async (req, res) => {
  * Guards ownership + existence + self-reference for both link and supersede.
  */
 const loadEdgePair = async (orgId, sourceId, targetId) => {
-  if (!mongoose.isValidObjectId(sourceId) || !mongoose.isValidObjectId(targetId)) {
+  if (
+    !mongoose.isValidObjectId(sourceId) ||
+    !mongoose.isValidObjectId(targetId)
+  ) {
     return { error: { status: 400, message: "Invalid decision ID" } };
   }
   if (String(sourceId) === String(targetId)) {
-    return { error: { status: 400, message: "A decision cannot link to itself" } };
+    return {
+      error: { status: 400, message: "A decision cannot link to itself" },
+    };
   }
   const [source, target] = await Promise.all([
     Decision.findOne({ _id: sourceId, organization: orgId }),
     Decision.findOne({ _id: targetId, organization: orgId }).select("_id"),
   ]);
   if (!source || !target) {
-    return { error: { status: 404, message: "Decision not found in your organization" } };
+    return {
+      error: {
+        status: 404,
+        message: "Decision not found in your organization",
+      },
+    };
   }
   return { source, target };
 };
@@ -261,7 +276,9 @@ export const linkDecisions = async (req, res) => {
       (rel) => rel.target?.toString() === String(targetId),
     );
     if (alreadyLinked) {
-      return res.status(409).json({ message: "These decisions are already linked" });
+      return res
+        .status(409)
+        .json({ message: "These decisions are already linked" });
     }
 
     const conf =
@@ -272,7 +289,12 @@ export const linkDecisions = async (req, res) => {
     await source.save();
 
     return res.status(200).json({
-      edge: { source: String(id), target: String(targetId), type: "relatesTo", confidence: conf },
+      edge: {
+        source: String(id),
+        target: String(targetId),
+        type: "relatesTo",
+        confidence: conf,
+      },
     });
   } catch (error) {
     console.error("Error linking decisions:", error);
@@ -299,11 +321,17 @@ export const supersedeDecision = async (req, res) => {
     await source.save();
 
     return res.status(200).json({
-      edge: { source: String(id), target: String(targetId), type: "supersededBy" },
+      edge: {
+        source: String(id),
+        target: String(targetId),
+        type: "supersededBy",
+      },
       status: "superseded",
     });
   } catch (error) {
     console.error("Error superseding decision:", error);
-    return res.status(500).json({ message: "Server error superseding decision" });
+    return res
+      .status(500)
+      .json({ message: "Server error superseding decision" });
   }
 };

--- a/server/routes/decisionGraphRoutes.js
+++ b/server/routes/decisionGraphRoutes.js
@@ -2,6 +2,9 @@ import express from "express";
 import {
   getDecisionGraph,
   getDecisionNeighbors,
+  createDecision,
+  linkDecisions,
+  supersedeDecision,
 } from "../controllers/decisionGraphController.js";
 import { apiLimiter } from "../middleware/rateLimiter.js";
 import userAuth from "../middleware/userAuth.js";
@@ -19,5 +22,17 @@ router.get("/", getDecisionGraph);
 
 // Get immediate neighbors for a specific decision
 router.get("/:id/neighbors", getDecisionNeighbors);
+
+// --- Mutations (Issue #2027) — view is enforced above; these add create/edit.
+// Viewers/guests lack knowledge:create|edit, so they remain read-only.
+
+// Create a new decision node
+router.post("/", requirePermission("knowledge", "create"), createDecision);
+
+// Link this decision to another (relatesTo edge)
+router.post("/:id/relations", requirePermission("knowledge", "edit"), linkDecisions);
+
+// Mark this decision as superseded by another
+router.post("/:id/supersede", requirePermission("knowledge", "edit"), supersedeDecision);
 
 export default router;

--- a/server/routes/decisionGraphRoutes.js
+++ b/server/routes/decisionGraphRoutes.js
@@ -30,9 +30,17 @@ router.get("/:id/neighbors", getDecisionNeighbors);
 router.post("/", requirePermission("knowledge", "create"), createDecision);
 
 // Link this decision to another (relatesTo edge)
-router.post("/:id/relations", requirePermission("knowledge", "edit"), linkDecisions);
+router.post(
+  "/:id/relations",
+  requirePermission("knowledge", "edit"),
+  linkDecisions,
+);
 
 // Mark this decision as superseded by another
-router.post("/:id/supersede", requirePermission("knowledge", "edit"), supersedeDecision);
+router.post(
+  "/:id/supersede",
+  requirePermission("knowledge", "edit"),
+  supersedeDecision,
+);
 
 export default router;

--- a/server/tests/decisionGraphMutations.test.js
+++ b/server/tests/decisionGraphMutations.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createDecision,
+  linkDecisions,
+  supersedeDecision,
+} from "../controllers/decisionGraphController.js";
+import Decision from "../models/decisionModel.js";
+import Meeting from "../models/meetingModel.js";
+
+vi.mock("../models/decisionModel.js", () => ({
+  default: { create: vi.fn(), findOne: vi.fn() },
+}));
+vi.mock("../models/meetingModel.js", () => ({
+  default: { findOne: vi.fn() },
+}));
+
+// A query-like object that both awaits to `doc` and supports `.select()`.
+const query = (doc) => ({
+  select: () => Promise.resolve(doc),
+  then: (resolve, reject) => Promise.resolve(doc).then(resolve, reject),
+});
+
+const mockRes = () => ({
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn().mockReturnThis(),
+});
+
+const OID_A = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const OID_B = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+describe("decisionGraph mutations (#2027)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("createDecision", () => {
+    it("creates a decision for a meeting in the caller's org (201)", async () => {
+      Meeting.findOne.mockReturnValue(query({ _id: OID_A }));
+      Decision.create.mockResolvedValue({
+        _id: { toString: () => "d1" },
+        text: "Adopt Rust",
+        owner: "alice",
+        status: "open",
+      });
+      const req = {
+        user: { organization: "org1" },
+        body: { text: "Adopt Rust", owner: "alice", sourceMeetingId: OID_A },
+      };
+      const res = mockRes();
+      await createDecision(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(Decision.create).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "Adopt Rust", organization: "org1", sourceMeetingId: OID_A }),
+      );
+    });
+
+    it("rejects missing text (400)", async () => {
+      const res = mockRes();
+      await createDecision({ user: { organization: "org1" }, body: { sourceMeetingId: OID_A } }, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(Decision.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid sourceMeetingId (400)", async () => {
+      const res = mockRes();
+      await createDecision(
+        { user: { organization: "org1" }, body: { text: "x", sourceMeetingId: "not-an-id" } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("404s when the source meeting is not in the org", async () => {
+      Meeting.findOne.mockReturnValue(query(null));
+      const res = mockRes();
+      await createDecision(
+        { user: { organization: "org1" }, body: { text: "x", sourceMeetingId: OID_A } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(Decision.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("linkDecisions", () => {
+    it("adds a relatesTo edge and saves (200)", async () => {
+      const source = { relatesTo: [], save: vi.fn().mockResolvedValue(true) };
+      Decision.findOne.mockImplementation((q) =>
+        query(q._id === OID_A ? source : { _id: OID_B }),
+      );
+      const res = mockRes();
+      await linkDecisions(
+        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B, confidence: 80 } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(source.relatesTo).toEqual([{ target: OID_B, confidence: 80 }]);
+      expect(source.save).toHaveBeenCalled();
+    });
+
+    it("rejects a self-link (400) without touching the DB", async () => {
+      const res = mockRes();
+      await linkDecisions(
+        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_A } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(Decision.findOne).not.toHaveBeenCalled();
+    });
+
+    it("409s when the edge already exists", async () => {
+      const source = { relatesTo: [{ target: { toString: () => OID_B } }], save: vi.fn() };
+      Decision.findOne.mockImplementation((q) =>
+        query(q._id === OID_A ? source : { _id: OID_B }),
+      );
+      const res = mockRes();
+      await linkDecisions(
+        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(source.save).not.toHaveBeenCalled();
+    });
+
+    it("404s when a decision is not in the org", async () => {
+      Decision.findOne.mockImplementation((q) => query(q._id === OID_A ? null : { _id: OID_B }));
+      const res = mockRes();
+      await linkDecisions(
+        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe("supersedeDecision", () => {
+    it("marks the decision superseded and saves (200)", async () => {
+      const source = { save: vi.fn().mockResolvedValue(true) };
+      Decision.findOne.mockImplementation((q) =>
+        query(q._id === OID_A ? source : { _id: OID_B }),
+      );
+      const res = mockRes();
+      await supersedeDecision(
+        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(source.supersededByMemory).toBe(OID_B);
+      expect(source.status).toBe("superseded");
+      expect(source.save).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/tests/decisionGraphMutations.test.js
+++ b/server/tests/decisionGraphMutations.test.js
@@ -48,13 +48,20 @@ describe("decisionGraph mutations (#2027)", () => {
       await createDecision(req, res);
       expect(res.status).toHaveBeenCalledWith(201);
       expect(Decision.create).toHaveBeenCalledWith(
-        expect.objectContaining({ text: "Adopt Rust", organization: "org1", sourceMeetingId: OID_A }),
+        expect.objectContaining({
+          text: "Adopt Rust",
+          organization: "org1",
+          sourceMeetingId: OID_A,
+        }),
       );
     });
 
     it("rejects missing text (400)", async () => {
       const res = mockRes();
-      await createDecision({ user: { organization: "org1" }, body: { sourceMeetingId: OID_A } }, res);
+      await createDecision(
+        { user: { organization: "org1" }, body: { sourceMeetingId: OID_A } },
+        res,
+      );
       expect(res.status).toHaveBeenCalledWith(400);
       expect(Decision.create).not.toHaveBeenCalled();
     });
@@ -62,7 +69,10 @@ describe("decisionGraph mutations (#2027)", () => {
     it("rejects an invalid sourceMeetingId (400)", async () => {
       const res = mockRes();
       await createDecision(
-        { user: { organization: "org1" }, body: { text: "x", sourceMeetingId: "not-an-id" } },
+        {
+          user: { organization: "org1" },
+          body: { text: "x", sourceMeetingId: "not-an-id" },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(400);
@@ -72,7 +82,10 @@ describe("decisionGraph mutations (#2027)", () => {
       Meeting.findOne.mockReturnValue(query(null));
       const res = mockRes();
       await createDecision(
-        { user: { organization: "org1" }, body: { text: "x", sourceMeetingId: OID_A } },
+        {
+          user: { organization: "org1" },
+          body: { text: "x", sourceMeetingId: OID_A },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(404);
@@ -88,7 +101,11 @@ describe("decisionGraph mutations (#2027)", () => {
       );
       const res = mockRes();
       await linkDecisions(
-        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B, confidence: 80 } },
+        {
+          user: { organization: "org1" },
+          params: { id: OID_A },
+          body: { targetId: OID_B, confidence: 80 },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(200);
@@ -99,7 +116,11 @@ describe("decisionGraph mutations (#2027)", () => {
     it("rejects a self-link (400) without touching the DB", async () => {
       const res = mockRes();
       await linkDecisions(
-        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_A } },
+        {
+          user: { organization: "org1" },
+          params: { id: OID_A },
+          body: { targetId: OID_A },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(400);
@@ -107,13 +128,20 @@ describe("decisionGraph mutations (#2027)", () => {
     });
 
     it("409s when the edge already exists", async () => {
-      const source = { relatesTo: [{ target: { toString: () => OID_B } }], save: vi.fn() };
+      const source = {
+        relatesTo: [{ target: { toString: () => OID_B } }],
+        save: vi.fn(),
+      };
       Decision.findOne.mockImplementation((q) =>
         query(q._id === OID_A ? source : { _id: OID_B }),
       );
       const res = mockRes();
       await linkDecisions(
-        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        {
+          user: { organization: "org1" },
+          params: { id: OID_A },
+          body: { targetId: OID_B },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(409);
@@ -121,10 +149,16 @@ describe("decisionGraph mutations (#2027)", () => {
     });
 
     it("404s when a decision is not in the org", async () => {
-      Decision.findOne.mockImplementation((q) => query(q._id === OID_A ? null : { _id: OID_B }));
+      Decision.findOne.mockImplementation((q) =>
+        query(q._id === OID_A ? null : { _id: OID_B }),
+      );
       const res = mockRes();
       await linkDecisions(
-        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        {
+          user: { organization: "org1" },
+          params: { id: OID_A },
+          body: { targetId: OID_B },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(404);
@@ -139,7 +173,11 @@ describe("decisionGraph mutations (#2027)", () => {
       );
       const res = mockRes();
       await supersedeDecision(
-        { user: { organization: "org1" }, params: { id: OID_A }, body: { targetId: OID_B } },
+        {
+          user: { organization: "org1" },
+          params: { id: OID_A },
+          body: { targetId: OID_B },
+        },
         res,
       );
       expect(res.status).toHaveBeenCalledWith(200);


### PR DESCRIPTION
Closes #2027 · resubmits the auto-closed #2167 with CI fixed (Prettier formatting applied; eslint + tests verified green).

### Problem
The decision graph was view/filter only — users could not create decisions or curate `relatesTo` / supersede edges. The backend model already supports these relationships.

### Backend
- **`decisionGraphController.js`** — `createDecision`, `linkDecisions` (relatesTo), `supersedeDecision`, org-scoped with validation (valid ObjectIds, target in same org, no self-links, no duplicate edges; create requires a `sourceMeetingId` in the callers org).
- **`decisionGraphRoutes.js`** — `POST /` (`knowledge:create`), `POST /:id/relations` + `POST /:id/supersede` (`knowledge:edit`). `view` is already enforced, so viewers/guests stay read-only.

### Frontend
- **`decisionGraphApi.js`** — `createDecision` / `linkDecisions` / `supersedeDecision`.
- **`useDecisionGraph`** — `refetch()` to reload after a mutation.
- **`DecisionGraphEditor.jsx`** — RBAC-gated (`useRBAC`) create + link/supersede panel, hidden for users without `knowledge` create/edit. Wired into the page.

### Acceptance criteria
- [x] Authorized user can create a decision node
- [x] Link/supersede with validation
- [x] Unauthorized users remain view-only (server RBAC + client gating)

### Tests
`server/tests/decisionGraphMutations.test.js` (9) — create/link/supersede branches (201/200, 400 self-link/missing text, 404 not-in-org, 409 duplicate); `client/.../decisionGraphApi.test.js` (3) new mutation calls. All green.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._