### PR TITLE
Harden SandboxedHtmlPreview with theme, size, and error UX (#2451)

### DIFF
--- a/client/src/components/RecapPreferences.jsx
+++ b/client/src/components/RecapPreferences.jsx
@@ -24,6 +24,8 @@ const RecapPreferences = () => {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [previewHtml, setPreviewHtml] = useState("");
+  const [previewError, setPreviewError] = useState("");
+  const [previewLoading, setPreviewLoading] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
   const quietHoursError = (() => {
@@ -96,6 +98,9 @@ const RecapPreferences = () => {
       toast.error("Please fix quiet hours configuration to preview.");
       return;
     }
+    setPreviewLoading(true);
+    setPreviewError("");
+    setIsPreviewOpen(true);
     try {
       const payload = {
         ...preferences,
@@ -110,9 +115,12 @@ const RecapPreferences = () => {
       };
       const html = await previewRecapEmail(payload);
       setPreviewHtml(sanitizeHtml(html));
-      setIsPreviewOpen(true);
     } catch {
+      setPreviewError("Failed to generate preview");
+      setPreviewHtml("");
       toast.error("Failed to generate preview");
+    } finally {
+      setPreviewLoading(false);
     }
   };
 
@@ -222,7 +230,10 @@ const RecapPreferences = () => {
         className="fixed z-50 inset-0 overflow-y-auto"
       >
         <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-          <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
+          <div
+            className="fixed inset-0 bg-black opacity-30"
+            aria-hidden="true"
+          />
           <span
             className="hidden sm:inline-block sm:align-middle sm:h-screen"
             aria-hidden="true"
@@ -242,7 +253,11 @@ const RecapPreferences = () => {
                   <SandboxedHtmlPreview
                     htmlContent={previewHtml}
                     title="Email Preview"
-                    className="min-h-[240px]"
+                    size="sm"
+                    theme="light"
+                    loading={previewLoading}
+                    error={previewError}
+                    onRetry={handlePreview}
                   />
                 </div>
               </div>

--- a/client/src/components/SandboxedHtmlPreview.jsx
+++ b/client/src/components/SandboxedHtmlPreview.jsx
@@ -1,6 +1,47 @@
-import React from "react";
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
+import { AlertCircle, Loader2, RefreshCw, Shield } from "lucide-react";
 import { sanitizeHtml } from "../utils/sanitizeHtml";
+
+export const SANDBOX_PREVIEW_POLICY = "";
+export const SANDBOX_POLICY_DESCRIPTION =
+  "Sandboxed preview — scripts, forms, navigation, and popups are blocked.";
+
+const SIZE_STYLES = {
+  sm: { minHeight: "240px", height: "320px" },
+  md: { minHeight: "400px", height: "480px" },
+  lg: { minHeight: "480px", height: "60vh" },
+};
+
+const LOAD_TIMEOUT_MS = 10000;
+
+const buildThemedSrcDoc = (html, { theme, printStylesheet }) => {
+  const baseStyles = `
+    html, body { margin: 0; padding: 16px; box-sizing: border-box; }
+    *, *::before, *::after { box-sizing: inherit; }
+    img { max-width: 100%; height: auto; }
+  `;
+
+  let themeStyles;
+  if (theme === "dark") {
+    themeStyles = "body { background: #0f172a; color: #e2e8f0; }";
+  } else if (theme === "light") {
+    themeStyles = "body { background: #ffffff; color: #0f172a; }";
+  } else {
+    themeStyles = `
+      body { background: #ffffff; color: #0f172a; }
+      @media (prefers-color-scheme: dark) {
+        body { background: #0f172a; color: #e2e8f0; }
+      }
+    `;
+  }
+
+  const printStyles = printStylesheet
+    ? `@media print { ${printStylesheet} }`
+    : "";
+
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><style>${baseStyles}${themeStyles}${printStyles}</style></head><body>${html}</body></html>`;
+};
 
 /**
  * SandboxedHtmlPreview
@@ -13,27 +54,119 @@ const SandboxedHtmlPreview = ({
   htmlContent,
   className = "",
   title = "Digest Preview",
+  theme = "auto",
+  size = "md",
+  height,
+  loading = false,
+  error = "",
+  onRetry,
+  printStylesheet = "",
+  showSandboxPolicy = true,
 }) => {
-  const sanitizedHtml = sanitizeHtml(htmlContent);
-  if (!sanitizedHtml) return null;
+  const [iframeLoadError, setIframeLoadError] = useState("");
+  const loadTimeoutRef = useRef(null);
+  const statusId = useId();
+
+  const sanitizedHtml = useMemo(() => sanitizeHtml(htmlContent), [htmlContent]);
+  const srcDoc = useMemo(() => {
+    if (!sanitizedHtml) return "";
+    return buildThemedSrcDoc(sanitizedHtml, { theme, printStylesheet });
+  }, [sanitizedHtml, theme, printStylesheet]);
+
+  const clearLoadTimeout = () => {
+    if (loadTimeoutRef.current) {
+      window.clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    clearLoadTimeout();
+    setIframeLoadError("");
+
+    if (!srcDoc || loading || error) {
+      return undefined;
+    }
+
+    loadTimeoutRef.current = window.setTimeout(() => {
+      setIframeLoadError("Preview failed to load.");
+    }, LOAD_TIMEOUT_MS);
+
+    return clearLoadTimeout;
+  }, [srcDoc, loading, error]);
+
+  const displayError = error || iframeLoadError;
+  const sizeStyle = height
+    ? { minHeight: height, height }
+    : SIZE_STYLES[size] || SIZE_STYLES.md;
+
+  if (!loading && !displayError && !sanitizedHtml) {
+    return null;
+  }
 
   return (
     <div
       className={`overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 ${className}`}
+      data-testid="sandboxed-html-preview"
     >
-      <iframe
-        title={title}
-        srcDoc={sanitizedHtml}
-        className="w-full h-full min-h-[400px] border-none"
-        // Maximum restriction sandbox:
-        // - No 'allow-scripts': prevents JS execution
-        // - No 'allow-same-origin': blocks access to parent cookies/storage
-        // - No 'allow-top-navigation': prevents redirecting the parent window
-        // - No 'allow-popups': prevents opening new windows
-        // - No 'allow-forms': prevents form submissions
-        sandbox=""
-        referrerPolicy="no-referrer"
-      />
+      {showSandboxPolicy && (
+        <div
+          className="flex items-center gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300"
+          data-testid="sandbox-policy-notice"
+        >
+          <Shield className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span>{SANDBOX_POLICY_DESCRIPTION}</span>
+        </div>
+      )}
+
+      {loading ? (
+        <div
+          className="flex items-center justify-center gap-2 text-slate-500 dark:text-slate-400"
+          style={sizeStyle}
+          role="status"
+          aria-live="polite"
+          aria-labelledby={statusId}
+          data-testid="sandboxed-html-preview-loading"
+        >
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+          <span id={statusId}>Loading preview...</span>
+        </div>
+      ) : displayError ? (
+        <div
+          className="flex flex-col items-center justify-center gap-3 px-4 text-center text-rose-600 dark:text-rose-400"
+          style={sizeStyle}
+          role="alert"
+          data-testid="sandboxed-html-preview-error"
+        >
+          <div className="flex items-center gap-2 text-sm">
+            <AlertCircle className="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span>{displayError}</span>
+          </div>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-xs font-semibold text-rose-700 hover:bg-rose-50 dark:border-rose-900 dark:bg-slate-900 dark:text-rose-300 dark:hover:bg-rose-950/40"
+            >
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+              Try again
+            </button>
+          )}
+        </div>
+      ) : (
+        <iframe
+          title={title}
+          srcDoc={srcDoc}
+          className="w-full border-none"
+          style={sizeStyle}
+          sandbox={SANDBOX_PREVIEW_POLICY}
+          referrerPolicy="no-referrer"
+          onLoad={() => {
+            clearLoadTimeout();
+            setIframeLoadError("");
+          }}
+        />
+      )}
     </div>
   );
 };
@@ -42,6 +175,14 @@ SandboxedHtmlPreview.propTypes = {
   htmlContent: PropTypes.string,
   className: PropTypes.string,
   title: PropTypes.string,
+  theme: PropTypes.oneOf(["light", "dark", "auto"]),
+  size: PropTypes.oneOf(["sm", "md", "lg"]),
+  height: PropTypes.string,
+  loading: PropTypes.bool,
+  error: PropTypes.string,
+  onRetry: PropTypes.func,
+  printStylesheet: PropTypes.string,
+  showSandboxPolicy: PropTypes.bool,
 };
 
 export default SandboxedHtmlPreview;

--- a/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
+++ b/client/src/components/__tests__/RecapPreferencesPreview.test.jsx
@@ -27,6 +27,12 @@ vi.mock("react-toastify", () => ({
   },
 }));
 
+vi.mock("@headlessui/react", () => {
+  const Dialog = ({ open, children }) => (open ? <div>{children}</div> : null);
+  Dialog.Title = ({ children, ...props }) => <h3 {...props}>{children}</h3>;
+  return { Dialog };
+});
+
 const defaultPreferences = {
   deliveryTiming: "immediate",
   includeSummary: true,
@@ -50,13 +56,14 @@ const openPreview = async (html) => {
   fireEvent.click(screen.getByRole("button", { name: /preview email/i }));
 
   await waitFor(() => {
+    expect(screen.getByTestId("sandboxed-html-preview")).toBeInTheDocument();
     expect(screen.getByTitle("Email Preview")).toBeInTheDocument();
   });
 
   return screen.getByTitle("Email Preview");
 };
 
-describe("RecapPreferences HTML preview sanitization (#1391)", () => {
+describe("RecapPreferences HTML preview sanitization (#1391, #2451)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getRecapPreferences.mockResolvedValue(defaultPreferences);
@@ -110,5 +117,25 @@ describe("RecapPreferences HTML preview sanitization (#1391)", () => {
     const srcDoc = iframe.getAttribute("srcdoc") || "";
     expect(srcDoc).toContain("Open recap");
     expect(srcDoc).not.toMatch(/javascript:/i);
+  });
+
+  it("shows recovery UI when recap preview generation fails", async () => {
+    previewRecapEmail.mockRejectedValueOnce(new Error("Preview failed"));
+    render(<RecapPreferences />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /preview email/i }),
+      ).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /preview email/i }));
+
+    expect(
+      await screen.findByTestId("sandboxed-html-preview-error"),
+    ).toHaveTextContent("Failed to generate preview");
+    expect(
+      screen.getByRole("button", { name: /try again/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/components/__tests__/SandboxedHtmlPreview.test.jsx
+++ b/client/src/components/__tests__/SandboxedHtmlPreview.test.jsx
@@ -1,12 +1,23 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
-import SandboxedHtmlPreview from "../SandboxedHtmlPreview.jsx";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import SandboxedHtmlPreview, {
+  SANDBOX_PREVIEW_POLICY,
+  SANDBOX_POLICY_DESCRIPTION,
+} from "../SandboxedHtmlPreview.jsx";
 
 const iframeSrcDoc = (title) =>
   screen.getByTitle(title).getAttribute("srcdoc") || "";
 
-describe("SandboxedHtmlPreview (#1391)", () => {
+describe("SandboxedHtmlPreview (#1391, #2451)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders sanitized HTML inside a maximally restricted iframe", () => {
     render(
       <SandboxedHtmlPreview
@@ -17,11 +28,14 @@ describe("SandboxedHtmlPreview (#1391)", () => {
 
     const iframe = screen.getByTitle("Email Preview");
     expect(iframe.tagName).toBe("IFRAME");
-    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("sandbox")).toBe(SANDBOX_PREVIEW_POLICY);
     expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
     expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
     expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
     expect(iframeSrcDoc("Email Preview")).toContain("Meeting Recap");
+    expect(screen.getByTestId("sandbox-policy-notice")).toHaveTextContent(
+      SANDBOX_POLICY_DESCRIPTION,
+    );
   });
 
   it("strips script tags before assigning srcDoc", () => {
@@ -93,5 +107,126 @@ describe("SandboxedHtmlPreview (#1391)", () => {
 
     expect(container.firstChild).toBeNull();
     expect(screen.queryByTitle("Email Preview")).not.toBeInTheDocument();
+  });
+
+  it("applies dark theme styles to the preview document", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Dark recap</p>"
+        title="Email Preview"
+        theme="dark"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("background: #0f172a");
+    expect(srcDoc).toContain("color: #e2e8f0");
+  });
+
+  it("applies light theme styles to the preview document", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Light recap</p>"
+        title="Email Preview"
+        theme="light"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("background: #ffffff");
+    expect(srcDoc).toContain("color: #0f172a");
+  });
+
+  it("applies size presets to the iframe", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Sized recap</p>"
+        title="Email Preview"
+        size="sm"
+      />,
+    );
+
+    const iframe = screen.getByTitle("Email Preview");
+    expect(iframe.style.minHeight).toBe("240px");
+    expect(iframe.style.height).toBe("320px");
+  });
+
+  it("injects optional print stylesheet rules", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Print recap</p>"
+        title="Email Preview"
+        printStylesheet="body { font-size: 12pt; }"
+      />,
+    );
+
+    const srcDoc = iframeSrcDoc("Email Preview");
+    expect(srcDoc).toContain("@media print");
+    expect(srcDoc).toContain("font-size: 12pt");
+  });
+
+  it("shows a loading state while preview content is fetching", () => {
+    render(
+      <SandboxedHtmlPreview htmlContent="" title="Email Preview" loading />,
+    );
+
+    expect(
+      screen.getByTestId("sandboxed-html-preview-loading"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/loading preview/i)).toBeInTheDocument();
+    expect(screen.queryByTitle("Email Preview")).not.toBeInTheDocument();
+  });
+
+  it("shows recovery UI when preview loading fails", () => {
+    const onRetry = vi.fn();
+    render(
+      <SandboxedHtmlPreview
+        htmlContent=""
+        title="Email Preview"
+        error="Failed to load digest preview"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("sandboxed-html-preview-error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to load digest preview"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error when the iframe does not load in time", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Slow recap</p>"
+        title="Email Preview"
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    expect(
+      screen.getByTestId("sandboxed-html-preview-error"),
+    ).toHaveTextContent("Preview failed to load.");
+  });
+
+  it("can hide the sandbox policy notice", () => {
+    render(
+      <SandboxedHtmlPreview
+        htmlContent="<p>Recap</p>"
+        title="Email Preview"
+        showSandboxPolicy={false}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("sandbox-policy-notice"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/meeting-details/DigestActions.jsx
+++ b/client/src/components/meeting-details/DigestActions.jsx
@@ -376,18 +376,7 @@ const DigestActions = ({ meetingId, onStatusUpdate, canManage = true }) => {
               </button>
             </div>
             <div className="flex-1 overflow-auto p-4 bg-slate-50 dark:bg-slate-950">
-              {previewLoading ? (
-                <div className="flex justify-center items-center h-64">
-                  <Loader2
-                    className="w-8 h-8 animate-spin text-blue-500"
-                    aria-label="Loading digest preview"
-                  />
-                </div>
-              ) : previewError && !previewHtml ? (
-                <div role="alert" className="text-center text-rose-600 py-12">
-                  {previewError}
-                </div>
-              ) : previewHtml ? (
+              {previewHtml || previewLoading || previewError ? (
                 <div className="space-y-3">
                   <div className="flex gap-2">
                     <button
@@ -415,8 +404,13 @@ const DigestActions = ({ meetingId, onStatusUpdate, canManage = true }) => {
                   </div>
                   {previewTab === "html" ? (
                     <SandboxedHtmlPreview
-                      htmlContent={previewHtml}
+                      htmlContent={previewHtml || ""}
                       title="Email Preview"
+                      size="lg"
+                      theme="auto"
+                      loading={previewLoading}
+                      error={previewError}
+                      onRetry={handlePreview}
                     />
                   ) : (
                     <pre

--- a/client/src/components/meeting-details/__tests__/DigestActions.test.jsx
+++ b/client/src/components/meeting-details/__tests__/DigestActions.test.jsx
@@ -21,9 +21,9 @@ vi.mock("../../../services", () => ({
 }));
 
 vi.mock("../../SandboxedHtmlPreview.jsx", () => ({
-  default: ({ htmlContent, title }) => (
+  default: ({ htmlContent, title, error }) => (
     <div data-testid="digest-html-preview" title={title}>
-      {htmlContent}
+      {error ? <div role="alert">{error}</div> : htmlContent}
     </div>
   ),
 }));


### PR DESCRIPTION
## Summary
- Harden `SandboxedHtmlPreview` with sandbox policy notice, theme/size props, loading/error recovery UI, and optional print stylesheet hook
- Wire digest and recap consumers to use shared loading/error/retry behavior
- Expand unit tests for sandbox, theme, size, print, loading, error, and consumer paths

Closes #2451

## Test plan
- [x] `cd client && npx vitest run src/components/__tests__/SandboxedHtmlPreview.test.jsx src/components/__tests__/RecapPreferencesPreview.test.jsx src/components/meeting-details/__tests__/DigestActions.test.jsx`
- [x] `npm run lint:changed --prefix client`
- [x] `npm run format:check:changed --prefix client`
- [ ] Open digest preview in Meeting Details → verify sandbox notice, HTML renders, error retry on API failure
- [ ] Open recap email preview in Recap Preferences → verify loading state, preview theme/size, error retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced HTML previews with light and dark themes, size options, loading indicators, and print styling.
  - Added clearer sandbox safety messaging and blocked potentially unsafe interactions.
  - Added retry options and helpful error messages when previews fail or time out.
  - Improved digest and recap preview dialogs to handle loading, errors, and empty content consistently.

- **Bug Fixes**
  - Preview failures now recover without closing the dialog.
  - Added timeout handling for previews that do not load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->