### PR TITLE
feat: contribution equity metrics + detail view (#2449)

### DIFF
--- a/client/src/components/MeetingDetails/ContributionSummaryPanel.jsx
+++ b/client/src/components/MeetingDetails/ContributionSummaryPanel.jsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { useMeetingContributions } from "../../hooks/useParticipantContributions";
+
+const DIMENSIONS = ["verbal", "decisional", "task", "collaborative"];
 
 const ContributionSummaryPanel = ({ meetingId }) => {
   const { data, isLoading, isError } = useMeetingContributions(meetingId);
+  const [showDetail, setShowDetail] = useState(false);
 
   if (isLoading)
     return (
@@ -17,6 +20,7 @@ const ContributionSummaryPanel = ({ meetingId }) => {
 
   const contributions = data?.contributions || [];
   const equityScore = data?.equityScore || 0;
+  const equity = data?.equity;
 
   if (contributions.length === 0) {
     return (
@@ -65,9 +69,71 @@ const ContributionSummaryPanel = ({ meetingId }) => {
           </div>
         ))}
       </div>
+
+      {showDetail && equity && (
+        <div className="mt-4 pt-3 border-t space-y-4">
+          <div>
+            <div className="text-xs font-medium text-gray-700 mb-2">
+              Equity by dimension (100 = perfectly even)
+            </div>
+            {DIMENSIONS.map((dim) => {
+              const value = equity.perDimension?.[dim] ?? 0;
+              return (
+                <div key={dim} className="mb-1">
+                  <div className="flex justify-between text-[11px] text-gray-500 capitalize">
+                    <span>{dim}</span>
+                    <span>{value}</span>
+                  </div>
+                  <div className="h-1.5 bg-gray-200 rounded overflow-hidden">
+                    <div
+                      className="h-full bg-indigo-500"
+                      style={{ width: `${value}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div>
+            <div className="text-xs font-medium text-gray-700 mb-2">
+              Contribution share
+            </div>
+            <ul className="space-y-1">
+              {(equity.distribution || []).map((p, i) => (
+                <li
+                  key={p.participantId || i}
+                  className="flex items-center gap-2 text-[11px]"
+                >
+                  <span
+                    className="w-24 shrink-0 truncate text-gray-600"
+                    title={p.participantName}
+                  >
+                    {p.participantName}
+                  </span>
+                  <span className="flex-1 h-1.5 bg-gray-200 rounded overflow-hidden">
+                    <span
+                      className="block h-full bg-emerald-500"
+                      style={{ width: `${p.share}%` }}
+                    />
+                  </span>
+                  <span className="w-10 shrink-0 text-right text-gray-500">
+                    {p.share}%
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+
       <div className="mt-4 pt-3 border-t text-center">
-        <button className="text-blue-600 hover:text-blue-800 text-sm font-medium">
-          View Detailed Profile &rarr;
+        <button
+          type="button"
+          onClick={() => setShowDetail((v) => !v)}
+          className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+        >
+          {showDetail ? "Hide Details" : "View Detailed Profile"} &rarr;
         </button>
       </div>
     </div>

--- a/server/controllers/participantContributionController.js
+++ b/server/controllers/participantContributionController.js
@@ -1,5 +1,6 @@
 import participantContributionService from "../services/participantContributionService.js";
 import ParticipantContribution from "../models/participantContributionModel.js";
+import { computeEquityBreakdown } from "../utils/contributionEquity.js";
 
 /**
  * Get contributions for a specific meeting
@@ -22,6 +23,7 @@ export const getContributionsByMeeting = async (req, res) => {
       return res.status(200).json({
         contributions: calculated,
         equityScore,
+        equity: computeEquityBreakdown(calculated),
       });
     }
 
@@ -31,6 +33,7 @@ export const getContributionsByMeeting = async (req, res) => {
     res.status(200).json({
       contributions,
       equityScore,
+      equity: computeEquityBreakdown(contributions),
     });
   } catch (error) {
     console.error("Error fetching participant contributions:", error);
@@ -54,6 +57,7 @@ export const calculateContributions = async (req, res) => {
       message: "Contributions calculated successfully",
       contributions,
       equityScore,
+      equity: computeEquityBreakdown(contributions),
     });
   } catch (error) {
     console.error("Error calculating participant contributions:", error);

--- a/server/tests/contributionEquity.test.js
+++ b/server/tests/contributionEquity.test.js
@@ -1,0 +1,94 @@
+import {
+  giniCoefficient,
+  equityFromGini,
+  computeEquityBreakdown,
+} from "../utils/contributionEquity.js";
+
+describe("giniCoefficient (Issue #2449)", () => {
+  it("is 0 for empty, single, all-equal, or all-zero inputs", () => {
+    expect(giniCoefficient([])).toBe(0);
+    expect(giniCoefficient([42])).toBe(0);
+    expect(giniCoefficient([50, 50, 50])).toBe(0);
+    expect(giniCoefficient([0, 0, 0])).toBe(0);
+  });
+
+  it("rises with inequality", () => {
+    // [0, 10]: absDiff = 20, /(2*2*10) = 0.5
+    expect(giniCoefficient([0, 10])).toBeCloseTo(0.5, 5);
+    expect(giniCoefficient([10, 90])).toBeGreaterThan(0);
+    expect(giniCoefficient([1, 99])).toBeGreaterThan(giniCoefficient([40, 60]));
+  });
+
+  it("ignores negative / non-finite values", () => {
+    expect(giniCoefficient([50, 50, -5, NaN])).toBe(0);
+  });
+});
+
+describe("equityFromGini", () => {
+  it("maps gini to a 0–100 equity score (100 = perfectly equal)", () => {
+    expect(equityFromGini(0)).toBe(100);
+    expect(equityFromGini(0.5)).toBe(50);
+    expect(equityFromGini(1)).toBe(0);
+  });
+});
+
+describe("computeEquityBreakdown", () => {
+  it("returns perfect equity for equal contributors", () => {
+    const out = computeEquityBreakdown([
+      {
+        participantId: "a",
+        overallImpact: 50,
+        dimensions: { verbal: 50, decisional: 50, task: 50, collaborative: 50 },
+      },
+      {
+        participantId: "b",
+        overallImpact: 50,
+        dimensions: { verbal: 50, decisional: 50, task: 50, collaborative: 50 },
+      },
+    ]);
+    expect(out.overall).toBe(100);
+    expect(out.gini).toBe(0);
+    expect(out.participantCount).toBe(2);
+    expect(out.perDimension).toEqual({
+      verbal: 100,
+      decisional: 100,
+      task: 100,
+      collaborative: 100,
+    });
+    expect(out.distribution.map((d) => d.share)).toEqual([50, 50]);
+  });
+
+  it("reflects inequality and sorts the distribution by score", () => {
+    const out = computeEquityBreakdown([
+      {
+        participantId: "low",
+        participantName: "Low",
+        overallImpact: 10,
+        dimensions: { verbal: 10 },
+      },
+      {
+        participantId: "high",
+        participantName: "High",
+        overallImpact: 30,
+        dimensions: { verbal: 30 },
+      },
+    ]);
+    expect(out.overall).toBeLessThan(100);
+    // total impact 40 → shares 75 / 25, highest first
+    expect(out.distribution[0]).toMatchObject({
+      participantId: "high",
+      share: 75,
+    });
+    expect(out.distribution[1]).toMatchObject({
+      participantId: "low",
+      share: 25,
+    });
+  });
+
+  it("is defensive: empty input → perfectly-equal, empty distribution", () => {
+    const out = computeEquityBreakdown([]);
+    expect(out.overall).toBe(100);
+    expect(out.participantCount).toBe(0);
+    expect(out.distribution).toEqual([]);
+  });
+});

--- a/server/utils/contributionEquity.js
+++ b/server/utils/contributionEquity.js
@@ -1,0 +1,77 @@
+/**
+ * Meeting contribution equity (Issue #2449).
+ *
+ * Pure metrics over per-participant contribution scores, so a facilitator can
+ * see how *evenly* participation is spread (not just who's on top). Equity is
+ * derived from the Gini coefficient of the participants' impact scores —
+ * overall and per dimension — plus each participant's share for charting. No IO.
+ */
+
+const DIMENSIONS = ["verbal", "decisional", "task", "collaborative"];
+
+/**
+ * Gini coefficient of a set of non-negative values: 0 = perfectly equal,
+ * approaching 1 = maximally unequal. An empty set or all-zero set is treated as
+ * perfectly equal (0).
+ */
+export function giniCoefficient(values) {
+  const nums = (Array.isArray(values) ? values : [])
+    .map(Number)
+    .filter((v) => Number.isFinite(v) && v >= 0);
+  const n = nums.length;
+  if (n === 0) return 0;
+  const total = nums.reduce((a, b) => a + b, 0);
+  if (total === 0) return 0;
+  let absDiff = 0;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = 0; j < n; j += 1) {
+      absDiff += Math.abs(nums[i] - nums[j]);
+    }
+  }
+  // absDiff / (2 * n^2 * mean), where mean = total / n → absDiff / (2 * n * total).
+  return absDiff / (2 * n * total);
+}
+
+/** Convert a Gini coefficient into a 0–100 equity score (100 = perfectly equal). */
+export const equityFromGini = (gini) => Math.round((1 - gini) * 100);
+
+const round3 = (n) => Math.round(n * 1000) / 1000;
+
+/**
+ * @param {Array<{ participantId?: string, participantName?: string, overallImpact?: number,
+ *                 dimensions?: { verbal?: number, decisional?: number, task?: number, collaborative?: number } }>} contributions
+ */
+export function computeEquityBreakdown(contributions) {
+  const list = Array.isArray(contributions) ? contributions : [];
+  const overallValues = list.map((c) => Number(c?.overallImpact ?? 0));
+
+  const perDimension = {};
+  for (const dim of DIMENSIONS) {
+    perDimension[dim] = equityFromGini(
+      giniCoefficient(list.map((c) => Number(c?.dimensions?.[dim] ?? 0))),
+    );
+  }
+
+  const totalImpact = overallValues.reduce((a, b) => a + (b > 0 ? b : 0), 0);
+  const distribution = list
+    .map((c) => {
+      const score = Number(c?.overallImpact ?? 0);
+      return {
+        participantId: c?.participantId ?? null,
+        participantName: c?.participantName ?? "Unknown",
+        score,
+        share:
+          totalImpact > 0 ? Math.round((score / totalImpact) * 1000) / 10 : 0,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const gini = giniCoefficient(overallValues);
+  return {
+    overall: equityFromGini(gini),
+    gini: round3(gini),
+    participantCount: list.length,
+    perDimension,
+    distribution,
+  };
+}


### PR DESCRIPTION
Closes #2449

### Problem
`ContributionSummaryPanel` showed a shallow top-3 list and a **dead "View Detailed Profile"** button; equity was a single opaque number with no breakdown or charts.

### Backend
- **`server/utils/contributionEquity.js`** — pure `giniCoefficient` + `computeEquityBreakdown`: overall + per-dimension equity (verbal / decisional / task / collaborative) from the **Gini coefficient** of participants' impact scores (100 = perfectly even), plus each participant's **contribution share** for charting. No IO.
- `participantContributionController` — includes the `equity` breakdown in the contributions + calculate responses (alongside the existing `equityScore`).
- **`server/tests/contributionEquity.test.js`** — 7 pure tests (gini edge cases incl. all-equal/all-zero/negatives, equity mapping, equal vs unequal breakdown, share sorting, defensive input).

### Frontend
- `ContributionSummaryPanel` — wires the dead CTA to a **detail view**: per-dimension equity bars + a per-participant contribution-share chart.

### Acceptance criteria
- [x] Detail view opens with real contribution metrics
- [x] Charts render for meetings with data
- [x] (equity recalculated on each fetch/calculate)

### Verified green before push
server `jest contributionEquity` → 7/7 · server + client `eslint` clean · `prettier` applied.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
