### PR TITLE
feat: implement action item snooze and custom warning alert options (#2589)

### DIFF
--- a/client/src/components/tasks/SnoozeAlertModal.jsx
+++ b/client/src/components/tasks/SnoozeAlertModal.jsx
@@ -1,0 +1,173 @@
+import React, { useState } from "react";
+import { X, Clock, Bell, AlertTriangle } from "lucide-react";
+
+export default function SnoozeAlertModal({ task, onClose, onSave }) {
+  const [snoozeOption, setSnoozeOption] = useState("none");
+  const [customSnoozeDate, setCustomSnoozeDate] = useState("");
+  const [customWarningOffsets, setCustomWarningOffsets] = useState(
+    task.customWarningOffsets?.join(", ") || "",
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const snoozePresets = [
+    { label: "Don't Snooze / Clear Snooze", value: "none" },
+    { label: "30 Minutes", value: "30m", minutes: 30 },
+    { label: "2 Hours", value: "2h", minutes: 120 },
+    { label: "12 Hours", value: "12h", minutes: 720 },
+    { label: "1 Day", value: "1d", minutes: 1440 },
+    { label: "3 Days", value: "3d", minutes: 4320 },
+    { label: "Custom Date & Time", value: "custom" },
+  ];
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    let snoozedUntil = null;
+    if (snoozeOption !== "none") {
+      if (snoozeOption === "custom") {
+        if (customSnoozeDate) {
+          snoozedUntil = new Date(customSnoozeDate).toISOString();
+        }
+      } else {
+        const preset = snoozePresets.find((p) => p.value === snoozeOption);
+        if (preset && preset.minutes) {
+          snoozedUntil = new Date(
+            Date.now() + preset.minutes * 60 * 1000,
+          ).toISOString();
+        }
+      }
+    }
+
+    // Parse offsets: comma separated numbers
+    const offsets = customWarningOffsets
+      .split(",")
+      .map((val) => parseInt(val.trim(), 10))
+      .filter((num) => !isNaN(num) && num > 0);
+
+    const success = await onSave(task.id, {
+      snoozedUntil,
+      customWarningOffsets: offsets,
+    });
+
+    setIsSubmitting(false);
+    if (success) {
+      onClose();
+    }
+  };
+
+  const isCurrentSnoozed =
+    task.snoozedUntil && new Date(task.snoozedUntil) > new Date();
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-xs animate-fade-in">
+      <div className="relative w-full max-w-md bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-2xl shadow-xl overflow-hidden animate-scale-up">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-slate-100 dark:border-slate-800 bg-linear-to-r from-blue-50/50 to-indigo-50/50 dark:from-slate-900/50 dark:to-slate-900/50">
+          <div className="flex items-center gap-2.5">
+            <Clock className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+            <h3 className="font-bold text-slate-900 dark:text-white">
+              Snooze & Alert Settings
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-5 space-y-6">
+          {/* Task Info */}
+          <div className="p-3.5 bg-slate-50 dark:bg-slate-900/50 border border-slate-100 dark:border-slate-800 rounded-xl">
+            <p className="text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+              Task Text
+            </p>
+            <p className="text-sm font-medium text-slate-855 dark:text-slate-205 line-clamp-2">
+              {task.title}
+            </p>
+            {isCurrentSnoozed && (
+              <div className="mt-2.5 inline-flex items-center gap-1 px-2.5 py-0.5 bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 text-xs font-black rounded-full border border-amber-100 dark:border-amber-900/50">
+                Snoozed until {new Date(task.snoozedUntil).toLocaleString()}
+              </div>
+            )}
+          </div>
+
+          {/* Snooze Options */}
+          <div className="space-y-2">
+            <label className="text-sm font-black text-slate-700 dark:text-slate-350 flex items-center gap-1.5">
+              <Clock className="w-4 h-4 text-slate-400" /> Snooze Duration
+            </label>
+            <div className="grid grid-cols-1 gap-2.5">
+              <select
+                value={snoozeOption}
+                onChange={(e) => setSnoozeOption(e.target.value)}
+                className="w-full px-3.5 py-2.5 text-sm border border-slate-200 dark:border-slate-700 rounded-xl bg-white dark:bg-slate-900 text-slate-850 dark:text-slate-200 outline-none focus:ring-2 focus:ring-blue-500/50 transition"
+              >
+                {snoozePresets.map((preset) => (
+                  <option key={preset.value} value={preset.value}>
+                    {preset.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {snoozeOption === "custom" && (
+              <div className="pt-2">
+                <input
+                  type="datetime-local"
+                  required
+                  value={customSnoozeDate}
+                  onChange={(e) => setCustomSnoozeDate(e.target.value)}
+                  className="w-full px-3.5 py-2.5 text-sm border border-slate-200 dark:border-slate-700 rounded-xl bg-white dark:bg-slate-900 text-slate-850 dark:text-slate-200 outline-none focus:ring-2 focus:ring-blue-500/50 transition"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Custom Warnings */}
+          <div className="space-y-2">
+            <label className="text-sm font-black text-slate-700 dark:text-slate-350 flex items-center gap-1.5">
+              <Bell className="w-4 h-4 text-slate-400" /> Custom SLA Warning
+              Offsets
+            </label>
+            <input
+              type="text"
+              value={customWarningOffsets}
+              onChange={(e) => setCustomWarningOffsets(e.target.value)}
+              placeholder="e.g. 180, 60 (for 3h and 1h warning offsets)"
+              className="w-full px-3.5 py-2.5 text-sm border border-slate-200 dark:border-slate-700 rounded-xl bg-white dark:bg-slate-900 text-slate-850 dark:text-slate-200 outline-none focus:ring-2 focus:ring-blue-500/50 placeholder-slate-400 dark:placeholder-slate-500 transition"
+            />
+            <p className="text-[11px] text-slate-450 dark:text-slate-500 flex items-start gap-1">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-amber-500" />
+              <span>
+                Enter comma-separated minutes before SLA breach to trigger
+                alerts. E.g. 180 is 3 hours before.
+              </span>
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="pt-4 border-t border-slate-100 dark:border-slate-800 flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4.5 py-2 rounded-xl border border-slate-200 dark:border-slate-700 text-sm font-semibold text-slate-700 dark:text-slate-355 hover:bg-slate-50 dark:hover:bg-slate-900 transition"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-2 px-5 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white text-sm font-semibold rounded-xl shadow-xs transition"
+            >
+              {isSubmitting ? "Saving..." : "Save Settings"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/tasks/TaskCard.jsx
+++ b/client/src/components/tasks/TaskCard.jsx
@@ -13,18 +13,21 @@ import {
   Clock,
 } from "lucide-react";
 import { STATUS_STYLES, PRIORITY_STYLES } from "../../utils/taskStyles";
+import SnoozeAlertModal from "./SnoozeAlertModal";
 
 export default function TaskCard({
   task,
   setSelectedTask,
   navigate,
   updateTaskStatus,
+  updateTask,
   toggleTaskReminder,
   selectable = false,
   selected = false,
   onToggleSelect,
   selectionDisabled = false,
 }) {
+  const [showSnoozeModal, setShowSnoozeModal] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isTogglingReminder, setIsTogglingReminder] = useState(false);
 
@@ -130,6 +133,11 @@ export default function TaskCard({
                 <Clock className="w-3 h-3" /> Due Soon
               </span>
             )}
+            {task.snoozedUntil && new Date(task.snoozedUntil) > new Date() && (
+              <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-black bg-indigo-100 dark:bg-indigo-950/80 text-indigo-800 dark:text-indigo-300 border border-indigo-300 dark:border-indigo-800 shrink-0">
+                <Clock className="w-3 h-3" /> Snoozed
+              </span>
+            )}
             {typeof task.importanceScore === "number" && (
               <span
                 className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-semibold border bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800 shrink-0"
@@ -233,6 +241,23 @@ export default function TaskCard({
           <button
             onClick={(e) => {
               e.stopPropagation();
+              setShowSnoozeModal(true);
+            }}
+            onKeyDown={handleStopPropagation}
+            title="Configure Snooze & Warning Alert options"
+            aria-label="Configure Snooze and Alert options for this task"
+            className={`p-2 rounded-lg border text-xs font-medium transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 ${
+              task.snoozedUntil && new Date(task.snoozedUntil) > new Date()
+                ? "bg-amber-50 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 border-amber-200 dark:border-amber-800 font-bold"
+                : "bg-slate-50 dark:bg-slate-800 text-slate-500 hover:text-slate-700 dark:hover:text-slate-350 border-slate-200 dark:border-slate-700"
+            }`}
+          >
+            <Clock className="w-4 h-4" />
+          </button>
+
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
               navigate(`/meeting/${task.meetingId}`);
             }}
             onKeyDown={handleStopPropagation}
@@ -244,6 +269,14 @@ export default function TaskCard({
           </button>
         </div>
       </div>
+
+      {showSnoozeModal && (
+        <SnoozeAlertModal
+          task={task}
+          onClose={() => setShowSnoozeModal(false)}
+          onSave={updateTask}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/tasks/__tests__/TaskSnoozeModal.test.jsx
+++ b/client/src/components/tasks/__tests__/TaskSnoozeModal.test.jsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import TaskCard from "../TaskCard.jsx";
+import SnoozeAlertModal from "../SnoozeAlertModal.jsx";
+
+const mockTask = {
+  id: "task-1",
+  title: "Finish quarterly security audit",
+  priority: "high",
+  status: "open",
+  dueDate: "2026-08-30T00:00:00.000Z",
+  owner: "Alice Uploader",
+  organization: "CyberDyne Systems",
+  meetingId: "meeting-123",
+  remindersEnabled: true,
+  snoozedUntil: null,
+  customWarningOffsets: [180],
+};
+
+describe("TaskCard Snooze Integration (#2589)", () => {
+  it("renders the snooze & alert settings button", () => {
+    render(<TaskCard task={mockTask} setSelectedTask={vi.fn()} />);
+
+    const snoozeButton = screen.getByRole("button", {
+      name: /configure snooze and alert options/i,
+    });
+    expect(snoozeButton).toBeInTheDocument();
+  });
+
+  it("renders the Snoozed badge when action item has a future snoozedUntil value", () => {
+    const snoozedTask = {
+      ...mockTask,
+      snoozedUntil: new Date(Date.now() + 50000).toISOString(),
+    };
+    render(<TaskCard task={snoozedTask} setSelectedTask={vi.fn()} />);
+
+    const badge = screen.getByText(/snoozed/i);
+    expect(badge).toBeInTheDocument();
+  });
+});
+
+describe("SnoozeAlertModal Features (#2589)", () => {
+  it("allows selecting preset snooze options and triggers onSave", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const onClose = vi.fn();
+
+    render(
+      <SnoozeAlertModal task={mockTask} onClose={onClose} onSave={onSave} />,
+    );
+
+    // Click select option
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "2h" } });
+
+    // Click Save
+    const saveButton = screen.getByRole("button", { name: /save settings/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("task-1", {
+        snoozedUntil: expect.any(String),
+        customWarningOffsets: [180],
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("permits customizing SLA warning offsets and triggers onSave with numeric arrays", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const onClose = vi.fn();
+
+    render(
+      <SnoozeAlertModal task={mockTask} onClose={onClose} onSave={onSave} />,
+    );
+
+    // Input custom warning offsets
+    const input = screen.getByPlaceholderText(/e\.g\. 180, 60/i);
+    fireEvent.change(input, { target: { value: "360, 120" } });
+
+    // Click Save
+    const saveButton = screen.getByRole("button", { name: /save settings/i });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("task-1", {
+        snoozedUntil: null,
+        customWarningOffsets: [360, 120],
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/hooks/useTasks.js
+++ b/client/src/hooks/useTasks.js
@@ -23,6 +23,8 @@ const mapActionItem = (item) => ({
     upcoming: false,
     overdue: false,
   },
+  snoozedUntil: item.snoozedUntil || null,
+  customWarningOffsets: item.customWarningOffsets || [],
 });
 
 export default function useTasks() {
@@ -191,6 +193,26 @@ export default function useTasks() {
     }
   };
 
+  const updateTask = async (taskId, updates) => {
+    try {
+      const res = await knowledgeApi.updateActionItem(taskId, updates);
+      if (res.data?.success) {
+        setTasks((prev) =>
+          prev.map((t) => (t.id === taskId ? { ...t, ...updates } : t)),
+        );
+        toast.success("Task updated successfully");
+        return true;
+      } else {
+        toast.error(res.data?.message || "Failed to update task");
+        return false;
+      }
+    } catch (err) {
+      console.error("Error updating task:", err);
+      toast.error(err.response?.data?.message || "Failed to update task");
+      return false;
+    }
+  };
+
   const toggleTaskReminder = async (taskId, currentEnabled) => {
     try {
       const newEnabled = !currentEnabled;
@@ -263,6 +285,7 @@ export default function useTasks() {
     sortedTasks,
     handleSort,
     updateTaskStatus,
+    updateTask,
     toggleTaskReminder,
     clearFilters,
     hasActiveFilters,

--- a/client/src/services/knowledgeApi.js
+++ b/client/src/services/knowledgeApi.js
@@ -20,6 +20,8 @@ export const knowledgeApi = {
   },
   updateActionItemStatus: (id, status) =>
     apiClient.patch(`/api/knowledge/action-items/${id}`, { status }),
+  updateActionItem: (id, updates) =>
+    apiClient.patch(`/api/action-items/${id}`, updates),
   toggleActionItemReminder: (id, enabled) =>
     apiClient.patch(`/api/knowledge/action-items/${id}/reminders`, { enabled }),
   getDecisions: (sortBy = "createdAt", status, options = {}) => {

--- a/server/controllers/actionItems.controller.js
+++ b/server/controllers/actionItems.controller.js
@@ -293,11 +293,17 @@ export const updateActionItem = async (req, res) => {
       "title",
       "text",
       "description",
+      "snoozedUntil",
+      "customWarningOffsets",
     ];
     const updates = {};
     allowedFields.forEach((field) => {
       if (req.body[field] !== undefined) updates[field] = req.body[field];
     });
+
+    if (updates.customWarningOffsets !== undefined) {
+      updates.warningsSent = [];
+    }
 
     if (updates.title && !updates.text) {
       updates.text = updates.title;
@@ -332,6 +338,49 @@ export const updateActionItem = async (req, res) => {
       new: true,
       runValidators: true,
     }).populate("assignee", "name avatar");
+
+    // --- Audit log for snooze / alert options ---
+    try {
+      const AuditService = (await import("../services/AuditService.js"))
+        .default;
+      const actingUserId = req.user._id || req.user.id;
+      const orgId =
+        item.organization || req.user.organization || req.user.organizationId;
+
+      if (updates.snoozedUntil !== undefined) {
+        const isSnoozed = updates.snoozedUntil !== null;
+        await AuditService.logAction({
+          actorId: actingUserId,
+          action: isSnoozed ? "ACTION_ITEM_SNOOZED" : "ACTION_ITEM_UNSNOOZED",
+          entity: "ActionItem",
+          entityId: id,
+          organizationId: orgId,
+          details: {
+            snoozedUntil: updates.snoozedUntil,
+            previousSnoozedUntil: item.snoozedUntil,
+          },
+        });
+      }
+
+      if (updates.customWarningOffsets !== undefined) {
+        await AuditService.logAction({
+          actorId: actingUserId,
+          action: "ACTION_ITEM_ALERT_OPTIONS_UPDATED",
+          entity: "ActionItem",
+          entityId: id,
+          organizationId: orgId,
+          details: {
+            customWarningOffsets: updates.customWarningOffsets,
+            previousWarningOffsets: item.customWarningOffsets,
+          },
+        });
+      }
+    } catch (auditErr) {
+      console.error(
+        "Audit log failed for action item snooze/alerts:",
+        auditErr,
+      );
+    }
 
     // --- Changelog Tracking ---
     try {

--- a/server/models/actionItemModel.js
+++ b/server/models/actionItemModel.js
@@ -251,6 +251,18 @@ const actionItemSchema = new mongoose.Schema(
     archivedAt: { type: Date, default: null },
     expiresAt: { type: Date, default: null },
     lifecycleHistory: { type: [lifecycleTransitionSchema], default: [] },
+    snoozedUntil: {
+      type: Date,
+      default: null,
+    },
+    customWarningOffsets: {
+      type: [Number],
+      default: [],
+    },
+    warningsSent: {
+      type: [Number],
+      default: [],
+    },
   },
   {
     timestamps: true,

--- a/server/services/actionItemSlaService.js
+++ b/server/services/actionItemSlaService.js
@@ -85,6 +85,78 @@ class ActionItemSlaService {
     for (const item of actionItems) {
       const targets = config.targets[item.priority] || config.targets.medium;
 
+      // Skip active alerting if snoozed
+      if (item.snoozedUntil && now < item.snoozedUntil) {
+        continue;
+      }
+
+      const isResolved = ["resolved", "completed"].includes(item.status);
+
+      // Check custom warning offsets before breach
+      if (item.customWarningOffsets && item.customWarningOffsets.length > 0) {
+        const responseBreachTime = new Date(
+          item.createdAt.getTime() +
+            targets.targetResponseHours * 60 * 60 * 1000,
+        );
+        const resolutionBreachTime = new Date(
+          item.createdAt.getTime() +
+            targets.targetResolutionHours * 60 * 60 * 1000,
+        );
+
+        for (const offset of item.customWarningOffsets) {
+          const warningTimeResponse = new Date(
+            responseBreachTime.getTime() - offset * 60 * 1000,
+          );
+          const warningTimeResolution = new Date(
+            resolutionBreachTime.getTime() - offset * 60 * 1000,
+          );
+
+          // Response Warning
+          if (
+            item.status === "open" &&
+            now >= warningTimeResponse &&
+            now < responseBreachTime &&
+            !item.warningsSent.includes(offset)
+          ) {
+            if (item.assignee) {
+              await createNotification(
+                item.assignee,
+                "SLA Response Warning Alert",
+                `The task "${item.text}" is approaching its Response SLA limit (${targets.targetResponseHours}h).`,
+                "tasks",
+                `/followup/tasks/${item._id}`,
+                "View Task",
+                { actionItemId: item._id },
+              );
+            }
+            item.warningsSent.push(offset);
+            await item.save();
+          }
+
+          // Resolution Warning
+          if (
+            !isResolved &&
+            now >= warningTimeResolution &&
+            now < resolutionBreachTime &&
+            !item.warningsSent.includes(offset)
+          ) {
+            if (item.assignee) {
+              await createNotification(
+                item.assignee,
+                "SLA Resolution Warning Alert",
+                `The task "${item.text}" is approaching its Resolution SLA limit (${targets.targetResolutionHours}h).`,
+                "tasks",
+                `/followup/tasks/${item._id}`,
+                "View Task",
+                { actionItemId: item._id },
+              );
+            }
+            item.warningsSent.push(offset);
+            await item.save();
+          }
+        }
+      }
+
       // Calculate actual hours since creation
       const hoursSinceCreation = (now - item.createdAt) / (1000 * 60 * 60);
 
@@ -104,7 +176,6 @@ class ActionItemSlaService {
       }
 
       // 2. Check Resolution SLA (Time to move to 'resolved' or 'completed')
-      const isResolved = ["resolved", "completed"].includes(item.status);
       let resolutionHours = hoursSinceCreation;
       if (isResolved && item.resolvedAt) {
         resolutionHours = (item.resolvedAt - item.createdAt) / (1000 * 60 * 60);

--- a/server/tests/actionItemSnooze.test.js
+++ b/server/tests/actionItemSnooze.test.js
@@ -1,0 +1,132 @@
+import request from "supertest";
+import { app } from "../server.js";
+import mongoose from "mongoose";
+import User from "../models/userModel.js";
+import Meeting from "../models/meetingModel.js";
+import ActionItem from "../models/actionItemModel.js";
+import ActionItemSlaBreach from "../models/actionItemSlaBreachModel.js";
+import AuditLog from "../models/auditLogModel.js";
+import ActionItemSlaService from "../services/actionItemSlaService.js";
+import { createClerkTestToken, authHeader } from "./helpers/clerkTestAuth.js";
+
+let adminToken;
+let adminUser;
+let meeting;
+let actionItem;
+
+const orgId = new mongoose.Types.ObjectId().toString();
+
+beforeEach(async () => {
+  await User.deleteMany({ email: /snooze-admin.*@example\.com/ });
+  await Meeting.deleteMany({ organization: orgId });
+  await ActionItem.deleteMany({ organization: orgId });
+  await ActionItemSlaBreach.deleteMany({ organization: orgId });
+  await AuditLog.deleteMany({});
+
+  adminUser = await User.create({
+    name: "Snooze Admin",
+    email: `snooze-admin-${Date.now()}@example.com`,
+    password: "Password123!",
+    role: "admin",
+    organization: orgId,
+    clerkUserId: `user_snooze_admin_${Date.now()}`,
+  });
+
+  adminToken = createClerkTestToken({
+    clerkUserId: adminUser.clerkUserId,
+    email: adminUser.email,
+  });
+
+  meeting = await Meeting.create({
+    title: "Snooze Planning",
+    date: new Date(),
+    duration: 30,
+    organization: orgId,
+    uploadedBy: adminUser._id,
+  });
+
+  actionItem = await ActionItem.create({
+    text: "Snooze the task SLA breaches",
+    sourceMeetingId: meeting._id,
+    organization: orgId,
+    assignee: adminUser._id,
+    dueDate: new Date(),
+    status: "open",
+    createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000), // 3 hours ago
+  });
+});
+
+describe("Action Item Snooze & Custom Notification Follow-up Pipeline (#2589)", () => {
+  it("should permit snoozing an action item and generate snooze/unsnooze audit logs", async () => {
+    const futureDate = new Date(Date.now() + 2 * 60 * 60 * 1000); // snooze for 2 hours
+
+    // 1. Snooze task
+    const snoozeRes = await request(app)
+      .patch(`/api/action-items/${actionItem._id}`)
+      .set(authHeader(adminToken))
+      .send({
+        snoozedUntil: futureDate.toISOString(),
+      });
+
+    expect(snoozeRes.statusCode).toBe(200);
+    expect(snoozeRes.body.success).toBe(true);
+    expect(new Date(snoozeRes.body.data.snoozedUntil).getTime()).toBeCloseTo(
+      futureDate.getTime(),
+      -2,
+    );
+
+    // Verify audit log
+    const snoozeLogs = await AuditLog.find({ action: "ACTION_ITEM_SNOOZED" });
+    expect(snoozeLogs.length).toBe(1);
+    expect(snoozeLogs[0].entityId.toString()).toBe(actionItem._id.toString());
+
+    // 2. Unsnooze task
+    const unsnoozeRes = await request(app)
+      .patch(`/api/action-items/${actionItem._id}`)
+      .set(authHeader(adminToken))
+      .send({
+        snoozedUntil: null,
+      });
+
+    expect(unsnoozeRes.statusCode).toBe(200);
+    expect(unsnoozeRes.body.success).toBe(true);
+    expect(unsnoozeRes.body.data.snoozedUntil).toBeNull();
+
+    // Verify unsnooze audit log
+    const unsnoozeLogs = await AuditLog.find({
+      action: "ACTION_ITEM_UNSNOOZED",
+    });
+    expect(unsnoozeLogs.length).toBe(1);
+  });
+
+  it("should support updating custom warning offsets and trigger audit logs", async () => {
+    const res = await request(app)
+      .patch(`/api/action-items/${actionItem._id}`)
+      .set(authHeader(adminToken))
+      .send({
+        customWarningOffsets: [180, 60],
+      });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.customWarningOffsets).toEqual([180, 60]);
+
+    // Verify audit log
+    const logs = await AuditLog.find({
+      action: "ACTION_ITEM_ALERT_OPTIONS_UPDATED",
+    });
+    expect(logs.length).toBe(1);
+  });
+
+  it("should skip SLA breach detection on snoozed action items", async () => {
+    // Modify item to be snoozed
+    actionItem.snoozedUntil = new Date(Date.now() + 1 * 60 * 60 * 1000); // snoozed for 1h
+    // Backdate createdAt to force a breach condition
+    actionItem.createdAt = new Date(Date.now() - 48 * 60 * 60 * 1000); // 48h ago
+    await actionItem.save();
+
+    const result = await ActionItemSlaService.detectBreaches(orgId);
+    // Since it's snoozed, it should bypass breach detection
+    expect(result.newBreaches).toBe(0);
+  });
+});


### PR DESCRIPTION
## 📝 Summary
This PR adds support for snoozing action items and configuring custom warnings offsets before SLA breaches occur, helping users manage alert fatigue.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2589

---

## ✨ Changes Made
- **Action Item Schema**:
  - Added `snoozedUntil` (Date), `customWarningOffsets` (`[Number]`), and `warningsSent` (`[Number]`) fields in `actionItemModel.js`.
- **SLA Detection Engine**:
  - Updates `actionItemSlaService.js` to bypass checks on snoozed tasks if `now < item.snoozedUntil`.
  - Calculates warning offsets relative to the breach target times and triggers notification warning alerts before breach occurs.
- **REST Controller Updates**:
  - Whitelisted new fields in `actionItems.controller.js`.
  - Emits `ACTION_ITEM_SNOOZED`, `ACTION_ITEM_UNSNOOZED`, and `ACTION_ITEM_ALERT_OPTIONS_UPDATED` events into `AuditService` log entries.
- **Snooze/Alerts Modal Component**:
  - Created `SnoozeAlertModal.jsx` offering select presets (30m, 2h, 12h, 1d, 3d, custom) and custom warnings offset list.
  - Integrated modal inside `TaskCard.jsx` showing the remaining snooze duration/badge.
- **Tests**:
  - Created `actionItemSnooze.test.js` (backend) and `TaskSnoozeModal.test.jsx` (frontend) validating compliance.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend Integration Tests
npm run test tests/actionItemSnooze.test.js --prefix server

# Frontend Component Tests
npm run test:ci --prefix client client/src/components/tasks/__tests__/TaskSnoozeModal.test.jsx
