### PR TITLE
security: remove hardcoded TOKEN_ENCRYPTION_KEY fallback in production, enforce fail-fast at boot #2626

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -41,8 +41,9 @@ MS_CLIENT_ID=
 MS_CLIENT_SECRET=
 MS_TENANT_ID=common
 MS_REDIRECT_URI=http://localhost:4000/api/calendar/outlook/callback
-# Required to encrypt Google/Microsoft OAuth tokens. No default — the process
-# fails closed if this (or CALENDAR_ENCRYPTION_KEY) is unset.
+# Required to encrypt Google/Microsoft OAuth tokens and Slack integration tokens.
+# No default — the process fails closed at boot if CALENDAR_ENCRYPTION_KEY or
+# TOKEN_ENCRYPTION_KEY is unset in non-test environments.
 CALENDAR_ENCRYPTION_KEY=
 TOKEN_ENCRYPTION_KEY=
 

--- a/server/server.js
+++ b/server/server.js
@@ -110,6 +110,13 @@ if (!process.env.JWT_SECRET) {
   );
 }
 
+if (process.env.NODE_ENV !== "test" && !process.env.TOKEN_ENCRYPTION_KEY) {
+  console.error(
+    "FATAL ERROR: TOKEN_ENCRYPTION_KEY environment variable is required but not set.",
+  );
+  process.exit(1);
+}
+
 // DATABASE & CACHE
 await connectDB();
 

--- a/server/tests/crypto.test.js
+++ b/server/tests/crypto.test.js
@@ -1,0 +1,68 @@
+import { jest } from "@jest/globals";
+import { spawnSync } from "child_process";
+import path from "path";
+
+const { encryptToken, decryptToken } = await import("../utils/crypto.js");
+
+describe("Crypto Token Encryption Utility (#2626)", () => {
+  let originalEnv;
+  let originalKey;
+
+  beforeEach(() => {
+    originalEnv = process.env.NODE_ENV;
+    originalKey = process.env.TOKEN_ENCRYPTION_KEY;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    process.env.TOKEN_ENCRYPTION_KEY = originalKey;
+  });
+
+  it("should encrypt and decrypt successfully when key is set", () => {
+    process.env.TOKEN_ENCRYPTION_KEY =
+      "my_super_secret_token_encryption_key_32";
+    const plaintext = "slack-token-12345";
+    const encrypted = encryptToken(plaintext);
+    expect(encrypted).toBeDefined();
+    expect(encrypted).not.toBe(plaintext);
+
+    const decrypted = decryptToken(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("should fail to encrypt/decrypt and throw error if key is unset in production", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.TOKEN_ENCRYPTION_KEY;
+
+    expect(() => encryptToken("some-token")).toThrow(
+      "TOKEN_ENCRYPTION_KEY is required but not set.",
+    );
+
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    decryptToken("iv:encryptedText:authTag");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to decrypt Slack token"),
+      expect.stringContaining("TOKEN_ENCRYPTION_KEY is required but not set."),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should fail fast and exit with code 1 at boot if TOKEN_ENCRYPTION_KEY is unset in production", () => {
+    const serverPath = path.resolve("server.js");
+    const result = spawnSync("node", [serverPath], {
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        TOKEN_ENCRYPTION_KEY: "",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    const stderr = result.stderr.toString();
+    expect(stderr).toContain(
+      "FATAL ERROR: TOKEN_ENCRYPTION_KEY environment variable is required but not set.",
+    );
+  });
+});

--- a/server/utils/crypto.js
+++ b/server/utils/crypto.js
@@ -3,10 +3,13 @@ import crypto from "crypto";
 const ALGORITHM = "aes-256-gcm";
 
 const getEncryptionKey = () => {
-  const key =
-    process.env.TOKEN_ENCRYPTION_KEY || "default_dev_token_encryption_key_32";
+  const key = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!key && process.env.NODE_ENV !== "test") {
+    throw new Error("TOKEN_ENCRYPTION_KEY is required but not set.");
+  }
+  const effectiveKey = key || "default_dev_token_encryption_key_32";
   // Always derive a 32-byte key via SHA-256 to prevent crashes
-  return crypto.createHash("sha256").update(key).digest();
+  return crypto.createHash("sha256").update(effectiveKey).digest();
 };
 
 /**


### PR DESCRIPTION
## 📝 Summary
This PR enhances secrets storage security by removing the insecure dev fallback `"default_dev_token_encryption_key_32"` when `TOKEN_ENCRYPTION_KEY` is unset in production. Misconfigured deployments will now fail fast during server boot.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2626

---

## ✨ Changes Made
- **Server Boot Validation**:
  - Added a check in `server/server.js` to ensure the server crashes fast and exits with code `1` at startup if `TOKEN_ENCRYPTION_KEY` is missing or empty in non-test environments.
- **Crypto Utility**:
  - Updated `server/utils/crypto.js` to throw an error inside `getEncryptionKey()` if the key is missing in production/development, ensuring defense-in-depth against silent dev key fallback usage.
- **Environment Documentation**:
  - Documented the required key requirements and boot-level fail-closed behaviors inside `server/.env.example`.
- **Testing**:
  - Added a dedicated unit test suite in `server/tests/crypto.test.js` validating successful encryption/decryption, error throwing in production, and subprocess boot checks confirming the application exits with code `1` on missing credentials.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Backend Crypto Unit Tests & Subprocess Boot Checks
$env:MONGOMS_MD5_CHECK="false"; npm run test tests/crypto.test.js --prefix server
