### PR TITLE
Mount PlaybookGuidancePanel in live Meeting Room (#2447)

### DIFF
--- a/client/src/components/PlaybookGuidancePanel.jsx
+++ b/client/src/components/PlaybookGuidancePanel.jsx
@@ -1,21 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { Clock, CheckCircle, ChevronRight, AlertTriangle } from "lucide-react";
-import { useMeetingPlaybook } from "../hooks/useMeetingPlaybook";
 
 const PlaybookGuidancePanel = ({
-  socket,
-  meetingId,
   playbook,
+  playbookState,
+  advanceStep,
+  emitTimerWarning,
   isFacilitator,
 }) => {
-  const { playbookState, advanceStep, emitTimerWarning } = useMeetingPlaybook(
-    socket,
-    meetingId,
-  );
   const [timeRemaining, setTimeRemaining] = useState(0);
 
   useEffect(() => {
-    if (!playbookState.isActive || !playbookState.startTime || !playbook)
+    if (!playbookState?.isActive || !playbookState.startTime || !playbook)
       return;
 
     const currentStep = playbook.steps[playbookState.currentStepIndex];
@@ -28,7 +24,6 @@ const PlaybookGuidancePanel = ({
       const remaining = Math.max(0, durationMs - elapsed);
       setTimeRemaining(remaining);
 
-      // Warning when < 1 minute remaining
       if (remaining < 60000 && remaining > 58000 && isFacilitator) {
         emitTimerWarning(playbookState.currentStepIndex);
       }
@@ -37,7 +32,7 @@ const PlaybookGuidancePanel = ({
     return () => clearInterval(interval);
   }, [playbookState, playbook, isFacilitator, emitTimerWarning]);
 
-  if (!playbook || !playbookState.isActive) {
+  if (!playbook || !playbookState?.isActive) {
     return null;
   }
 
@@ -61,6 +56,7 @@ const PlaybookGuidancePanel = ({
   return (
     <div
       className={`bg-white dark:bg-gray-800 rounded-lg shadow-sm border ${playbookState.timerWarning ? "border-red-500" : "border-gray-200 dark:border-gray-700"} p-4`}
+      data-testid="playbook-guidance-panel"
     >
       <div className="flex items-center gap-2 font-bold text-lg border-b dark:border-gray-700 pb-3 mb-3">
         <CheckCircle className="text-green-500" size={20} />
@@ -112,6 +108,7 @@ const PlaybookGuidancePanel = ({
         <div className="mt-6">
           {!isLastStep ? (
             <button
+              type="button"
               onClick={handleNextStep}
               className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md flex items-center justify-center gap-2 transition-colors"
             >
@@ -119,6 +116,7 @@ const PlaybookGuidancePanel = ({
             </button>
           ) : (
             <button
+              type="button"
               disabled
               className="w-full py-2 bg-gray-200 dark:bg-gray-700 text-gray-500 cursor-not-allowed rounded-md"
             >

--- a/client/src/components/meeting-room/MeetingRoomPlaybookPanel.jsx
+++ b/client/src/components/meeting-room/MeetingRoomPlaybookPanel.jsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { BookOpen, Loader2, Play } from "lucide-react";
+import PlaybookGuidancePanel from "../PlaybookGuidancePanel.jsx";
+import {
+  fetchPlaybookById,
+  fetchPlaybooks,
+} from "../../api/meetingPlaybookApi.js";
+import { useMeetingPlaybook } from "../../hooks/useMeetingPlaybook.js";
+
+const MeetingRoomPlaybookPanel = ({ socket, meetingId, isFacilitator }) => {
+  const { playbookState, startPlaybook, advanceStep, emitTimerWarning } =
+    useMeetingPlaybook(socket, meetingId);
+  const [playbooks, setPlaybooks] = useState([]);
+  const [activePlaybook, setActivePlaybook] = useState(null);
+  const [selectedPlaybookId, setSelectedPlaybookId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const loadPlaybooks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchPlaybooks();
+      setPlaybooks(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error("Failed to load playbooks:", err);
+      setError("Unable to load playbooks.");
+      setPlaybooks([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPlaybooks();
+  }, [loadPlaybooks]);
+
+  useEffect(() => {
+    const playbookId = playbookState.playbookId;
+    if (!playbookId) {
+      setActivePlaybook(null);
+      return;
+    }
+
+    let cancelled = false;
+    const loadActivePlaybook = async () => {
+      try {
+        const playbook = await fetchPlaybookById(playbookId);
+        if (!cancelled) {
+          setActivePlaybook(playbook);
+        }
+      } catch (err) {
+        console.error("Failed to load active playbook:", err);
+        if (!cancelled) {
+          setError("Unable to load the active playbook.");
+        }
+      }
+    };
+
+    loadActivePlaybook();
+    return () => {
+      cancelled = true;
+    };
+  }, [playbookState.playbookId]);
+
+  useEffect(() => {
+    if (selectedPlaybookId || !playbooks.length) return;
+    setSelectedPlaybookId(playbooks[0]._id);
+  }, [playbooks, selectedPlaybookId]);
+
+  const handleStartPlaybook = () => {
+    if (!selectedPlaybookId) return;
+    startPlaybook(selectedPlaybookId);
+  };
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center justify-center gap-2 py-12 text-gray-400"
+        role="status"
+      >
+        <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+        <span>Loading playbook guidance...</span>
+      </div>
+    );
+  }
+
+  if (error && !activePlaybook) {
+    return (
+      <div className="rounded-lg border border-red-500/40 bg-red-950/20 p-4 text-sm text-red-200">
+        <p>{error}</p>
+        <button
+          type="button"
+          onClick={loadPlaybooks}
+          className="mt-3 text-red-100 underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (playbookState.isActive && activePlaybook) {
+    return (
+      <PlaybookGuidancePanel
+        playbook={activePlaybook}
+        playbookState={playbookState}
+        advanceStep={advanceStep}
+        emitTimerWarning={emitTimerWarning}
+        isFacilitator={isFacilitator}
+      />
+    );
+  }
+
+  if (!playbooks.length) {
+    return (
+      <div
+        className="rounded-lg border border-dashed border-gray-700 bg-gray-900 p-6 text-center"
+        data-testid="meeting-room-playbook-empty"
+      >
+        <BookOpen className="mx-auto h-8 w-8 text-indigo-400 mb-3" />
+        <h3 className="text-lg font-semibold text-white mb-2">
+          No playbook assigned
+        </h3>
+        <p className="text-sm text-gray-400 mb-4">
+          Create or assign a meeting playbook to guide facilitators through live
+          steps.
+        </p>
+        <Link
+          to="/playbooks"
+          className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+        >
+          Assign a playbook
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="meeting-room-playbook-setup">
+      <div>
+        <h3 className="text-lg font-semibold text-white mb-1">
+          Playbook guidance
+        </h3>
+        <p className="text-sm text-gray-400">
+          Start the assigned playbook to share live step prompts with everyone
+          in this room.
+        </p>
+      </div>
+
+      <label className="block text-sm text-gray-300">
+        Select playbook
+        <select
+          value={selectedPlaybookId}
+          onChange={(e) => setSelectedPlaybookId(e.target.value)}
+          className="mt-1 w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white"
+        >
+          {playbooks.map((playbook) => (
+            <option key={playbook._id} value={playbook._id}>
+              {playbook.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {isFacilitator ? (
+        <button
+          type="button"
+          onClick={handleStartPlaybook}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+        >
+          <Play className="h-4 w-4" />
+          Start playbook guidance
+        </button>
+      ) : (
+        <p className="text-sm text-gray-500">
+          Waiting for a facilitator to start playbook guidance.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MeetingRoomPlaybookPanel;

--- a/client/src/components/meeting-room/__tests__/MeetingRoomPlaybookPanel.test.jsx
+++ b/client/src/components/meeting-room/__tests__/MeetingRoomPlaybookPanel.test.jsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import MeetingRoomPlaybookPanel from "../MeetingRoomPlaybookPanel.jsx";
+
+vi.mock("../../../api/meetingPlaybookApi.js", () => ({
+  fetchPlaybooks: vi.fn(),
+  fetchPlaybookById: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useMeetingPlaybook.js", () => ({
+  useMeetingPlaybook: vi.fn(),
+}));
+
+import {
+  fetchPlaybooks,
+  fetchPlaybookById,
+} from "../../../api/meetingPlaybookApi.js";
+import { useMeetingPlaybook } from "../../../hooks/useMeetingPlaybook.js";
+
+const samplePlaybook = {
+  _id: "pb-1",
+  name: "Sprint Retro",
+  steps: [
+    {
+      title: "Set the stage",
+      durationMinutes: 5,
+      facilitatorPrompts: ["Welcome the team"],
+      expectedOutputs: ["Shared context"],
+    },
+  ],
+};
+
+describe("MeetingRoomPlaybookPanel (#2447)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useMeetingPlaybook.mockReturnValue({
+      playbookState: {
+        isActive: false,
+        playbookId: null,
+        currentStepIndex: 0,
+        startTime: null,
+        timerWarning: false,
+      },
+      startPlaybook: vi.fn(),
+      advanceStep: vi.fn(),
+      emitTimerWarning: vi.fn(),
+    });
+  });
+
+  it("shows empty CTA when no playbooks exist", async () => {
+    fetchPlaybooks.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <MeetingRoomPlaybookPanel
+          socket={{}}
+          meetingId="meeting-1"
+          isFacilitator
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByTestId("meeting-room-playbook-empty"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /assign a playbook/i }),
+    ).toHaveAttribute("href", "/playbooks");
+  });
+
+  it("loads playbooks and lets facilitators start guidance", async () => {
+    fetchPlaybooks.mockResolvedValue([samplePlaybook]);
+    const startPlaybook = vi.fn();
+    useMeetingPlaybook.mockReturnValue({
+      playbookState: {
+        isActive: false,
+        playbookId: null,
+        currentStepIndex: 0,
+        startTime: null,
+        timerWarning: false,
+      },
+      startPlaybook,
+      advanceStep: vi.fn(),
+      emitTimerWarning: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingRoomPlaybookPanel
+          socket={{}}
+          meetingId="meeting-1"
+          isFacilitator
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByTestId("meeting-room-playbook-setup"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /start playbook guidance/i }),
+    );
+    expect(startPlaybook).toHaveBeenCalledWith("pb-1");
+  });
+
+  it("renders active playbook steps from fetched playbook", async () => {
+    fetchPlaybooks.mockResolvedValue([samplePlaybook]);
+    fetchPlaybookById.mockResolvedValue(samplePlaybook);
+    useMeetingPlaybook.mockReturnValue({
+      playbookState: {
+        isActive: true,
+        playbookId: "pb-1",
+        currentStepIndex: 0,
+        startTime: Date.now(),
+        timerWarning: false,
+      },
+      startPlaybook: vi.fn(),
+      advanceStep: vi.fn(),
+      emitTimerWarning: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <MeetingRoomPlaybookPanel
+          socket={{}}
+          meetingId="meeting-1"
+          isFacilitator
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playbook-guidance-panel")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Step 1: Set the stage/i)).toBeInTheDocument();
+    expect(fetchPlaybookById).toHaveBeenCalledWith("pb-1");
+  });
+});

--- a/client/src/components/meetings/MeetingHeader.jsx
+++ b/client/src/components/meetings/MeetingHeader.jsx
@@ -14,6 +14,7 @@ import {
   Timer,
   ShieldAlert,
   PenTool,
+  BookOpen,
 } from "lucide-react";
 
 export default function MeetingHeader({
@@ -46,6 +47,7 @@ export default function MeetingHeader({
   const isAgendaOpen = activePanel === "agenda";
   const isCanvasOpen = activePanel === "canvas";
   const isAttendanceOpen = activePanel === "attendance";
+  const isPlaybookOpen = activePanel === "playbook";
 
   return (
     <header
@@ -180,6 +182,26 @@ export default function MeetingHeader({
           <Timer size={16} />
           <span className="hidden sm:inline">
             {isAgendaOpen ? "Hide Agenda" : "Agenda"}
+          </span>
+        </button>
+
+        {/* Playbook Guidance Toggle */}
+        <button
+          type="button"
+          onClick={() => onTogglePanel("playbook")}
+          aria-pressed={isPlaybookOpen}
+          className={`flex items-center gap-1.5 text-sm font-semibold px-4 py-2 rounded-xl transition-all cursor-pointer ${
+            isPlaybookOpen
+              ? "bg-indigo-600 text-white hover:bg-indigo-700"
+              : "bg-gray-800 text-gray-300 hover:text-white hover:bg-gray-700"
+          }`}
+          title={
+            isPlaybookOpen ? "Hide playbook guidance" : "Open playbook guidance"
+          }
+        >
+          <BookOpen size={16} />
+          <span className="hidden sm:inline">
+            {isPlaybookOpen ? "Hide Playbook" : "Playbook"}
           </span>
         </button>
 

--- a/client/src/pages/MeetingRoom.jsx
+++ b/client/src/pages/MeetingRoom.jsx
@@ -26,6 +26,7 @@ import LiveCaptions from "../components/meetings/LiveCaptions.jsx";
 import AttendanceTracker from "../components/meetings/AttendanceTracker.jsx";
 import LiveIcebreakerBanner from "../components/meeting-room/LiveIcebreakerBanner.jsx";
 import CollaborativeCanvas from "../components/meeting-room/CollaborativeCanvas.jsx";
+import MeetingRoomPlaybookPanel from "../components/meeting-room/MeetingRoomPlaybookPanel.jsx";
 
 import DeviceSetupModal from "../components/meetings/DeviceSetupModal.jsx";
 import axios from "../services/apiClient.js";
@@ -70,6 +71,7 @@ const MEETING_ROOM_PANELS = {
   AGENDA: "agenda",
   CANVAS: "canvas",
   ATTENDANCE: "attendance",
+  PLAYBOOK: "playbook",
 };
 
 const MeetingRoom = () => {
@@ -127,6 +129,7 @@ const MeetingRoom = () => {
   const showAgenda = activePanel === MEETING_ROOM_PANELS.AGENDA;
   const showCanvas = activePanel === MEETING_ROOM_PANELS.CANVAS;
   const showAttendance = activePanel === MEETING_ROOM_PANELS.ATTENDANCE;
+  const showPlaybook = activePanel === MEETING_ROOM_PANELS.PLAYBOOK;
 
   // Canvas color assignment based on user identity for remote cursor distinction
   const canvasColor = useMemo(() => {
@@ -973,6 +976,21 @@ const MeetingRoom = () => {
                 className="w-full md:w-[360px] lg:w-[400px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-y-auto flex flex-col transition-all duration-300"
               >
                 <AttendanceTracker meetingId={roomId} isHost={isHost} />
+              </div>
+            )}
+
+            {showPlaybook && (
+              <div
+                data-testid="meeting-room-playbook-panel"
+                className="w-full md:w-[360px] lg:w-[400px] shrink-0 p-4 bg-gray-950 border-l border-gray-800 overflow-y-auto flex flex-col transition-all duration-300"
+              >
+                <MeetingRoomPlaybookPanel
+                  socket={socketRef?.current || socket}
+                  meetingId={roomId}
+                  isFacilitator={
+                    userRole === "facilitator" || userRole === "host" || isHost
+                  }
+                />
               </div>
             )}
 

--- a/client/src/pages/__tests__/MeetingRoomPlaybookPanelMount.test.jsx
+++ b/client/src/pages/__tests__/MeetingRoomPlaybookPanelMount.test.jsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MeetingRoom from "../MeetingRoom.jsx";
+import AppContent from "../../context/AppContent.js";
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => ({ roomId: "room-playbook-123" }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({
+    isSignedIn: true,
+    isLoaded: true,
+    userId: "user_1",
+  }),
+}));
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => ({
+    id: "socket_1",
+    auth: {},
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: {} }) },
+  createClerkSocketOptions: vi.fn(async () => ({
+    auth: { token: "token_1" },
+    transports: ["websocket"],
+  })),
+  getClerkBearerToken: vi.fn(async () => "token_1"),
+}));
+
+vi.mock("../../hooks/useDevicePermission", () => ({
+  default: () => ({
+    selectedCamera: "cam-1",
+    selectedMicrophone: "mic-1",
+    releaseStream: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useWebRTC", () => ({
+  default: () => ({
+    socketRef: { current: { on: vi.fn(), emit: vi.fn(), disconnect: vi.fn() } },
+    userVideoRef: { current: null },
+    streamRef: { current: null },
+  }),
+}));
+
+vi.mock("../../hooks/useLiveTranscription", () => ({
+  default: () => ({
+    toggleTranscription: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useReactions", () => ({
+  default: () => ({
+    reactions: [],
+    sendReaction: vi.fn(),
+    onCooldown: false,
+  }),
+}));
+
+vi.mock("../../utils/mediaStream", () => ({
+  resolveMeetingMediaStream: vi.fn().mockResolvedValue({
+    getTracks: () => [],
+    getAudioTracks: () => [],
+    getVideoTracks: () => [],
+  }),
+  getTrackEnabledState: vi
+    .fn()
+    .mockReturnValue({ micOn: true, cameraOn: true }),
+}));
+
+vi.mock("../../components/meetings/DeviceSetupModal.jsx", () => ({
+  default: ({ onJoin }) => (
+    <div data-testid="device-setup">
+      <button type="button" onClick={() => onJoin(null)}>
+        Mock Join Button
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../../components/meetings/CollaborativeEditor.jsx", () => ({
+  default: () => <div data-testid="editor">Editor</div>,
+}));
+
+vi.mock("../../components/meetings/ParkingLotPanel.jsx", () => ({
+  default: () => <div data-testid="parking-lot-content">Parking Lot</div>,
+}));
+
+vi.mock("../../components/meeting-details/PollSection.jsx", () => ({
+  default: () => <div data-testid="poll-section">Polls</div>,
+}));
+
+vi.mock("../../components/meeting-details/AgendaTimer.jsx", () => ({
+  default: ({ compact }) => (
+    <div data-testid={compact ? "agenda-timer-banner" : "agenda-timer"}>
+      Agenda
+    </div>
+  ),
+}));
+
+vi.mock("../../components/meetings/LiveCaptions.jsx", () => ({
+  default: () => <div data-testid="captions">Captions</div>,
+}));
+
+vi.mock("../../components/meeting-room/LiveIcebreakerBanner.jsx", () => ({
+  default: () => <div data-testid="icebreaker" />,
+}));
+
+vi.mock("../../components/meeting-room/MultiLanguageTranscript.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meetings/TranscriptPanel.jsx", () => ({
+  default: ({ showTranscript }) =>
+    showTranscript ? (
+      <div data-testid="meeting-room-transcript-panel">Transcript</div>
+    ) : null,
+}));
+
+vi.mock("../../components/meetings/ReactionBar.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meetings/ReactionOverlay.jsx", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/meetings/MeetingControlBar.jsx", () => ({
+  default: () => <div data-testid="control-bar">Controls</div>,
+}));
+
+vi.mock("../../components/meetings/PeerVideo.jsx", () => ({
+  default: () => <div data-testid="peer-video" />,
+}));
+
+vi.mock("../../components/meeting-room/BreakoutRoomPanel.jsx", () => ({
+  default: () => <div data-testid="breakout-room-panel" />,
+}));
+
+vi.mock("../../components/meeting-room/MeetingRoomPlaybookPanel.jsx", () => ({
+  default: () => (
+    <div data-testid="meeting-room-playbook-content">Playbook Panel</div>
+  ),
+}));
+
+const wrapper = ({ children }) => (
+  <AppContent.Provider
+    value={{
+      userData: { _id: "mongo_user_1", name: "Alice", role: "member" },
+    }}
+  >
+    {children}
+  </AppContent.Provider>
+);
+
+const joinMeeting = async () => {
+  fireEvent.click(screen.getByRole("button", { name: /mock join button/i }));
+  await waitFor(() => {
+    expect(
+      screen.getByRole("banner", { name: /meeting room header/i }),
+    ).toBeInTheDocument();
+  });
+};
+
+describe("MeetingRoom playbook panel mount (#2447)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens the playbook side panel from the meeting header", async () => {
+    render(<MeetingRoom />, { wrapper });
+    await joinMeeting();
+
+    fireEvent.click(screen.getByRole("button", { name: /^playbook$/i }));
+
+    expect(
+      screen.getByTestId("meeting-room-playbook-panel"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("meeting-room-playbook-content"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Mount `PlaybookGuidancePanel` in Meeng Room via a new Playbook side panel
- Fetch playbooks in-room; facilitators can start guidance; empty state links to `/playbooks`
- Add unit tests for panel fetch/start/active states and Meeting Room mount wiring

Closes #2447

## Test plan
- [x] `cd client && npx vitest run src/components/meeting-room/__tests__/MeetingRoomPlaybookPanel.test.jsx src/pages/__tests__/MeetingRoomPlaybookPanelMount.test.jsx`
- [x] `npm run lint:changed --prefix client`
- [x] `npm run format:check:changed --prefix client`
- [ ] Join a live meeting as facilitator → open Playbook panel → start guidance → verify steps render
- [ ] Open Playbook panel with no playbooks → verify empty CTA to `/playbooks`