### PR TITLE
feat: add copy link quick share button (#2545)

### DIFF
--- a/client/src/components/meeting-details/MeetingHeader.jsx
+++ b/client/src/components/meeting-details/MeetingHeader.jsx
@@ -9,6 +9,7 @@ import {
   Bookmark,
   MessageSquare,
   Link2,
+  Copy,
   BellOff,
   Bell,
   ShieldAlert,
@@ -88,6 +89,13 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
     } finally {
       setMuteLoading(false);
     }
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => toast.success("Link copied!"))
+      .catch(() => toast.error("Failed to copy link"));
   };
 
   if (!meeting) return null;
@@ -262,6 +270,13 @@ const MeetingHeader = ({ meeting, onShare, onShareInvite, onPresent }) => {
               <Link2 className="w-4 h-4" /> Share Invite
             </button>
           )}
+          <button
+            onClick={handleCopyLink}
+            className="flex items-center gap-2 px-3 py-1.5 bg-slate-50 text-slate-700 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 rounded-lg text-sm font-medium transition-colors"
+            title="Copy link to clipboard"
+          >
+            <Copy className="w-4 h-4" /> Copy Link
+          </button>
           <button
             onClick={onShare}
             className="flex items-center gap-2 px-3 py-1.5 bg-indigo-50 text-indigo-700 hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-300 dark:hover:bg-indigo-900/50 rounded-lg text-sm font-medium transition-colors"


### PR DESCRIPTION
# Pull Request

## Description

Added a unified utility for calculating and displaying meeting durations in a human-readable format (e.g., "1h 15m") across the application, resolving the issue where users had to manually calculate duration from timestamps.

### Changes:
- **Frontend Utilities** (`client/src/utils/timeUtils.js`):
  - Created `calculateDuration(startTime, endTime)` to automatically compute and format the difference between two timestamps.
  - Created `formatDuration(totalMinutes)` as a shared formatter for displaying durations.
- **Components Updated**:
  - `MeetingCard.jsx`: Updated the duration display to prioritize calculating from `startTime` and `endTime`, falling back to the default `duration` field.
  - `MeetingMetadata.jsx`: Refactored to remove the localized duration formatter and use the new shared `timeUtils` functions instead.
  - `MeetingHeader.jsx`: Refactored to utilize the shared `timeUtils` functions for formatting duration.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2546

## Testing

Verified that durations calculate and format correctly for various test cases, including meetings under an hour (e.g., "45m") and over an hour (e.g., "1h 30m", "2h"). Also verified that fallbacks to the pre-existing `duration` field work as expected when raw timestamps are unavailable.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

N/A — Visual layout remains the same, but the duration values are now accurately calculated and formatted universally using the new utility.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
