### PR TITLE
feat(session-cards): route and finish Session Gallery (Navbar orphan)

### DIFF
--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -163,9 +163,30 @@ const AsyncMeetingsDashboard = lazy(
 );
 const MeetingPlaybooks = lazy(() => import("../pages/MeetingPlaybooks.jsx"));
 const TopicIntelligence = lazy(() => import("../pages/TopicIntelligence.jsx"));
+const SessionGallery = lazy(() => import("../pages/SessionGallery.jsx"));
 
 const ProtectedRoutes = (
   <React.Fragment>
+    <Route
+      path="/session-cards"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <SessionGallery />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/session-gallery"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <SessionGallery />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
     <Route
       path="/topics/analytics"
       element={

--- a/client/src/routes/__tests__/SessionGalleryRouteWiring.test.jsx
+++ b/client/src/routes/__tests__/SessionGalleryRouteWiring.test.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes } from "react-router-dom";
+import ProtectedRoutes from "../ProtectedRoutes";
+import AppContent from "../../context/AppContent";
+import { sessionCardApi } from "../../services";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../services", () => ({
+  sessionCardApi: {
+    getSessionCards: vi.fn(),
+    deleteSessionCard: vi.fn(),
+  },
+}));
+
+describe("SessionGallery Route Wiring (#2437)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderRoute = (initialPath = "/session-cards") => {
+    sessionCardApi.getSessionCards.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          sessions: [],
+          pagination: { total: 0, page: 1, limit: 24, totalPages: 1 },
+        },
+      },
+    });
+
+    const mockContext = {
+      userData: {
+        _id: "u_1",
+        email: "user@example.com",
+        currentOrganization: "org_1",
+        hasCompletedOnboarding: true,
+      },
+      isLoggedin: true,
+      role: "admin",
+    };
+
+    return render(
+      <AppContent.Provider value={mockContext}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>{ProtectedRoutes}</Routes>
+        </MemoryRouter>
+      </AppContent.Provider>,
+    );
+  };
+
+  it("successfully resolves and mounts SessionGallery on /session-cards", async () => {
+    renderRoute("/session-cards");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Organization Session Cards"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("successfully resolves and mounts SessionGallery on /session-gallery alias", async () => {
+    renderRoute("/session-gallery");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Organization Session Cards"),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2437

## Description
This PR registers and routes the `SessionGallery` page in `ProtectedRoutes.jsx` on `/session-cards` (referenced in the Navbar) and `/session-gallery`, connecting session card browsing, filtering, search, pagination, and deletion flows.

## Proposed Changes
- **Route Registration**:
  - Lazy loaded and mounted `SessionGallery.jsx` under `/session-cards` and `/session-gallery` in `ProtectedRoutes.jsx` protected behind authentication and error boundaries.
- **Unit & Route Tests**:
  - Verified full test coverage with `SessionGallery.test.jsx` (4/4 passing) and route resolution test `SessionGalleryRouteWiring.test.jsx` (2/2 passing).

## Checklist
- [x] Related Issue is linked (Fixes #2437).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a protected Session Gallery page accessible through `/session-cards`.
  - Added `/session-gallery` as an alternate route to the same gallery.
  - Added error handling around the new page for a more reliable navigation experience.

- **Tests**
  - Added coverage confirming both routes correctly display the Session Gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->