### PR TITLE
[Bug]: Prevent decision impact upsert races and transcript search out-of-order resolution

### DIFF
--- a/client/src/components/transcripts/TranscriptSearchPanel.jsx
+++ b/client/src/components/transcripts/TranscriptSearchPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { Search, Loader2, Calendar, User, Clock, FileText } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import api from "../../services/apiClient.js";
@@ -20,31 +20,48 @@ const TranscriptSearchPanel = () => {
     return () => clearTimeout(handler);
   }, [query]);
 
-  const fetchResults = useCallback(async () => {
-    if (!debouncedQuery.trim()) {
-      setResults([]);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const { data } = await api.get("/api/transcripts/search/global", {
-        params: { q: debouncedQuery, speaker },
-      });
-      if (data.success) {
-        setResults(data.data.results || []);
-      }
-    } catch (err) {
-      console.error(err);
-      setError("Failed to search transcripts.");
-    } finally {
-      setLoading(false);
-    }
-  }, [debouncedQuery, speaker]);
-
   useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchResults = async () => {
+      if (!debouncedQuery.trim()) {
+        setResults([]);
+        return;
+      }
+      setLoading(true);
+      setError(null);
+      try {
+        const { data } = await api.get("/api/transcripts/search/global", {
+          params: { q: debouncedQuery, speaker },
+          signal: controller.signal,
+        });
+        if (data.success) {
+          setResults(data.data.results || []);
+        }
+      } catch (err) {
+        if (
+          api.isCancel?.(err) ||
+          err.name === "CanceledError" ||
+          err.name === "AbortError" ||
+          err.code === "ERR_CANCELED"
+        ) {
+          return;
+        }
+        console.error(err);
+        setError("Failed to search transcripts.");
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
     fetchResults();
-  }, [fetchResults]);
+
+    return () => {
+      controller.abort();
+    };
+  }, [debouncedQuery, speaker]);
 
   const highlightText = (text) => {
     if (!debouncedQuery) return text;

--- a/client/src/components/transcripts/__tests__/TranscriptSearchPanel.test.jsx
+++ b/client/src/components/transcripts/__tests__/TranscriptSearchPanel.test.jsx
@@ -1,0 +1,288 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import TranscriptSearchPanel from "../TranscriptSearchPanel";
+import api from "../../../services/apiClient.js";
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+    isCancel: vi.fn(),
+  },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe("TranscriptSearchPanel", () => {
+  const mockResults = [
+    {
+      meetingId: "meet-1",
+      meetingTitle: "Project Kickoff",
+      meetingDate: "2023-10-01T10:00:00Z",
+      score: 0.95,
+      segmentIndex: 5,
+      contextSegments: [
+        {
+          speaker: "Alice",
+          startTime: 120,
+          text: "We should finalize the design mockups.",
+        },
+        {
+          speaker: "Bob",
+          startTime: 125,
+          text: "I agree, the design is crucial here.",
+        },
+      ],
+    },
+    {
+      meetingId: "meet-2",
+      meetingTitle: "Design Sync",
+      meetingDate: "2023-10-05T14:00:00Z",
+      score: 0.88,
+      segmentIndex: 12,
+      contextSegments: [
+        {
+          speaker: "Charlie",
+          startTime: 300,
+          text: "The new design looks great on mobile.",
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderComponent = () => {
+    return render(
+      <BrowserRouter>
+        <TranscriptSearchPanel />
+      </BrowserRouter>,
+    );
+  };
+
+  it("renders initial empty state properly", () => {
+    renderComponent();
+    expect(screen.getByText("Global Transcript Search")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Search exactly what was said..."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Filter by speaker..."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Enter a phrase or keyword/i)).toBeInTheDocument();
+  });
+
+  it("fetches and displays search results after typing with debounce", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: mockResults } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "design" } });
+
+    // We expect the searching text to appear while debounce + api call resolves
+    // waitFor handles waiting for the timeout naturally
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith(
+        "/api/transcripts/search/global",
+        expect.objectContaining({
+          params: { q: "design", speaker: "" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Project Kickoff")).toBeInTheDocument();
+      expect(screen.getByText("Design Sync")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("Charlie")).toBeInTheDocument();
+    expect(screen.getByText("2:00")).toBeInTheDocument();
+    expect(screen.getByText("5:00")).toBeInTheDocument();
+  });
+
+  it("handles filtering by speaker", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: [mockResults[1]] } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    const speakerInput = screen.getByPlaceholderText("Filter by speaker...");
+
+    fireEvent.change(searchInput, { target: { value: "design" } });
+    fireEvent.change(speakerInput, { target: { value: "Charlie" } });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith(
+        "/api/transcripts/search/global",
+        expect.objectContaining({
+          params: { q: "design", speaker: "Charlie" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Design Sync")).toBeInTheDocument();
+      expect(screen.queryByText("Project Kickoff")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no results match the query", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: [] } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "nonexistentquery" } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No utterances found matching/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/"nonexistentquery"/i)).toBeInTheDocument();
+    });
+  });
+
+  it("handles API errors gracefully", async () => {
+    const error = new Error("Network Error");
+    api.get.mockRejectedValueOnce(error);
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "error query" } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to search transcripts."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("aborts previous requests when a new request is made", async () => {
+    api.get.mockResolvedValue({
+      data: { success: true, data: { results: [mockResults[0]] } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "first" } });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(1);
+    });
+
+    const abortSignal1 = api.get.mock.calls[0][1].signal;
+    expect(abortSignal1.aborted).toBe(false);
+
+    fireEvent.change(searchInput, { target: { value: "second" } });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+
+    expect(abortSignal1.aborted).toBe(true);
+  });
+
+  it("navigates to the correct meeting and segment when clicking a result", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: mockResults } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "design" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Project Kickoff")).toBeInTheDocument();
+    });
+
+    const resultElement = screen.getByText("Project Kickoff").closest(".group");
+    fireEvent.click(resultElement);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/transcript/meet-1?highlight=design&segment=5",
+    );
+  });
+
+  it("highlights the matched text properly", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: mockResults } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+    fireEvent.change(searchInput, { target: { value: "design" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Project Kickoff")).toBeInTheDocument();
+    });
+
+    const marks = document.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks[0].textContent.toLowerCase()).toBe("design");
+    expect(marks[0].className).toContain("bg-yellow-300");
+  });
+
+  it("clears results when query becomes empty", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { success: true, data: { results: mockResults } },
+    });
+
+    renderComponent();
+
+    const searchInput = screen.getByPlaceholderText(
+      "Search exactly what was said...",
+    );
+
+    fireEvent.change(searchInput, { target: { value: "design" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Project Kickoff")).toBeInTheDocument();
+    });
+
+    fireEvent.change(searchInput, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Project Kickoff")).not.toBeInTheDocument();
+      expect(
+        screen.getByText(/Enter a phrase or keyword/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/hooks/useDecisionImpact.js
+++ b/client/src/hooks/useDecisionImpact.js
@@ -6,26 +6,44 @@ export const useDecisionImpact = (decisionId) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const fetchImpact = useCallback(async () => {
-    if (!decisionId) return;
+  const fetchImpact = useCallback(
+    async (options = {}) => {
+      if (!decisionId) return;
 
-    setLoading(true);
-    setError(null);
-    try {
-      const response = await api.get(`/api/decisions/${decisionId}/impact`);
-      setImpactData(response.data);
-    } catch (err) {
-      if (err.response?.status !== 404) {
-        setError(err.response?.data?.message || err.message);
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.get(
+          `/api/decisions/${decisionId}/impact`,
+          options,
+        );
+        setImpactData(response.data);
+      } catch (err) {
+        if (
+          api.isCancel?.(err) ||
+          err.name === "CanceledError" ||
+          err.name === "AbortError" ||
+          err.code === "ERR_CANCELED"
+        ) {
+          return;
+        }
+        if (err.response?.status !== 404) {
+          setError(err.response?.data?.message || err.message);
+        }
+        setImpactData(null);
+      } finally {
+        if (!options.signal?.aborted) {
+          setLoading(false);
+        }
       }
-      setImpactData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [decisionId]);
+    },
+    [decisionId],
+  );
 
   useEffect(() => {
-    fetchImpact();
+    const controller = new AbortController();
+    fetchImpact({ signal: controller.signal });
+    return () => controller.abort();
   }, [fetchImpact]);
 
   const updateImpact = async (updates) => {

--- a/server/controllers/decisionImpactController.js
+++ b/server/controllers/decisionImpactController.js
@@ -27,26 +27,43 @@ export const updateDecisionImpact = async (req, res, next) => {
       return res.status(404).json({ message: "Decision not found" });
     }
 
-    let impact = await DecisionImpact.findOne({ decisionId });
-    if (impact) {
-      // Update existing
-      if (outcomeStatus) impact.outcomeStatus = outcomeStatus;
-      if (impactScore !== undefined) impact.impactScore = impactScore;
-      if (evidence) impact.evidence = evidence; // expects array of strings
-      if (nextReviewDate !== undefined) impact.nextReviewDate = nextReviewDate;
-      await impact.save();
+    const updateData = {};
+    const setOnInsert = {
+      owner: req.user?.id || req.user?._id || "system",
+    };
+
+    if (outcomeStatus) {
+      updateData.outcomeStatus = outcomeStatus;
     } else {
-      // Create new
-      impact = new DecisionImpact({
-        decisionId,
-        owner: req.user?.id || req.user?._id || "system", // adjust based on auth
-        outcomeStatus: outcomeStatus || "pending",
-        impactScore: impactScore || null,
-        evidence: evidence || [],
-        nextReviewDate: nextReviewDate || null,
-      });
-      await impact.save();
+      setOnInsert.outcomeStatus = "pending";
     }
+
+    if (impactScore !== undefined) {
+      updateData.impactScore = impactScore;
+    } else {
+      setOnInsert.impactScore = null;
+    }
+
+    if (evidence) {
+      updateData.evidence = evidence;
+    } else {
+      setOnInsert.evidence = [];
+    }
+
+    if (nextReviewDate !== undefined) {
+      updateData.nextReviewDate = nextReviewDate;
+    } else {
+      setOnInsert.nextReviewDate = null;
+    }
+
+    const impact = await DecisionImpact.findOneAndUpdate(
+      { decisionId },
+      {
+        $set: updateData,
+        $setOnInsert: setOnInsert,
+      },
+      { upsert: true, new: true },
+    );
 
     res.json(impact);
   } catch (error) {

--- a/server/services/audioAnalyticsService.js
+++ b/server/services/audioAnalyticsService.js
@@ -3,6 +3,7 @@ import Meeting from "../models/meetingModel.js";
 import User from "../models/userModel.js";
 import Transcript from "../models/transcriptModel.js";
 import { groupByPeriod } from "../utils/periodBucket.js";
+import mongoose from "mongoose";
 
 /**
  * Audio Analytics Service
@@ -281,10 +282,13 @@ export const analyzeMeeting = async (meetingId) => {
       // Find or create speaker analytics
       const speakerId = segment.speaker.toString();
       if (!speakerMap.has(speakerId)) {
-        const user = await User.findById(speakerId);
+        let user = null;
+        if (mongoose.isValidObjectId(speakerId)) {
+          user = await User.findById(speakerId);
+        }
         speakerMap.set(speakerId, {
           userId: speakerId,
-          name: user?.name || segment.speakerName || "Unknown",
+          name: user?.name || segment.speakerName || "Guest",
           email: user?.email || "",
           totalTime: 0,
           interventionCount: 0,

--- a/server/tests/decisionImpactController.test.js
+++ b/server/tests/decisionImpactController.test.js
@@ -1,0 +1,220 @@
+import { jest } from "@jest/globals";
+import {
+  getDecisionImpact,
+  updateDecisionImpact,
+  getImpactReport,
+} from "../controllers/decisionImpactController.js";
+import DecisionImpact from "../models/decisionImpactModel.js";
+import Decision from "../models/decisionModel.js";
+
+describe("Decision Impact Controller", () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {
+      params: {},
+      body: {},
+      user: { id: "user-123", _id: "user-123" },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  describe("getDecisionImpact", () => {
+    it("should return 404 if impact record is not found", async () => {
+      req.params.decisionId = "dec-1";
+      DecisionImpact.findOne = jest.fn().mockResolvedValue(null);
+
+      await getDecisionImpact(req, res, next);
+
+      expect(DecisionImpact.findOne).toHaveBeenCalledWith({
+        decisionId: "dec-1",
+      });
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Impact record not found",
+      });
+    });
+
+    it("should return the impact record if found", async () => {
+      req.params.decisionId = "dec-1";
+      const mockImpact = {
+        _id: "impact-1",
+        decisionId: "dec-1",
+        impactScore: 85,
+      };
+      DecisionImpact.findOne = jest.fn().mockResolvedValue(mockImpact);
+
+      await getDecisionImpact(req, res, next);
+
+      expect(res.status).not.toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(mockImpact);
+    });
+
+    it("should pass errors to next()", async () => {
+      req.params.decisionId = "dec-1";
+      const error = new Error("Database Error");
+      DecisionImpact.findOne = jest.fn().mockRejectedValue(error);
+
+      await getDecisionImpact(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe("updateDecisionImpact", () => {
+    it("should return 404 if the associated Decision is not found", async () => {
+      req.params.decisionId = "dec-1";
+      Decision.findById = jest.fn().mockResolvedValue(null);
+
+      await updateDecisionImpact(req, res, next);
+
+      expect(Decision.findById).toHaveBeenCalledWith("dec-1");
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Decision not found" });
+    });
+
+    it("should upsert the impact record with all provided fields", async () => {
+      req.params.decisionId = "dec-1";
+      req.body = {
+        outcomeStatus: "successful",
+        impactScore: 90,
+        evidence: ["increased revenue"],
+        nextReviewDate: "2023-12-01",
+      };
+
+      Decision.findById = jest.fn().mockResolvedValue({ _id: "dec-1" });
+
+      const mockUpdated = { _id: "impact-1", ...req.body };
+      DecisionImpact.findOneAndUpdate = jest
+        .fn()
+        .mockResolvedValue(mockUpdated);
+
+      await updateDecisionImpact(req, res, next);
+
+      expect(DecisionImpact.findOneAndUpdate).toHaveBeenCalledWith(
+        { decisionId: "dec-1" },
+        {
+          $set: {
+            outcomeStatus: "successful",
+            impactScore: 90,
+            evidence: ["increased revenue"],
+            nextReviewDate: "2023-12-01",
+          },
+          $setOnInsert: {
+            owner: "user-123",
+          },
+        },
+        { upsert: true, new: true },
+      );
+      expect(res.json).toHaveBeenCalledWith(mockUpdated);
+    });
+
+    it("should set default values via $setOnInsert for missing fields", async () => {
+      req.params.decisionId = "dec-1";
+      req.body = {}; // No fields provided
+
+      Decision.findById = jest.fn().mockResolvedValue({ _id: "dec-1" });
+      DecisionImpact.findOneAndUpdate = jest
+        .fn()
+        .mockResolvedValue({ _id: "impact-1" });
+
+      await updateDecisionImpact(req, res, next);
+
+      expect(DecisionImpact.findOneAndUpdate).toHaveBeenCalledWith(
+        { decisionId: "dec-1" },
+        {
+          $set: {},
+          $setOnInsert: {
+            owner: "user-123",
+            outcomeStatus: "pending",
+            impactScore: null,
+            evidence: [],
+            nextReviewDate: null,
+          },
+        },
+        { upsert: true, new: true },
+      );
+    });
+
+    it('should handle missing req.user by setting owner to "system"', async () => {
+      req.user = undefined; // No user
+      req.params.decisionId = "dec-1";
+      req.body = {};
+
+      Decision.findById = jest.fn().mockResolvedValue({ _id: "dec-1" });
+      DecisionImpact.findOneAndUpdate = jest
+        .fn()
+        .mockResolvedValue({ _id: "impact-1" });
+
+      await updateDecisionImpact(req, res, next);
+
+      expect(DecisionImpact.findOneAndUpdate).toHaveBeenCalledWith(
+        { decisionId: "dec-1" },
+        expect.objectContaining({
+          $setOnInsert: expect.objectContaining({
+            owner: "system",
+          }),
+        }),
+        { upsert: true, new: true },
+      );
+    });
+
+    it("should pass errors to next() during update", async () => {
+      req.params.decisionId = "dec-1";
+      Decision.findById = jest.fn().mockResolvedValue({ _id: "dec-1" });
+      const error = new Error("Database connection failed");
+      DecisionImpact.findOneAndUpdate = jest.fn().mockRejectedValue(error);
+
+      await updateDecisionImpact(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe("getImpactReport", () => {
+    it("should aggregate and return success rates and average impact scores", async () => {
+      const mockStats = [
+        { _id: "successful", count: 5, avgImpactScore: 85 },
+        { _id: "pending", count: 2, avgImpactScore: null },
+      ];
+
+      DecisionImpact.aggregate = jest.fn().mockResolvedValue(mockStats);
+
+      await getImpactReport(req, res, next);
+
+      expect(DecisionImpact.aggregate).toHaveBeenCalledWith([
+        {
+          $group: {
+            _id: "$outcomeStatus",
+            count: { $sum: 1 },
+            avgImpactScore: { $avg: "$impactScore" },
+          },
+        },
+      ]);
+
+      expect(res.json).toHaveBeenCalledWith(mockStats);
+    });
+
+    it("should handle empty aggregation results", async () => {
+      DecisionImpact.aggregate = jest.fn().mockResolvedValue([]);
+
+      await getImpactReport(req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it("should pass errors to next() during aggregation", async () => {
+      const error = new Error("Aggregation failed");
+      DecisionImpact.aggregate = jest.fn().mockRejectedValue(error);
+
+      await getImpactReport(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+});


### PR DESCRIPTION
- closes #2705

### Description
This pull request introduces optimizations to database operations and enhances the resilience of the audio analytics pipeline. Additionally, it improves the responsiveness of frontend components by implementing intelligent network request cancellation.

### Changes Made
- Refactored `updateDecisionImpact` in `decisionImpactController.js` to utilize atomic `findOneAndUpdate` with `upsert` options, streamlining database writes and improving concurrency handling.
- Enhanced the `analyzeMeeting` pipeline in `audioAnalyticsService.js` to gracefully validate `speakerId` formats via `mongoose.isValidObjectId`, employing a "Guest" fallback strategy for non-standard labels.
- Integrated `AbortController` into `TranscriptSearchPanel.jsx` to efficiently cancel superseded network requests during rapid user input, ensuring the UI consistently reflects the latest search state.
- Implemented `AbortController` within the `useDecisionImpact.js` hook to better manage component lifecycles and prevent state contamination during rapid navigation.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript search responsiveness by canceling outdated requests when search criteria change.
  * Prevented stale decision impact results and errors from appearing after requests are canceled.
  * Improved handling of invalid speaker identifiers with clearer guest labeling.
  * Made decision impact updates more reliable and consistent when records are created or updated.
  * Improved transcript search behavior for empty searches, no results, highlighting, navigation, and API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->