### PR TITLE
security: fix IDOR on getMeetingTokens by authorizing hosts/admins inside organization #2624

### DIFF
--- a/server/controllers/guestAccessController.js
+++ b/server/controllers/guestAccessController.js
@@ -61,10 +61,41 @@ class GuestAccessController {
   static async getMeetingTokens(req, res, next) {
     try {
       const { meetingId } = req.params;
+      const userId = req.user?._id || req.user?.id;
 
       const meeting = await Meeting.findById(meetingId);
       if (!meeting) {
         return next(new NotFoundError("Meeting not found"));
+      }
+
+      const isHost =
+        meeting.uploadedBy?.toString() === userId?.toString() ||
+        meeting.host?.toString() === userId?.toString();
+      const isAdmin =
+        req.user?.role === "admin" ||
+        req.user?.role === "owner" ||
+        req.user?.isAdmin;
+      const isOrgMember =
+        req.user?.organization &&
+        meeting.organization &&
+        req.user.organization.toString() === meeting.organization.toString();
+
+      // Check organization membership first to prevent cross-tenant enumeration
+      if (!isOrgMember) {
+        return next(
+          new ForbiddenError(
+            "Unauthorized to view guest tokens for this meeting",
+          ),
+        );
+      }
+
+      // Check host or admin authorization
+      if (!isHost && !isAdmin) {
+        return next(
+          new ForbiddenError(
+            "Only authorized hosts or admins can list guest tokens for this meeting",
+          ),
+        );
       }
 
       const tokens = await GuestAccessService.getMeetingTokens(meetingId);

--- a/server/tests/guestAccessController.vitest.test.js
+++ b/server/tests/guestAccessController.vitest.test.js
@@ -43,6 +43,7 @@ const {
   submitGuestFeedback,
   createToken,
   revokeToken,
+  getMeetingTokens,
 } = await import("../controllers/guestAccessController.js");
 
 const Meeting = (await import("../models/meetingModel.js")).default;
@@ -328,6 +329,112 @@ describe("guestAccessController (#2454)", () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           message: "Token revoked",
+        }),
+      );
+    });
+  });
+
+  describe("getMeetingTokens", () => {
+    it("allows meeting host to list tokens", async () => {
+      req.params = { meetingId: mockMeetingId };
+      req.user = {
+        _id: mockUserId,
+        id: mockUserId,
+        organization: mockOrgId,
+        role: "member",
+      };
+
+      Meeting.findById.mockResolvedValue({
+        _id: mockMeetingId,
+        uploadedBy: mockUserId,
+        organization: mockOrgId,
+      });
+
+      const mockTokens = [{ _id: "t1", guestEmail: "a@b.com" }];
+      GuestAccessToken.find.mockReturnValue({
+        sort: vi.fn().mockResolvedValue(mockTokens),
+      });
+
+      await getMeetingTokens(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockTokens);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("allows admin to list tokens even if not host", async () => {
+      req.params = { meetingId: mockMeetingId };
+      req.user = {
+        _id: "another-admin",
+        id: "another-admin",
+        organization: mockOrgId,
+        role: "admin",
+      };
+
+      Meeting.findById.mockResolvedValue({
+        _id: mockMeetingId,
+        uploadedBy: "some-host",
+        organization: mockOrgId,
+      });
+
+      const mockTokens = [{ _id: "t1", guestEmail: "a@b.com" }];
+      GuestAccessToken.find.mockReturnValue({
+        sort: vi.fn().mockResolvedValue(mockTokens),
+      });
+
+      await getMeetingTokens(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockTokens);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-host and non-admin from same org with 403", async () => {
+      req.params = { meetingId: mockMeetingId };
+      req.user = {
+        _id: "regular-member",
+        id: "regular-member",
+        organization: mockOrgId,
+        role: "member",
+      };
+
+      Meeting.findById.mockResolvedValue({
+        _id: mockMeetingId,
+        uploadedBy: "some-host",
+        organization: mockOrgId,
+      });
+
+      await getMeetingTokens(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 403,
+          message: expect.stringContaining("Only authorized hosts or admins"),
+        }),
+      );
+    });
+
+    it("rejects callers from different organization (cross-org IDOR protection) with 403", async () => {
+      req.params = { meetingId: mockMeetingId };
+      req.user = {
+        _id: mockUserId,
+        id: mockUserId,
+        organization: "different-org-id",
+        role: "admin",
+      };
+
+      Meeting.findById.mockResolvedValue({
+        _id: mockMeetingId,
+        uploadedBy: "some-host",
+        organization: mockOrgId,
+      });
+
+      await getMeetingTokens(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 403,
+          message: expect.stringContaining("Unauthorized to view guest tokens"),
         }),
       );
     });


### PR DESCRIPTION
## 📝 Summary
This PR fixes an IDOR vulnerability on the `getMeetingTokens` endpoint of the `guestAccessController` by ensuring that only authorized hosts and organization admins can list guest access tokens for a meeting in their organization, preventing cross-tenant leakage of token metadata.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2624

---

## ✨ Changes Made
- **REST Endpoints & Controllers**:
  - Enforced organization membership check inside `getMeetingTokens` in `guestAccessController.js` to block cross-org/cross-tenant requests.
  - Enforced meeting host (`meeting.uploadedBy` / `meeting.host`) or organization admin (`req.user.role` is `admin`/`owner` or `req.user.isAdmin` is true) role check inside `getMeetingTokens`.
  - Returns `403 Forbidden` instead of leaking token metadata on unauthorized calls.
- **Testing**:
  - Expanded `guestAccessController.vitest.test.js` to cover the `getMeetingTokens` controller method.
  - Added positive tests for meeting hosts and organization admins.
  - Added negative tests verifying that non-hosts (ordinary organization members) and cross-organization callers are rejected with a `403` status.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend Controller Unit/Integration Tests
npx vitest run tests/guestAccessController.vitest.test.js

# Backend Service Unit Tests
$env:MONGOMS_MD5_CHECK="false"; npm run test services/__tests__/guestAccessService.test.js --prefix server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted guest token listings to authorized meeting hosts and administrators.
  - Blocked non-members from accessing guest tokens across organizations.
  - Added authorization checks to prevent unauthorized token enumeration.

- **Tests**
  - Added coverage for host and administrator access.
  - Added tests confirming forbidden responses for unauthorized and cross-organization requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->