### PR TITLE
[Bug]: Eliminate notification pipeline N+1 query timeouts and polling bottlenecks

### DIFF
--- a/client/src/pages/MeetingAnalytics.jsx
+++ b/client/src/pages/MeetingAnalytics.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { usePolling } from "../hooks/usePolling.js";
 import apiClient from "../services/apiClient.js";
@@ -48,6 +48,8 @@ const MeetingAnalytics = () => {
   const [goalStats, setGoalStats] = useState([]);
   const [activeTab, setActiveTab] = useState("overview");
 
+  const pollAbortController = useRef(null);
+
   // Owns the completion poll below, including its teardown on unmount (#1455).
   const { startPolling } = usePolling();
 
@@ -96,49 +98,62 @@ const MeetingAnalytics = () => {
     }
   }, [analytics]);
 
+  const startPoll = useCallback(() => {
+    if (pollAbortController.current) {
+      pollAbortController.current.abort();
+    }
+    pollAbortController.current = new AbortController();
+    const signal = pollAbortController.current.signal;
+
+    startPolling(
+      async () => {
+        try {
+          const { data } = await apiClient.get(
+            `/api/analytics/meetings/${meetingId}`,
+            { signal },
+          );
+
+          if (data.status === "completed") {
+            setAnalytics(data);
+            setAnalyzing(false);
+            toast.success("Analysis completed!");
+            return true;
+          }
+
+          if (data.status === "failed") {
+            setAnalyzing(false);
+            toast.error("Analysis failed");
+            return true;
+          }
+
+          return false;
+        } catch {
+          return false;
+        }
+      },
+      {
+        intervalMs: 5000,
+        timeoutMs: 120000,
+        onTimeout: () => setAnalyzing(false),
+        onError: (err) => console.error("Error polling:", err),
+      },
+    );
+  }, [meetingId, startPolling]);
+
+  useEffect(() => {
+    if (analytics?.status === "analyzing" && !analyzing) {
+      setAnalyzing(true);
+      startPoll();
+    }
+  }, [analytics, analyzing, startPoll]);
+
   const triggerAnalysis = async () => {
     try {
       setAnalyzing(true);
       await apiClient.post(`/api/analytics/analyze/${meetingId}`);
 
       toast.info("Analysis started. This may take up to 60 seconds.");
-
-      // Poll for completion. The interval and its 2-minute deadline used to be
-      // plain `const`s inside this handler, so nothing on the unmount path
-      // could clear them and navigating away left the poll running (#1455).
-      startPolling(
-        async ({ signal }) => {
-          try {
-            const { data } = await apiClient.get(
-              `/api/analytics/meetings/${meetingId}`,
-              { signal },
-            );
-
-            if (data.status === "completed") {
-              setAnalytics(data);
-              setAnalyzing(false);
-              toast.success("Analysis completed!");
-              return true;
-            }
-
-            if (data.status === "failed") {
-              setAnalyzing(false);
-              toast.error("Analysis failed");
-              return true;
-            }
-
-            return false;
-          } catch {
-            return false;
-          }
-        },
-        {
-          intervalMs: 5000,
-          timeoutMs: 120000,
-          onTimeout: () => setAnalyzing(false),
-          onError: (err) => console.error("Error polling:", err),
-        },
-      );
+      startPoll();
     } catch (err) {
       console.error("Error triggering analysis:", err);
       toast.error("Failed to start analysis");

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -88,10 +88,25 @@ export const createNotifications = async (recipients, payload) => {
 
   const createdLogs = [];
   try {
+    const users = await User.find({ _id: { $in: uniqueIds } });
+    const prefs = await NotificationPreference.find({
+      user: { $in: uniqueIds },
+    });
+
+    const userMap = users.reduce((acc, user) => {
+      acc[user._id.toString()] = user;
+      return acc;
+    }, {});
+
+    const prefMap = prefs.reduce((acc, pref) => {
+      acc[pref.user.toString()] = pref;
+      return acc;
+    }, {});
+
     for (const userId of uniqueIds) {
-      const prefs = await NotificationPreference.findOne({ user: userId });
+      const userPrefs = prefMap[userId];
       const routingCat = getRoutingCategory(category, title, description);
-      const routing = prefs?.routingPreferences?.[routingCat] || {
+      const routing = userPrefs?.routingPreferences?.[routingCat] || {
         slack: true,
         email: true,
         inApp: true,
@@ -107,11 +122,11 @@ export const createNotifications = async (recipients, payload) => {
 
       const threshold = forceImmediate
         ? 0
-        : (prefs?.batchThresholdMinutes ?? 5);
+        : (userPrefs?.batchThresholdMinutes ?? 5);
 
       if (threshold === 0) {
         // Dispatch immediately
-        const user = await User.findById(userId);
+        const user = userMap[userId];
         if (routing.inApp) {
           const log = await notificationModel.create({
             user: userId,
@@ -185,76 +200,108 @@ export const processNotificationQueue = async () => {
       groups[key].push(item);
     }
 
+    const processedIds = [];
+    const failedIds = [];
+
     for (const key in groups) {
       const items = groups[key];
       const firstItem = items[0];
       const userId = firstItem.userId;
       const category = firstItem.category;
+      const itemIds = items.map((it) => it._id);
 
-      const user = await User.findById(userId);
-      if (!user) continue;
+      try {
+        const user = await User.findById(userId);
+        if (!user) {
+          failedIds.push(...itemIds);
+          continue;
+        }
 
-      const prefs = await NotificationPreference.findOne({ user: userId });
-      const routingCat = getRoutingCategory(
-        category,
-        firstItem.title,
-        firstItem.description,
-      );
-      const routing = prefs?.routingPreferences?.[routingCat] || {
-        slack: true,
-        email: true,
-        inApp: true,
-      };
-
-      let finalTitle = firstItem.title;
-      let finalDescription = firstItem.description;
-      let finalActionUrl = firstItem.actionUrl;
-
-      if (items.length > 1) {
-        finalTitle = `[Digest] You have ${items.length} new updates in ${
-          routingCat === "slaAlerts"
-            ? "SLAs"
-            : routingCat === "comments"
-              ? "Comments"
-              : "Recaps"
-        }`;
-        finalDescription = items
-          .map((it, idx) => `${idx + 1}. ${it.title}: ${it.description}`)
-          .join("\n");
-      }
-
-      if (routing.inApp) {
-        await notificationModel.create({
-          user: userId,
-          title: finalTitle,
-          description: finalDescription,
+        const prefs = await NotificationPreference.findOne({ user: userId });
+        const routingCat = getRoutingCategory(
           category,
-          actionUrl: finalActionUrl,
-          actionLabel: firstItem.actionLabel,
-          metadata: firstItem.metadata,
+          firstItem.title,
+          firstItem.description,
+        );
+        const routing = prefs?.routingPreferences?.[routingCat] || {
+          slack: true,
+          email: true,
+          inApp: true,
+        };
+
+        let finalTitle = firstItem.title;
+        let finalDescription = firstItem.description;
+        let finalActionUrl = firstItem.actionUrl;
+
+        if (items.length > 1) {
+          finalTitle = `[Digest] You have ${items.length} new updates in ${
+            routingCat === "slaAlerts"
+              ? "SLAs"
+              : routingCat === "comments"
+                ? "Comments"
+                : "Recaps"
+          }`;
+          finalDescription = items
+            .map((it, idx) => `${idx + 1}. ${it.title}: ${it.description}`)
+            .join("\n");
+        }
+
+        if (routing.inApp) {
+          await notificationModel.create({
+            user: userId,
+            title: finalTitle,
+            description: finalDescription,
+            category,
+            actionUrl: finalActionUrl,
+            actionLabel: firstItem.actionLabel,
+            metadata: firstItem.metadata,
+          });
+        }
+
+        if (routing.email && user.email) {
+          await EmailService.sendNotificationEmail(
+            user.email,
+            finalTitle,
+            finalDescription,
+          );
+        }
+
+        if (routing.slack && user.organization) {
+          await sendSlackNotification(
+            user.organization,
+            `*${finalTitle}*\n${finalDescription}`,
+          );
+        }
+
+        processedIds.push(...itemIds);
+      } catch (err) {
+        console.error(
+          `❌ Failed to dispatch notifications for user ${userId}:`,
+          err,
+        );
+        failedIds.push(...itemIds);
+      }
+    }
+
+    if (processedIds.length > 0 || failedIds.length > 0) {
+      const bulkOps = [];
+      if (processedIds.length > 0) {
+        bulkOps.push({
+          updateMany: {
+            filter: { _id: { $in: processedIds } },
+            update: { $set: { status: "processed" } },
+          },
         });
       }
-
-      if (routing.email && user.email) {
-        await EmailService.sendNotificationEmail(
-          user.email,
-          finalTitle,
-          finalDescription,
-        );
+      if (failedIds.length > 0) {
+        bulkOps.push({
+          updateMany: {
+            filter: { _id: { $in: failedIds } },
+            update: { $set: { status: "failed" } },
+          },
+        });
       }
-
-      if (routing.slack && user.organization) {
-        await sendSlackNotification(
-          user.organization,
-          `*${finalTitle}*\n${finalDescription}`,
-        );
-      }
-
-      const ids = items.map((it) => it._id);
-      await QueuedNotification.updateMany(
-        { _id: { $in: ids } },
-        { $set: { status: "processed" } },
-      );
+      await QueuedNotification.bulkWrite(bulkOps);
     }
   } catch (error) {
     console.error("❌ Error in processNotificationQueue:", error);


### PR DESCRIPTION
- closes #2704

### Description
This PR enhances the performance and resilience of the background notification service and optimizes frontend polling behaviors. The core enhancements focus on reducing database load by implementing batch operations during notification dispatch and improving state management for polling in the meeting analytics component to prevent overlapping network requests.

### Changes Made
- **Notification Service Restructuring**: 
  - Updated `createNotifications` to pre-fetch `User` and `NotificationPreference` records using a bulk `$in` query, mapping them in memory to eliminate N+1 queries during large dispatch events.
  - Implemented a `try/catch` block for individual message dispatches inside `processNotificationQueue` so that the batch processor can continue seamlessly even if one recipient encounters an error.
  - Aggregated status updates in `processNotificationQueue` to utilize a single `QueuedNotification.bulkWrite` command.
- **Meeting Analytics Optimization**: 
  - Introduced an `AbortController` managed via `useRef` to explicitly abort any existing polling cycles before initiating a new analysis run.
  - Added an automatic lifecycle check to resume polling automatically if the component mounts while the meeting is in an `"analyzing"` state.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have verified that these changes operate as intended in a local environment
