### PR TITLE
feat(settings): mount Language Preferences settings page

### DIFF
--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -619,6 +619,45 @@ const Settings = () => {
             </div>
           </div>
 
+          {/* Language & Translation Preferences Section */}
+          <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm fade-in-up stagger-3">
+            <div className="flex items-center gap-3 mb-6">
+              <div className="p-2 bg-blue-50 dark:bg-blue-900/30 rounded-xl">
+                <Globe className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+                  Language & Translation
+                </h2>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Manage primary language, live transcription translation, and
+                  glossaries
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="flex items-center justify-between py-3">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                    Language Preferences & Translation
+                  </p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                    Configure default meeting languages, glossary mappings, and
+                    translation quality
+                  </p>
+                </div>
+                <button
+                  onClick={() => navigate("/settings/language")}
+                  className="text-xs font-semibold text-blue-600 hover:text-blue-800 dark:hover:text-blue-400 flex items-center gap-1 transition-colors cursor-pointer"
+                >
+                  Manage Languages
+                  <ChevronRight className="w-3 h-3" />
+                </button>
+              </div>
+            </div>
+          </div>
+
           {/* Notification Preferences Section */}
           <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm fade-in-up stagger-4">
             <div className="flex items-center gap-3 mb-6">

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -163,9 +163,42 @@ const AsyncMeetingsDashboard = lazy(
 );
 const MeetingPlaybooks = lazy(() => import("../pages/MeetingPlaybooks.jsx"));
 const TopicIntelligence = lazy(() => import("../pages/TopicIntelligence.jsx"));
+const LanguagePreferences = lazy(
+  () => import("../pages/LanguagePreferences.jsx"),
+);
 
 const ProtectedRoutes = (
   <React.Fragment>
+    <Route
+      path="/settings/language"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <LanguagePreferences />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/language-preferences"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <LanguagePreferences />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/translations/preferences"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <LanguagePreferences />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
     <Route
       path="/topics/analytics"
       element={

--- a/client/src/routes/__tests__/LanguagePreferencesRouteWiring.test.jsx
+++ b/client/src/routes/__tests__/LanguagePreferencesRouteWiring.test.jsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes } from "react-router-dom";
+import ProtectedRoutes from "../ProtectedRoutes";
+import AppContent from "../../context/AppContent";
+import apiClient from "../../services/apiClient";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+describe("LanguagePreferences Route Wiring (#2438)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockImplementation((url) => {
+      if (url === "/api/translations/preferences") {
+        return Promise.resolve({
+          data: {
+            preferences: {
+              autoTranslate: true,
+              showConfidenceScores: true,
+              preferredProvider: "auto",
+              defaultSourceLanguage: "en",
+              defaultTargetLanguages: ["es"],
+              customGlossary: [],
+            },
+          },
+        });
+      }
+      if (url === "/api/translations/languages") {
+        return Promise.resolve({
+          data: { languages: [{ code: "en", name: "English" }] },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  const renderRoute = (initialPath = "/settings/language") => {
+    const mockContext = {
+      userData: {
+        _id: "u_1",
+        email: "user@example.com",
+        currentOrganization: "org_1",
+        hasCompletedOnboarding: true,
+      },
+      isLoggedin: true,
+      role: "admin",
+    };
+
+    return render(
+      <AppContent.Provider value={mockContext}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>{ProtectedRoutes}</Routes>
+        </MemoryRouter>
+      </AppContent.Provider>,
+    );
+  };
+
+  it("successfully mounts LanguagePreferences on /settings/language", async () => {
+    renderRoute("/settings/language");
+
+    await waitFor(() => {
+      expect(screen.getByText("Language Preferences")).toBeInTheDocument();
+    });
+  });
+
+  it("successfully mounts LanguagePreferences on /language-preferences alias", async () => {
+    renderRoute("/language-preferences");
+
+    await waitFor(() => {
+      expect(screen.getByText("Language Preferences")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2438

## Description
This PR routes and links the `LanguagePreferences` settings page in `ProtectedRoutes.jsx` under `/settings/language`, `/language-preferences`, and `/translations/preferences`, and adds an accessible navigation card within `Settings.jsx`.

## Proposed Changes
- **Route Registration**:
  - Lazy loaded and registered `LanguagePreferences.jsx` under `/settings/language`, `/language-preferences`, and `/translations/preferences` in `ProtectedRoutes.jsx`.
- **Settings UI Discovery**:
  - Added a dedicated Language & Translation Preferences section card in `Settings.jsx` directing users to `/settings/language`.
- **Unit & Route Tests**:
  - Added route verification test suite `client/src/routes/__tests__/LanguagePreferencesRouteWiring.test.jsx` (2/2 passing) and verified `LanguagePreferencesApiClient.test.jsx` (2/2 passing).

## Checklist
- [x] Related Issue is linked (Fixes #2438).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.