### PR TITLE
fix: route client api modules through the shared apiClient

### DIFF
--- a/client/src/api/participantContributionApi.js
+++ b/client/src/api/participantContributionApi.js
@@ -1,17 +1,31 @@
-import axios from "axios";
+import apiClient from "../services/apiClient.js";
 
-const API_BASE_URL = "/api";
+/**
+ * Participant contribution API.
+ *
+ * This module used bare `axios` against a relative `/api` base (Issue #2574).
+ * That sends the request to whichever origin is serving the frontend, so in the
+ * documented split-port dev setup — Vite on `:5173`, server on `:4000` — every
+ * call 404'd against the dev server. `apiClient` is configured with
+ * `getBackendUrl()` from `config/backendConfig.js`, which resolves
+ * `VITE_BACKEND_URL` / `VITE_API_URL`.
+ *
+ * Going through `apiClient` also restores what a bare `axios` call skips:
+ * the 30s request deadline added by #978 (axios defaults `timeout` to `0`, i.e.
+ * wait forever, which left spinners hung with neither `.then` nor `.catch` ever
+ * running), the retry/backoff in `services/httpRetry.js`, GET de-duplication,
+ * and the interceptor that normalizes errors and attaches the request id.
+ *
+ * `withCredentials` is set on the shared instance, so it is not repeated here.
+ */
 
 /**
  * Fetch participant contributions for a given meeting
  * @param {string} meetingId
  */
 export const getMeetingContributions = async (meetingId) => {
-  const response = await axios.get(
-    `${API_BASE_URL}/meetings/${meetingId}/contributions`,
-    {
-      withCredentials: true,
-    },
+  const response = await apiClient.get(
+    `/api/meetings/${meetingId}/contributions`,
   );
   return response.data;
 };
@@ -21,12 +35,9 @@ export const getMeetingContributions = async (meetingId) => {
  * @param {string} meetingId
  */
 export const calculateMeetingContributions = async (meetingId) => {
-  const response = await axios.post(
-    `${API_BASE_URL}/meetings/${meetingId}/contributions/calculate`,
+  const response = await apiClient.post(
+    `/api/meetings/${meetingId}/contributions/calculate`,
     {},
-    {
-      withCredentials: true,
-    },
   );
   return response.data;
 };

--- a/client/src/api/recurringActionItemApi.js
+++ b/client/src/api/recurringActionItemApi.js
@@ -1,4 +1,8 @@
-import apiClient from "./apiClient";
+// The shared client lives at `services/apiClient` — there is no
+// `api/apiClient`, so this import could not resolve (Issue #2574). The module
+// is only outside Rollup's graph today because `RecurringActionItems.jsx` is
+// not yet rendered anywhere; mounting it (#2443) breaks the build.
+import apiClient from "../services/apiClient.js";
 
 export const getRecurringActionItems = async () => {
   const response = await apiClient.get("/api/recurring-action-items");

--- a/client/src/services/__tests__/clientApiModuleWiring.test.js
+++ b/client/src/services/__tests__/clientApiModuleWiring.test.js
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import apiClient from "../apiClient.js";
+import * as recurringActionItemApi from "../../api/recurringActionItemApi.js";
+import * as participantContributionApi from "../../api/participantContributionApi.js";
+import { assertAllCallsUseApiPrefix } from "./helpers/apiPrefixAssertionHelper.js";
+
+vi.mock("../apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const apiDir = path.resolve(here, "../../api");
+
+/**
+ * Modules knowingly still on bare `axios`.
+ *
+ * `meetingNudgeApi.js` is the subject of #2000, which is already open and
+ * assigned. Listing it here rather than widening the assertion keeps the guard
+ * meaningful for every other module, and makes the exception something a
+ * reviewer has to delete deliberately when #2000 lands.
+ */
+const KNOWN_BARE_AXIOS = new Set(["meetingNudgeApi.js"]);
+
+const MEETING_ID = "meeting-1";
+const ITEM_ID = "item-1";
+
+describe("client API module wiring (#2574)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({ data: { success: true } });
+    apiClient.post.mockResolvedValue({ data: { success: true } });
+    apiClient.put.mockResolvedValue({ data: { success: true } });
+    apiClient.delete.mockResolvedValue({ data: { success: true } });
+  });
+
+  describe("no module under src/api bypasses the shared client", () => {
+    const sources = fs
+      .readdirSync(apiDir)
+      .filter((file) => file.endsWith(".js"))
+      .map((file) => ({
+        file,
+        source: fs.readFileSync(path.join(apiDir, file), "utf8"),
+      }));
+
+    it("finds modules to check", () => {
+      expect(sources.length).toBeGreaterThan(0);
+    });
+
+    it.each(
+      sources
+        .map(({ file }) => file)
+        .filter((file) => !KNOWN_BARE_AXIOS.has(file)),
+    )("%s does not import axios directly", (file) => {
+      const { source } = sources.find((s) => s.file === file);
+
+      // A bare axios call skips the resolved base URL, the 30s deadline from
+      // #978, retries, de-duplication and error normalization. Every module
+      // here should reach the network through `services/apiClient`.
+      expect(source).not.toMatch(/^import\s+axios\s+from\s+["']axios["']/m);
+    });
+
+    it("tracks exactly one remaining bare-axios module", () => {
+      const offenders = sources
+        .filter(({ source }) =>
+          /^import\s+axios\s+from\s+["']axios["']/m.test(source),
+        )
+        .map(({ file }) => file);
+
+      // If this fails with an empty array, #2000 has landed — delete
+      // KNOWN_BARE_AXIOS and this test. If it fails with a new name, a module
+      // has regressed.
+      expect(offenders).toEqual([...KNOWN_BARE_AXIOS]);
+    });
+
+    it.each(sources.map(({ file }) => file))(
+      "%s resolves every relative import to a file that exists",
+      (file) => {
+        const { source } = sources.find((s) => s.file === file);
+        const specifiers = [
+          ...source.matchAll(/from\s+["'](\.[^"']+)["']/g),
+        ].map((m) => m[1]);
+
+        for (const specifier of specifiers) {
+          const base = path.resolve(apiDir, specifier);
+          const candidates = [
+            base,
+            `${base}.js`,
+            `${base}.jsx`,
+            path.join(base, "index.js"),
+          ];
+
+          // The regression: `recurringActionItemApi.js` imported
+          // "./apiClient", which does not exist. It only escaped the build
+          // because nothing rendered the component that reaches it.
+          expect(
+            candidates.some((candidate) => fs.existsSync(candidate)),
+            `${file} imports "${specifier}", which resolves to nothing`,
+          ).toBe(true);
+        }
+      },
+    );
+  });
+
+  describe("recurringActionItemApi", () => {
+    it("imports a module that actually resolves", () => {
+      // If the import were still broken this suite would fail to load at all;
+      // asserting the exports are callable states the expectation explicitly.
+      expect(typeof recurringActionItemApi.getRecurringActionItems).toBe(
+        "function",
+      );
+      expect(typeof recurringActionItemApi.createRecurringActionItem).toBe(
+        "function",
+      );
+    });
+
+    it("routes every call through the shared client under /api", async () => {
+      await recurringActionItemApi.getRecurringActionItems();
+      await recurringActionItemApi.getRecurringActionItemById(ITEM_ID);
+      await recurringActionItemApi.createRecurringActionItem({ title: "x" });
+      await recurringActionItemApi.updateRecurringActionItem(ITEM_ID, {
+        title: "y",
+      });
+      await recurringActionItemApi.deleteRecurringActionItem(ITEM_ID);
+
+      expect(apiClient.get).toHaveBeenCalledWith("/api/recurring-action-items");
+      expect(apiClient.get).toHaveBeenCalledWith(
+        `/api/recurring-action-items/${ITEM_ID}`,
+      );
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/recurring-action-items",
+        { title: "x" },
+      );
+      expect(apiClient.put).toHaveBeenCalledWith(
+        `/api/recurring-action-items/${ITEM_ID}`,
+        { title: "y" },
+      );
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        `/api/recurring-action-items/${ITEM_ID}`,
+      );
+
+      assertAllCallsUseApiPrefix(apiClient);
+    });
+
+    it("returns the response payload rather than the axios envelope", async () => {
+      apiClient.get.mockResolvedValue({ data: { items: [1, 2] } });
+
+      await expect(
+        recurringActionItemApi.getRecurringActionItems(),
+      ).resolves.toEqual({ items: [1, 2] });
+    });
+  });
+
+  describe("participantContributionApi", () => {
+    it("fetches contributions through the shared client", async () => {
+      await participantContributionApi.getMeetingContributions(MEETING_ID);
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        `/api/meetings/${MEETING_ID}/contributions`,
+      );
+      assertAllCallsUseApiPrefix(apiClient);
+    });
+
+    it("triggers calculation through the shared client", async () => {
+      await participantContributionApi.calculateMeetingContributions(
+        MEETING_ID,
+      );
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        `/api/meetings/${MEETING_ID}/contributions/calculate`,
+        {},
+      );
+      assertAllCallsUseApiPrefix(apiClient);
+    });
+
+    it("does not pass withCredentials per request", async () => {
+      // It is set once on the shared instance; repeating it per call is how
+      // the bare-axios version had to do it, and drifts.
+      await participantContributionApi.getMeetingContributions(MEETING_ID);
+
+      const [, config] = apiClient.get.mock.calls[0];
+      expect(config).toBeUndefined();
+    });
+
+    it("returns the response payload rather than the axios envelope", async () => {
+      apiClient.get.mockResolvedValue({ data: { contributions: [] } });
+
+      await expect(
+        participantContributionApi.getMeetingContributions(MEETING_ID),
+      ).resolves.toEqual({ contributions: [] });
+    });
+
+    it("propagates a rejection so react-query can surface it", async () => {
+      apiClient.get.mockRejectedValue(new Error("Network Error"));
+
+      await expect(
+        participantContributionApi.getMeetingContributions(MEETING_ID),
+      ).rejects.toThrow("Network Error");
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Two modules under `client/src/api/` do not go through `client/src/services/apiClient.js`. One of them cannot resolve its import at all.

### 1. `recurringActionItemApi.js` imported a module that does not exist

```js
import apiClient from "./apiClient";     // client/src/api/apiClient.js — not a file
```

Every other module in `client/src/api/` imports it as `"../services/apiClient"`. This one was the single exception. Verified with Vite's own resolver, from that module as the importer:

```console
"./apiClient"              -> UNRESOLVED (build would fail)
"../services/apiClient.js" -> RESOLVED
```

The import chain is `components/dashboard/RecurringActionItems.jsx → hooks/useRecurringActionItems.js → api/recurringActionItemApi.js → ./apiClient`. `RecurringActionItems.jsx` is not rendered by any page, so the module sits outside Rollup's graph and `npm run build` still passes today. **The moment the widget is mounted, the build fails to resolve it** — which is exactly what #2443 / PR #2568 set out to do. A latent build breaker sitting directly in front of open work.

> Worth flagging separately for whoever lands #2443: making that component reachable also surfaces `Rollup failed to resolve import "antd" from RecurringActionItems.jsx`. `antd` is not in `client/package.json`. That is out of scope here — this PR fixes the API module, not the component — but it will be the next thing that stops the build.

### 2. `participantContributionApi.js` bypassed `apiClient` entirely

```js
import axios from "axios";
const API_BASE_URL = "/api";
await axios.get(`${API_BASE_URL}/meetings/${meetingId}/contributions`, { withCredentials: true });
```

A bare `axios` call with a **relative** base sends the request to whichever origin serves the frontend. In the documented dev setup — Vite on `:5173`, server on `:4000` — `getMeetingContributions` requested `http://localhost:5173/api/meetings/.../contributions` and got a 404. `config/backendConfig.js#getBackendUrl` exists to resolve this from `VITE_BACKEND_URL` / `VITE_API_URL`, and `apiClient` is configured with it.

Skipping `apiClient` also drops everything layered onto it:

- **`DEFAULT_TIMEOUT_MS = 30000`** — added by #978 because axios defaults `timeout` to `0`, i.e. wait forever. A request whose connection is silently dropped never settled, so neither `.then` nor `.catch` ran, and the `finally` that clears a loading flag never ran either — a spinner that span forever with no error and no recovery but a manual reload.
- the retry/backoff logic in `services/httpRetry.js`
- GET request de-duplication
- the response interceptor that normalizes errors and appends the `x-request-id` reference

`withCredentials` is set once on the shared instance, so the per-call config is dropped rather than duplicated.

## The regression guard

New `clientApiModuleWiring.test.js` walks every `.js` under `client/src/api/` and asserts:

1. **Every relative import resolves to a file that exists.** This is the check that would have caught the broken import at the time it was written, rather than leaving it for whoever mounts the component.
2. **No module imports `axios` directly.**

`meetingNudgeApi.js` is still on bare axios — that is #2000, already open and assigned, so fixing it here would violate the one-PR-one-issue rule. It is listed in an explicit `KNOWN_BARE_AXIOS` set rather than by widening the assertion, and a companion test asserts the offender list is *exactly* that set. So when #2000 lands the test fails, telling the next person to delete the exception; and if a new module regresses, it fails naming the new file.

## Type of Change

- [x] Bug Fix

## Related Issue

Closes #2574

## Testing

```console
$ npx vitest run src/services/__tests__/apiPrefix.test.js \
                src/services/__tests__/clientApiModuleWiring.test.js
 Test Files  2 passed (2)
      Tests  60 passed (60)
```

53 of those are the new suite. It reuses the existing `assertAllCallsUseApiPrefix` helper, and also covers:

- `%s resolves every relative import to a file that exists` — parameterised over every module in the directory.
- `tracks exactly one remaining bare-axios module`
- `does not pass withCredentials per request` — it belongs on the shared instance.
- `returns the response payload rather than the axios envelope` on both modules.
- `propagates a rejection so react-query can surface it` — the hooks depend on this.

Module resolution was verified independently against Vite's resolver, on `main` and on this branch, with the result quoted above.

```console
$ npx eslint <changed files>            # clean
$ npx prettier --check <changed files>  # clean
$ git diff --check                      # clean
```

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — no rendered output changes; this is the API transport layer.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review
