### PR TITLE
Feature/2664 membership request permission

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -51,16 +51,3 @@ createRoot(document.getElementById("root")).render(
     </ClerkAuthProvider>
   </BrowserRouter>,
 );
-
-if ("serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    navigator.serviceWorker
-      .register("/sw.js")
-      .then((registration) => {
-        console.log("SW registered: ", registration);
-      })
-      .catch((registrationError) => {
-        console.log("SW registration failed: ", registrationError);
-      });
-  });
-}

--- a/client/src/services/__tests__/asyncMeetings.integration.test.js
+++ b/client/src/services/__tests__/asyncMeetings.integration.test.js
@@ -60,10 +60,7 @@ describe("Async Meetings Client Service Integration Tests (#2666)", () => {
       const answers = [
         { question: "What did you complete?", answer: "Implemented feature X" },
       ];
-      const res = await asyncMeetingApi.submitAsyncUpdate(
-        "async-100",
-        answers,
-      );
+      const res = await asyncMeetingApi.submitAsyncUpdate("async-100", answers);
 
       expect(apiClient.post).toHaveBeenCalledWith(
         "/async-meetings/async-100/submit",

--- a/client/src/services/__tests__/attendance.integration.test.js
+++ b/client/src/services/__tests__/attendance.integration.test.js
@@ -17,7 +17,9 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
 
   describe("Contract Assertions", () => {
     it("should call GET /meetings/:meetingId/attendance when fetching attendance", async () => {
-      const mockResponse = { data: [{ email: "user@example.com", status: "invited" }] };
+      const mockResponse = {
+        data: [{ email: "user@example.com", status: "invited" }],
+      };
       apiClient.get.mockResolvedValueOnce(mockResponse);
 
       const res = await meetingAttendanceApi.getMeetingAttendance("m-100");
@@ -124,9 +126,9 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       };
       apiClient.post.mockRejectedValueOnce(valError);
 
-      await expect(
-        meetingAttendanceApi.checkIn("m-100", null),
-      ).rejects.toThrow("Email is required for check-in");
+      await expect(meetingAttendanceApi.checkIn("m-100", null)).rejects.toThrow(
+        "Email is required for check-in",
+      );
     });
 
     it("handles 400 validation error when check-out email is missing", async () => {
@@ -137,9 +139,9 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       };
       apiClient.post.mockRejectedValueOnce(valError);
 
-      await expect(
-        meetingAttendanceApi.checkOut("m-100", ""),
-      ).rejects.toThrow("Email is required for check-out");
+      await expect(meetingAttendanceApi.checkOut("m-100", "")).rejects.toThrow(
+        "Email is required for check-out",
+      );
     });
   });
 });

--- a/client/src/services/__tests__/ownershipTransfer.integration.test.js
+++ b/client/src/services/__tests__/ownershipTransfer.integration.test.js
@@ -43,10 +43,9 @@ describe("Ownership Transfer Client Service Integration Tests (#2666)", () => {
 
       const res = await transferApi.initiateTransfer("m-100", "u-200");
 
-      expect(apiClient.post).toHaveBeenCalledWith(
-        "/meetings/m-100/transfers",
-        { targetUserId: "u-200" },
-      );
+      expect(apiClient.post).toHaveBeenCalledWith("/meetings/m-100/transfers", {
+        targetUserId: "u-200",
+      });
       expect(res).toEqual(mockResponse);
     });
 
@@ -98,13 +97,15 @@ describe("Ownership Transfer Client Service Integration Tests (#2666)", () => {
       };
       apiClient.post.mockRejectedValueOnce(notFoundError);
 
-      await expect(transferApi.acceptTransfer("nonexistent-id")).rejects.toThrow(
-        "resource was not found",
-      );
+      await expect(
+        transferApi.acceptTransfer("nonexistent-id"),
+      ).rejects.toThrow("resource was not found");
     });
 
     it("handles 400 validation error when initiating transfer to self", async () => {
-      const validationError = new Error("Cannot transfer ownership to yourself");
+      const validationError = new Error(
+        "Cannot transfer ownership to yourself",
+      );
       validationError.response = {
         status: 400,
         data: { error: "Cannot transfer ownership to yourself" },

--- a/client/src/services/offlineQueue.js
+++ b/client/src/services/offlineQueue.js
@@ -1,4 +1,12 @@
-// client/src/services/offlineQueue.js
+/**
+ * client/src/services/offlineQueue.js
+ * Offline Mutation Queue service using IndexedDB.
+ *
+ * OFFLINE QUEUE LIMITATION:
+ * Queued offline mutations must contain serializable, JSON-compatible request payloads.
+ * Binary/file/blob payloads (e.g., FormData containing Files/Blobs) are not supported
+ * by this offline mutation queue.
+ */
 
 const DB_NAME = "offline-mutations-db";
 const STORE_NAME = "mutations";
@@ -88,7 +96,7 @@ export const subscribeQueue = (callback) => {
 
 /**
  * Queue a mutation to IndexedDB.
- * @param {Object} mutation { url, method, headers, body, idempotencyKey }
+ * @param {Object} mutation { url, method, headers, body, idempotencyKey } Note: body must contain JSON-serializable data; binary/blob payloads are not supported.
  */
 export const queueMutation = async (mutation) => {
   const db = await openDB();

--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -1,53 +1,75 @@
 /**
- * sw.js
- * Foundational Service Worker for Offline-First PWA capabilities.
- * Intercepts requests and serves from cache when offline.
+ * client/src/sw.js
+ * Consolidated Service Worker source for VitePWA (injectManifest strategy).
+ * Handles offline capabilities, background sync, Workbox precaching, dynamic caching, and Web Push notifications.
  */
 
-const CACHE_NAME = "meet-on-memory-v1";
-const STATIC_ASSETS = ["/", "/index.html", "/manifest.json", "/favicon.ico"];
+import { clientsClaim } from "workbox-core";
+import { precacheAndRoute, cleanupOutdatedCaches } from "workbox-precaching";
+import { registerRoute } from "workbox-routing";
+import {
+  StaleWhileRevalidate,
+  CacheFirst,
+  NetworkOnly,
+  NetworkFirst,
+} from "workbox-strategies";
 
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      console.log("[Service Worker] Caching static assets");
-      return cache.addAll(STATIC_ASSETS);
-    }),
-  );
-  self.skipWaiting();
-});
+self.skipWaiting();
+clientsClaim();
 
-self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames
-          .filter((name) => name !== CACHE_NAME)
-          .map((name) => caches.delete(name)),
-      );
-    }),
-  );
-  self.clients.claim();
-});
+// Precache static assets injected by VitePWA
+cleanupOutdatedCaches();
+precacheAndRoute(self.__WB_MANIFEST || []);
 
-self.addEventListener("fetch", (event) => {
-  // Simple network-first, fallback to cache strategy for API calls and static assets
-  if (event.request.method === "GET") {
-    event.respondWith(
-      fetch(event.request)
-        .then((response) => {
-          const resClone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => {
-            cache.put(event.request, resClone);
-          });
-          return response;
-        })
-        .catch(() => caches.match(event.request)),
-    );
-  }
-});
+// ---------------------------------------------------------------------------
+// Custom Workbox Routing
+// ---------------------------------------------------------------------------
 
-// Background sync for offline mutations
+// 1. Ensure authenticated API requests are NEVER cached
+registerRoute(
+  ({ url, request }) =>
+    url.pathname.startsWith("/api/") || request.headers.has("Authorization"),
+  new NetworkOnly(),
+);
+
+// 2. Policy data cache
+registerRoute(
+  /\/api\/policies(\?.*)?$/,
+  new StaleWhileRevalidate({
+    cacheName: "policy-data-cache",
+  }),
+);
+
+// 3. Policy PDF cache
+registerRoute(
+  /\/api\/policies\/download\//,
+  new CacheFirst({
+    cacheName: "policy-pdf-cache",
+  }),
+);
+
+// 4. Runtime caching for static resources (scripts, styles, images)
+registerRoute(
+  ({ request }) =>
+    request.destination === "script" ||
+    request.destination === "style" ||
+    request.destination === "image",
+  new StaleWhileRevalidate({
+    cacheName: "static-resources",
+  }),
+);
+
+// 5. Offline support for navigation requests
+registerRoute(
+  ({ request }) => request.mode === "navigate",
+  new NetworkFirst({
+    cacheName: "pages-cache",
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Background Sync for Offline Mutations
+// ---------------------------------------------------------------------------
 const DB_NAME = "offline-mutations-db";
 const STORE_NAME = "mutations";
 const DB_VERSION = 1;
@@ -208,7 +230,9 @@ self.addEventListener("message", (event) => {
   }
 });
 
-// Web Push Notification Events
+// ---------------------------------------------------------------------------
+// Web Push Notifications
+// ---------------------------------------------------------------------------
 self.addEventListener("push", (event) => {
   let data = {};
   if (event.data) {
@@ -251,41 +275,3 @@ self.addEventListener("notificationclick", (event) => {
       }),
   );
 });
-
-/* eslint-disable no-undef */
-importScripts(
-  "https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js",
-);
-
-if (workbox) {
-  // Ensure authenticated API requests are NEVER cached.
-  workbox.routing.registerRoute(({ url, request }) => {
-    // Exclude requests that include Authorization headers or target protected API endpoints
-    if (
-      url.pathname.startsWith("/api/") ||
-      request.headers.has("Authorization")
-    ) {
-      return true;
-    }
-    return false;
-  }, new workbox.strategies.NetworkOnly());
-
-  // Continue runtime caching for static assets.
-  workbox.routing.registerRoute(
-    ({ request }) =>
-      request.destination === "script" ||
-      request.destination === "style" ||
-      request.destination === "image",
-    new workbox.strategies.StaleWhileRevalidate({
-      cacheName: "static-resources",
-    }),
-  );
-
-  // Preserve offline support for public resources
-  workbox.routing.registerRoute(
-    ({ request }) => request.mode === "navigate",
-    new workbox.strategies.NetworkFirst({
-      cacheName: "pages-cache",
-    }),
-  );
-}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -20,39 +20,12 @@ export default defineConfig({
       },
     }),
     VitePWA({
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.js",
       registerType: "autoUpdate",
-      workbox: {
+      injectManifest: {
         maximumFileSizeToCacheInBytes: 10000000,
-        runtimeCaching: [
-          {
-            urlPattern: /\/api\/policies(\?.*)?$/,
-            handler: "StaleWhileRevalidate",
-            options: {
-              cacheName: "policy-data-cache",
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 86400 * 30, // 30 days
-              },
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            urlPattern: /\/api\/policies\/download\//,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "policy-pdf-cache",
-              expiration: {
-                maxEntries: 100,
-                maxAgeSeconds: 86400 * 30, // 30 days
-              },
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-        ],
       },
     }),
   ],

--- a/server/controllers/agendaVoteController.js
+++ b/server/controllers/agendaVoteController.js
@@ -1,10 +1,6 @@
 import * as agendaVoteService from "../services/agendaVoteService.js";
 import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
-import {
-  ValidationError,
-  ForbiddenError,
-  AppError,
-} from "../utils/errors.js";
+import { ValidationError, ForbiddenError, AppError } from "../utils/errors.js";
 
 /**
  * Helper to determine if a user is a host or admin for a meeting.

--- a/server/controllers/agendaVoteController.js
+++ b/server/controllers/agendaVoteController.js
@@ -1,5 +1,10 @@
 import * as agendaVoteService from "../services/agendaVoteService.js";
 import { resolveAccessibleMeeting } from "../utils/resolveAccessibleMeeting.js";
+import {
+  ValidationError,
+  ForbiddenError,
+  AppError,
+} from "../utils/errors.js";
 
 /**
  * Helper to determine if a user is a host or admin for a meeting.
@@ -51,23 +56,23 @@ const isHostOrAdmin = (meeting, user) => {
  * Cast or update a vote
  * POST /api/meetings/:meetingId/agenda-votes/:agendaItemId
  */
-export const castVote = async (req, res) => {
+export const castVote = async (req, res, next) => {
   try {
     const { meetingId, agendaItemId } = req.params;
     const { vote } = req.body;
     const userId = req.user._id || req.user.id;
 
     if (![1, -1].includes(Number(vote))) {
-      return res
-        .status(400)
-        .json({ error: "Vote must be 1 (upvote) or -1 (downvote)" });
+      return next(
+        new ValidationError("Vote must be 1 (upvote) or -1 (downvote)"),
+      );
     }
 
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
-      return res
-        .status(access.error.status)
-        .json({ error: access.error.message });
+      return next(
+        new AppError(access.error.message, access.error.status || 400),
+      );
     }
 
     const newVote = await agendaVoteService.castVote(
@@ -88,8 +93,7 @@ export const castVote = async (req, res) => {
 
     res.status(200).json({ vote: newVote, tally: updatedTally });
   } catch (error) {
-    console.error("Error casting vote:", error);
-    res.status(500).json({ error: "Failed to cast vote" });
+    return next(error);
   }
 };
 
@@ -97,16 +101,16 @@ export const castVote = async (req, res) => {
  * Remove a vote
  * DELETE /api/meetings/:meetingId/agenda-votes/:agendaItemId
  */
-export const removeVote = async (req, res) => {
+export const removeVote = async (req, res, next) => {
   try {
     const { meetingId, agendaItemId } = req.params;
     const userId = req.user._id || req.user.id;
 
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
-      return res
-        .status(access.error.status)
-        .json({ error: access.error.message });
+      return next(
+        new AppError(access.error.message, access.error.status || 400),
+      );
     }
 
     await agendaVoteService.removeVote(meetingId, agendaItemId, userId);
@@ -122,8 +126,7 @@ export const removeVote = async (req, res) => {
 
     res.status(200).json({ message: "Vote removed", tally: updatedTally });
   } catch (error) {
-    console.error("Error removing vote:", error);
-    res.status(500).json({ error: "Failed to remove vote" });
+    return next(error);
   }
 };
 
@@ -131,24 +134,23 @@ export const removeVote = async (req, res) => {
  * Get all vote tallies for a meeting
  * GET /api/meetings/:meetingId/agenda-votes
  */
-export const getVoteTally = async (req, res) => {
+export const getVoteTally = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
     const userId = req.user._id || req.user.id;
 
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
-      return res
-        .status(access.error.status)
-        .json({ error: access.error.message });
+      return next(
+        new AppError(access.error.message, access.error.status || 400),
+      );
     }
 
     const tally = await agendaVoteService.getVoteTally(meetingId);
     const userVotes = await agendaVoteService.getUserVotes(meetingId, userId);
     res.status(200).json({ tally, userVotes });
   } catch (error) {
-    console.error("Error fetching vote tally:", error);
-    res.status(500).json({ error: "Failed to fetch vote tally" });
+    return next(error);
   }
 };
 
@@ -156,24 +158,25 @@ export const getVoteTally = async (req, res) => {
  * Auto-sort agenda by votes
  * POST /api/meetings/:meetingId/agenda-votes/auto-sort
  */
-export const autoSortByVotes = async (req, res) => {
+export const autoSortByVotes = async (req, res, next) => {
   try {
     const { meetingId } = req.params;
 
     const access = await resolveAccessibleMeeting(meetingId, req.user);
     if (access.error) {
-      return res
-        .status(access.error.status)
-        .json({ error: access.error.message });
+      return next(
+        new AppError(access.error.message, access.error.status || 400),
+      );
     }
 
     const meeting = access.meeting;
 
     if (!isHostOrAdmin(meeting, req.user)) {
-      return res.status(403).json({
-        error:
+      return next(
+        new ForbiddenError(
           "Forbidden: Only meeting hosts or admins can auto-sort the agenda",
-      });
+        ),
+      );
     }
 
     const updatedAgenda = await agendaVoteService.autoSortByVotes(meetingId);
@@ -191,9 +194,6 @@ export const autoSortByVotes = async (req, res) => {
       agendaItems: updatedAgenda,
     });
   } catch (error) {
-    console.error("Error auto-sorting agenda:", error);
-    res
-      .status(400)
-      .json({ error: error.message || "Failed to auto-sort agenda" });
+    return next(error);
   }
 };

--- a/server/controllers/guestAccessController.js
+++ b/server/controllers/guestAccessController.js
@@ -3,6 +3,12 @@ import Meeting from "../models/meetingModel.js";
 import Comment from "../models/commentModel.js";
 import ActionItem from "../models/actionItemModel.js";
 import mongoose from "mongoose";
+import {
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+  UnauthorizedError,
+} from "../utils/errors.js";
 
 /**
  * Controller for managing guest access tokens and host analytics feedback loop.
@@ -10,7 +16,7 @@ import mongoose from "mongoose";
 class GuestAccessController {
   // --- Authenticated routes for hosts / admins ---
 
-  static async createToken(req, res) {
+  static async createToken(req, res, next) {
     try {
       const { meetingId } = req.params;
       const { guestEmail, label, permissions, expiresAt, maxViews } = req.body;
@@ -18,7 +24,7 @@ class GuestAccessController {
 
       const meeting = await Meeting.findById(meetingId);
       if (!meeting) {
-        return res.status(404).json({ error: "Meeting not found" });
+        return next(new NotFoundError("Meeting not found"));
       }
 
       if (
@@ -26,9 +32,9 @@ class GuestAccessController {
         meeting.organization &&
         meeting.organization.toString() !== req.user.organization.toString()
       ) {
-        return res
-          .status(403)
-          .json({ error: "Unauthorized to create token for this meeting" });
+        return next(
+          new ForbiddenError("Unauthorized to create token for this meeting"),
+        );
       }
 
       const { rawToken, guestToken } = await GuestAccessService.generateToken({
@@ -48,29 +54,27 @@ class GuestAccessController {
         tokenRecord: guestToken,
       });
     } catch (error) {
-      console.error("Error creating guest token:", error);
-      return res.status(500).json({ error: "Internal server error" });
+      return next(error);
     }
   }
 
-  static async getMeetingTokens(req, res) {
+  static async getMeetingTokens(req, res, next) {
     try {
       const { meetingId } = req.params;
 
       const meeting = await Meeting.findById(meetingId);
       if (!meeting) {
-        return res.status(404).json({ error: "Meeting not found" });
+        return next(new NotFoundError("Meeting not found"));
       }
 
       const tokens = await GuestAccessService.getMeetingTokens(meetingId);
       return res.status(200).json(tokens);
     } catch (error) {
-      console.error("Error fetching guest tokens:", error);
-      return res.status(500).json({ error: "Internal server error" });
+      return next(error);
     }
   }
 
-  static async revokeToken(req, res) {
+  static async revokeToken(req, res, next) {
     try {
       const { tokenId } = req.params;
       const revokedBy = req.user._id || req.user.id;
@@ -85,26 +89,25 @@ class GuestAccessController {
         .status(200)
         .json({ message: "Token revoked", token: revokedToken });
     } catch (error) {
-      console.error("Error revoking guest token:", error);
-      return res.status(400).json({ error: error.message });
+      return next(new ValidationError(error.message));
     }
   }
 
   /**
    * Retrieves join metrics, token audit trails, and feedback records for a specific meeting.
    */
-  static async getHostAnalytics(req, res) {
+  static async getHostAnalytics(req, res, next) {
     try {
       const meetingId = req.params.meetingId || req.query.meetingId;
       const userId = req.user?._id || req.user?.id;
 
       if (!meetingId) {
-        return res.status(400).json({ error: "Meeting ID is required" });
+        return next(new ValidationError("Meeting ID is required"));
       }
 
       const meeting = await Meeting.findById(meetingId);
       if (!meeting) {
-        return res.status(404).json({ error: "Meeting not found" });
+        return next(new NotFoundError("Meeting not found"));
       }
 
       const isHost =
@@ -120,35 +123,32 @@ class GuestAccessController {
         req.user.organization.toString() === meeting.organization.toString();
 
       if (!isHost && !isAdmin && !isOrgMember) {
-        return res
-          .status(403)
-          .json({ error: "Unauthorized to view analytics for this meeting" });
+        return next(
+          new ForbiddenError("Unauthorized to view analytics for this meeting"),
+        );
       }
 
       const analytics = await GuestAccessService.getHostAnalytics(meetingId);
       return res.status(200).json(analytics);
     } catch (error) {
-      console.error("Error retrieving meeting analytics:", error);
-      return res
-        .status(500)
-        .json({ error: "Failed to retrieve meeting analytics." });
+      return next(error);
     }
   }
 
   /**
    * Streams room feedback matrices directly as a CSV download.
    */
-  static async exportFeedbackCSV(req, res) {
+  static async exportFeedbackCSV(req, res, next) {
     try {
       const meetingId = req.params.meetingId || req.query.meetingId;
 
       if (!meetingId) {
-        return res.status(400).json({ error: "Meeting ID is required" });
+        return next(new ValidationError("Meeting ID is required"));
       }
 
       const meeting = await Meeting.findById(meetingId);
       if (!meeting) {
-        return res.status(404).json({ error: "Meeting not found" });
+        return next(new NotFoundError("Meeting not found"));
       }
 
       const userId = req.user?._id || req.user?.id;
@@ -165,9 +165,9 @@ class GuestAccessController {
         req.user.organization.toString() === meeting.organization.toString();
 
       if (!isHost && !isAdmin && !isOrgMember) {
-        return res
-          .status(403)
-          .json({ error: "Unauthorized to export feedback for this meeting" });
+        return next(
+          new ForbiddenError("Unauthorized to export feedback for this meeting"),
+        );
       }
 
       const csvContent = await GuestAccessService.exportFeedbackCSV(meetingId);
@@ -179,14 +179,13 @@ class GuestAccessController {
       );
       return res.status(200).send(csvContent);
     } catch (error) {
-      console.error("Error exporting feedback CSV:", error);
-      return res.status(500).json({ error: "Feedback compilation failed." });
+      return next(error);
     }
   }
 
   // --- Unauthenticated routes for guests ---
 
-  static async getGuestMeetingData(req, res) {
+  static async getGuestMeetingData(req, res, next) {
     try {
       const { token } = req.params;
 
@@ -198,7 +197,7 @@ class GuestAccessController {
       );
 
       if (!meeting) {
-        return res.status(404).json({ error: "Meeting not found" });
+        return next(new NotFoundError("Meeting not found"));
       }
 
       const responseData = {
@@ -233,23 +232,21 @@ class GuestAccessController {
 
       return res.status(200).json(responseData);
     } catch (error) {
-      console.error("Error validating guest token:", error);
-      return res.status(401).json({ error: error.message });
+      return next(new UnauthorizedError(error.message));
     }
   }
 
-  static async recordGuestJoin(req, res) {
+  static async recordGuestJoin(req, res, next) {
     try {
       const { token } = req.params;
       const updatedToken = await GuestAccessService.recordJoin(token);
       return res.status(200).json({ success: true, token: updatedToken });
     } catch (error) {
-      console.error("Error recording guest join:", error);
-      return res.status(400).json({ error: error.message });
+      return next(new ValidationError(error.message));
     }
   }
 
-  static async addGuestComment(req, res) {
+  static async addGuestComment(req, res, next) {
     try {
       const { token } = req.params;
       const { body } = req.body;
@@ -257,9 +254,9 @@ class GuestAccessController {
       const validToken = await GuestAccessService.validateAndRecordView(token);
 
       if (!validToken.permissions.includes("add_comments")) {
-        return res
-          .status(403)
-          .json({ error: "Token does not grant comment permission" });
+        return next(
+          new ForbiddenError("Token does not grant comment permission"),
+        );
       }
 
       const meetingId = validToken.meetingId._id || validToken.meetingId;
@@ -274,12 +271,11 @@ class GuestAccessController {
 
       return res.status(201).json({ message: "Comment added", comment });
     } catch (error) {
-      console.error("Error adding guest comment:", error);
-      return res.status(400).json({ error: error.message });
+      return next(new ValidationError(error.message));
     }
   }
 
-  static async submitGuestFeedback(req, res) {
+  static async submitGuestFeedback(req, res, next) {
     try {
       const { token } = req.params;
       const { rating, comments, guestName } = req.body;
@@ -300,8 +296,7 @@ class GuestAccessController {
         .status(201)
         .json({ message: "Feedback submitted successfully", feedback });
     } catch (error) {
-      console.error("Error submitting guest feedback:", error);
-      return res.status(400).json({ error: error.message });
+      return next(new ValidationError(error.message));
     }
   }
 }

--- a/server/controllers/guestAccessController.js
+++ b/server/controllers/guestAccessController.js
@@ -166,7 +166,9 @@ class GuestAccessController {
 
       if (!isHost && !isAdmin && !isOrgMember) {
         return next(
-          new ForbiddenError("Unauthorized to export feedback for this meeting"),
+          new ForbiddenError(
+            "Unauthorized to export feedback for this meeting",
+          ),
         );
       }
 

--- a/server/controllers/membershipRequestController.js
+++ b/server/controllers/membershipRequestController.js
@@ -227,6 +227,7 @@ export const addCommentToMembershipRequest = async (req, res, next) => {
       req.user.id,
       id,
       text,
+      req.user.organization,
     );
 
     sendSuccess(res, { request }, "Comment added successfully.", 201);

--- a/server/controllers/organizationController.js
+++ b/server/controllers/organizationController.js
@@ -4,7 +4,12 @@
 // All business logic lives in server/services/OrganizationService.js.
 
 import * as OrganizationService from "../services/OrganizationService.js";
-import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import { sendSuccess } from "../utils/responseHandler.js";
+import {
+  UnauthorizedError,
+  ValidationError,
+  ConflictError,
+} from "../utils/errors.js";
 
 /**
  * ✅ Create or Join Organization
@@ -12,21 +17,18 @@ import { sendSuccess, sendError } from "../utils/responseHandler.js";
  * - If not → create new org as Admin
  * - Returns updated user with populated org
  */
-export const createOrJoinOrganization = async (req, res) => {
+export const createOrJoinOrganization = async (req, res, next) => {
   try {
     const { name } = req.body;
 
     // Validate authentication
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     // Validate org name
     if (!name || !name.trim()) {
-      return res.status(400).json({
-        success: false,
-        message: "Please provide an organization name.",
-      });
+      return next(new ValidationError("Please provide an organization name."));
     }
 
     const result = await OrganizationService.createOrJoinOrganization(
@@ -36,8 +38,7 @@ export const createOrJoinOrganization = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error creating/joining organization:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -45,13 +46,12 @@ export const createOrJoinOrganization = async (req, res) => {
  * ✅ Get All Organizations (For listing)
  * Returns: { success: true, organizations: [...] }
  */
-export const getAllOrganizations = async (req, res) => {
+export const getAllOrganizations = async (req, res, next) => {
   try {
     const result = await OrganizationService.getAllOrganizations();
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organizations:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -59,10 +59,10 @@ export const getAllOrganizations = async (req, res) => {
  * ✅ Join organization by ID (member flow)
  * Body: { organizationId: "<org id>" }
  */
-export const joinOrganization = async (req, res) => {
+export const joinOrganization = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.joinOrganizationById(
@@ -72,8 +72,7 @@ export const joinOrganization = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error joining organization by ID:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -81,10 +80,10 @@ export const joinOrganization = async (req, res) => {
  * ✅ Select organization (for users with multiple orgs)
  * Body: { organizationId: "<org id>" }
  */
-export const selectOrganization = async (req, res) => {
+export const selectOrganization = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.selectOrganization(
@@ -94,8 +93,7 @@ export const selectOrganization = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error selecting organization:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -103,10 +101,10 @@ export const selectOrganization = async (req, res) => {
  * ✅ Get organization members
  * Returns: { success: true, members: [...] }
  */
-export const getOrganizationMembers = async (req, res) => {
+export const getOrganizationMembers = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.getOrganizationMembers(
@@ -115,8 +113,7 @@ export const getOrganizationMembers = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organization members:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -125,7 +122,7 @@ export const getOrganizationMembers = async (req, res) => {
  * Returns only public information, no private data
  * Route: GET /api/organizations/public/:slug
  */
-export const getPublicOrganizationBySlug = async (req, res) => {
+export const getPublicOrganizationBySlug = async (req, res, next) => {
   try {
     const result = await OrganizationService.getPublicOrganizationBySlug(
       req.params.slug,
@@ -133,19 +130,14 @@ export const getPublicOrganizationBySlug = async (req, res) => {
 
     return sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching public organization:", error);
-    return sendError(
-      res,
-      error.statusCode || 500,
-      error.message || "Server error",
-    );
+    return next(error);
   }
 };
 
 /**
  * ✅ Browse public organizations with pagination and filters
  */
-export const browsePublicOrganizations = async (req, res) => {
+export const browsePublicOrganizations = async (req, res, next) => {
   try {
     const page = parseInt(req.query.page) || 1;
     const limit = parseInt(req.query.limit) || 12;
@@ -155,11 +147,11 @@ export const browsePublicOrganizations = async (req, res) => {
 
     // Validate pagination parameters
     if (page < 1 || limit < 1 || limit > 50) {
-      return res.status(400).json({
-        success: false,
-        message:
+      return next(
+        new ValidationError(
           "Invalid pagination parameters. Page must be >= 1 and limit must be between 1 and 50.",
-      });
+        ),
+      );
     }
 
     const userId = req.user?.id || req.user?._id || null;
@@ -175,12 +167,7 @@ export const browsePublicOrganizations = async (req, res) => {
 
     return sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error browsing public organizations:", error);
-    return sendError(
-      res,
-      error.statusCode || 500,
-      error.message || "Server error",
-    );
+    return next(error);
   }
 };
 
@@ -189,7 +176,7 @@ export const browsePublicOrganizations = async (req, res) => {
  * Query params: q (search query), page, limit
  * Returns: { success: true, organizations: [...], pagination: {...} }
  */
-export const searchOrganizations = async (req, res) => {
+export const searchOrganizations = async (req, res, next) => {
   try {
     const { q } = req.query;
     const page = parseInt(req.query.page) || 1;
@@ -197,25 +184,18 @@ export const searchOrganizations = async (req, res) => {
     const userId = req.user?.id || req.user?._id || null;
 
     if (!q || !q.trim()) {
-      return res.status(400).json({
-        success: false,
-        message: "Search query is required.",
-      });
+      return next(new ValidationError("Search query is required."));
     }
 
     if (q.trim().length < 2) {
-      return res.status(400).json({
-        success: false,
-        message: "Search query must be at least 2 characters.",
-      });
+      return next(
+        new ValidationError("Search query must be at least 2 characters."),
+      );
     }
 
     // Validate pagination parameters
     if (page < 1 || limit < 1 || limit > 50) {
-      return res.status(400).json({
-        success: false,
-        message: "Invalid pagination parameters.",
-      });
+      return next(new ValidationError("Invalid pagination parameters."));
     }
 
     const result = await OrganizationService.searchOrganizations(
@@ -227,8 +207,7 @@ export const searchOrganizations = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error searching organizations:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -236,18 +215,17 @@ export const searchOrganizations = async (req, res) => {
  * ✅ Get user's joined organizations
  * GET /api/organizations/user
  */
-export const getUserOrganizations = async (req, res) => {
+export const getUserOrganizations = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.getUserOrganizations(req.user.id);
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching user organizations:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -255,10 +233,10 @@ export const getUserOrganizations = async (req, res) => {
  * ✅ Create Organization (New version)
  * POST /api/organizations
  */
-export const createOrganization = async (req, res) => {
+export const createOrganization = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.createOrganization(
@@ -268,11 +246,10 @@ export const createOrganization = async (req, res) => {
 
     sendSuccess(res, result, null, 201);
   } catch (error) {
-    console.error("❌ Error creating organization:", error);
     if (error.code === 11000) {
-      return sendError(res, 409, "Organization slug already exists.");
+      return next(new ConflictError("Organization slug already exists."));
     }
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -280,12 +257,12 @@ export const createOrganization = async (req, res) => {
  * ✅ Get All Organizations (Paginated)
  * GET /api/organizations
  */
-export const getOrganizations = async (req, res) => {
+export const getOrganizations = async (req, res, next) => {
   try {
     const { visibility, page = 1, limit = 20 } = req.query;
 
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.getOrganizations(
@@ -297,8 +274,7 @@ export const getOrganizations = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organizations:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -306,10 +282,10 @@ export const getOrganizations = async (req, res) => {
  * ✅ Get Organization by ID or Slug
  * GET /api/organizations/:idOrSlug
  */
-export const getOrganizationById = async (req, res) => {
+export const getOrganizationById = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.getOrganizationById(
@@ -319,8 +295,7 @@ export const getOrganizationById = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organization:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -328,10 +303,10 @@ export const getOrganizationById = async (req, res) => {
  * ✅ Get Organization Settings
  * GET /api/organizations/current/settings
  */
-export const getOrganizationSettings = async (req, res) => {
+export const getOrganizationSettings = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const orgIdOrSlug = req.query.orgId || req.params.id || null;
@@ -342,8 +317,7 @@ export const getOrganizationSettings = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organization settings:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -351,10 +325,10 @@ export const getOrganizationSettings = async (req, res) => {
  * ✅ Update Organization
  * PUT /api/organizations/:id
  */
-export const updateOrganization = async (req, res) => {
+export const updateOrganization = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.updateOrganization(
@@ -365,8 +339,7 @@ export const updateOrganization = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error updating organization:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -374,10 +347,10 @@ export const updateOrganization = async (req, res) => {
  * ✅ Delete Organization
  * DELETE /api/organizations/:id
  */
-export const deleteOrganization = async (req, res) => {
+export const deleteOrganization = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.deleteOrganization(
@@ -387,8 +360,7 @@ export const deleteOrganization = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error deleting organization:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -396,10 +368,10 @@ export const deleteOrganization = async (req, res) => {
  * ✅ Get Organization Members by ID
  * GET /api/organizations/:id/members
  */
-export const getOrganizationMembersById = async (req, res) => {
+export const getOrganizationMembersById = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const result = await OrganizationService.getOrganizationMembersById(
@@ -409,8 +381,7 @@ export const getOrganizationMembersById = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organization members:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -418,17 +389,17 @@ export const getOrganizationMembersById = async (req, res) => {
  * ✅ Get Organization Leaderboard
  * GET /api/organizations/:id/leaderboard
  */
-export const getOrganizationLeaderboard = async (req, res) => {
+export const getOrganizationLeaderboard = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const orgId =
       req.params.id ||
       (req.user.organization ? req.user.organization.toString() : null);
     if (!orgId) {
-      return sendError(res, 400, "Organization ID is required.");
+      return next(new ValidationError("Organization ID is required."));
     }
 
     const result = await OrganizationService.getOrganizationLeaderboard(
@@ -438,8 +409,7 @@ export const getOrganizationLeaderboard = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching organization leaderboard:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -447,10 +417,10 @@ export const getOrganizationLeaderboard = async (req, res) => {
  * ✅ Invite Member to Organization
  * POST /api/organizations/:id/invite
  */
-export const inviteMember = async (req, res) => {
+export const inviteMember = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const userId = req.user.id || req.user._id;
@@ -458,7 +428,7 @@ export const inviteMember = async (req, res) => {
     const { email, role, message } = req.body;
 
     if (!email) {
-      return sendError(res, 400, "Email address is required.");
+      return next(new ValidationError("Email address is required."));
     }
 
     const result = await OrganizationService.inviteMemberToOrganization(
@@ -469,8 +439,7 @@ export const inviteMember = async (req, res) => {
 
     sendSuccess(res, result, null, 201);
   } catch (error) {
-    console.error("❌ Error inviting member:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -478,10 +447,10 @@ export const inviteMember = async (req, res) => {
  * ✅ Accept Invite Token
  * POST /api/organizations/invite/:token/accept
  */
-export const acceptInviteToken = async (req, res) => {
+export const acceptInviteToken = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const userId = req.user.id || req.user._id;
@@ -494,8 +463,7 @@ export const acceptInviteToken = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error accepting invite:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -503,10 +471,10 @@ export const acceptInviteToken = async (req, res) => {
  * ✅ Update Member Role
  * PATCH /api/organizations/:id/members/:userId/role
  */
-export const updateMemberRole = async (req, res) => {
+export const updateMemberRole = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -515,7 +483,7 @@ export const updateMemberRole = async (req, res) => {
     const { role, reason } = req.body;
 
     if (!role) {
-      return sendError(res, 400, "Role is required.");
+      return next(new ValidationError("Role is required."));
     }
 
     const result = await OrganizationService.updateMemberRole(
@@ -528,8 +496,7 @@ export const updateMemberRole = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error updating member role:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -537,10 +504,10 @@ export const updateMemberRole = async (req, res) => {
  * ✅ Deactivate Member
  * PATCH /api/organizations/:id/members/:userId/deactivate
  */
-export const deactivateMember = async (req, res) => {
+export const deactivateMember = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -557,8 +524,7 @@ export const deactivateMember = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error deactivating member:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -566,10 +532,10 @@ export const deactivateMember = async (req, res) => {
  * ✅ Reactivate Member
  * PATCH /api/organizations/:id/members/:userId/reactivate
  */
-export const reactivateMember = async (req, res) => {
+export const reactivateMember = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -584,8 +550,7 @@ export const reactivateMember = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error reactivating member:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -593,10 +558,10 @@ export const reactivateMember = async (req, res) => {
  * ✅ Update Member Capacity
  * PATCH /api/organizations/:id/members/:userId/capacity
  */
-export const updateMemberCapacity = async (req, res) => {
+export const updateMemberCapacity = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -612,8 +577,7 @@ export const updateMemberCapacity = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error updating member capacity:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -621,10 +585,10 @@ export const updateMemberCapacity = async (req, res) => {
  * ✅ Get Member Role History
  * GET /api/organizations/:id/members/:userId/role-history
  */
-export const getMemberRoleHistory = async (req, res) => {
+export const getMemberRoleHistory = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -639,8 +603,7 @@ export const getMemberRoleHistory = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching role history:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -648,10 +611,10 @@ export const getMemberRoleHistory = async (req, res) => {
  * ✅ Remove Member from Organization
  * DELETE /api/organizations/:id/members/:userId
  */
-export const removeMember = async (req, res) => {
+export const removeMember = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -666,8 +629,7 @@ export const removeMember = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error removing member:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };
 
@@ -675,10 +637,10 @@ export const removeMember = async (req, res) => {
  * ✅ Get Paginated Audit Logs
  * GET /api/organizations/:id/audit-log
  */
-export const getPaginatedAuditLogs = async (req, res) => {
+export const getPaginatedAuditLogs = async (req, res, next) => {
   try {
     if (!req.user || (!req.user.id && !req.user._id)) {
-      return sendError(res, 401, "Authentication failed.");
+      return next(new UnauthorizedError("Authentication failed."));
     }
 
     const actorId = req.user.id || req.user._id;
@@ -692,7 +654,6 @@ export const getPaginatedAuditLogs = async (req, res) => {
 
     sendSuccess(res, result);
   } catch (error) {
-    console.error("❌ Error fetching audit logs:", error);
-    sendError(res, error.statusCode || 500, error.message || "Server error");
+    return next(error);
   }
 };

--- a/server/controllers/transcriptController.js
+++ b/server/controllers/transcriptController.js
@@ -1659,7 +1659,8 @@ export const persistCaptionSegments = async (req, res) => {
         await resolveSpeakerAttribution(meetingId, raw, user);
 
       const speaker = attrSpeaker;
-      const speakerId = attrSpeakerId || (raw.speakerId ? String(raw.speakerId) : null);
+      const speakerId =
+        attrSpeakerId || (raw.speakerId ? String(raw.speakerId) : null);
       const startTime =
         typeof raw.startTime === "number"
           ? raw.startTime

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -42,7 +42,9 @@ const errorHandler = (err, req, res, next) => {
     return res.status(400).json(
       withRequestId(req, {
         success: false,
+        error: "MalformedJsonError",
         message: "Invalid JSON payload.",
+        code: "INVALID_JSON",
       }),
     );
   }
@@ -52,7 +54,9 @@ const errorHandler = (err, req, res, next) => {
     return res.status(413).json(
       withRequestId(req, {
         success: false,
+        error: "PayloadTooLargeError",
         message: "Request payload is too large.",
+        code: "PAYLOAD_TOO_LARGE",
       }),
     );
   }
@@ -66,14 +70,33 @@ const errorHandler = (err, req, res, next) => {
     return res.status(400).json(
       withRequestId(req, {
         success: false,
+        error: "ValidationError",
         message: "Validation failed.",
+        code: "VALIDATION_ERROR",
         details,
       }),
     );
   }
 
   if (err instanceof AppError) {
-    const payload = { success: false, message: err.message };
+    const payload = {
+      success: false,
+      error: err.name || "AppError",
+      message: err.message,
+      code:
+        err.code ||
+        (err.statusCode === 404
+          ? "NOT_FOUND"
+          : err.statusCode === 400
+            ? "VALIDATION_ERROR"
+            : err.statusCode === 401
+              ? "UNAUTHORIZED"
+              : err.statusCode === 403
+                ? "FORBIDDEN"
+                : err.statusCode === 409
+                  ? "CONFLICT"
+                  : "APP_ERROR"),
+    };
     if (err.details) payload.details = err.details;
     requestLog.warn("Handled application error", {
       statusCode: err.statusCode,
@@ -91,7 +114,9 @@ const errorHandler = (err, req, res, next) => {
     return res.status(400).json(
       withRequestId(req, {
         success: false,
+        error: "ValidationError",
         message: "Invalid data provided.",
+        code: "VALIDATION_ERROR",
         details,
       }),
     );
@@ -105,7 +130,9 @@ const errorHandler = (err, req, res, next) => {
     return res.status(400).json(
       withRequestId(req, {
         success: false,
+        error: "CastError",
         message: `Invalid value for field '${err.path}'.`,
+        code: "INVALID_ID",
       }),
     );
   }
@@ -116,9 +143,11 @@ const errorHandler = (err, req, res, next) => {
   return res.status(500).json(
     withRequestId(req, {
       success: false,
+      error: err?.name || "InternalServerError",
       message: isProd
         ? "Internal Server Error"
         : err?.message || "Internal Server Error",
+      code: err?.code || "INTERNAL_SERVER_ERROR",
       ...(isProd ? {} : { stack: err?.stack }),
     }),
   );

--- a/server/routes/membershipRequestRoutes.js
+++ b/server/routes/membershipRequestRoutes.js
@@ -45,7 +45,13 @@ router.get(
 );
 
 // Comments on request
-router.post("/:id/comments", writeLimiter, addCommentToMembershipRequest);
+router.post(
+  "/:id/comments",
+  writeLimiter,
+  requireOrgMembership,
+  requirePermission("team_members", "view"),
+  addCommentToMembershipRequest,
+);
 
 // Manage requests
 router.patch(

--- a/server/services/MembershipRequestService.js
+++ b/server/services/MembershipRequestService.js
@@ -13,6 +13,7 @@ import {
   ForbiddenError,
   ValidationError,
 } from "../utils/errors.js";
+import { isSameOrganization } from "../utils/organizationScope.js";
 
 class MembershipRequestService {
   /**
@@ -85,7 +86,7 @@ class MembershipRequestService {
   /**
    * Add a comment to a membership request
    */
-  static async addComment(userId, requestId, text) {
+  static async addComment(userId, requestId, text, userOrgId = null) {
     if (!this._isValidObjectId(requestId)) {
       throw new ValidationError("Invalid membership request ID.");
     }
@@ -99,6 +100,10 @@ class MembershipRequestService {
 
     if (!request) {
       throw new NotFoundError("Membership request not found.");
+    }
+
+    if (userOrgId && !isSameOrganization(request.organization, userOrgId)) {
+      throw new ForbiddenError("Not authorized to comment on this request.");
     }
 
     const isRequester = request.user.toString() === userId.toString();

--- a/server/tests/asyncMeetings.integration.test.js
+++ b/server/tests/asyncMeetings.integration.test.js
@@ -40,9 +40,8 @@ jest.unstable_mockModule("../middleware/rateLimiter.js", () => ({
   writeLimiter: (req, res, next) => next(),
 }));
 
-const { default: asyncMeetingRoutes } = await import(
-  "../routes/asyncMeetingRoutes.js"
-);
+const { default: asyncMeetingRoutes } =
+  await import("../routes/asyncMeetingRoutes.js");
 
 describe("Async Meetings Server Integration Tests (#2666)", () => {
   let app;

--- a/server/tests/attendance.integration.test.js
+++ b/server/tests/attendance.integration.test.js
@@ -35,9 +35,8 @@ jest.unstable_mockModule("../middleware/userAuth.js", () => ({
   sanitizeAuthRequestForLog: jest.fn(),
 }));
 
-const { default: attendanceRoutes } = await import(
-  "../routes/meetingAttendanceRoutes.js"
-);
+const { default: attendanceRoutes } =
+  await import("../routes/meetingAttendanceRoutes.js");
 
 describe("Meeting Attendance Server Integration Tests (#2666)", () => {
   let app;

--- a/server/tests/errorHandlerMiddleware.test.js
+++ b/server/tests/errorHandlerMiddleware.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import errorHandler from "../middleware/errorHandler.js";
+import {
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+} from "../utils/errors.js";
+
+describe("errorHandler middleware (#2663)", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {
+      requestId: "req-test-123",
+      header: vi.fn(),
+      get: vi.fn(),
+    };
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+    next = vi.fn();
+  });
+
+  it("handles ValidationError with HTTP 400 and normalized { error, message, code } shape", () => {
+    const err = new ValidationError("Invalid email address");
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "ValidationError",
+        message: "Invalid email address",
+        code: "VALIDATION_ERROR",
+        requestId: "req-test-123",
+      }),
+    );
+  });
+
+  it("handles UnauthorizedError with HTTP 401 and normalized shape", () => {
+    const err = new UnauthorizedError("Authentication token expired");
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "UnauthorizedError",
+        message: "Authentication token expired",
+        code: "UNAUTHORIZED",
+        requestId: "req-test-123",
+      }),
+    );
+  });
+
+  it("handles ForbiddenError with HTTP 403 and normalized shape", () => {
+    const err = new ForbiddenError("Not allowed to access resource");
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "ForbiddenError",
+        message: "Not allowed to access resource",
+        code: "FORBIDDEN",
+        requestId: "req-test-123",
+      }),
+    );
+  });
+
+  it("handles NotFoundError with HTTP 404 and normalized shape", () => {
+    const err = new NotFoundError("Meeting not found");
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "NotFoundError",
+        message: "Meeting not found",
+        code: "NOT_FOUND",
+        requestId: "req-test-123",
+      }),
+    );
+  });
+
+  it("handles ConflictError with HTTP 409 and normalized shape", () => {
+    const err = new ConflictError("Organization slug already exists");
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "ConflictError",
+        message: "Organization slug already exists",
+        code: "CONFLICT",
+        requestId: "req-test-123",
+      }),
+    );
+  });
+
+  it("handles unhandled 500 errors gracefully with internal server error code", () => {
+    const err = new Error("Unexpected database explosion");
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      errorHandler(err, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: "Error",
+          message: "Internal Server Error",
+          code: "INTERNAL_SERVER_ERROR",
+          requestId: "req-test-123",
+        }),
+      );
+      expect(res.json.mock.calls[0][0].stack).toBeUndefined();
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
+  it("handles Mongoose CastError with HTTP 400 and INVALID_ID code", () => {
+    const err = { name: "CastError", path: "_id", value: "invalid-id" };
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "CastError",
+        message: "Invalid value for field '_id'.",
+        code: "INVALID_ID",
+      }),
+    );
+  });
+});

--- a/server/tests/guestAccessController.vitest.test.js
+++ b/server/tests/guestAccessController.vitest.test.js
@@ -51,13 +51,14 @@ const GuestAccessToken = (await import("../models/guestAccessTokenModel.js"))
 const GuestFeedback = (await import("../models/guestFeedbackModel.js")).default;
 
 describe("guestAccessController (#2454)", () => {
-  let req, res;
+  let req, res, next;
   const mockUserId = "507f1f77bcf86cd799439011";
   const mockOrgId = "507f1f77bcf86cd799439022";
   const mockMeetingId = "507f1f77bcf86cd799439033";
 
   beforeEach(() => {
     vi.clearAllMocks();
+    next = vi.fn();
     req = {
       user: {
         _id: mockUserId,
@@ -183,12 +184,14 @@ describe("guestAccessController (#2454)", () => {
         organization: mockOrgId,
       });
 
-      await getHostAnalytics(req, res);
+      await getHostAnalytics(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.json).toHaveBeenCalledWith({
-        error: "Unauthorized to view analytics for this meeting",
-      });
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 403,
+          message: "Unauthorized to view analytics for this meeting",
+        }),
+      );
     });
   });
 

--- a/server/tests/liveTranscriptSpeakerAttribution.integration.test.js
+++ b/server/tests/liveTranscriptSpeakerAttribution.integration.test.js
@@ -78,9 +78,8 @@ jest.unstable_mockModule("../models/RecordingSession.js", () => ({
   },
 }));
 
-const { uploadTranscriptChunk, persistCaptionSegments } = await import(
-  "../controllers/transcriptController.js"
-);
+const { uploadTranscriptChunk, persistCaptionSegments } =
+  await import("../controllers/transcriptController.js");
 
 describe("Live Transcript Chunk Speaker Attribution Integration Tests (#2665)", () => {
   let app;
@@ -210,9 +209,24 @@ describe("Live Transcript Chunk Speaker Attribution Integration Tests (#2665)", 
       .post(`/api/meetings/${mockMeetingId}/transcript/captions`)
       .send({
         segments: [
-          { text: "First point by Alice", speakerId: "spk_1", startTime: 0, endTime: 3 },
-          { text: "Second point by Bob", speakerId: "spk_2", startTime: 3, endTime: 6 },
-          { text: "Follow-up by Alice", speakerId: "spk_1", startTime: 6, endTime: 9 },
+          {
+            text: "First point by Alice",
+            speakerId: "spk_1",
+            startTime: 0,
+            endTime: 3,
+          },
+          {
+            text: "Second point by Bob",
+            speakerId: "spk_2",
+            startTime: 3,
+            endTime: 6,
+          },
+          {
+            text: "Follow-up by Alice",
+            speakerId: "spk_1",
+            startTime: 6,
+            endTime: 9,
+          },
         ],
       });
 

--- a/server/tests/membershipRequestCommentAuth.test.js
+++ b/server/tests/membershipRequestCommentAuth.test.js
@@ -1,0 +1,186 @@
+/**
+ * Issue #2664 — Add permission gate to membership request comment endpoint
+ *
+ * Tests:
+ * 1. Unauthenticated caller -> rejected (401)
+ * 2. Authenticated user without required team_members permission -> rejected (403)
+ * 3. Authenticated user with permission but from WRONG organization -> rejected (403)
+ * 4. Authenticated user with correct permission AND correct organization -> allowed (201)
+ * 5. Valid request/comment behavior remains successful for authorized caller.
+ */
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { requireOrgMembership, requirePermission } from "../middleware/rbac.js";
+import MembershipRequestService from "../services/MembershipRequestService.js";
+import MembershipRequest from "../models/membershipRequestModel.js";
+import Membership from "../models/membershipModel.js";
+import { addCommentToMembershipRequest } from "../controllers/membershipRequestController.js";
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const USER_ID = new mongoose.Types.ObjectId();
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: vi.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+describe("Membership Request Comment Endpoint Authorization (#2664)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Middleware Gate Checks", () => {
+    it("1. Unauthenticated caller is rejected with 401 by requireOrgMembership and requirePermission", () => {
+      const req = { user: null };
+      const res = makeRes();
+      const next = vi.fn();
+
+      requireOrgMembership(req, res, next);
+      expect(res.statusCode).toBe(401);
+      expect(res.body.success).toBe(false);
+      expect(next).not.toHaveBeenCalled();
+
+      const resPerm = makeRes();
+      const nextPerm = vi.fn();
+      requirePermission("team_members", "view")(req, resPerm, nextPerm);
+      expect(resPerm.statusCode).toBe(401);
+      expect(resPerm.body.success).toBe(false);
+      expect(nextPerm).not.toHaveBeenCalled();
+    });
+
+    it("2. Authenticated user without role is rejected with 403 by requirePermission", () => {
+      const req = { user: { _id: USER_ID, organization: ORG_A } };
+      const res = makeRes();
+      const next = vi.fn();
+
+      requirePermission("team_members", "view")(req, res, next);
+      expect(res.statusCode).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain("No role assigned");
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("2b. Authenticated user missing required team_members permission is rejected with 403", () => {
+      const req = { user: { _id: USER_ID, organization: ORG_A, role: "invalid_role" } };
+      const res = makeRes();
+      const next = vi.fn();
+
+      requirePermission("team_members", "view")(req, res, next);
+      expect(res.statusCode).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain("You don't have permission");
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("Passes middleware when user has organization and valid team_members:view role", () => {
+      const req = { user: { _id: USER_ID, organization: ORG_A, role: "member" } };
+      const resOrg = makeRes();
+      const nextOrg = vi.fn();
+      requireOrgMembership(req, resOrg, nextOrg);
+      expect(nextOrg).toHaveBeenCalled();
+
+      const resPerm = makeRes();
+      const nextPerm = vi.fn();
+      requirePermission("team_members", "view")(req, resPerm, nextPerm);
+      expect(nextPerm).toHaveBeenCalled();
+    });
+  });
+
+  describe("Organization Boundary Enforcement", () => {
+    it("3. Rejects comment when user organization differs from membership request organization", async () => {
+      const requestId = new mongoose.Types.ObjectId();
+      const mockReqDoc = {
+        _id: requestId,
+        user: new mongoose.Types.ObjectId(),
+        organization: { _id: ORG_B, owner: new mongoose.Types.ObjectId() },
+        comments: [],
+      };
+
+      vi.spyOn(MembershipRequest, "findById").mockReturnValue({
+        populate: vi.fn().mockResolvedValue(mockReqDoc),
+      });
+
+      await expect(
+        MembershipRequestService.addComment(
+          USER_ID.toString(),
+          requestId.toString(),
+          "Hello cross org",
+          ORG_A.toString(), // User belongs to ORG_A, request belongs to ORG_B
+        ),
+      ).rejects.toThrow("Not authorized to comment on this request.");
+    });
+
+    it("4. Allows comment when user organization matches membership request organization and user has access", async () => {
+      const requestId = new mongoose.Types.ObjectId();
+      const mockReqDoc = {
+        _id: requestId,
+        user: USER_ID,
+        organization: { _id: ORG_A, owner: USER_ID },
+        comments: [],
+        save: vi.fn().mockResolvedValue(true),
+        populate: vi.fn().mockResolvedValue(true),
+      };
+
+      vi.spyOn(MembershipRequest, "findById").mockReturnValue({
+        populate: vi.fn().mockResolvedValue(mockReqDoc),
+      });
+      vi.spyOn(Membership, "findOne").mockReturnValue({
+        lean: vi.fn().mockResolvedValue(null),
+      });
+
+      const res = await MembershipRequestService.addComment(
+        USER_ID.toString(),
+        requestId.toString(),
+        "Valid comment same org",
+        ORG_A.toString(), // User belongs to ORG_A, request belongs to ORG_A
+      );
+
+      expect(mockReqDoc.comments.length).toBe(1);
+      expect(mockReqDoc.comments[0].text).toBe("Valid comment same org");
+      expect(res).toBe(mockReqDoc);
+    });
+  });
+
+  describe("Controller Flow & Response Shape Preservation", () => {
+    it("5. addCommentToMembershipRequest controller returns 201 with created comment for authorized caller", async () => {
+      const requestId = new mongoose.Types.ObjectId().toString();
+      const mockRequest = { _id: requestId, comments: [{ text: "Test comment" }] };
+
+      vi.spyOn(MembershipRequestService, "addComment").mockResolvedValue(mockRequest);
+
+      const req = {
+        params: { id: requestId },
+        body: { text: "Test comment" },
+        user: { id: USER_ID.toString(), organization: ORG_A.toString() },
+      };
+      const res = makeRes();
+      const next = vi.fn();
+
+      await addCommentToMembershipRequest(req, res, next);
+
+      expect(MembershipRequestService.addComment).toHaveBeenCalledWith(
+        USER_ID.toString(),
+        requestId,
+        "Test comment",
+        ORG_A.toString(),
+      );
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.request).toEqual(mockRequest);
+      expect(res.body.message).toBe("Comment added successfully.");
+    });
+  });
+});

--- a/server/tests/membershipRequestCommentAuth.test.js
+++ b/server/tests/membershipRequestCommentAuth.test.js
@@ -74,7 +74,9 @@ describe("Membership Request Comment Endpoint Authorization (#2664)", () => {
     });
 
     it("2b. Authenticated user missing required team_members permission is rejected with 403", () => {
-      const req = { user: { _id: USER_ID, organization: ORG_A, role: "invalid_role" } };
+      const req = {
+        user: { _id: USER_ID, organization: ORG_A, role: "invalid_role" },
+      };
       const res = makeRes();
       const next = vi.fn();
 
@@ -86,7 +88,9 @@ describe("Membership Request Comment Endpoint Authorization (#2664)", () => {
     });
 
     it("Passes middleware when user has organization and valid team_members:view role", () => {
-      const req = { user: { _id: USER_ID, organization: ORG_A, role: "member" } };
+      const req = {
+        user: { _id: USER_ID, organization: ORG_A, role: "member" },
+      };
       const resOrg = makeRes();
       const nextOrg = vi.fn();
       requireOrgMembership(req, resOrg, nextOrg);
@@ -157,9 +161,14 @@ describe("Membership Request Comment Endpoint Authorization (#2664)", () => {
   describe("Controller Flow & Response Shape Preservation", () => {
     it("5. addCommentToMembershipRequest controller returns 201 with created comment for authorized caller", async () => {
       const requestId = new mongoose.Types.ObjectId().toString();
-      const mockRequest = { _id: requestId, comments: [{ text: "Test comment" }] };
+      const mockRequest = {
+        _id: requestId,
+        comments: [{ text: "Test comment" }],
+      };
 
-      vi.spyOn(MembershipRequestService, "addComment").mockResolvedValue(mockRequest);
+      vi.spyOn(MembershipRequestService, "addComment").mockResolvedValue(
+        mockRequest,
+      );
 
       const req = {
         params: { id: requestId },

--- a/server/tests/minutesApproval.integration.test.js
+++ b/server/tests/minutesApproval.integration.test.js
@@ -23,9 +23,8 @@ jest.unstable_mockModule("@clerk/express", () => ({
   },
 }));
 
-const { default: minutesApprovalRoutes } = await import(
-  "../routes/minutesApprovalRoutes.js"
-);
+const { default: minutesApprovalRoutes } =
+  await import("../routes/minutesApprovalRoutes.js");
 
 describe("Minutes Approval Server Integration Tests (#2666)", () => {
   let app;
@@ -44,10 +43,7 @@ describe("Minutes Approval Server Integration Tests (#2666)", () => {
       req.user = mockUser;
       next();
     });
-    app.use(
-      "/api/meetings/:meetingId/minutes-approval",
-      minutesApprovalRoutes,
-    );
+    app.use("/api/meetings/:meetingId/minutes-approval", minutesApprovalRoutes);
 
     unauthApp = express();
     unauthApp.use(express.json());

--- a/server/tests/ownershipTransfer.integration.test.js
+++ b/server/tests/ownershipTransfer.integration.test.js
@@ -56,12 +56,10 @@ jest.unstable_mockModule("../middleware/userAuth.js", () => ({
   sanitizeAuthRequestForLog: jest.fn(),
 }));
 
-const { default: meetingOwnershipTransferRoutes } = await import(
-  "../routes/meetingOwnershipTransferRoutes.js"
-);
-const { initiateTransfer } = await import(
-  "../controllers/meetingOwnershipTransferController.js"
-);
+const { default: meetingOwnershipTransferRoutes } =
+  await import("../routes/meetingOwnershipTransferRoutes.js");
+const { initiateTransfer } =
+  await import("../controllers/meetingOwnershipTransferController.js");
 
 describe("Ownership Transfer Server Integration Tests (#2666)", () => {
   let app;
@@ -72,13 +70,19 @@ describe("Ownership Transfer Server Integration Tests (#2666)", () => {
     app = express();
     app.use(express.json());
     app.use("/api/ownership-transfers", meetingOwnershipTransferRoutes);
-    app.post("/api/meetings/:meetingId/transfers", (req, res, next) => {
-      if (!req.headers.authorization) {
-        return res.status(401).json({ success: false, message: "Unauthorized" });
-      }
-      req.user = mockUser;
-      next();
-    }, initiateTransfer);
+    app.post(
+      "/api/meetings/:meetingId/transfers",
+      (req, res, next) => {
+        if (!req.headers.authorization) {
+          return res
+            .status(401)
+            .json({ success: false, message: "Unauthorized" });
+        }
+        req.user = mockUser;
+        next();
+      },
+      initiateTransfer,
+    );
   });
 
   describe("GET /api/ownership-transfers/inbox", () => {

--- a/server/utils/errors.js
+++ b/server/utils/errors.js
@@ -19,12 +19,26 @@ export class AppError extends Error {
    * @param {number} statusCode    - HTTP status code to send back
    * @param {boolean} isOperational - true = expected failure (bad input, not found);
    *                                  false = programming bug (should never happen)
+   * @param {string} [code]        - Machine-readable error code
    */
-  constructor(message, statusCode, isOperational = true) {
+  constructor(message, statusCode, isOperational = true, code = null) {
     super(message);
     this.name = this.constructor.name;
     this.statusCode = statusCode;
     this.isOperational = isOperational;
+    this.code =
+      code ||
+      (statusCode === 404
+        ? "NOT_FOUND"
+        : statusCode === 400
+          ? "VALIDATION_ERROR"
+          : statusCode === 401
+            ? "UNAUTHORIZED"
+            : statusCode === 403
+              ? "FORBIDDEN"
+              : statusCode === 409
+                ? "CONFLICT"
+                : "APP_ERROR");
 
     // Maintains proper prototype chain for instanceof checks
     Object.setPrototypeOf(this, new.target.prototype);
@@ -43,9 +57,14 @@ export class ValidationError extends AppError {
   /**
    * @param {string}  message - Readable error message
    * @param {Array}   details - Optional array of field-level issues (e.g. from Zod)
+   * @param {string}  code    - Optional error code
    */
-  constructor(message = "Validation failed", details = null) {
-    super(message, 400);
+  constructor(
+    message = "Validation failed",
+    details = null,
+    code = "VALIDATION_ERROR",
+  ) {
+    super(message, 400, true, code);
     this.details = details;
   }
 }
@@ -54,8 +73,11 @@ export class ValidationError extends AppError {
 // 401 Unauthorized — request missing valid authentication
 // ──────────────────────────────────────────────────────────────
 export class UnauthorizedError extends AppError {
-  constructor(message = "Unauthorized. Login required.") {
-    super(message, 401);
+  constructor(
+    message = "Unauthorized. Login required.",
+    code = "UNAUTHORIZED",
+  ) {
+    super(message, 401, true, code);
   }
 }
 
@@ -63,8 +85,11 @@ export class UnauthorizedError extends AppError {
 // 403 Forbidden — authenticated but lacks permission
 // ──────────────────────────────────────────────────────────────
 export class ForbiddenError extends AppError {
-  constructor(message = "You do not have permission to perform this action.") {
-    super(message, 403);
+  constructor(
+    message = "You do not have permission to perform this action.",
+    code = "FORBIDDEN",
+  ) {
+    super(message, 403, true, code);
   }
 }
 
@@ -72,8 +97,8 @@ export class ForbiddenError extends AppError {
 // 409 Conflict — resource already exists or state conflict
 // ──────────────────────────────────────────────────────────────
 export class ConflictError extends AppError {
-  constructor(message = "Resource already exists.") {
-    super(message, 409);
+  constructor(message = "Resource already exists.", code = "CONFLICT") {
+    super(message, 409, true, code);
   }
 }
 
@@ -81,7 +106,7 @@ export class ConflictError extends AppError {
 // 404 Not Found — requested resource does not exist
 // ──────────────────────────────────────────────────────────────
 export class NotFoundError extends AppError {
-  constructor(message = "Resource not found.") {
-    super(message, 404);
+  constructor(message = "Resource not found.", code = "NOT_FOUND") {
+    super(message, 404, true, code);
   }
 }

--- a/server/utils/responseHandler.js
+++ b/server/utils/responseHandler.js
@@ -39,7 +39,12 @@ export const sendError = (
 };
 
 export const errorResponse = sendError;
-export const successResponse = (res, statusCode = 200, message = "Success", data = {}) => {
+export const successResponse = (
+  res,
+  statusCode = 200,
+  message = "Success",
+  data = {},
+) => {
   return res.status(statusCode).json({
     success: true,
     message,


### PR DESCRIPTION
# Pull Request

## Description

Adds an authorization gate to the membership request comment endpoint.

- Requires the appropriate `team_members` permission.
- Verifies that the membership request belongs to the caller's organization.
- Prevents unauthorized cross-organization comments.
- Adds negative authorization test coverage.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [x] Security Improvement
- [ ] Other

## Related Issue

Closes #2664

## Testing

Added authorization tests covering unauthenticated users, missing permissions, cross-organization access, and authorized users.

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

## Screenshots

Not applicable — no UI changes.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent machine-readable error codes and error types to API error responses.
  - Improved offline support and caching for policy documents, static resources, and app navigation.
  - Added authorization checks for membership request comments, including organization and permission validation.

- **Bug Fixes**
  - Improved error handling consistency across organization, guest access, and voting features.
  - Prevented unauthorized users from adding comments to membership requests.

- **Tests**
  - Added coverage for standardized errors and membership comment authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->