### PR TITLE
feat: risk register export + mitigation status workflow (#2463)

### DIFF
--- a/client/src/pages/RiskRegister.jsx
+++ b/client/src/pages/RiskRegister.jsx
@@ -43,6 +43,23 @@ const RiskRegister = () => {
     }
   };
 
+  const handleExport = async () => {
+    try {
+      const blob = await meetingRiskApi.exportRisks(orgId, "csv");
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "risk-register.csv";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      toast.error("Failed to export risks");
+    }
+  };
+
   const categories = [
     "All",
     "Technical",
@@ -115,6 +132,13 @@ const RiskRegister = () => {
               className="px-4 py-2 bg-slate-800 hover:bg-slate-700 rounded-lg text-sm font-medium transition-colors border border-slate-700 shadow-sm flex items-center gap-2"
             >
               Refresh
+            </button>
+            <button
+              onClick={handleExport}
+              disabled={risks.length === 0}
+              className="px-4 py-2 bg-slate-800 hover:bg-slate-700 rounded-lg text-sm font-medium transition-colors border border-slate-700 shadow-sm flex items-center gap-2 disabled:opacity-50"
+            >
+              Export CSV
             </button>
           </div>
         </div>

--- a/client/src/services/meetingRiskApi.js
+++ b/client/src/services/meetingRiskApi.js
@@ -35,6 +35,22 @@ const meetingRiskApi = {
     );
     return response.data;
   },
+
+  updateRiskStatus: async (riskId, data) => {
+    const response = await api.patch(
+      `/api/meeting-risks/${riskId}/status`,
+      data,
+    );
+    return response.data;
+  },
+
+  exportRisks: async (organizationId, format = "csv") => {
+    const response = await api.get(
+      `/api/meeting-risks/organization/${organizationId}/export`,
+      { params: { format }, responseType: "blob" },
+    );
+    return response.data;
+  },
 };
 
 export default meetingRiskApi;

--- a/server/controllers/meetingRiskController.js
+++ b/server/controllers/meetingRiskController.js
@@ -1,6 +1,11 @@
 import MeetingRisk from "../models/meetingRiskModel.js";
 import Meeting from "../models/meetingModel.js";
 import { calculateRiskScore } from "../services/riskScoringService.js";
+import {
+  risksToCsv,
+  isValidRiskTransition,
+  RISK_STATUSES,
+} from "../utils/riskExport.js";
 
 export const createRisk = async (req, res) => {
   try {
@@ -57,6 +62,84 @@ export const getRisksByOrganization = async (req, res) => {
     res.status(200).json({ success: true, data: risks });
   } catch (error) {
     console.error("Error fetching organization risks:", error);
+    res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+/**
+ * Export an organization's risk register as CSV (default) or JSON.
+ * @route GET /api/meeting-risks/organization/:organizationId/export?format=csv|json
+ */
+export const exportOrganizationRisks = async (req, res) => {
+  try {
+    const { organizationId } = req.params;
+    const format = (req.query.format || "csv").toString().toLowerCase();
+
+    const risks = await MeetingRisk.find({ organizationId })
+      .populate("ownerId", "firstName lastName")
+      .sort("-createdAt")
+      .lean();
+
+    if (format === "json") {
+      res.setHeader("Content-Type", "application/json");
+      res.setHeader(
+        "Content-Disposition",
+        'attachment; filename="risk-register.json"',
+      );
+      return res.status(200).send(JSON.stringify(risks, null, 2));
+    }
+
+    const csv = risksToCsv(risks);
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      'attachment; filename="risk-register.csv"',
+    );
+    return res.status(200).send(csv);
+  } catch (error) {
+    console.error("Error exporting risks:", error);
+    res.status(500).json({ success: false, message: "Server error" });
+  }
+};
+
+/**
+ * Move a risk through its mitigation status workflow (with transition
+ * validation) and optionally (re)assign its owner.
+ * @route PATCH /api/meeting-risks/:riskId/status
+ */
+export const updateRiskStatus = async (req, res) => {
+  try {
+    const { riskId } = req.params;
+    const { status, ownerId } = req.body;
+
+    if (!RISK_STATUSES.includes(status)) {
+      return res.status(400).json({
+        success: false,
+        message: `status must be one of: ${RISK_STATUSES.join(", ")}`,
+      });
+    }
+
+    const risk = await MeetingRisk.findById(riskId);
+    if (!risk) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Risk not found" });
+    }
+
+    if (!isValidRiskTransition(risk.status, status)) {
+      return res.status(400).json({
+        success: false,
+        message: `Cannot move a risk from "${risk.status}" to "${status}"`,
+      });
+    }
+
+    risk.status = status;
+    if (ownerId !== undefined) risk.ownerId = ownerId;
+    await risk.save();
+
+    res.status(200).json({ success: true, data: risk });
+  } catch (error) {
+    console.error("Error updating risk status:", error);
     res.status(500).json({ success: false, message: "Server error" });
   }
 };

--- a/server/routes/meetingRiskRoutes.js
+++ b/server/routes/meetingRiskRoutes.js
@@ -7,6 +7,8 @@ import {
   updateRisk,
   deleteRisk,
   linkActionItem,
+  exportOrganizationRisks,
+  updateRiskStatus,
 } from "../controllers/meetingRiskController.js";
 
 const router = express.Router();
@@ -14,8 +16,10 @@ const router = express.Router();
 router.use(protect);
 
 router.post("/", createRisk);
+router.get("/organization/:organizationId/export", exportOrganizationRisks);
 router.get("/organization/:organizationId", getRisksByOrganization);
 router.get("/meeting/:meetingId", getRisksByMeeting);
+router.patch("/:riskId/status", updateRiskStatus);
 router.put("/:riskId", updateRisk);
 router.delete("/:riskId", deleteRisk);
 router.post("/:riskId/action-items", linkActionItem);

--- a/server/tests/riskExport.test.js
+++ b/server/tests/riskExport.test.js
@@ -1,0 +1,70 @@
+import {
+  risksToCsv,
+  isValidRiskTransition,
+  RISK_STATUS_TRANSITIONS,
+} from "../utils/riskExport.js";
+
+describe("risksToCsv (Issue #2463)", () => {
+  it("emits a header and one row per risk, with owner name resolved", () => {
+    const csv = risksToCsv([
+      {
+        title: "Vendor delay",
+        category: "Schedule",
+        status: "Open",
+        probability: 4,
+        impact: 3,
+        riskScore: 12,
+        ownerId: { firstName: "Ada", lastName: "Lovelace" },
+        mitigationPlan: "Add buffer",
+        description: "Vendor may slip",
+      },
+    ]);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe(
+      "Title,Category,Status,Probability,Impact,Score,Owner,Mitigation Plan,Description",
+    );
+    expect(lines[1]).toBe(
+      "Vendor delay,Schedule,Open,4,3,12,Ada Lovelace,Add buffer,Vendor may slip",
+    );
+  });
+
+  it("escapes commas, quotes, and newlines per RFC 4180", () => {
+    const csv = risksToCsv([
+      {
+        title: 'Risk, with "comma"',
+        description: "line1\nline2",
+        status: "Open",
+      },
+    ]);
+    const row = csv.split("\n").slice(1).join("\n");
+    expect(row).toContain('"Risk, with ""comma"""');
+    expect(row).toContain('"line1\nline2"');
+  });
+
+  it("returns just the header for an empty or non-array input", () => {
+    expect(risksToCsv([]).split("\n")).toHaveLength(1);
+    expect(risksToCsv(null).split("\n")).toHaveLength(1);
+  });
+});
+
+describe("isValidRiskTransition", () => {
+  it("allows defined transitions and same-status no-ops", () => {
+    expect(isValidRiskTransition("Open", "Mitigated")).toBe(true);
+    expect(isValidRiskTransition("Mitigated", "Closed")).toBe(true);
+    expect(isValidRiskTransition("Closed", "Open")).toBe(true); // reopen
+    expect(isValidRiskTransition("Open", "Open")).toBe(true);
+  });
+
+  it("rejects undefined transitions and unknown statuses", () => {
+    expect(isValidRiskTransition("Closed", "Mitigated")).toBe(false);
+    expect(isValidRiskTransition("Realized", "Open")).toBe(false);
+    expect(isValidRiskTransition("Open", "Banana")).toBe(false);
+  });
+
+  it("every listed target is a valid status", () => {
+    const valid = new Set(["Open", "Mitigated", "Closed", "Realized"]);
+    for (const targets of Object.values(RISK_STATUS_TRANSITIONS)) {
+      for (const t of targets) expect(valid.has(t)).toBe(true);
+    }
+  });
+});

--- a/server/utils/riskExport.js
+++ b/server/utils/riskExport.js
@@ -1,0 +1,59 @@
+/**
+ * Risk register export + status workflow helpers (Issue #2463).
+ *
+ * Pure, IO-free: a CSV serializer for a risk set and the allowed mitigation
+ * status transitions. Unit-tested.
+ */
+
+export const RISK_STATUSES = ["Open", "Mitigated", "Closed", "Realized"];
+
+// Allowed mitigation status transitions (a closure loop, with reopen paths).
+export const RISK_STATUS_TRANSITIONS = {
+  Open: ["Mitigated", "Realized", "Closed"],
+  Mitigated: ["Closed", "Realized", "Open"],
+  Realized: ["Closed", "Mitigated"],
+  Closed: ["Open"],
+};
+
+/** Whether a risk may move from `from` to `to` (a no-op to the same status is allowed). */
+export function isValidRiskTransition(from, to) {
+  if (!RISK_STATUSES.includes(to)) return false;
+  if (from === to) return true;
+  return (RISK_STATUS_TRANSITIONS[from] || []).includes(to);
+}
+
+const CSV_COLUMNS = [
+  ["title", "Title"],
+  ["category", "Category"],
+  ["status", "Status"],
+  ["probability", "Probability"],
+  ["impact", "Impact"],
+  ["riskScore", "Score"],
+  ["owner", "Owner"],
+  ["mitigationPlan", "Mitigation Plan"],
+  ["description", "Description"],
+];
+
+/** RFC-4180 field escaping: wrap in quotes and double embedded quotes when needed. */
+function csvField(value) {
+  const s = value === null || value === undefined ? "" : String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+const ownerName = (owner) => {
+  if (!owner || typeof owner !== "object") return "";
+  return `${owner.firstName ?? ""} ${owner.lastName ?? ""}`.trim();
+};
+
+/** Serialize a list of risks to a CSV string (header + one row per risk). */
+export function risksToCsv(risks) {
+  const list = Array.isArray(risks) ? risks : [];
+  const header = CSV_COLUMNS.map(([, label]) => csvField(label)).join(",");
+  const rows = list.map((risk) =>
+    CSV_COLUMNS.map(([key]) => {
+      const value = key === "owner" ? ownerName(risk?.ownerId) : risk?.[key];
+      return csvField(value);
+    }).join(","),
+  );
+  return [header, ...rows].join("\n");
+}


### PR DESCRIPTION
Closes #2463

### Problem
Risk tracking had no closure loop — status could be set to any value with no workflow, and there was no way to export the register.

### Backend
- **`server/utils/riskExport.js`** — pure `risksToCsv` (RFC-4180 escaping, owner name resolved) + `RISK_STATUS_TRANSITIONS` / `isValidRiskTransition` (a mitigation state machine: Open→Mitigated/Realized/Closed, with reopen paths). No IO.
- `meetingRiskController` — **`exportOrganizationRisks`** (`GET /organization/:id/export?format=csv|json`, streams a downloadable file) + **`updateRiskStatus`** (`PATCH /:riskId/status` — **validates the transition**, optional owner (re)assignment).
- **`server/tests/riskExport.test.js`** — 6 pure tests (CSV rows + escaping + empty input, valid vs invalid transitions, every transition target is a valid status).

### Frontend
- `meetingRiskApi.updateRiskStatus` + `exportRisks`; the Risk Register page gets an **Export CSV** button (blob download).

### Acceptance criteria
- [x] Risks can move through mitigation statuses (validated transitions)
- [x] Owners are assignable (via the status endpoint / existing update)
- [x] Export downloads the risk set (CSV/JSON)
- [x] Authorization enforced (userAuth middleware, matching sibling routes)

### Verified green before push
server `jest riskExport` → 6/6 · server + client `eslint` clean · `prettier` applied. (Caught + fixed a field-name bug so the CSV reads the real `probability`/`impact`/`riskScore` fields.)

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
