### PR TITLE
feat: meeting-goal series outcome rollup (#2466)

### DIFF
--- a/client/src/components/meetings/MeetingGoalsPanel.jsx
+++ b/client/src/components/meetings/MeetingGoalsPanel.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { toast } from "react-toastify";
 import { Plus, Trash2, CheckCircle, Circle, ArrowRight } from "lucide-react";
 import { meetingGoalApi } from "../../services";
+import SeriesGoalRollup from "./SeriesGoalRollup";
 
 const MeetingGoalsPanel = ({ meeting, currentUser }) => {
   const [goals, setGoals] = useState([]);
@@ -353,6 +354,8 @@ const MeetingGoalsPanel = ({ meeting, currentUser }) => {
           )}
         </div>
       )}
+
+      <SeriesGoalRollup meetingId={meeting?._id} />
     </div>
   );
 };

--- a/client/src/components/meetings/SeriesGoalRollup.jsx
+++ b/client/src/components/meetings/SeriesGoalRollup.jsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import { BarChart3, ChevronDown, ChevronUp } from "lucide-react";
+import { meetingGoalApi } from "../../services";
+
+const asPercent = (rate) => `${Math.round((rate || 0) * 100)}%`;
+
+/**
+ * Issue #2466 — series goal rollup.
+ * Loads and displays aggregated goal outcomes across every occurrence of this
+ * meeting's series (overall completion + per-occurrence breakdown).
+ */
+const SeriesGoalRollup = ({ meetingId }) => {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const load = async () => {
+    if (!meetingId) return;
+    setOpen(true);
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await meetingGoalApi.getSeriesGoalRollup(meetingId);
+      setData(res.data);
+    } catch (e) {
+      setError(
+        e?.response?.data?.message || "Could not load the series rollup.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const rollup = data?.rollup;
+
+  return (
+    <div className="mt-4 rounded-lg border border-gray-200 dark:border-gray-700">
+      <button
+        type="button"
+        onClick={() => (open ? setOpen(false) : load())}
+        className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200"
+      >
+        <span className="flex items-center gap-2">
+          <BarChart3 size={14} /> Series goal rollup
+        </span>
+        {open ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {open && (
+        <div className="border-t border-gray-100 px-3 py-3 dark:border-gray-700">
+          {loading ? (
+            <p className="text-xs text-gray-500">Loading…</p>
+          ) : error ? (
+            <p className="text-xs text-red-500">{error}</p>
+          ) : rollup && rollup.totalGoals > 0 ? (
+            <div className="space-y-3">
+              <div>
+                <div className="mb-1 flex items-center justify-between text-xs text-gray-600 dark:text-gray-300">
+                  <span>
+                    Overall completion across {data.meetingCount} meeting
+                    {data.meetingCount === 1 ? "" : "s"}
+                  </span>
+                  <span className="font-semibold">
+                    {asPercent(rollup.completionRate)}
+                  </span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded bg-gray-200 dark:bg-gray-700">
+                  <div
+                    className="h-full bg-emerald-500"
+                    style={{ width: asPercent(rollup.completionRate) }}
+                  />
+                </div>
+                <div className="mt-1 text-[11px] text-gray-500">
+                  {rollup.achievedCount} achieved ·{" "}
+                  {rollup.byStatus.partially_achieved} partial ·{" "}
+                  {rollup.byStatus.not_achieved} missed ·{" "}
+                  {rollup.byStatus.pending} pending ({rollup.totalGoals} goals)
+                </div>
+              </div>
+
+              <ul className="space-y-1">
+                {rollup.perOccurrence.map((occ, i) => (
+                  <li
+                    key={occ.meetingId || i}
+                    className="flex items-center gap-2 text-[11px]"
+                  >
+                    <span className="w-16 shrink-0 text-gray-500">
+                      {occ.occurrence != null
+                        ? `#${occ.occurrence}`
+                        : "Meeting"}
+                    </span>
+                    <span className="h-1.5 flex-1 overflow-hidden rounded bg-gray-200 dark:bg-gray-700">
+                      <span
+                        className="block h-full bg-emerald-500"
+                        style={{ width: asPercent(occ.completionRate) }}
+                      />
+                    </span>
+                    <span className="w-10 shrink-0 text-right text-gray-600 dark:text-gray-300">
+                      {asPercent(occ.completionRate)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="text-xs text-gray-500">
+              No goals recorded for this series yet.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SeriesGoalRollup;

--- a/client/src/services/meetingGoalApi.js
+++ b/client/src/services/meetingGoalApi.js
@@ -15,6 +15,9 @@ const meetingGoalApi = {
 
   getOrgGoalStats: (orgId) =>
     apiClient.get(`/api/meeting-goals/org/${orgId}/stats`),
+
+  getSeriesGoalRollup: (meetingId) =>
+    apiClient.get(`/api/meeting-goals/meeting/${meetingId}/series-rollup`),
 };
 
 export default meetingGoalApi;

--- a/server/controllers/meetingGoalController.js
+++ b/server/controllers/meetingGoalController.js
@@ -2,6 +2,7 @@ import { z } from "zod";
 import MeetingGoal from "../models/meetingGoalModel.js";
 import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
+import { computeGoalRollup } from "../utils/goalRollup.js";
 
 const setGoalsSchema = z.object({
   goals: z
@@ -117,6 +118,72 @@ export const getGoals = async (req, res, next) => {
     }
 
     return res.status(200).json({ success: true, meetingGoal });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Aggregate goal outcomes across every occurrence of a meeting's series.
+ * If the meeting is not part of a series, the rollup covers just that meeting.
+ * @route GET /api/meeting-goals/meeting/:meetingId/series-rollup
+ */
+export const getSeriesGoalRollup = async (req, res, next) => {
+  try {
+    const { meetingId } = req.params;
+    const userOrg = req.user.organization || req.user.activeOrganization;
+
+    if (!userOrg) {
+      return res
+        .status(403)
+        .json({ success: false, message: "Organization required" });
+    }
+
+    const meeting = await Meeting.findOne({
+      _id: meetingId,
+      organization: userOrg,
+      deletedAt: null,
+    });
+
+    if (!meeting) {
+      return res.status(403).json({
+        success: false,
+        message: "Access denied: different organization or meeting not found",
+      });
+    }
+
+    // Every meeting in the same series (org-scoped); or just this one if it's standalone.
+    const seriesFilter = meeting.series
+      ? { series: meeting.series, organization: userOrg, deletedAt: null }
+      : { _id: meeting._id, organization: userOrg, deletedAt: null };
+    const meetings = await Meeting.find(seriesFilter).select(
+      "_id seriesOccurrence title",
+    );
+
+    const meetingIds = meetings.map((m) => m._id);
+    const goalDocs = await MeetingGoal.find({
+      meetingId: { $in: meetingIds },
+      organization: userOrg,
+    });
+    const goalsByMeeting = new Map(
+      goalDocs.map((doc) => [doc.meetingId.toString(), doc.goals]),
+    );
+
+    const entries = meetings.map((m) => ({
+      meetingId: m._id,
+      seriesOccurrence:
+        typeof m.seriesOccurrence === "number" ? m.seriesOccurrence : null,
+      goals: goalsByMeeting.get(m._id.toString()) || [],
+    }));
+
+    const rollup = computeGoalRollup(entries);
+
+    return res.status(200).json({
+      success: true,
+      seriesId: meeting.series || null,
+      meetingCount: meetings.length,
+      rollup,
+    });
   } catch (error) {
     next(error);
   }

--- a/server/routes/meetingGoalRoutes.js
+++ b/server/routes/meetingGoalRoutes.js
@@ -5,6 +5,7 @@ import {
   getGoals,
   updateGoalStatus,
   getOrgGoalStats,
+  getSeriesGoalRollup,
 } from "../controllers/meetingGoalController.js";
 
 const router = express.Router();
@@ -13,6 +14,7 @@ router.use(userAuth);
 
 router.post("/meeting/:meetingId", setGoals);
 router.get("/meeting/:meetingId", getGoals);
+router.get("/meeting/:meetingId/series-rollup", getSeriesGoalRollup);
 router.patch("/meeting/:meetingId/goal/:goalId", updateGoalStatus);
 router.get("/org/:orgId/stats", getOrgGoalStats);
 

--- a/server/tests/goalRollup.test.js
+++ b/server/tests/goalRollup.test.js
@@ -1,0 +1,84 @@
+import { computeGoalRollup } from "../utils/goalRollup.js";
+
+describe("computeGoalRollup (Issue #2466)", () => {
+  it("returns zeroed metrics for no entries", () => {
+    const r = computeGoalRollup([]);
+    expect(r.totalGoals).toBe(0);
+    expect(r.completionRate).toBe(0);
+    expect(r.meetingsWithGoals).toBe(0);
+    expect(r.byStatus).toEqual({
+      pending: 0,
+      achieved: 0,
+      partially_achieved: 0,
+      not_achieved: 0,
+    });
+    expect(r.perOccurrence).toEqual([]);
+  });
+
+  it("counts statuses and weights completion (achieved=1, partial=0.5, else 0)", () => {
+    const r = computeGoalRollup([
+      {
+        meetingId: "m1",
+        seriesOccurrence: 1,
+        goals: [
+          { status: "achieved" },
+          { status: "partially_achieved" },
+          { status: "pending" },
+          { status: "not_achieved" },
+        ],
+      },
+    ]);
+    expect(r.totalGoals).toBe(4);
+    expect(r.byStatus).toEqual({
+      pending: 1,
+      achieved: 1,
+      partially_achieved: 1,
+      not_achieved: 1,
+    });
+    expect(r.achievedCount).toBe(1);
+    // (1 + 0.5 + 0 + 0) / 4 = 0.375
+    expect(r.completionRate).toBe(0.375);
+    expect(r.meetingsWithGoals).toBe(1);
+  });
+
+  it("aggregates across a series and reports per-occurrence, sorted", () => {
+    const r = computeGoalRollup([
+      {
+        meetingId: "m2",
+        seriesOccurrence: 2,
+        goals: [{ status: "achieved" }, { status: "achieved" }],
+      },
+      {
+        meetingId: "m1",
+        seriesOccurrence: 1,
+        goals: [{ status: "pending" }, { status: "achieved" }],
+      },
+    ]);
+    expect(r.totalGoals).toBe(4);
+    // 3 achieved + 1 pending → 3/4 = 0.75
+    expect(r.completionRate).toBe(0.75);
+    expect(r.perOccurrence.map((o) => o.occurrence)).toEqual([1, 2]);
+    expect(r.perOccurrence[0].completionRate).toBe(0.5); // occ 1: 1 of 2
+    expect(r.perOccurrence[1].completionRate).toBe(1); // occ 2: 2 of 2
+  });
+
+  it("treats unknown/missing statuses as pending and ignores non-goal entries", () => {
+    const r = computeGoalRollup([
+      {
+        meetingId: "m1",
+        seriesOccurrence: 1,
+        goals: [{ status: "banana" }, {}],
+      },
+      { meetingId: "m2", seriesOccurrence: 2, goals: [] }, // no goals → not counted in meetingsWithGoals
+    ]);
+    expect(r.totalGoals).toBe(2);
+    expect(r.byStatus.pending).toBe(2);
+    expect(r.completionRate).toBe(0);
+    expect(r.meetingsWithGoals).toBe(1);
+  });
+
+  it("is defensive against non-array input", () => {
+    expect(computeGoalRollup(null).totalGoals).toBe(0);
+    expect(computeGoalRollup(undefined).perOccurrence).toEqual([]);
+  });
+});

--- a/server/utils/goalRollup.js
+++ b/server/utils/goalRollup.js
@@ -1,0 +1,87 @@
+/**
+ * Meeting-goal outcome rollup (Issue #2466).
+ *
+ * Pure aggregation over the goal outcomes of a set of meetings (e.g. every
+ * occurrence in a series). Turns raw goal statuses into completion metrics —
+ * overall and per occurrence — so a series view can show whether goals are
+ * actually being met across recurring meetings. No DB or IO; unit-tested.
+ */
+
+export const GOAL_STATUSES = [
+  "pending",
+  "achieved",
+  "partially_achieved",
+  "not_achieved",
+];
+
+// A partially-achieved goal counts as half toward completion.
+const STATUS_WEIGHT = {
+  achieved: 1,
+  partially_achieved: 0.5,
+  pending: 0,
+  not_achieved: 0,
+};
+
+const emptyByStatus = () => ({
+  pending: 0,
+  achieved: 0,
+  partially_achieved: 0,
+  not_achieved: 0,
+});
+
+const round4 = (n) => Math.round(n * 10000) / 10000;
+
+/**
+ * @param {Array<{ meetingId?: any, seriesOccurrence?: number|null, goals?: Array<{ status?: string }> }>} entries
+ * @returns rollup metrics: totals, byStatus counts, weighted completionRate (0–1),
+ *          and a per-occurrence breakdown sorted by occurrence.
+ */
+export function computeGoalRollup(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const byStatus = emptyByStatus();
+  let totalGoals = 0;
+  let weighted = 0;
+  let meetingsWithGoals = 0;
+  const perOccurrence = [];
+
+  for (const entry of list) {
+    const goals = Array.isArray(entry?.goals) ? entry.goals : [];
+    if (goals.length > 0) meetingsWithGoals += 1;
+
+    const occByStatus = emptyByStatus();
+    let occWeighted = 0;
+
+    for (const goal of goals) {
+      const status = GOAL_STATUSES.includes(goal?.status)
+        ? goal.status
+        : "pending";
+      byStatus[status] += 1;
+      occByStatus[status] += 1;
+      totalGoals += 1;
+      weighted += STATUS_WEIGHT[status];
+      occWeighted += STATUS_WEIGHT[status];
+    }
+
+    perOccurrence.push({
+      meetingId: entry?.meetingId ?? null,
+      occurrence:
+        typeof entry?.seriesOccurrence === "number"
+          ? entry.seriesOccurrence
+          : null,
+      total: goals.length,
+      byStatus: occByStatus,
+      completionRate: goals.length ? round4(occWeighted / goals.length) : 0,
+    });
+  }
+
+  perOccurrence.sort((a, b) => (a.occurrence ?? 0) - (b.occurrence ?? 0));
+
+  return {
+    totalGoals,
+    meetingsWithGoals,
+    byStatus,
+    achievedCount: byStatus.achieved,
+    completionRate: totalGoals ? round4(weighted / totalGoals) : 0,
+    perOccurrence,
+  };
+}


### PR DESCRIPTION
Closes #2466

### Problem
Per-goal outcome tracking exists (`updateGoalStatus`), but there was **no series rollup** — no way to see whether goals are actually being met across a recurring meeting series.

### Backend
- **`server/utils/goalRollup.js`** — pure `computeGoalRollup(entries)`: aggregates goal statuses into overall + per-occurrence completion metrics (achieved = 1, partially_achieved = 0.5, else 0), sorted by occurrence. No DB/IO.
- **`getSeriesGoalRollup`** — org-scoped `GET /api/meeting-goals/meeting/:meetingId/series-rollup`: gathers every meeting in the series (or just this one if standalone), loads their goals, returns the rollup.
- **`server/tests/goalRollup.test.js`** — 5 pure tests (weighting, per-occurrence breakdown + sort, unknown/missing statuses → pending, defensive on non-array input).

### Frontend
- `meetingGoalApi.getSeriesGoalRollup` + **`SeriesGoalRollup.jsx`** — a collapsible panel showing overall completion and a per-occurrence bar breakdown; mounted in `MeetingGoalsPanel`.

### Acceptance criteria
- [x] Goals show completion state (existing per-goal status; surfaced in the rollup)
- [x] Series view aggregates outcomes
- [x] Updates persist (via existing goal status endpoint)
- [x] Tests cover rollup

### Verified locally (green before push)
server `jest goalRollup` → 5/5 · server + client `eslint` clean · `prettier` applied to all changed files.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible series-wide goals summary to meeting panels.
  * View overall completion progress, goal status counts, and results for each meeting occurrence.
  * Displays a clear message when no goals have been recorded.

* **Bug Fixes**
  * Improved handling of incomplete or unrecognized goal statuses in summary calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->