### PR TITLE
feat: add copy link quick share button (#2545)

### DIFF
--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -9,6 +9,7 @@ import {
   Bookmark,
   MessageSquare,
   Link2,
+  Copy,
   BellOff,
   Bell,
   ShieldAlert,
@@ -88,6 +89,13 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
     } finally {
       setMuteLoading(false);
     }
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => toast.success("Link copied!"))
+      .catch(() => toast.error("Failed to copy link"));
   };
 
   if (!meeting) return null;
@@ -262,6 +270,13 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
               <Link2 className="w-4 h-4" /> Share Invite
             </button>
           )}
+          <button
+            onClick={handleCopyLink}
+            className="flex items-center gap-2 px-3 py-1.5 bg-slate-50 text-slate-700 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 rounded-lg text-sm font-medium transition-colors"
+            title="Copy link to clipboard"
+          >
+            <Copy className="w-4 h-4" /> Copy Link
+          </button>
           <button
             onClick={onShare}
             className="flex items-center gap-2 px-3 py-1.5 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-300 dark:hover:bg-indigo-900/50 rounded-lg text-sm font-medium transition-colors"


### PR DESCRIPTION
# Pull Request

## Description

Added a "Copy Link" quick share button to the meeting header on the meeting details page. This button utilizes the native `navigator.clipboard.writeText()` API to copy the current page's URL (`window.location.href`) to the user's clipboard, eliminating the need to manually copy the URL from the browser's address bar. A brief success toast notification ("Link copied!") appears to confirm the action.

### Changes:
- **Frontend** (`client/src/components/meeting-details/MeetingHeader.jsx`):
  - Imported the `Copy` icon from `lucide-react`.
  - Added a `handleCopyLink` function that leverages the Clipboard API.
  - Rendered the "Copy Link" button alongside the existing share and calendar actions in the meeting header.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2545

## Testing

Verified that clicking the "Copy Link" button successfully copies the correct URL to the clipboard and displays the success toast notification. Also tested failure edge cases (e.g., restricted clipboard permissions) to ensure the error toast appears appropriately.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — A new button with a copy icon now appears in the top right action bar of the meeting details page.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy Link” button to meeting headers.
  * Meeting links are copied to the clipboard with confirmation or error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->