### PR TITLE
feat: add Markdown export format for meeting notes (#2543)

### DIFF
--- a/client/src/components/export/ExportDialog.jsx
+++ b/client/src/components/export/ExportDialog.jsx
@@ -103,7 +103,7 @@ const ExportDialog = ({ meetingId, onClose }) => {
               Export Meeting Minutes
             </h2>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              Generate custom branded PDF, DOCX, or HTML export files
+              Generate custom branded PDF, DOCX, HTML, or Markdown export files
             </p>
           </div>
           <button
@@ -221,7 +221,7 @@ const ExportDialog = ({ meetingId, onClose }) => {
               Export Format
             </label>
             <div className="flex gap-3">
-              {["pdf", "docx", "html"].map((fmt) => (
+              {["pdf", "docx", "html", "md"].map((fmt) => (
                 <button
                   key={fmt}
                   type="button"

--- a/client/src/services/exportTemplateApi.js
+++ b/client/src/services/exportTemplateApi.js
@@ -56,7 +56,7 @@ export const exportTemplateApi = {
   },
 
   /**
-   * Generate and download meeting export (PDF, DOCX, HTML) using a template
+   * Generate and download meeting export (PDF, DOCX, HTML, MD) using a template
    */
   exportMeeting: async (meetingId, payload) => {
     const response = await apiClient.post(

--- a/server/routes/export.routes.js
+++ b/server/routes/export.routes.js
@@ -8,7 +8,7 @@ import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
 const router = express.Router();
 router.use(userAuth);
 
-const VALID_FORMATS = ["pdf", "docx", "html"];
+const VALID_FORMATS = ["pdf", "docx", "html", "md"];
 
 /**
  * Helper to get active user organization ID
@@ -193,7 +193,7 @@ const exportMeetingWithTemplate = async (req, res) => {
     if (!VALID_FORMATS.includes(format)) {
       return res.status(400).json({
         success: false,
-        error: "Invalid export format. Must be pdf, docx, or html.",
+        error: "Invalid export format. Must be pdf, docx, html, or md.",
       });
     }
 
@@ -239,6 +239,29 @@ const exportMeetingWithTemplate = async (req, res) => {
       contentType =
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
       extension = "docx";
+    } else if (format === "md") {
+      // Convert rendered HTML to plain Markdown text
+      const mdContent = htmlContent
+        .replace(/<h1[^>]*>(.*?)<\/h1>/gi, '# $1\n\n')
+        .replace(/<h2[^>]*>(.*?)<\/h2>/gi, '## $1\n\n')
+        .replace(/<h3[^>]*>(.*?)<\/h3>/gi, '### $1\n\n')
+        .replace(/<h4[^>]*>(.*?)<\/h4>/gi, '#### $1\n\n')
+        .replace(/<strong[^>]*>(.*?)<\/strong>/gi, '**$1**')
+        .replace(/<em[^>]*>(.*?)<\/em>/gi, '*$1*')
+        .replace(/<li[^>]*>(.*?)<\/li>/gi, '- $1\n')
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/<p[^>]*>(.*?)<\/p>/gi, '$1\n\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+      buffer = Buffer.from(mdContent, 'utf-8');
+      contentType = "text/markdown";
+      extension = "md";
     } else {
       buffer = Buffer.from(fullHTML);
       contentType = "text/html";


### PR DESCRIPTION
# Pull Request

## Description

Added Markdown (`.md`) as a new export format for meeting notes. Users can now download meeting summaries, transcripts, and action items as clean Markdown files directly from the Export Dialog on the meeting details page. The backend converts the template-rendered HTML into well-structured Markdown using regex-based HTML-to-MD conversion (headings, bold, italic, lists, paragraphs, and HTML entity decoding).

### Changes:
- **Backend** (`server/routes/export.routes.js`): Added `"md"` to `VALID_FORMATS`, implemented a new `md` branch in `exportMeetingWithTemplate` that converts rendered HTML to Markdown, and updated the validation error message.
- **Frontend** (`client/src/components/export/ExportDialog.jsx`): Added `"md"` to the format selector buttons and updated the dialog subtitle to mention Markdown.
- **Frontend** (`client/src/services/exportTemplateApi.js`): Updated JSDoc comment to include MD as a supported format.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2543

## Testing

Verified that the Markdown format button appears in the Export Dialog alongside PDF, DOCX, and HTML. Confirmed backend route accepts `"md"` as a valid format and generates a downloadable `.md` file.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — The only visible UI change is an additional "MD" button in the export format selector row within the Export Dialog modal.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
