### PR TITLE
fix(security): add fileFilter and extension validation to session slides and video upload multer config

### DIFF
--- a/server/routes/sessionRoutes.js
+++ b/server/routes/sessionRoutes.js
@@ -33,8 +33,93 @@ const storage = multer.diskStorage({
   },
 });
 
+export const ALLOWED_SLIDE_MIME_TYPES = [
+  "application/pdf",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.apple.keynote",
+  "application/x-iwork-keynote-sffkey",
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+];
+
+export const ALLOWED_SLIDE_EXTENSIONS = [
+  ".pdf",
+  ".ppt",
+  ".pptx",
+  ".key",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+];
+
+export const ALLOWED_VIDEO_MIME_TYPES = [
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+  "video/x-matroska",
+  "video/x-msvideo",
+  "video/mp4v-es",
+];
+
+export const ALLOWED_VIDEO_EXTENSIONS = [
+  ".mp4",
+  ".webm",
+  ".mov",
+  ".mkv",
+  ".avi",
+  ".m4v",
+];
+
+export const sessionFileFilter = (req, file, cb) => {
+  const ext = path.extname(file.originalname || "").toLowerCase();
+  const mimetype = (file.mimetype || "").toLowerCase();
+
+  if (file.fieldname === "slides") {
+    const isMimeValid = ALLOWED_SLIDE_MIME_TYPES.includes(mimetype);
+    const isExtValid = ALLOWED_SLIDE_EXTENSIONS.includes(ext);
+
+    if (!isMimeValid || !isExtValid) {
+      return cb(
+        new Error(
+          `Invalid slide file format (${file.originalname}). Allowed extensions: ${ALLOWED_SLIDE_EXTENSIONS.join(
+            ", ",
+          )}`,
+        ),
+        false,
+      );
+    }
+    return cb(null, true);
+  }
+
+  if (file.fieldname === "video") {
+    const isMimeValid =
+      ALLOWED_VIDEO_MIME_TYPES.includes(mimetype) ||
+      mimetype.startsWith("video/");
+    const isExtValid = ALLOWED_VIDEO_EXTENSIONS.includes(ext);
+
+    if (!isMimeValid || !isExtValid) {
+      return cb(
+        new Error(
+          `Invalid video file format (${file.originalname}). Allowed extensions: ${ALLOWED_VIDEO_EXTENSIONS.join(
+            ", ",
+          )}`,
+        ),
+        false,
+      );
+    }
+    return cb(null, true);
+  }
+
+  return cb(new Error(`Unexpected field for upload: ${file.fieldname}`), false);
+};
+
 const upload = multer({
   storage: storage,
+  fileFilter: sessionFileFilter,
   limits: { fileSize: 100 * 1024 * 1024 }, // 100MB limit
 });
 

--- a/server/tests/sessionUploadFileFilter.test.js
+++ b/server/tests/sessionUploadFileFilter.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, jest } from "@jest/globals";
+
+jest.unstable_mockModule("../controllers/sessionController.js", () => ({
+  generateSession: jest.fn(),
+  getSessions: jest.fn(),
+  getSessionById: jest.fn(),
+  createSession: jest.fn(),
+  updateSession: jest.fn(),
+  deleteSession: jest.fn(),
+}));
+
+const {
+  sessionFileFilter,
+  ALLOWED_SLIDE_EXTENSIONS,
+  ALLOWED_SLIDE_MIME_TYPES,
+  ALLOWED_VIDEO_EXTENSIONS,
+  ALLOWED_VIDEO_MIME_TYPES,
+} = await import("../routes/sessionRoutes.js");
+
+describe("Session Upload Multer sessionFileFilter (#2737)", () => {
+  it("exports allowed extensions and mime types for slides and video", () => {
+    expect(ALLOWED_SLIDE_EXTENSIONS).toContain(".pdf");
+    expect(ALLOWED_SLIDE_EXTENSIONS).toContain(".pptx");
+    expect(ALLOWED_SLIDE_MIME_TYPES).toContain("application/pdf");
+    expect(ALLOWED_VIDEO_EXTENSIONS).toContain(".mp4");
+    expect(ALLOWED_VIDEO_EXTENSIONS).toContain(".webm");
+    expect(ALLOWED_VIDEO_MIME_TYPES).toContain("video/mp4");
+  });
+
+  describe("Slides Field Validation", () => {
+    it("accepts valid presentation and image slide formats", () => {
+      const validSlides = [
+        {
+          fieldname: "slides",
+          originalname: "deck.pdf",
+          mimetype: "application/pdf",
+        },
+        {
+          fieldname: "slides",
+          originalname: "pitch.pptx",
+          mimetype:
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        },
+        {
+          fieldname: "slides",
+          originalname: "legacy.ppt",
+          mimetype: "application/vnd.ms-powerpoint",
+        },
+        {
+          fieldname: "slides",
+          originalname: "slide1.png",
+          mimetype: "image/png",
+        },
+        {
+          fieldname: "slides",
+          originalname: "slide2.jpg",
+          mimetype: "image/jpeg",
+        },
+        {
+          fieldname: "slides",
+          originalname: "slide3.webp",
+          mimetype: "image/webp",
+        },
+      ];
+
+      validSlides.forEach((file) => {
+        const cb = jest.fn();
+        sessionFileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(null, true);
+      });
+    });
+
+    it("rejects malicious or invalid extensions in slides field", () => {
+      const invalidSlides = [
+        {
+          fieldname: "slides",
+          originalname: "malware.exe",
+          mimetype: "application/x-msdownload",
+        },
+        {
+          fieldname: "slides",
+          originalname: "exploit.sh",
+          mimetype: "text/x-shellscript",
+        },
+        {
+          fieldname: "slides",
+          originalname: "hack.php",
+          mimetype: "application/x-php",
+        },
+        {
+          fieldname: "slides",
+          originalname: "payload.js",
+          mimetype: "application/javascript",
+        },
+      ];
+
+      invalidSlides.forEach((file) => {
+        const cb = jest.fn();
+        sessionFileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining("Invalid slide file format"),
+          }),
+          false,
+        );
+      });
+    });
+  });
+
+  describe("Video Field Validation", () => {
+    it("accepts valid video formats", () => {
+      const validVideos = [
+        {
+          fieldname: "video",
+          originalname: "session.mp4",
+          mimetype: "video/mp4",
+        },
+        {
+          fieldname: "video",
+          originalname: "recording.webm",
+          mimetype: "video/webm",
+        },
+        {
+          fieldname: "video",
+          originalname: "presentation.mov",
+          mimetype: "video/quicktime",
+        },
+        {
+          fieldname: "video",
+          originalname: "archive.mkv",
+          mimetype: "video/x-matroska",
+        },
+      ];
+
+      validVideos.forEach((file) => {
+        const cb = jest.fn();
+        sessionFileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(null, true);
+      });
+    });
+
+    it("rejects non-video or malicious payloads in video field", () => {
+      const invalidVideos = [
+        {
+          fieldname: "video",
+          originalname: "video_trojan.exe",
+          mimetype: "application/octet-stream",
+        },
+        {
+          fieldname: "video",
+          originalname: "script.sh",
+          mimetype: "text/x-sh",
+        },
+        {
+          fieldname: "video",
+          originalname: "notes.txt",
+          mimetype: "text/plain",
+        },
+      ];
+
+      invalidVideos.forEach((file) => {
+        const cb = jest.fn();
+        sessionFileFilter({}, file, cb);
+        expect(cb).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining("Invalid video file format"),
+          }),
+          false,
+        );
+      });
+    });
+  });
+
+  describe("Unexpected Field Validation", () => {
+    it("rejects uploads under unexpected field names", () => {
+      const cb = jest.fn();
+      sessionFileFilter(
+        {},
+        {
+          fieldname: "avatar",
+          originalname: "avatar.png",
+          mimetype: "image/png",
+        },
+        cb,
+      );
+      expect(cb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Unexpected field for upload"),
+        }),
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
Resolves #2737

This PR adds strict file type and extension validation to the session slides and video upload endpoint multer configuration in `server/routes/sessionRoutes.js`.

### Summary of Changes
1. **Upload Security & MIME Validation (`server/routes/sessionRoutes.js`)**:
   - Defined allowlists for slides (`ALLOWED_SLIDE_MIME_TYPES` and `ALLOWED_SLIDE_EXTENSIONS` including PDF, PPTX, PPT, KEY, PNG, JPG, JPEG, WEBP) and videos (`ALLOWED_VIDEO_MIME_TYPES` and `ALLOWED_VIDEO_EXTENSIONS` including MP4, WEBM, MOV, MKV, AVI, M4V).
   - Implemented `sessionFileFilter` inspecting both field names, MIME types, and file extensions.
   - Attached `sessionFileFilter` to the Multer upload instance.
   - Rejected unexpected fields and unauthorized/malicious file types with explicit descriptive error messages.
2. **Automated Testing (`server/tests/sessionUploadFileFilter.test.js`)**:
   - Added comprehensive unit test suite covering:
     - Slide allowlist acceptance (PDF, PPTX, PPT, images).
     - Slide payload rejection (malicious .exe, .sh, .php, .js).
     - Video allowlist acceptance (MP4, WEBM, MOV, MKV).
     - Video payload rejection (.exe, .sh, .txt).
     - Unexpected field rejection.

Fixes #2737