### PR TITLE
feat: Knowledge Contradiction Detection

### DIFF
--- a/client/src/components/Knowledge/MeetingContradictionInspector.jsx
+++ b/client/src/components/Knowledge/MeetingContradictionInspector.jsx
@@ -1,0 +1,286 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { toast } from "react-toastify";
+import { knowledgeApi } from "../../services/knowledgeApi";
+import {
+  AlertTriangle,
+  ShieldAlert,
+  Loader2,
+  ScanSearch,
+  CheckCircle2,
+  XCircle,
+  PenLine,
+  Sparkles,
+  RefreshCw,
+} from "lucide-react";
+
+const MeetingContradictionInspector = ({ meetingId, onResolved }) => {
+  const [conflicts, setConflicts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [scanning, setScanning] = useState(false);
+  const [resolvingId, setResolvingId] = useState(null);
+  const [customValues, setCustomValues] = useState({});
+
+  const loadMeetingConflicts = useCallback(async () => {
+    if (!meetingId) return;
+    setLoading(true);
+    try {
+      const res = await knowledgeApi.getMeetingConflicts(meetingId);
+      if (res.data?.success) {
+        setConflicts(res.data.conflicts || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch meeting conflicts:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [meetingId]);
+
+  useEffect(() => {
+    loadMeetingConflicts();
+  }, [loadMeetingConflicts]);
+
+  const handleScanMeeting = async () => {
+    if (!meetingId) return;
+    setScanning(true);
+    try {
+      const res = await knowledgeApi.scanMeetingConflicts(meetingId, {
+        dryRun: false,
+      });
+      if (res.data?.success) {
+        const total = res.data.report?.totalConflictsFound || 0;
+        toast.success(
+          total > 0
+            ? `Contradiction scan complete — ${total} contradiction${total === 1 ? "" : "s"} identified.`
+            : "Contradiction scan complete — no knowledge conflicts found.",
+        );
+        await loadMeetingConflicts();
+      }
+    } catch (err) {
+      console.error("Error scanning meeting conflicts:", err);
+      toast.error(
+        err.response?.data?.message || "Failed to scan meeting contradictions.",
+      );
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handleResolve = async (conflictId, resolutionType, extra = {}) => {
+    setResolvingId(conflictId);
+    try {
+      const res = await knowledgeApi.resolveConflict(conflictId, {
+        resolutionType,
+        ...extra,
+      });
+      if (res.data?.success) {
+        toast.success("Knowledge contradiction resolved.");
+        setConflicts((prev) => prev.filter((c) => c._id !== conflictId));
+        if (onResolved) onResolved(conflictId);
+      }
+    } catch (err) {
+      console.error("Failed to resolve conflict:", err);
+      toast.error(err.response?.data?.message || "Failed to resolve conflict.");
+    } finally {
+      setResolvingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div
+        data-testid="meeting-contradiction-loading"
+        className="p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex items-center justify-center gap-2 text-sm text-gray-500"
+      >
+        <Loader2 className="w-4 h-4 animate-spin text-amber-500" />
+        Checking for knowledge contradictions...
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="meeting-contradiction-inspector" className="space-y-4">
+      {/* Contradictions Banner / Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-4 rounded-2xl border border-amber-200 dark:border-amber-900/50 bg-amber-50/70 dark:bg-amber-950/20">
+        <div className="flex items-center gap-3">
+          <div className="p-2.5 rounded-xl bg-amber-100 dark:bg-amber-900/60 text-amber-600 dark:text-amber-400">
+            <ShieldAlert className="w-5 h-5" />
+          </div>
+          <div>
+            <h3 className="text-base font-bold text-gray-900 dark:text-white flex items-center gap-2">
+              Knowledge Contradictions
+              <span
+                data-testid="contradiction-badge"
+                className={`px-2 py-0.5 rounded-full text-xs font-semibold ${
+                  conflicts.length > 0
+                    ? "bg-amber-200 text-amber-900 dark:bg-amber-900 dark:text-amber-200"
+                    : "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300"
+                }`}
+              >
+                {conflicts.length}{" "}
+                {conflicts.length === 1 ? "conflict" : "conflicts"}
+              </span>
+            </h3>
+            <p className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+              Identifies statements in this meeting that conflict with existing
+              organizational knowledge.
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleScanMeeting}
+          disabled={scanning}
+          data-testid="scan-meeting-btn"
+          className="px-3.5 py-2 rounded-xl bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold shadow-sm transition-colors flex items-center justify-center gap-1.5 disabled:opacity-60 shrink-0"
+        >
+          {scanning ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <ScanSearch className="w-3.5 h-3.5" />
+          )}
+          Scan Contradictions
+        </button>
+      </div>
+
+      {/* Conflicts List */}
+      {conflicts.length === 0 ? (
+        <div className="p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 text-center space-y-1">
+          <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400 flex items-center justify-center gap-1.5">
+            <CheckCircle2 className="w-4 h-4" />
+            No knowledge contradictions detected for this meeting.
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            All decisions and action items align cleanly with stored
+            organizational records.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {conflicts.map((conflict) => (
+            <div
+              key={conflict._id}
+              data-testid={`conflict-card-${conflict._id}`}
+              className="p-4 rounded-2xl border border-amber-200 dark:border-amber-900/50 bg-white dark:bg-gray-900 shadow-sm space-y-3"
+            >
+              {/* Conflict Explanation & Confidence */}
+              <div className="flex items-start justify-between gap-3 pb-2 border-b border-gray-100 dark:border-gray-800">
+                <div className="flex items-center gap-2 text-xs font-semibold text-amber-700 dark:text-amber-400">
+                  <Sparkles className="w-4 h-4 text-amber-500" />
+                  <span>AI Confidence: {conflict.confidence}%</span>
+                </div>
+                <span className="text-[11px] uppercase tracking-wider font-bold text-gray-400">
+                  {conflict.modelType}
+                </span>
+              </div>
+
+              <p className="text-xs text-gray-700 dark:text-gray-300 leading-relaxed font-medium">
+                {conflict.explanation}
+              </p>
+
+              {/* Side-by-side statement comparison */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {(conflict.memberSnapshots || []).map((member, idx) => {
+                  const isCurrentMeetingMember =
+                    member.sourceMeetingId?.toString() ===
+                      meetingId.toString() ||
+                    member.meetingId?.toString() === meetingId.toString() ||
+                    member.meeting?.toString() === meetingId.toString();
+
+                  return (
+                    <div
+                      key={member.memoryId || idx}
+                      className={`p-3 rounded-xl border flex flex-col justify-between space-y-2 ${
+                        isCurrentMeetingMember
+                          ? "bg-blue-50/50 border-blue-200 dark:bg-blue-950/20 dark:border-blue-900/50"
+                          : "bg-gray-50/50 border-gray-200 dark:bg-gray-800/40 dark:border-gray-700"
+                      }`}
+                    >
+                      <div>
+                        <span className="text-[10px] font-bold uppercase tracking-wider text-gray-500 block mb-1">
+                          {isCurrentMeetingMember
+                            ? "This Meeting's Statement"
+                            : "Existing Org Knowledge Record"}
+                        </span>
+                        <p className="text-xs text-gray-900 dark:text-white font-medium">
+                          "{member.text}"
+                        </p>
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() =>
+                          handleResolve(conflict._id, "kept_member", {
+                            keptMemoryId: member.memoryId,
+                          })
+                        }
+                        disabled={resolvingId === conflict._id}
+                        data-testid={`keep-member-btn-${member.memoryId}`}
+                        className="w-full mt-2 py-1.5 px-2.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold transition-colors flex items-center justify-center gap-1 disabled:opacity-50"
+                      >
+                        {resolvingId === conflict._id ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <CheckCircle2 className="w-3.5 h-3.5" />
+                        )}
+                        {isCurrentMeetingMember
+                          ? "Keep Meeting Statement"
+                          : "Keep Stored Knowledge"}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Custom correction / Dismiss Toolbar */}
+              <div className="pt-2 border-t border-gray-100 dark:border-gray-800 flex flex-col sm:flex-row gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter custom resolved text..."
+                  value={customValues[conflict._id] || ""}
+                  onChange={(e) =>
+                    setCustomValues((prev) => ({
+                      ...prev,
+                      [conflict._id]: e.target.value,
+                    }))
+                  }
+                  className="flex-1 px-3 py-1.5 border border-gray-300 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 text-xs text-gray-900 dark:text-gray-100 outline-none focus:ring-2 focus:ring-amber-500"
+                  data-testid={`custom-input-${conflict._id}`}
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    handleResolve(conflict._id, "custom_value", {
+                      customValue: customValues[conflict._id] || "",
+                    })
+                  }
+                  disabled={
+                    resolvingId === conflict._id || !customValues[conflict._id]
+                  }
+                  data-testid={`save-custom-btn-${conflict._id}`}
+                  className="px-3 py-1.5 rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-xs font-semibold text-gray-700 dark:text-gray-300 transition-colors flex items-center justify-center gap-1 disabled:opacity-50"
+                >
+                  <PenLine className="w-3.5 h-3.5" />
+                  Save Correction
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => handleResolve(conflict._id, "dismissed")}
+                  disabled={resolvingId === conflict._id}
+                  data-testid={`dismiss-btn-${conflict._id}`}
+                  className="px-3 py-1.5 rounded-xl text-xs font-semibold text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors flex items-center justify-center gap-1 disabled:opacity-50"
+                >
+                  <XCircle className="w-3.5 h-3.5" />
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MeetingContradictionInspector;

--- a/client/src/components/Knowledge/__tests__/MeetingContradictionInspector.test.jsx
+++ b/client/src/components/Knowledge/__tests__/MeetingContradictionInspector.test.jsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MeetingContradictionInspector from "../MeetingContradictionInspector.jsx";
+import { knowledgeApi } from "../../../services/knowledgeApi";
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services/knowledgeApi", () => ({
+  knowledgeApi: {
+    getMeetingConflicts: vi.fn(),
+    scanMeetingConflicts: vi.fn(),
+    resolveConflict: vi.fn(),
+  },
+}));
+
+describe("MeetingContradictionInspector Component", () => {
+  const mockMeetingId = "meeting123";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders zero contradictions state when no conflicts exist", async () => {
+    knowledgeApi.getMeetingConflicts.mockResolvedValue({
+      data: { success: true, conflicts: [] },
+    });
+
+    render(<MeetingContradictionInspector meetingId={mockMeetingId} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("meeting-contradiction-inspector"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("contradiction-badge")).toHaveTextContent(
+      "0 conflicts",
+    );
+    expect(
+      screen.getByText(
+        "No knowledge contradictions detected for this meeting.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders conflict card with side-by-side statements when conflicts exist", async () => {
+    const mockConflict = {
+      _id: "conflict1",
+      modelType: "decision",
+      confidence: 85,
+      explanation: "Differing database choices detected between meetings.",
+      memberSnapshots: [
+        {
+          memoryId: "mem1",
+          text: "Database is PostgreSQL",
+          sourceMeetingId: "otherMeeting",
+        },
+        {
+          memoryId: "mem2",
+          text: "Database migrated to MongoDB",
+          sourceMeetingId: mockMeetingId,
+        },
+      ],
+    };
+
+    knowledgeApi.getMeetingConflicts.mockResolvedValue({
+      data: { success: true, conflicts: [mockConflict] },
+    });
+
+    render(<MeetingContradictionInspector meetingId={mockMeetingId} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conflict-card-conflict1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("AI Confidence: 85%")).toBeInTheDocument();
+    expect(screen.getByText('"Database is PostgreSQL"')).toBeInTheDocument();
+    expect(
+      screen.getByText('"Database migrated to MongoDB"'),
+    ).toBeInTheDocument();
+  });
+
+  it("runs contradiction scan when scan button is clicked", async () => {
+    knowledgeApi.getMeetingConflicts.mockResolvedValue({
+      data: { success: true, conflicts: [] },
+    });
+    knowledgeApi.scanMeetingConflicts.mockResolvedValue({
+      data: { success: true, report: { totalConflictsFound: 1 } },
+    });
+
+    render(<MeetingContradictionInspector meetingId={mockMeetingId} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scan-meeting-btn")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("scan-meeting-btn"));
+
+    await waitFor(() => {
+      expect(knowledgeApi.scanMeetingConflicts).toHaveBeenCalledWith(
+        mockMeetingId,
+        { dryRun: false },
+      );
+    });
+  });
+
+  it("resolves conflict by keeping selected member statement", async () => {
+    const mockConflict = {
+      _id: "conflict1",
+      modelType: "decision",
+      confidence: 90,
+      explanation: "Owner mismatch detected.",
+      memberSnapshots: [
+        {
+          memoryId: "mem1",
+          text: "Frontend owner is Alice",
+          sourceMeetingId: mockMeetingId,
+        },
+      ],
+    };
+
+    knowledgeApi.getMeetingConflicts.mockResolvedValue({
+      data: { success: true, conflicts: [mockConflict] },
+    });
+    knowledgeApi.resolveConflict.mockResolvedValue({
+      data: { success: true },
+    });
+
+    render(<MeetingContradictionInspector meetingId={mockMeetingId} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("keep-member-btn-mem1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("keep-member-btn-mem1"));
+
+    await waitFor(() => {
+      expect(knowledgeApi.resolveConflict).toHaveBeenCalledWith("conflict1", {
+        resolutionType: "kept_member",
+        keptMemoryId: "mem1",
+      });
+    });
+  });
+});

--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -76,6 +76,7 @@ import ActionItemsList from "../components/actionItems/ActionItemsList";
 import DecisionVotingPanel from "../components/meetings/DecisionVotingPanel";
 import { Printer } from "lucide-react";
 import RetrospectiveBoard from "../components/meeting-details/RetrospectiveBoard";
+import MeetingContradictionInspector from "../components/knowledge/MeetingContradictionInspector";
 
 const MeetingDetails = () => {
   const { id } = useParams();
@@ -544,6 +545,10 @@ const MeetingDetails = () => {
 
           <div className="mt-6 mb-6">
             <DecisionVotingPanel meetingId={meeting._id} />
+          </div>
+
+          <div className="mt-6 mb-6">
+            <MeetingContradictionInspector meetingId={meeting._id} />
           </div>
 
           <RetentionQuizSection

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -150,6 +150,19 @@ export const knowledgeApi = {
       ...(customValue ? { customValue } : {}),
       ...(note ? { note } : {}),
     }),
+  getMeetingConflicts: (meetingId, status = "open") =>
+    apiClient.get(
+      `/api/knowledge/conflicts/meeting/${meetingId}?status=${status}`,
+    ),
+  scanMeetingConflicts: (
+    meetingId,
+    { dryRun = false, useAI = true, minConfidence } = {},
+  ) =>
+    apiClient.post(`/api/knowledge/conflicts/scan/meeting/${meetingId}`, {
+      dryRun,
+      useAI,
+      ...(minConfidence !== undefined ? { minConfidence } : {}),
+    }),
   getMemoryTelemetry: (timeframe = "30d") =>
     apiClient.get(`/api/knowledge/analytics/telemetry?timeframe=${timeframe}`),
 };

--- a/server/controllers/conflictController.js
+++ b/server/controllers/conflictController.js
@@ -1,6 +1,8 @@
 import AuditLog from "../models/auditLogModel.js";
 import {
   detectConflicts,
+  detectMeetingConflicts,
+  getMeetingConflicts,
   listConflictSets,
   getConflictSetById,
   resolveConflictSet,
@@ -342,5 +344,52 @@ export const bulkResolveConflicts = async (req, res) => {
   } catch (error) {
     console.error("bulkResolveConflicts error:", error);
     sendError(res, 500, "Failed to bulk resolve conflicts");
+  }
+};
+
+/**
+ * POST /api/knowledge/conflicts/scan/meeting/:meetingId
+ * Scans a single meeting's decisions and action items against organizational knowledge.
+ */
+export const scanMeetingForConflicts = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+    const organization = req.user.organization || null;
+    const { dryRun = false, useAI = true, minConfidence } = req.body || {};
+
+    const report = await detectMeetingConflicts({
+      meetingId,
+      organization,
+      dryRun: dryRun !== false,
+      useAI: useAI !== false,
+      ...(minConfidence !== undefined ? { minConfidence } : {}),
+    });
+
+    sendSuccess(res, { report });
+  } catch (error) {
+    console.error("scanMeetingForConflicts error:", error);
+    sendError(res, 500, "Failed to scan meeting for knowledge contradictions");
+  }
+};
+
+/**
+ * GET /api/knowledge/conflicts/meeting/:meetingId
+ * Returns conflicts involving memories from a specific meeting.
+ */
+export const getMeetingConflictsController = async (req, res) => {
+  try {
+    const { meetingId } = req.params;
+    const organization = req.user.organization || null;
+    const { status = "open" } = req.query;
+
+    const conflicts = await getMeetingConflicts(meetingId, {
+      organization,
+      status,
+    });
+
+    sendSuccess(res, { count: conflicts.length, conflicts });
+  } catch (error) {
+    console.error("getMeetingConflictsController error:", error);
+    sendError(res, 500, "Failed to fetch meeting conflicts");
   }
 };

--- a/server/routes/knowledgeRoutes.js
+++ b/server/routes/knowledgeRoutes.js
@@ -35,6 +35,8 @@ import {
   resolveConflict,
   getConflictAuditHistory,
   bulkResolveConflicts,
+  scanMeetingForConflicts,
+  getMeetingConflictsController,
 } from "../controllers/conflictController.js";
 import {
   getSnapshots,
@@ -233,6 +235,19 @@ router.post(
   requireOrgMembership,
   requirePermission("knowledge", "resolve_conflicts"),
   bulkResolveConflicts,
+);
+router.post(
+  "/conflicts/scan/meeting/:meetingId",
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("knowledge", "resolve_conflicts"),
+  scanMeetingForConflicts,
+);
+router.get(
+  "/conflicts/meeting/:meetingId",
+  requireOrgMembership,
+  requirePermission("knowledge", "view"),
+  getMeetingConflictsController,
 );
 router.get(
   "/conflicts/:id",

--- a/server/services/conflictDetection/conflictDetectionService.js
+++ b/server/services/conflictDetection/conflictDetectionService.js
@@ -127,6 +127,139 @@ export async function detectConflicts({
   };
 }
 
+export async function detectMeetingConflicts({
+  meetingId,
+  organization = null,
+  dryRun = true,
+  useAI = true,
+  minConfidence = DEFAULT_MIN_CONFIDENCE,
+} = {}) {
+  if (!meetingId) {
+    throw new Error("meetingId is required for meeting conflict scan");
+  }
+
+  const results = {};
+  for (const modelType of Object.keys(MODEL_REGISTRY)) {
+    const { Model } = assertSupportedModel(modelType);
+    const meetingRecords = await Model.find({
+      $or: [
+        { sourceMeetingId: meetingId },
+        { meetingId },
+        { meeting: meetingId },
+      ],
+      status: { $ne: "superseded" },
+    }).lean();
+
+    if (!meetingRecords.length) {
+      results[modelType] = {
+        modelType,
+        recordsScanned: 0,
+        conflictsFound: 0,
+        conflicts: [],
+      };
+      continue;
+    }
+
+    const meetingRecordIds = new Set(
+      meetingRecords.map((r) => r._id.toString()),
+    );
+    const allOrgRecords = await fetchMemoriesForConflictScan(
+      Model,
+      organization,
+    );
+
+    const pairwiseConflicts = [];
+    for (const mRecord of meetingRecords) {
+      for (const otherRecord of allOrgRecords) {
+        if (mRecord._id.toString() === otherRecord._id.toString()) continue;
+
+        const analysis = await detectContradiction(mRecord, otherRecord, {
+          useAI,
+          minConfidence,
+        });
+
+        if (analysis.isContradiction) {
+          pairwiseConflicts.push({
+            members: [mRecord, otherRecord],
+            analysis,
+          });
+        }
+      }
+    }
+
+    const { clusters, pairwiseByCluster } = await buildConflictClusters(
+      allOrgRecords.filter((r) =>
+        pairwiseConflicts.some((pc) =>
+          pc.members.some((m) => m._id.toString() === r._id.toString()),
+        ),
+      ),
+      { useAI, minConfidence },
+    );
+
+    const meetingClusters = [];
+    const meetingPairwise = [];
+    for (let i = 0; i < clusters.length; i++) {
+      const cluster = clusters[i];
+      if (cluster.some((r) => meetingRecordIds.has(r._id.toString()))) {
+        meetingClusters.push(cluster);
+        meetingPairwise.push(pairwiseByCluster[i]);
+      }
+    }
+
+    const conflictSummaries = [];
+    for (let i = 0; i < meetingClusters.length; i++) {
+      const summary = await storeConflictCluster(
+        modelType,
+        meetingClusters[i],
+        meetingPairwise[i],
+        { organization, dryRun },
+      );
+      if (summary) conflictSummaries.push(summary);
+    }
+
+    results[modelType] = {
+      modelType,
+      recordsScanned: meetingRecords.length,
+      conflictsFound: meetingClusters.length,
+      conflicts: conflictSummaries,
+    };
+  }
+
+  const totalConflictsFound = Object.values(results).reduce(
+    (sum, r) => sum + r.conflictsFound,
+    0,
+  );
+
+  return {
+    meetingId: meetingId.toString(),
+    dryRun,
+    organization: organization ? organization.toString() : null,
+    totalConflictsFound,
+    results,
+  };
+}
+
+export async function getMeetingConflicts(
+  meetingId,
+  { organization = null, status = "open" } = {},
+) {
+  const allConflicts = await listConflictSets(null, {
+    organization,
+    status,
+    limit: 200,
+  });
+  const meetingIdStr = meetingId.toString();
+
+  return allConflicts.filter((cs) =>
+    (cs.memberSnapshots || []).some(
+      (m) =>
+        m.sourceMeetingId?.toString() === meetingIdStr ||
+        m.meetingId?.toString() === meetingIdStr ||
+        m.meeting?.toString() === meetingIdStr,
+    ),
+  );
+}
+
 export {
   MODEL_REGISTRY,
   DEFAULT_MIN_CONFIDENCE,

--- a/server/tests/meetingContradictionScan.test.js
+++ b/server/tests/meetingContradictionScan.test.js
@@ -1,0 +1,74 @@
+import mongoose from "mongoose";
+import Decision from "../models/decisionModel.js";
+import ActionItem from "../models/actionItemModel.js";
+import ConflictSet from "../models/conflictModel.js";
+import {
+  detectMeetingConflicts,
+  getMeetingConflicts,
+} from "../services/conflictDetection/conflictDetectionService.js";
+
+const organizationId = new mongoose.Types.ObjectId();
+const meetingA = new mongoose.Types.ObjectId();
+const meetingB = new mongoose.Types.ObjectId();
+
+beforeAll(async () => {
+  await mongoose.connect(
+    `${process.env.TEST_MONGODB_URI}/meeting_conflict_scan`,
+  );
+});
+
+describe("detectMeetingConflicts", () => {
+  test("detects contradictions specific to a single meeting's decisions", async () => {
+    const [dOld, dNew] = await Decision.create([
+      {
+        text: "Database is PostgreSQL",
+        sourceMeetingId: meetingA,
+        organization: organizationId,
+        createdAt: new Date("2026-01-01"),
+      },
+      {
+        text: "Database migrated to MongoDB",
+        sourceMeetingId: meetingB,
+        organization: organizationId,
+        createdAt: new Date("2026-01-10"),
+      },
+    ]);
+
+    const report = await detectMeetingConflicts({
+      meetingId: meetingB,
+      organization: organizationId,
+      dryRun: false,
+      useAI: false,
+    });
+
+    expect(report.meetingId).toBe(meetingB.toString());
+    expect(report.totalConflictsFound).toBe(1);
+    expect(report.results.decision.conflictsFound).toBe(1);
+
+    const storedConflicts = await getMeetingConflicts(meetingB, {
+      organization: organizationId,
+    });
+    expect(storedConflicts).toHaveLength(1);
+    expect(storedConflicts[0].memberIds.map((id) => id.toString())).toContain(
+      dNew._id.toString(),
+    );
+  });
+
+  test("returns 0 conflicts when meeting decisions have no contradictions", async () => {
+    const meetingClean = new mongoose.Types.ObjectId();
+    await Decision.create({
+      text: "Deploy security patch to production",
+      sourceMeetingId: meetingClean,
+      organization: organizationId,
+    });
+
+    const report = await detectMeetingConflicts({
+      meetingId: meetingClean,
+      organization: organizationId,
+      dryRun: true,
+      useAI: false,
+    });
+
+    expect(report.totalConflictsFound).toBe(0);
+  });
+});


### PR DESCRIPTION
I have implemented the Knowledge Contradiction Detection system.

Summary of Accomplishments
Meeting-Level Contradiction Scanning Engine:

Added detectMeetingConflicts & getMeetingConflicts in conflictDetectionService.js to evaluate decisions and action items from a specific meeting against all stored organizational knowledge.
Added controllers scanMeetingForConflicts & getMeetingConflictsController in conflictController.js
.
Registered endpoints POST /api/knowledge/conflicts/scan/meeting/:meetingId and GET /api/knowledge/conflicts/meeting/:meetingId in knowledgeRoutes.js
.
Frontend Contradiction Inspection Component:

Built MeetingContradictionInspector.jsx
 featuring:
Contradiction Alert badge showing active conflict counts.
Side-by-side statement comparisons (This Meeting's Statement vs Existing Org Knowledge Record).
AI confidence scores & explanation text.
1-click resolution actions (Keep Meeting Statement, Keep Stored Knowledge, Save Custom Correction, Dismiss).
On-demand meeting contradiction scanning.
Integrated MeetingContradictionInspector into MeetingDetails.jsx
.
Automated Unit Tests:

Server test suite: 

meetingContradictionScan.test.js
 (2/2 Jest tests passing).
Client test suite: 

MeetingContradictionInspector.test.jsx
 (4/4 Vitest tests passing).


closes #2172