### PR TITLE
feat: implement meeting effectiveness recommendations actioning loop and dynamic series trends #2469

### DIFF
--- a/client/src/pages/MeetingEffectiveness.jsx
+++ b/client/src/pages/MeetingEffectiveness.jsx
@@ -29,6 +29,7 @@ import {
   FileCheck,
 } from "lucide-react";
 import { useEffectivenessScore } from "../hooks/useEffectivenessScore";
+import apiClient from "../services/apiClient.js";
 
 const MeetingEffectiveness = () => {
   const { meetingId } = useParams();
@@ -48,6 +49,89 @@ const MeetingEffectiveness = () => {
     clearError,
   } = useEffectivenessScore();
 
+  const [actionedRecs, setActionedRecs] = React.useState({});
+  const [actioningRec, setActioningRec] = React.useState(null);
+
+  const handleCreateAction = async (recKey, text, description) => {
+    setActioningRec(recKey);
+    try {
+      await apiClient.post(`/api/action-items/meetings/${meetingId}`, {
+        text,
+        description,
+        priority: "medium",
+      });
+      setActionedRecs((prev) => ({ ...prev, [recKey]: true }));
+    } catch (err) {
+      console.error("Failed to create action item from recommendation:", err);
+    } finally {
+      setActioningRec(null);
+    }
+  };
+
+  const getRecommendations = () => {
+    if (!meetingScore || !meetingScore.dimensions) return [];
+    const { dimensions } = meetingScore;
+    const list = [];
+
+    if ((dimensions.goalCompletionRate ?? 0) < 80) {
+      list.push({
+        key: "goals",
+        title: "Improve Goal Alignment",
+        description:
+          "Define clearer goals at the start of meetings to improve alignment.",
+        actionText:
+          "Define SMART goals for the next recurring meeting and list them in the agenda.",
+        icon: <Target className="text-blue-500" size={20} />,
+      });
+    }
+    if ((dimensions.actionItemFollowThrough ?? 0) < 80) {
+      list.push({
+        key: "actions",
+        title: "Follow up on Action Items",
+        description:
+          "Set explicit due dates and assignees for all action items.",
+        actionText:
+          "Review and assign clear due dates and owners to all open action items.",
+        icon: <FileCheck className="text-indigo-500" size={20} />,
+      });
+    }
+    if ((dimensions.participantSatisfaction ?? 0) < 80) {
+      list.push({
+        key: "satisfaction",
+        title: "Boost Participant Satisfaction",
+        description:
+          "Collect feedback to improve attendee engagement and address concerns.",
+        actionText:
+          "Send a post-meeting engagement feedback survey to all attendees.",
+        icon: <ThumbsUp className="text-emerald-500" size={20} />,
+      });
+    }
+    if ((dimensions.decisionClarity ?? 0) < 80) {
+      list.push({
+        key: "clarity",
+        title: "Enhance Meeting Clarity",
+        description:
+          "Summarize key decisions before ending the meeting to ensure agreement.",
+        actionText:
+          "Summarize decisions and update the decision log before the next meeting ends.",
+        icon: <CheckCircle className="text-purple-500" size={20} />,
+      });
+    }
+    if ((dimensions.timeEfficiency ?? 0) < 80) {
+      list.push({
+        key: "time",
+        title: "Optimize Time Efficiency",
+        description:
+          "Strictly adhere to the agenda and assign a timekeeper to prevent going over time.",
+        actionText:
+          "Time-box each agenda item for the next meeting and assign a timekeeper.",
+        icon: <Clock className="text-amber-500" size={20} />,
+      });
+    }
+
+    return list;
+  };
+
   const handleRefresh = () => {
     clearError();
     if (meetingId) {
@@ -56,8 +140,9 @@ const MeetingEffectiveness = () => {
     if (organizationId) {
       fetchOrgTrends(organizationId);
     }
-    if (seriesId) {
-      fetchSeriesTrends(seriesId);
+    const activeSeriesId = seriesId || meetingScore?.seriesId;
+    if (activeSeriesId) {
+      fetchSeriesTrends(activeSeriesId);
     }
   };
 
@@ -68,17 +153,14 @@ const MeetingEffectiveness = () => {
     if (organizationId) {
       fetchOrgTrends(organizationId);
     }
-    if (seriesId) {
-      fetchSeriesTrends(seriesId);
+  }, [meetingId, organizationId, fetchMeetingScore, fetchOrgTrends]);
+
+  useEffect(() => {
+    const activeSeriesId = seriesId || meetingScore?.seriesId;
+    if (activeSeriesId) {
+      fetchSeriesTrends(activeSeriesId);
     }
-  }, [
-    meetingId,
-    organizationId,
-    seriesId,
-    fetchMeetingScore,
-    fetchOrgTrends,
-    fetchSeriesTrends,
-  ]);
+  }, [seriesId, meetingScore?.seriesId, fetchSeriesTrends]);
 
   const getScoreBadge = (score) => {
     if (score >= 80) {
@@ -371,6 +453,90 @@ const MeetingEffectiveness = () => {
               </div>
             </div>
           )}
+
+          {/* Actionable Recommendations */}
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-1 flex items-center gap-2">
+              <ShieldAlert className="text-blue-600" size={20} />
+              Actionable Recommendations
+            </h2>
+            <p className="text-xs text-gray-500 mb-4">
+              Turn diagnostic findings into tracked improvement tasks.
+            </p>
+
+            {getRecommendations().length > 0 ? (
+              <div className="space-y-4">
+                {getRecommendations().map((rec) => {
+                  const isActioned = actionedRecs[rec.key];
+                  const isLoading = actioningRec === rec.key;
+
+                  return (
+                    <div
+                      key={rec.key}
+                      className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 p-4 bg-gray-50 rounded-xl border border-gray-150 transition-all hover:bg-gray-100/50"
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="p-2 bg-white rounded-lg border border-gray-100 shadow-sm shrink-0">
+                          {rec.icon}
+                        </div>
+                        <div>
+                          <h4 className="font-semibold text-gray-900 text-sm">
+                            {rec.title}
+                          </h4>
+                          <p className="text-xs text-gray-500 mt-0.5">
+                            {rec.description}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() =>
+                          handleCreateAction(
+                            rec.key,
+                            rec.actionText,
+                            rec.description,
+                          )
+                        }
+                        disabled={isActioned || isLoading}
+                        className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-semibold shadow-sm transition-all shrink-0 ${
+                          isActioned
+                            ? "bg-emerald-50 text-emerald-700 border border-emerald-200"
+                            : isLoading
+                              ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                              : "bg-blue-600 text-white hover:bg-blue-700 hover:shadow-md active:scale-95"
+                        }`}
+                      >
+                        {isActioned ? (
+                          <>
+                            <CheckCircle size={14} />
+                            Actioned
+                          </>
+                        ) : isLoading ? (
+                          <>
+                            <RefreshCw size={14} className="animate-spin" />
+                            Creating...
+                          </>
+                        ) : (
+                          "Create Action Item"
+                        )}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="py-8 text-center bg-emerald-50/50 rounded-lg border border-dashed border-emerald-200 text-emerald-800">
+                <CheckCircle
+                  className="mx-auto mb-2 text-emerald-600"
+                  size={32}
+                />
+                <h4 className="font-semibold text-sm">All Metrics Healthy</h4>
+                <p className="text-xs text-emerald-600 mt-0.5">
+                  Great job! All meeting effectiveness dimensions are currently
+                  scored above 80.
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/client/src/pages/__tests__/MeetingEffectiveness.test.jsx
+++ b/client/src/pages/__tests__/MeetingEffectiveness.test.jsx
@@ -1,12 +1,21 @@
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import MeetingEffectiveness from "../MeetingEffectiveness.jsx";
 import { useEffectivenessScore } from "../../hooks/useEffectivenessScore.js";
 
 vi.mock("../../hooks/useEffectivenessScore.js", () => ({
   useEffectivenessScore: vi.fn(),
+}));
+
+vi.mock("../../services/apiClient.js", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
 }));
 
 // Mock recharts so test doesn't fail on SVG DOM size calculations
@@ -131,5 +140,66 @@ describe("MeetingEffectiveness Page Component", () => {
     expect(screen.getByText("92%")).toBeInTheDocument();
     expect(screen.getByText("90%")).toBeInTheDocument();
     expect(screen.getByTestId("radar-chart")).toBeInTheDocument();
+  });
+
+  it("renders recommendations based on low scores and calls apiClient.post when Create Action Item is clicked", async () => {
+    const mockPost = vi.fn().mockResolvedValue({ success: true });
+    const apiClient = (await import("../../services/apiClient.js")).default;
+    apiClient.post = mockPost;
+
+    useEffectivenessScore.mockReturnValue({
+      loading: false,
+      error: null,
+      meetingScore: {
+        overallScore: 72,
+        dimensions: {
+          goalCompletionRate: 90,
+          actionItemFollowThrough: 65,
+          participantSatisfaction: 85,
+          decisionClarity: 70,
+          timeEfficiency: 95,
+        },
+      },
+      orgTrends: [],
+      seriesTrends: [],
+      fetchMeetingScore: mockFetchMeetingScore,
+      fetchOrgTrends: mockFetchOrgTrends,
+      fetchSeriesTrends: mockFetchSeriesTrends,
+      clearError: mockClearError,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/effectiveness/m-123"]}>
+        <Routes>
+          <Route
+            path="/effectiveness/:meetingId"
+            element={<MeetingEffectiveness />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Actionable Recommendations")).toBeInTheDocument();
+    expect(screen.getByText("Follow up on Action Items")).toBeInTheDocument();
+    expect(screen.getByText("Enhance Meeting Clarity")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Improve Goal Alignment"),
+    ).not.toBeInTheDocument();
+
+    const createBtn = screen.getAllByRole("button", {
+      name: "Create Action Item",
+    })[0];
+    await act(async () => {
+      fireEvent.click(createBtn);
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/action-items/meetings/m-123",
+      expect.objectContaining({
+        text: expect.any(String),
+        description: expect.any(String),
+        priority: "medium",
+      }),
+    );
   });
 });

--- a/server/tests/effectivenessScoreService.test.js
+++ b/server/tests/effectivenessScoreService.test.js
@@ -1,20 +1,16 @@
 import { jest } from "@jest/globals";
 
-const { default: effectivenessScoreService } = await import(
-  "../services/effectivenessScoreService.js"
-);
-const { default: EffectivenessScore } = await import(
-  "../models/effectivenessScoreModel.js"
-);
+const { default: effectivenessScoreService } =
+  await import("../services/effectivenessScoreService.js");
+const { default: EffectivenessScore } =
+  await import("../models/effectivenessScoreModel.js");
 const { default: MeetingGoal } = await import("../models/meetingGoalModel.js");
 const { default: ActionItem } = await import("../models/actionItemModel.js");
-const { default: MeetingFeedback } = await import(
-  "../models/meetingFeedbackModel.js"
-);
+const { default: MeetingFeedback } =
+  await import("../models/meetingFeedbackModel.js");
 const { default: Decision } = await import("../models/decisionModel.js");
-const { default: MeetingAnalytics } = await import(
-  "../models/MeetingAnalytics.js"
-);
+const { default: MeetingAnalytics } =
+  await import("../models/MeetingAnalytics.js");
 
 describe("Effectiveness Score Service", () => {
   beforeEach(() => {
@@ -36,7 +32,7 @@ describe("Effectiveness Score Service", () => {
           ],
         }); // Score: (2*1 + 1*0.5) / 4 = 2.5 / 4 = 62.5% -> 63
 
-      const findActionItemsSpy = jest
+      jest
         .spyOn(ActionItem, "find")
         .mockResolvedValue([
           { status: "completed" },
@@ -45,22 +41,20 @@ describe("Effectiveness Score Service", () => {
           { status: "pending" },
         ]); // Score: 3/4 = 75% -> 75
 
-      const findFeedbackSpy = jest
+      jest
         .spyOn(MeetingFeedback, "find")
         .mockResolvedValue([{ rating: 4 }, { rating: 5 }]); // Score: 4.5/5 = 90% -> 90
 
-      const findDecisionsSpy = jest
+      jest
         .spyOn(Decision, "find")
         .mockResolvedValue([{ status: "final" }, { status: "draft" }]); // Score: 1/2 = 50% -> 50
 
-      const findOneAnalyticsSpy = jest
-        .spyOn(MeetingAnalytics, "findOne")
-        .mockResolvedValue({
-          durationMetrics: {
-            scheduledDuration: 60,
-            actualDuration: 60,
-          },
-        }); // Score: 100% -> 100
+      jest.spyOn(MeetingAnalytics, "findOne").mockResolvedValue({
+        durationMetrics: {
+          scheduledDuration: 60,
+          actualDuration: 60,
+        },
+      }); // Score: 100% -> 100
 
       const findOneAndUpdateScoreSpy = jest
         .spyOn(EffectivenessScore, "findOneAndUpdate")

--- a/server/tests/effectivenessScoreService.test.js
+++ b/server/tests/effectivenessScoreService.test.js
@@ -1,70 +1,80 @@
 import { jest } from "@jest/globals";
-import effectivenessScoreService from "../services/effectivenessScoreService.js";
-import EffectivenessScore from "../models/effectivenessScoreModel.js";
-import MeetingGoal from "../models/meetingGoalModel.js";
-import ActionItem from "../models/actionItemModel.js";
-import MeetingFeedback from "../models/meetingFeedbackModel.js";
-import Decision from "../models/decisionModel.js";
-import MeetingAnalytics from "../models/MeetingAnalytics.js";
 
-jest.mock("../models/effectivenessScoreModel.js");
-jest.mock("../models/meetingGoalModel.js");
-jest.mock("../models/actionItemModel.js");
-jest.mock("../models/meetingFeedbackModel.js");
-jest.mock("../models/decisionModel.js");
-jest.mock("../models/MeetingAnalytics.js");
+const { default: effectivenessScoreService } = await import(
+  "../services/effectivenessScoreService.js"
+);
+const { default: EffectivenessScore } = await import(
+  "../models/effectivenessScoreModel.js"
+);
+const { default: MeetingGoal } = await import("../models/meetingGoalModel.js");
+const { default: ActionItem } = await import("../models/actionItemModel.js");
+const { default: MeetingFeedback } = await import(
+  "../models/meetingFeedbackModel.js"
+);
+const { default: Decision } = await import("../models/decisionModel.js");
+const { default: MeetingAnalytics } = await import(
+  "../models/MeetingAnalytics.js"
+);
 
 describe("Effectiveness Score Service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe("calculateMeetingScore", () => {
     it("should correctly calculate and save score", async () => {
       // Mock data
-      MeetingGoal.findOne.mockResolvedValue({
-        goals: [
-          { status: "achieved" },
-          { status: "achieved" },
-          { status: "partially_achieved" },
-          { status: "not_achieved" },
-        ],
-      }); // Score: (2*1 + 1*0.5) / 4 = 2.5 / 4 = 62.5% -> 63
+      const findOneGoalSpy = jest
+        .spyOn(MeetingGoal, "findOne")
+        .mockResolvedValue({
+          goals: [
+            { status: "achieved" },
+            { status: "achieved" },
+            { status: "partially_achieved" },
+            { status: "not_achieved" },
+          ],
+        }); // Score: (2*1 + 1*0.5) / 4 = 2.5 / 4 = 62.5% -> 63
 
-      ActionItem.find.mockResolvedValue([
-        { status: "completed" },
-        { status: "completed" },
-        { status: "completed" },
-        { status: "pending" },
-      ]); // Score: 3/4 = 75% -> 75
+      const findActionItemsSpy = jest
+        .spyOn(ActionItem, "find")
+        .mockResolvedValue([
+          { status: "completed" },
+          { status: "completed" },
+          { status: "completed" },
+          { status: "pending" },
+        ]); // Score: 3/4 = 75% -> 75
 
-      MeetingFeedback.find.mockResolvedValue([{ rating: 4 }, { rating: 5 }]); // Score: 4.5/5 = 90% -> 90
+      const findFeedbackSpy = jest
+        .spyOn(MeetingFeedback, "find")
+        .mockResolvedValue([{ rating: 4 }, { rating: 5 }]); // Score: 4.5/5 = 90% -> 90
 
-      Decision.find.mockResolvedValue([
-        { status: "final" },
-        { status: "draft" },
-      ]); // Score: 1/2 = 50% -> 50
+      const findDecisionsSpy = jest
+        .spyOn(Decision, "find")
+        .mockResolvedValue([{ status: "final" }, { status: "draft" }]); // Score: 1/2 = 50% -> 50
 
-      MeetingAnalytics.findOne.mockResolvedValue({
-        durationMetrics: {
-          scheduledDuration: 60,
-          actualDuration: 60,
-        },
-      }); // Score: 100% -> 100
+      const findOneAnalyticsSpy = jest
+        .spyOn(MeetingAnalytics, "findOne")
+        .mockResolvedValue({
+          durationMetrics: {
+            scheduledDuration: 60,
+            actualDuration: 60,
+          },
+        }); // Score: 100% -> 100
 
-      EffectivenessScore.findOneAndUpdate.mockImplementation(
-        (query, update) => update,
-      );
+      const findOneAndUpdateScoreSpy = jest
+        .spyOn(EffectivenessScore, "findOneAndUpdate")
+        .mockImplementation((query, update) => update);
 
       const result = await effectivenessScoreService.calculateMeetingScore(
         "meetingId",
         "orgId",
       );
 
-      expect(MeetingGoal.findOne).toHaveBeenCalledWith({
+      expect(findOneGoalSpy).toHaveBeenCalledWith({
         meetingId: "meetingId",
       });
-      expect(EffectivenessScore.findOneAndUpdate).toHaveBeenCalled();
+      expect(findOneAndUpdateScoreSpy).toHaveBeenCalled();
 
       const { dimensions } = result;
       expect(dimensions.goalCompletionRate).toBe(63);


### PR DESCRIPTION
## 📝 Summary
This PR implements the meeting effectiveness recommendation actioning loop and enables automatic rendering of recurring series trends dynamically fetched from the database when loaded.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2469

---

## ✨ Changes Made
- **Actionable Recommendations UI**:
  - Dynamically parses the 5 performance dimensions of `meetingScore` (Goals, Action Items, Clarity, Time Efficiency, Participant Satisfaction) inside `MeetingEffectiveness.jsx`.
  - Suggests specific corrective recommendations for any dimension scoring `< 80`.
  - Displays a "Create Action Item" CTA next to each recommendation, allowing the user to turn a diagnostic finding into a tracked task using `apiClient.post` to `/api/action-items/meetings/:meetingId`.
  - Handles disabled, loading ("Creating..."), and success ("Actioned") states dynamically.
- **Dynamic Series Trends**:
  - Updated frontend `useEffect` blocks to automatically load series trends using `meetingScore.seriesId` if the `seriesId` query parameter is missing from the page URL.
- **Testing**:
  - Mocked `apiClient` endpoints inside `MeetingEffectiveness.test.jsx`.
  - Added test coverage confirming that low-scoring dimensions render correct recommendations and clicking the "Create Action Item" CTA calls the backend with the appropriate payload.
  - Wrapped async test clicks in `act` blocks to prevent console warnings during test execution.
  - Corrected unhoisted ESM mock statements in `effectivenessScoreService.test.js` using dynamic imports and Mongoose spies (`jest.spyOn`).

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Frontend Page Component Tests
npx vitest run src/pages/__tests__/MeetingEffectiveness.test.jsx

# Backend Service Tests
$env:MONGOMS_MD5_CHECK="false"; npm run test tests/effectivenessScoreService.test.js --prefix server
