### PR TITLE
feat(risks): consolidate RiskRegister routing and add navigation discoverability

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,7 +15,6 @@ import ErrorBoundary from "./components/ErrorBoundary.jsx";
 import AppContent from "./context/AppContent.js";
 
 const NotFound = lazy(() => import("./pages/NotFound.jsx"));
-const RiskRegister = lazy(() => import("./pages/RiskRegister.jsx"));
 
 const App = () => {
   const location = useLocation();
@@ -62,14 +61,6 @@ const App = () => {
             <Routes>
               {PublicRoutes}
               {ProtectedRoutes}
-              <Route
-                path="/risks"
-                element={
-                  <ProtectedRoute>
-                    <RiskRegister />
-                  </ProtectedRoute>
-                }
-              />
               {/* ✅ Fallback route — send unknown routes to NotFound */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -565,6 +565,11 @@ const Navbar = () => {
             icon: AlertTriangle,
           },
           {
+            label: t("navbar.riskRegister", "Risk Register"),
+            href: "/risks",
+            icon: ShieldAlert,
+          },
+          {
             label: t("navbar.bookmarks"),
             href: "/bookmarks",
             icon: Bookmark,

--- a/client/src/pages/RiskRegister.jsx
+++ b/client/src/pages/RiskRegister.jsx
@@ -44,12 +44,16 @@ const RiskRegister = () => {
   const isAdminOrOwner =
     userData?.role === "admin" || userData?.role === "owner";
 
+  const effectiveOrgId =
+    orgId ||
+    userData?.currentOrganization?._id ||
+    userData?.currentOrganization ||
+    userData?.organization;
+
   useEffect(() => {
-    if (orgId) {
-      fetchDashboardData();
-      fetchMembers();
-    }
-  }, [orgId]);
+    fetchDashboardData();
+    fetchMembers();
+  }, [effectiveOrgId]);
 
   const fetchDashboardData = async () => {
     try {
@@ -157,9 +161,11 @@ const RiskRegister = () => {
   };
 
   const filteredRisks = risks.filter((risk) => {
+    const riskName = risk.title || risk.riskTitle || "";
+    const riskDesc = risk.description || "";
     const matchesSearch =
-      risk.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      risk.description?.toLowerCase().includes(searchTerm.toLowerCase());
+      riskName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      riskDesc.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesCategory =
       filterCategory === "All" || risk.category === filterCategory;
     const matchesCell = selectedCell
@@ -464,7 +470,9 @@ const RiskRegister = () => {
                             >
                               <td className="p-4">
                                 <div className="font-medium text-slate-200 truncate max-w-[200px] xl:max-w-[300px]">
-                                  {risk.title}
+                                  {risk.title ||
+                                    risk.riskTitle ||
+                                    "Untitled Risk"}
                                 </div>
                                 <div className="text-xs text-slate-500 truncate max-w-[200px] xl:max-w-[300px] mt-1 flex items-center gap-1">
                                   {risk.meetingId?.title || "Unknown Meeting"}
@@ -493,12 +501,16 @@ const RiskRegister = () => {
                               <td className="p-4">
                                 <div className="flex items-center gap-2">
                                   <span
-                                    className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold ${getRiskColor(risk.riskScore)}`}
+                                    className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold ${getRiskColor(risk.riskScore ?? risk.probability * risk.impact)}`}
                                   >
-                                    {risk.riskScore}
+                                    {risk.riskScore ??
+                                      risk.probability * risk.impact}
                                   </span>
                                   <span className="text-xs font-medium text-slate-400">
-                                    {getRiskLevel(risk.riskScore)}
+                                    {getRiskLevel(
+                                      risk.riskScore ??
+                                        risk.probability * risk.impact,
+                                    )}
                                   </span>
                                 </div>
                               </td>

--- a/client/src/routes/ProtectedRoutes.jsx
+++ b/client/src/routes/ProtectedRoutes.jsx
@@ -185,6 +185,7 @@ const IntegrationMarketplaceHub = lazy(
   () => import("../pages/IntegrationMarketplaceHub.jsx"),
 );
 const SentimentTrends = lazy(() => import("../pages/SentimentTrends.jsx"));
+const RiskRegister = lazy(() => import("../pages/RiskRegister.jsx"));
 const AsyncMeetingsDashboard = lazy(
   () => import("../pages/AsyncMeetingsDashboard.jsx"),
 );
@@ -194,6 +195,36 @@ const SessionGallery = lazy(() => import("../pages/SessionGallery.jsx"));
 
 const ProtectedRoutes = (
   <React.Fragment>
+    <Route
+      path="/risks"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <RiskRegister />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/risk-register"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <RiskRegister />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path="/risks/matrix"
+      element={
+        <ProtectedRoute>
+          <RouteErrorBoundary>
+            <RiskRegister />
+          </RouteErrorBoundary>
+        </ProtectedRoute>
+      }
+    />
     <Route
       path="/session-cards"
       element={

--- a/client/src/routes/__tests__/RiskRegisterRouteWiring.test.jsx
+++ b/client/src/routes/__tests__/RiskRegisterRouteWiring.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter, Routes } from "react-router-dom";
+import ProtectedRoutes from "../ProtectedRoutes";
+import AppContent from "../../context/AppContent";
+import meetingRiskApi from "../../services/meetingRiskApi";
+import { organizationApi } from "../../services/organizationApi";
+
+vi.mock("../../hooks/useRBAC.js", () => ({
+  useRBAC: () => ({
+    hasPermission: () => true,
+  }),
+}));
+
+vi.mock("../../components/Navbar.jsx", () => ({
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: () => ({ orgId: "org_1" }),
+}));
+
+vi.mock("../../services/meetingRiskApi", () => ({
+  default: {
+    getRiskDashboard: vi.fn(),
+    mitigateRisk: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/organizationApi", () => ({
+  organizationApi: {
+    getMembers: vi.fn(),
+  },
+}));
+
+describe("RiskRegister Route Wiring (#2644)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    meetingRiskApi.getRiskDashboard.mockResolvedValue({
+      success: true,
+      data: {
+        risks: [
+          {
+            _id: "r_1",
+            title: "Vendor Dependency Outage",
+            category: "Technical",
+            probability: 4,
+            impact: 5,
+            severityScore: 20,
+            status: "Identified",
+          },
+        ],
+        escalations: [],
+      },
+    });
+
+    organizationApi.getMembers.mockResolvedValue({
+      data: {
+        success: true,
+        data: [{ user: { _id: "u_1", name: "Risk Manager" } }],
+      },
+    });
+  });
+
+  const renderRoute = (initialPath = "/risks") => {
+    const mockContext = {
+      userData: {
+        _id: "u_1",
+        email: "user@example.com",
+        currentOrganization: "org_1",
+        role: "admin",
+        hasCompletedOnboarding: true,
+      },
+      isLoggedin: true,
+    };
+
+    return render(
+      <AppContent.Provider value={mockContext}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>{ProtectedRoutes}</Routes>
+        </MemoryRouter>
+      </AppContent.Provider>,
+    );
+  };
+
+  it("successfully mounts RiskRegister on /risks within ProtectedRoutes", async () => {
+    renderRoute("/risks");
+
+    await waitFor(() => {
+      expect(screen.getByText("Vendor Dependency Outage")).toBeInTheDocument();
+    });
+  });
+
+  it("successfully mounts RiskRegister on alias /risk-register", async () => {
+    renderRoute("/risk-register");
+
+    await waitFor(() => {
+      expect(screen.getByText("Vendor Dependency Outage")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2644

## Description
This PR moves `RiskRegister` routing out of `App.jsx` and consolidates it directly into `ProtectedRoutes.jsx` under `/risks`, `/risk-register`, and `/risks/matrix`, and adds a prominent navigation link under the Workspace dropdown in `Navbar.jsx` for full discoverability.

## Proposed Changes
- **Route Consolidation**:
  - Lazy loaded and registered `RiskRegister.jsx` under `/risks`, `/risk-register`, and `/risks/matrix` in `ProtectedRoutes.jsx`.
  - Removed redundant outer route definition in `App.jsx`.
- **Navigation Discoverability**:
  - Added a dedicated "Risk Register" item under the Workspace navigation section in `Navbar.jsx` with `ShieldAlert` icon.
- **Defensive Data Handling & Tests**:
  - Made risk search and severity score fallback defensive in `RiskRegister.jsx`.
  - Added unit test suite `client/src/routes/__tests__/RiskRegisterRouteWiring.test.jsx` (2/2 passing).

## Checklist
- [x] Related Issue is linked (Fixes #2644).
- [x] Project builds successfully.
- [x] Code is formatted.
- [x] Unit tests added and passing cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Risk Register page accessible from the workspace navigation.
  * Added protected routes for `/risks`, `/risk-register`, and `/risks/matrix`.
  * Improved risk data loading and display when details are incomplete, including fallback titles and scores.

* **Tests**
  * Added coverage verifying Risk Register routes load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->