### PR TITLE
feat: implement weekly insights history archive browser and admin share/email actions #2470

### DIFF
--- a/client/src/__tests__/weeklyInsightApiPrefix.test.js
+++ b/client/src/__tests__/weeklyInsightApiPrefix.test.js
@@ -3,6 +3,8 @@ import {
   getLatestInsight,
   getInsightHistory,
   triggerManualGeneration,
+  shareWeeklyInsight,
+  emailWeeklyInsight,
 } from "../services/weeklyInsightApi.js";
 import apiClient from "../services/apiClient.js";
 
@@ -50,6 +52,30 @@ describe("Weekly Insights API Prefix Suite (#2620)", () => {
 
     expect(apiClient.post).toHaveBeenCalledWith(
       "/api/weekly-insights/org-123/generate",
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it("should call shareWeeklyInsight with /api/weekly-insights/:orgId/insights/:insightId/share", async () => {
+    const mockData = { success: true, shareLink: "http://share-link" };
+    apiClient.post.mockResolvedValueOnce({ data: mockData });
+
+    const result = await shareWeeklyInsight("org-123", "ins-456");
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/weekly-insights/org-123/insights/ins-456/share",
+    );
+    expect(result).toEqual(mockData);
+  });
+
+  it("should call emailWeeklyInsight with /api/weekly-insights/:orgId/insights/:insightId/email", async () => {
+    const mockData = { success: true, message: "Emails sent" };
+    apiClient.post.mockResolvedValueOnce({ data: mockData });
+
+    const result = await emailWeeklyInsight("org-123", "ins-456");
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/weekly-insights/org-123/insights/ins-456/email",
     );
     expect(result).toEqual(mockData);
   });

--- a/client/src/pages/WeeklyInsights.jsx
+++ b/client/src/pages/WeeklyInsights.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import AppContent from "../context/AppContent";
 import Navbar from "../components/Navbar.jsx";
@@ -6,7 +6,11 @@ import { toast } from "react-toastify";
 import {
   getLatestInsight,
   triggerManualGeneration,
+  getInsightHistory,
+  shareWeeklyInsight,
+  emailWeeklyInsight,
 } from "../services/weeklyInsightApi.js";
+import { useRBAC } from "../hooks/useRBAC.js";
 import {
   Loader2,
   Zap,
@@ -15,44 +19,79 @@ import {
   RefreshCw,
   Briefcase,
   Sparkles,
+  Share2,
+  Mail,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const WeeklyInsights = () => {
   const { t } = useTranslation();
   const { activeOrganization } = useContext(AppContent);
+  const { userRole } = useRBAC();
+  const isAdmin = userRole === "admin" || userRole === "owner";
 
   const [insight, setInsight] = useState(null);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
+  const [history, setHistory] = useState([]);
+  const [selectedInsightId, setSelectedInsightId] = useState("");
+  const [sharing, setSharing] = useState(false);
+  const [emailing, setEmailing] = useState(false);
 
-  useEffect(() => {
-    const fetchInsight = async () => {
-      setLoading(true);
-      try {
-        const data = await getLatestInsight(activeOrganization._id);
-        setInsight(data);
-      } catch (error) {
-        console.error("Failed to fetch latest insight:", error);
-        toast.error(t("weeklyInsights.fetchError", "Failed to load insights."));
-      } finally {
-        setLoading(false);
+  const fetchHistory = useCallback(async () => {
+    if (!activeOrganization) return;
+    try {
+      const data = await getInsightHistory(activeOrganization._id, 1, 50);
+      setHistory(data.insights || []);
+    } catch (error) {
+      console.error("Failed to fetch history:", error);
+    }
+  }, [activeOrganization]);
+
+  const fetchInsight = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getLatestInsight(activeOrganization._id);
+      setInsight(data);
+      if (data) {
+        setSelectedInsightId(data._id);
       }
-    };
-
-    if (activeOrganization) {
-      fetchInsight();
+    } catch (error) {
+      console.error("Failed to fetch latest insight:", error);
+      toast.error(t("weeklyInsights.fetchError", "Failed to load insights."));
+    } finally {
+      setLoading(false);
     }
   }, [activeOrganization, t]);
+
+  useEffect(() => {
+    if (activeOrganization) {
+      fetchInsight();
+      fetchHistory();
+    }
+  }, [activeOrganization, fetchInsight, fetchHistory]);
+
+  const handleSelectInsight = (e) => {
+    const id = e.target.value;
+    setSelectedInsightId(id);
+    const selected = history.find((h) => h._id === id);
+    if (selected) {
+      setInsight(selected);
+    }
+  };
 
   const handleGenerate = async () => {
     setGenerating(true);
     try {
       const data = await triggerManualGeneration(activeOrganization._id);
       setInsight(data);
+      if (data) {
+        setSelectedInsightId(data._id);
+      }
       toast.success(
         t("weeklyInsights.generated", "Weekly insight generated successfully."),
       );
+      await fetchHistory();
     } catch (error) {
       console.error("Failed to generate insight:", error);
       toast.error(
@@ -63,11 +102,56 @@ const WeeklyInsights = () => {
     }
   };
 
+  const handleShare = async () => {
+    if (!insight) return;
+    setSharing(true);
+    try {
+      const response = await shareWeeklyInsight(
+        activeOrganization._id,
+        insight._id,
+      );
+      if (response && response.shareLink) {
+        await navigator.clipboard.writeText(response.shareLink);
+        toast.success(
+          t("weeklyInsights.shared", "Share link copied to clipboard!"),
+        );
+      }
+    } catch (error) {
+      console.error("Failed to share insight:", error);
+      toast.error(
+        t("weeklyInsights.shareError", "Failed to generate share link."),
+      );
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  const handleEmail = async () => {
+    if (!insight) return;
+    setEmailing(true);
+    try {
+      await emailWeeklyInsight(activeOrganization._id, insight._id);
+      toast.success(
+        t(
+          "weeklyInsights.emailed",
+          "Weekly digest emailed to all active members successfully!",
+        ),
+      );
+    } catch (error) {
+      console.error("Failed to email insight:", error);
+      toast.error(
+        t("weeklyInsights.emailError", "Failed to send email digest."),
+      );
+    } finally {
+      setEmailing(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <Navbar />
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex justify-between items-center mb-8">
+        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
           <div>
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
               Weekly Insights Digest
@@ -77,18 +161,76 @@ const WeeklyInsights = () => {
               7 days.
             </p>
           </div>
-          <button
-            onClick={handleGenerate}
-            disabled={generating}
-            className="flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
-          >
-            {generating ? (
-              <RefreshCw className="w-5 h-5 mr-2 animate-spin" />
-            ) : (
-              <Zap className="w-5 h-5 mr-2" />
+
+          <div className="flex flex-wrap items-center gap-3 w-full md:w-auto">
+            {/* History Selector */}
+            {history.length > 0 && (
+              <select
+                value={selectedInsightId || ""}
+                onChange={handleSelectInsight}
+                className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                {history.map((h) => {
+                  const dateLabel = `${new Date(
+                    h.startDate,
+                  ).toLocaleDateString()} - ${new Date(
+                    h.endDate,
+                  ).toLocaleDateString()}`;
+                  return (
+                    <option key={h._id} value={h._id}>
+                      {dateLabel}
+                    </option>
+                  );
+                })}
+              </select>
             )}
-            Generate Now
-          </button>
+
+            {/* Share CTA */}
+            {insight && (
+              <button
+                onClick={handleShare}
+                disabled={sharing}
+                className="flex items-center justify-center p-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 transition-colors disabled:opacity-50"
+                title={t("weeklyInsights.share", "Copy share link")}
+              >
+                {sharing ? (
+                  <RefreshCw className="w-5 h-5 animate-spin" />
+                ) : (
+                  <Share2 className="w-5 h-5" />
+                )}
+              </button>
+            )}
+
+            {/* Email Digest CTA (Admin Only) */}
+            {insight && isAdmin && (
+              <button
+                onClick={handleEmail}
+                disabled={emailing}
+                className="flex items-center justify-center p-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-700 transition-colors disabled:opacity-50"
+                title={t("weeklyInsights.emailDigest", "Send email digest")}
+              >
+                {emailing ? (
+                  <RefreshCw className="w-5 h-5 animate-spin" />
+                ) : (
+                  <Mail className="w-5 h-5" />
+                )}
+              </button>
+            )}
+
+            {/* Generate CTA */}
+            <button
+              onClick={handleGenerate}
+              disabled={generating}
+              className="flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 font-medium text-sm transition-colors"
+            >
+              {generating ? (
+                <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+              ) : (
+                <Zap className="w-4 h-4 mr-2" />
+              )}
+              Generate Now
+            </button>
+          </div>
         </div>
 
         {loading ? (

--- a/client/src/services/weeklyInsightApi.js
+++ b/client/src/services/weeklyInsightApi.js
@@ -18,3 +18,17 @@ export const triggerManualGeneration = async (orgId) => {
   );
   return response.data;
 };
+
+export const shareWeeklyInsight = async (orgId, insightId) => {
+  const response = await apiClient.post(
+    `/api/weekly-insights/${orgId}/insights/${insightId}/share`,
+  );
+  return response.data;
+};
+
+export const emailWeeklyInsight = async (orgId, insightId) => {
+  const response = await apiClient.post(
+    `/api/weekly-insights/${orgId}/insights/${insightId}/email`,
+  );
+  return response.data;
+};

--- a/server/controllers/weeklyInsightController.js
+++ b/server/controllers/weeklyInsightController.js
@@ -1,5 +1,7 @@
 import WeeklyInsight from "../models/weeklyInsightModel.js";
 import { generateInsight } from "../services/weeklyInsightService.js";
+import Membership from "../models/membershipModel.js";
+import EmailService from "../services/EmailService.js";
 
 export const getLatestInsight = async (req, res, next) => {
   try {
@@ -55,6 +57,79 @@ export const triggerManualGeneration = async (req, res, next) => {
         .json({ message: "No meetings found in the past 7 days to analyze." });
     }
     res.status(201).json(insight);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const shareWeeklyInsight = async (req, res, next) => {
+  try {
+    const { orgId, insightId } = req.params;
+    const insight = await WeeklyInsight.findOne({
+      _id: insightId,
+      organization: orgId,
+    });
+    if (!insight) {
+      return res.status(404).json({ message: "Insight not found" });
+    }
+
+    if (!insight.deliveredAt) {
+      insight.deliveredAt = new Date();
+      await insight.save();
+    }
+
+    const shareLink = `${
+      process.env.CLIENT_URL || "http://localhost:5173"
+    }/weekly-insights/${orgId}?insightId=${insightId}`;
+    res.status(200).json({ success: true, shareLink });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const emailWeeklyInsight = async (req, res, next) => {
+  try {
+    const { orgId, insightId } = req.params;
+    const insight = await WeeklyInsight.findOne({
+      _id: insightId,
+      organization: orgId,
+    });
+    if (!insight) {
+      return res.status(404).json({ message: "Insight not found" });
+    }
+
+    const memberships = await Membership.find({
+      organization: orgId,
+      status: "active",
+    }).populate("user");
+
+    const dateStr = new Date(insight.startDate).toISOString().split("T")[0];
+    const subject = `Weekly Insight Digest: Week of ${dateStr}`;
+    const description = `Here is the Weekly Insight Digest for your organization:\n\n${
+      insight.aiSummary
+    }\n\nRead more at: ${
+      process.env.CLIENT_URL || "http://localhost:5173"
+    }/weekly-insights/${orgId}?insightId=${insightId}`;
+
+    for (const m of memberships) {
+      if (m.user && m.user.email) {
+        await EmailService.sendNotificationEmail(
+          m.user.email,
+          subject,
+          description,
+        );
+      }
+    }
+
+    if (!insight.deliveredAt) {
+      insight.deliveredAt = new Date();
+      await insight.save();
+    }
+
+    res.status(200).json({
+      success: true,
+      message: "Digest emailed to all active members successfully.",
+    });
   } catch (error) {
     next(error);
   }

--- a/server/routes/weeklyInsightRoutes.js
+++ b/server/routes/weeklyInsightRoutes.js
@@ -3,6 +3,8 @@ import {
   getLatestInsight,
   getInsightHistory,
   triggerManualGeneration,
+  shareWeeklyInsight,
+  emailWeeklyInsight,
 } from "../controllers/weeklyInsightController.js";
 import userAuth from "../middleware/userAuth.js";
 import { requireRole } from "../middleware/rbac.js";
@@ -25,6 +27,16 @@ router.post(
   "/:orgId/generate",
   requireRole(["owner", "admin"]),
   triggerManualGeneration,
+);
+router.post(
+  "/:orgId/insights/:insightId/share",
+  requireRole(["owner", "admin"]),
+  shareWeeklyInsight,
+);
+router.post(
+  "/:orgId/insights/:insightId/email",
+  requireRole(["owner", "admin"]),
+  emailWeeklyInsight,
 );
 
 export default router;

--- a/server/tests/weeklyInsightApiPrefixGuards.test.js
+++ b/server/tests/weeklyInsightApiPrefixGuards.test.js
@@ -20,6 +20,20 @@ jest.unstable_mockModule("../services/weeklyInsightService.js", () => ({
   generateInsight: (...args) => mockGenerateInsight(...args),
 }));
 
+const mockMembershipFind = jest.fn();
+jest.unstable_mockModule("../models/membershipModel.js", () => ({
+  default: {
+    find: (...args) => mockMembershipFind(...args),
+  },
+}));
+
+const mockSendNotificationEmail = jest.fn();
+jest.unstable_mockModule("../services/EmailService.js", () => ({
+  default: {
+    sendNotificationEmail: (...args) => mockSendNotificationEmail(...args),
+  },
+}));
+
 const mockUser = {
   _id: new mongoose.Types.ObjectId().toString(),
   name: "Admin User",
@@ -139,6 +153,67 @@ describe("Weekly Insights Server API Route Prefix Guards Suite (#2620)", () => {
       const orgId = new mongoose.Types.ObjectId().toString();
       const res = await request(app)
         .post(`/weekly-insights/${orgId}/generate`)
+        .set("Authorization", "Bearer valid-token");
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should return 200 for POST /api/weekly-insights/:orgId/insights/:insightId/share", async () => {
+      const orgId = new mongoose.Types.ObjectId().toString();
+      const insightId = new mongoose.Types.ObjectId().toString();
+      const mockInsight = {
+        _id: insightId,
+        organization: orgId,
+        save: jest.fn().mockResolvedValue(true),
+      };
+      mockFindOne.mockResolvedValueOnce(mockInsight);
+
+      const res = await request(app)
+        .post(`/api/weekly-insights/${orgId}/insights/${insightId}/share`)
+        .set("Authorization", "Bearer valid-token");
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.shareLink).toContain(insightId);
+    });
+
+    it("should return 404 for un-prefixed POST /weekly-insights/:orgId/insights/:insightId/share", async () => {
+      const orgId = new mongoose.Types.ObjectId().toString();
+      const insightId = new mongoose.Types.ObjectId().toString();
+      const res = await request(app)
+        .post(`/weekly-insights/${orgId}/insights/${insightId}/share`)
+        .set("Authorization", "Bearer valid-token");
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should return 200 for POST /api/weekly-insights/:orgId/insights/:insightId/email", async () => {
+      const orgId = new mongoose.Types.ObjectId().toString();
+      const insightId = new mongoose.Types.ObjectId().toString();
+      const mockInsight = {
+        _id: insightId,
+        organization: orgId,
+        startDate: new Date(),
+        save: jest.fn().mockResolvedValue(true),
+      };
+      mockFindOne.mockResolvedValueOnce(mockInsight);
+      mockMembershipFind.mockReturnValueOnce({
+        populate: jest.fn().mockResolvedValue([]),
+      });
+
+      const res = await request(app)
+        .post(`/api/weekly-insights/${orgId}/insights/${insightId}/email`)
+        .set("Authorization", "Bearer valid-token");
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it("should return 404 for un-prefixed POST /weekly-insights/:orgId/insights/:insightId/email", async () => {
+      const orgId = new mongoose.Types.ObjectId().toString();
+      const insightId = new mongoose.Types.ObjectId().toString();
+      const res = await request(app)
+        .post(`/weekly-insights/${orgId}/insights/${insightId}/email`)
         .set("Authorization", "Bearer valid-token");
 
       expect(res.status).toBe(404);


### PR DESCRIPTION
## 📝 Summary
This PR implements the weekly insights history archive browser on the frontend, and adds sharing (direct clipboard copy link) and email digest distribution actions restricted to administrators.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Test improvement
- [ ] CI/CD or build change

## 🔗 Related Issue
Closes #2470

---

## ✨ Changes Made
- **Backend API Endpoints**:
  - Implemented `shareWeeklyInsight` in `weeklyInsightController.js` to generate a copyable share link and mark the digest as shared (`deliveredAt` updated).
  - Implemented `emailWeeklyInsight` in `weeklyInsightController.js` to compile the digest and email it automatically to all active organization members using `EmailService.sendNotificationEmail` and Mongoose `Membership` schema lookup.
  - Mapped routes to `/api/weekly-insights/:orgId/insights/:insightId/share` and `email`, gating access using `requireRole(["owner", "admin"])`.
- **Frontend Weekly Insights Interface**:
  - Implemented a week selector dropdown allowing users to browse prior weeks of insights retrieved via the paginated `getInsightHistory` service.
  - Integrated a "Share" CTA (copies a direct shareable URL to the clipboard on click).
  - Integrated an "Email Digest" CTA, gated with `useRBAC()` so that it is only visible/active for administrators (`owner` / `admin` roles).
- **Testing**:
  - Expanded `weeklyInsightApiPrefix.test.js` to verify client API functions `shareWeeklyInsight` and `emailWeeklyInsight` issue correct backend requests.
  - Expanded `weeklyInsightApiPrefixGuards.test.js` to validate prefixed share and email routes return `200` success, and unprefixed requests properly return `404` not found.

---

## 🧪 Testing
- [x] Tests pass
- [x] Linters run successfully
- [x] Tested locally

**Testing Details:**
Run tests:
```bash
# Frontend Unit/Integration API Tests
npx vitest run src/__tests__/weeklyInsightApiPrefix.test.js

# Backend Integration Route Prefix Guards Tests
$env:MONGOMS_MD5_CHECK="false"; npm run test tests/weeklyInsightApiPrefixGuards.test.js --prefix server
