### PR TITLE
fix: route integration marketplace configure links correctly (#2636)

### DIFF
--- a/client/src/pages/OrganizationSettings.jsx
+++ b/client/src/pages/OrganizationSettings.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useCallback,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
 import {
   Building2,
@@ -786,7 +786,38 @@ const ImagePreview = ({
 // Main component
 const OrganizationSettings = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { getUserData, setUserData } = useContext(AppContent);
+
+  useEffect(() => {
+    if (location.hash && !loading) {
+      const id = location.hash.replace("#", "");
+      const element = document.getElementById(id);
+      if (element) {
+        setTimeout(() => {
+          element.scrollIntoView({ behavior: "smooth", block: "start" });
+          // Highlight it temporarily
+          element.classList.add(
+            "ring-2",
+            "ring-indigo-500",
+            "ring-offset-2",
+            "dark:ring-offset-slate-900",
+            "rounded-xl",
+            "transition-all",
+            "duration-1000",
+          );
+          setTimeout(() => {
+            element.classList.remove(
+              "ring-2",
+              "ring-indigo-500",
+              "ring-offset-2",
+              "dark:ring-offset-slate-900",
+            );
+          }, 3000);
+        }, 100);
+      }
+    }
+  }, [location.hash, loading]);
 
   // Loading & state management
   const [loading, setLoading] = useState(true);
@@ -2210,7 +2241,10 @@ const OrganizationSettings = () => {
           </div>
 
           {/* SECTION 4: INTEGRATIONS */}
-          <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm">
+          <div
+            id="integrations"
+            className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-2xl p-6 shadow-sm"
+          >
             <div className="flex items-center gap-3 mb-6 pb-4 border-b border-slate-100 dark:border-slate-800">
               <div className="p-2 bg-orange-50 dark:bg-orange-900/30 rounded-xl text-orange-600 dark:text-orange-400">
                 <Blocks className="w-5 h-5" />
@@ -2226,25 +2260,35 @@ const OrganizationSettings = () => {
             </div>
 
             <div className="space-y-4">
-              <NotionConnectPanel canEdit={canEdit} />
-              <GitHubConnectPanel organizationId={metadata._id} />
-              <SlackConnectPanel
-                organizationId={metadata._id}
-                canEdit={canEdit}
-              />
-              <IssueTrackerConfig
-                provider="jira"
-                title="Jira Integration"
-                description="Automatically sync Action Items to Jira issues."
-                icon={<Blocks className="w-6 h-6 text-blue-600" />}
-              />
+              <div id="notion">
+                <NotionConnectPanel canEdit={canEdit} />
+              </div>
+              <div id="github">
+                <GitHubConnectPanel organizationId={metadata._id} />
+              </div>
+              <div id="slack">
+                <SlackConnectPanel
+                  organizationId={metadata._id}
+                  canEdit={canEdit}
+                />
+              </div>
+              <div id="jira">
+                <IssueTrackerConfig
+                  provider="jira"
+                  title="Jira Integration"
+                  description="Automatically sync Action Items to Jira issues."
+                  icon={<Blocks className="w-6 h-6 text-blue-600" />}
+                />
+              </div>
 
-              <IssueTrackerConfig
-                provider="linear"
-                title="Linear Integration"
-                description="Automatically sync Action Items to Linear issues."
-                icon={<Blocks className="w-6 h-6 text-indigo-600" />}
-              />
+              <div id="linear">
+                <IssueTrackerConfig
+                  provider="linear"
+                  title="Linear Integration"
+                  description="Automatically sync Action Items to Linear issues."
+                  icon={<Blocks className="w-6 h-6 text-indigo-600" />}
+                />
+              </div>
             </div>
           </div>
 

--- a/client/src/pages/__tests__/IntegrationMarketplaceHub.test.jsx
+++ b/client/src/pages/__tests__/IntegrationMarketplaceHub.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { IntegrationMarketplaceHub } from "../IntegrationMarketplaceHub.jsx";
+
+import apiClient from "../../services/apiClient.js";
+
+// Mocking react-router-dom
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Mock apiClient
+vi.mock("../../services/apiClient.js");
+
+describe("IntegrationMarketplaceHub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({
+      data: {
+        success: true,
+        integrations: [
+          {
+            id: "jira",
+            name: "Jira Issue Tracker",
+            category: "Project Management",
+            description: "File candidate bug tasks",
+            recommendationOrder: 4,
+            isConnected: true,
+            configurationRoute: "/organization/settings#jira",
+          },
+          {
+            id: "slack",
+            name: "Slack Notification Core",
+            category: "Communication",
+            description: "Broadcast operational real-time updates",
+            recommendationOrder: 1,
+            isConnected: false,
+            configurationRoute: "/organization/settings#slack",
+          },
+        ],
+      },
+    });
+  });
+
+  it("should navigate to the correct configuration route when Configure/Setup is clicked", async () => {
+    render(
+      <MemoryRouter>
+        <IntegrationMarketplaceHub />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Jira Issue Tracker")).toBeInTheDocument();
+    });
+
+    const configureButtons = screen.getAllByRole("button", {
+      name: /^(Configure|Setup Link)$/i,
+    });
+    expect(configureButtons.length).toBe(2);
+
+    // Jira is connected -> "Configure", Slack is not -> "Setup Link"
+    const jiraBtn = screen.getByRole("button", { name: "Configure" });
+    fireEvent.click(jiraBtn);
+    expect(mockNavigate).toHaveBeenCalledWith("/organization/settings#jira");
+
+    const slackBtn = screen.getByRole("button", { name: "Setup Link" });
+    fireEvent.click(slackBtn);
+    expect(mockNavigate).toHaveBeenCalledWith("/organization/settings#slack");
+  });
+});

--- a/server/controllers/integrationMarketplaceController.js
+++ b/server/controllers/integrationMarketplaceController.js
@@ -36,7 +36,7 @@ export const getMarketplaceStatusAggregation = async (req, res) => {
         recommendationOrder: 1,
         isConnected: !!(slack && slack.isActive),
         lastSyncedAt: slack?.lastSyncHeartbeat || null,
-        configurationRoute: "/admin/settings/organization/slack",
+        configurationRoute: "/organization/settings#slack",
       },
       {
         id: "notion",
@@ -47,7 +47,7 @@ export const getMarketplaceStatusAggregation = async (req, res) => {
         recommendationOrder: 2,
         isConnected: !!(notion && notion.accessToken),
         lastSyncedAt: notion?.lastSyncHeartbeat || null,
-        configurationRoute: "/admin/settings/organization/notion",
+        configurationRoute: "/organization/settings#notion",
       },
       {
         id: "github",
@@ -58,7 +58,7 @@ export const getMarketplaceStatusAggregation = async (req, res) => {
         recommendationOrder: 3,
         isConnected: !!(github && github.installationId),
         lastSyncedAt: github?.lastSyncHeartbeat || null,
-        configurationRoute: "/admin/settings/organization/github",
+        configurationRoute: "/organization/settings#github",
       },
       {
         id: "jira",
@@ -69,7 +69,7 @@ export const getMarketplaceStatusAggregation = async (req, res) => {
         recommendationOrder: 4,
         isConnected: !!(jira && jira.apiToken),
         lastSyncedAt: jira?.lastSyncHeartbeat || null,
-        configurationRoute: "/admin/settings/organization/jira",
+        configurationRoute: "/organization/settings#jira",
       },
       {
         id: "calendar",
@@ -80,7 +80,7 @@ export const getMarketplaceStatusAggregation = async (req, res) => {
         recommendationOrder: 5,
         isConnected: !!(calendar && calendar.isAuthorized),
         lastSyncedAt: calendar?.lastSyncHeartbeat || null,
-        configurationRoute: "/admin/settings/organization/calendar",
+        configurationRoute: "/organization/settings#calendar",
       },
     ];
 


### PR DESCRIPTION
## Description
This PR addresses Issue #2636 by pointing configuration routes to the real settings paths with a hash query, and ensuring the `IntegrationMarketplaceHub` correctly navigates to them.

### Problem
Integration marketplace setup buttons routed users to non-existent `/admin/settings/organization/slack` paths which were undefined 404 routes. Integrations actually live under `/organization/settings`.

### Changes Made
1. **API Updates (`integrationMarketplaceController.js`)**: Updated the `configurationRoute` strings in the marketplace payload to use hash routing (e.g. `/organization/settings#slack`).
2. **Frontend Settings View (`OrganizationSettings.jsx`)**: Added `id` tags (`id="slack"`, `id="jira"`, etc.) to the respective integration panels inside the "Integrations" section. Implemented a `useEffect` utilizing `useLocation().hash` to automatically scroll the relevant integration panel into view and briefly highlight it for UX context.
3. **UI Testing (`IntegrationMarketplaceHub.test.jsx`)**: Added a test suite that mocks the marketplace API response and validates that both the "Configure" and "Setup Link" buttons correctly dispatch `navigate()` routing intents to the correct configuration routes.

## Testing
- [x] Unit Tests run locally (`npx vitest run src/pages/__tests__/IntegrationMarketplaceHub.test.jsx`)
- [x] CI Pipeline validation (`npm run validate:pr --prefix client`) passes.

Closes #2636 