### PR TITLE
fix(series-diff): fix broken meeting link route and SPA navigation in SeriesEvolutionTimeline

### DIFF
--- a/client/src/components/meetings/SeriesEvolutionTimeline.jsx
+++ b/client/src/components/meetings/SeriesEvolutionTimeline.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { apiClient as api } from "../../services"; // assuming standard api utility
+import { Link } from "react-router-dom";
+import apiClient from "../../services/apiClient.js";
 import {
   LineChart,
   Line,
@@ -22,7 +23,9 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
   useEffect(() => {
     const fetchTimeline = async () => {
       try {
-        const response = await api.get(`/api/series-diff/${seriesId}/timeline`);
+        const response = await apiClient.get(
+          `/api/series-diff/${seriesId}/timeline`,
+        );
         setTimelineData(response.data);
       } catch (err) {
         console.error("Failed to fetch timeline:", err);
@@ -44,7 +47,7 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
     setLoadingDiff(true);
     setSelectedDiffIndex(index);
     try {
-      const response = await api.get(
+      const response = await apiClient.get(
         `/api/series-diff/compare?m1Id=${prevMeetingId}&m2Id=${currMeetingId}`,
       );
       setPairwiseDiff(response.data);
@@ -74,7 +77,20 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
       </div>
     );
 
-  const { timeline, trendMetrics } = timelineData;
+  const timeline = Array.isArray(timelineData?.timeline)
+    ? timelineData.timeline
+    : [];
+  const trendMetrics = timelineData?.trendMetrics || {
+    actionItemCompletionRate: 0,
+    decisionVelocity: 0,
+  };
+  const actionItemCompletionRate = (
+    (trendMetrics.actionItemCompletionRate ?? 0) * 100
+  ).toFixed(1);
+  const decisionVelocity = Number(trendMetrics.decisionVelocity ?? 0).toFixed(
+    1,
+  );
+
   const chartData = timeline.map((m) => ({
     name: `Occ #${m.occurrence}`,
     added: m.diffSummary?.added || 0,
@@ -95,7 +111,7 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
               Action Item Completion Rate
             </p>
             <p className="text-3xl font-bold text-blue-600">
-              {(trendMetrics.actionItemCompletionRate * 100).toFixed(1)}%
+              {actionItemCompletionRate}%
             </p>
           </div>
           <div className="p-4 bg-purple-50 rounded-lg border border-purple-100">
@@ -103,7 +119,7 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
               Avg Decisions per Meeting
             </p>
             <p className="text-3xl font-bold text-purple-600">
-              {trendMetrics.decisionVelocity.toFixed(1)}
+              {decisionVelocity}
             </p>
           </div>
         </div>
@@ -212,12 +228,13 @@ const SeriesEvolutionTimeline = ({ seriesId }) => {
                       </span>
                     </div>
                   </div>
-                  <a
-                    href={`/meetings/${meeting.meetingId}`}
+                  <Link
+                    to={`/meeting/${meeting.meetingId}`}
                     className="text-sm text-blue-600 hover:underline"
+                    data-testid={`view-meeting-${meeting.meetingId}`}
                   >
                     View Meeting
-                  </a>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/client/src/components/meetings/__tests__/SeriesEvolutionTimeline.test.jsx
+++ b/client/src/components/meetings/__tests__/SeriesEvolutionTimeline.test.jsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import SeriesEvolutionTimeline from "../SeriesEvolutionTimeline.jsx";
+import apiClient from "../../../services/apiClient.js";
+
+vi.mock("../../../services/apiClient.js", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+// Mock recharts responsive container to render in JSDOM
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+  };
+});
+
+describe("SeriesEvolutionTimeline (#2738)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state when timeline array is empty", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        timeline: [],
+        trendMetrics: {
+          actionItemCompletionRate: 0,
+          decisionVelocity: 0,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SeriesEvolutionTimeline seriesId="series_123" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No meetings found in this series."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders error state when API call fails", async () => {
+    apiClient.get.mockRejectedValueOnce(new Error("Network Error"));
+
+    render(
+      <MemoryRouter>
+        <SeriesEvolutionTimeline seriesId="series_123" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load series timeline."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders meetings with React Router Link to /meeting/:id", async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        timeline: [
+          {
+            meetingId: "m_101",
+            title: "Architecture Planning Kickoff",
+            occurrence: 1,
+            date: "2026-03-01T10:00:00.000Z",
+            diffSummary: {
+              added: 5,
+              removed: 0,
+              carriedOver: 0,
+              completedActionItems: 2,
+            },
+          },
+          {
+            meetingId: "m_102",
+            title: "Architecture Planning Follow-up",
+            occurrence: 2,
+            date: "2026-03-08T10:00:00.000Z",
+            diffSummary: {
+              added: 3,
+              removed: 1,
+              carriedOver: 2,
+              completedActionItems: 4,
+            },
+          },
+        ],
+        trendMetrics: {
+          actionItemCompletionRate: 0.85,
+          decisionVelocity: 3.5,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SeriesEvolutionTimeline seriesId="series_123" />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Architecture Planning Kickoff"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Architecture Planning Follow-up"),
+      ).toBeInTheDocument();
+    });
+
+    // Check trend metrics
+    expect(screen.getByText("85.0%")).toBeInTheDocument();
+    expect(screen.getByText("3.5")).toBeInTheDocument();
+
+    // Check links target /meeting/:id (singular) and not /meetings/:id
+    const link1 = screen.getByTestId("view-meeting-m_101");
+    const link2 = screen.getByTestId("view-meeting-m_102");
+
+    expect(link1).toHaveAttribute("href", "/meeting/m_101");
+    expect(link2).toHaveAttribute("href", "/meeting/m_102");
+  });
+});


### PR DESCRIPTION
## Description
Resolves #2738

This PR fixes broken meeting links and full-page reloads in `SeriesEvolutionTimeline.jsx`.

### Summary of Changes
1. **Link & Route Target Fix (`client/src/components/meetings/SeriesEvolutionTimeline.jsx`)**:
   - Replaced raw anchor `<a href={`/meetings/${meeting.meetingId}`}>` with React Router's `<Link to={`/meeting/${meeting.meetingId}`}>`.
   - Corrected destination route to canonical singular `/meeting/:id` path to prevent 404 / NotFound transitions.
   - Preserved SPA client state and eliminated page reloads.
2. **Defensive API Client & Metric Handling**:
   - Switched to standard `apiClient` import and guarded `trendMetrics` calculation.
3. **Automated Testing (`client/src/components/meetings/__tests__/SeriesEvolutionTimeline.test.jsx`)**:
   - Added unit test suite validating timeline card rendering, empty state handling, API failure handling, and verified link elements point to `/meeting/:id`.

Fixes #2738