### PR TITLE
feat: add standup report delivery channels

### DIFF
--- a/server/jobs/__tests__/standupReportJob.test.js
+++ b/server/jobs/__tests__/standupReportJob.test.js
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { deliverStandupReport } from "../standupReportJob.js";
+import EmailService from "../../services/EmailService.js";
+import { sendSlackNotification } from "../../services/slackService.js";
+import User from "../../models/userModel.js";
+
+vi.mock("../../services/EmailService.js", () => ({
+  default: {
+    sendNotificationEmail: vi.fn().mockResolvedValue(),
+  },
+}));
+
+vi.mock("../../services/slackService.js", () => ({
+  sendSlackNotification: vi.fn().mockResolvedValue(),
+}));
+
+vi.mock("../../models/userModel.js", () => ({
+  default: {
+    findById: vi.fn(),
+  },
+}));
+
+describe("StandupReportJob Delivery Channels (Issue #2639)", () => {
+  const mockUser = {
+    _id: "user123",
+    name: "Jane Doe",
+    email: "jane@example.com",
+  };
+
+  const mockReport = {
+    _id: "report123",
+    aiSummary: "Completed sprint tasks and aligned on roadmap.",
+    completedActionItems: [{ text: "Fix auth bug" }],
+    upcomingActionItems: [{ text: "Write tests" }],
+    blockers: [{ text: "Waiting for API specs" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    User.findById.mockResolvedValue(mockUser);
+  });
+
+  it("1. Email preference triggers EmailService.sendNotificationEmail", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(User.findById).toHaveBeenCalledWith("user123");
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledWith(
+      "jane@example.com",
+      expect.stringContaining("Daily Standup Report"),
+      expect.stringContaining("Completed sprint tasks"),
+    );
+    expect(sendSlackNotification).not.toHaveBeenCalled();
+  });
+
+  it("2. Slack preference triggers sendSlackNotification", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["slack"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(sendSlackNotification).toHaveBeenCalledTimes(1);
+    expect(sendSlackNotification).toHaveBeenCalledWith(
+      "org123",
+      expect.stringContaining("Daily Standup Report for Jane Doe"),
+    );
+    expect(EmailService.sendNotificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("3. Both email and slack preferences trigger both deliveries", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "weekly",
+      deliveryChannels: ["email", "slack"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+    expect(sendSlackNotification).toHaveBeenCalledTimes(1);
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledWith(
+      "jane@example.com",
+      expect.stringContaining("Weekly Standup Report"),
+      expect.any(String),
+    );
+    expect(sendSlackNotification).toHaveBeenCalledWith(
+      "org123",
+      expect.stringContaining("Weekly Standup Report for Jane Doe"),
+    );
+  });
+
+  it("4. No delivery channels (or only in-app) trigger neither notifier", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["in-app"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(EmailService.sendNotificationEmail).not.toHaveBeenCalled();
+    expect(sendSlackNotification).not.toHaveBeenCalled();
+  });
+
+  it("5. Email notifier failure is handled gracefully", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email"],
+    };
+    EmailService.sendNotificationEmail.mockRejectedValueOnce(
+      new Error("SMTP Connection Failed"),
+    );
+
+    await expect(deliverStandupReport(pref, mockReport)).resolves.not.toThrow();
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("6. Slack notifier failure is handled gracefully", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["slack"],
+    };
+    sendSlackNotification.mockRejectedValueOnce(new Error("Slack Rate Limit"));
+
+    await expect(deliverStandupReport(pref, mockReport)).resolves.not.toThrow();
+    expect(sendSlackNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("7. Email failure does not prevent Slack delivery when both are configured", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email", "slack"],
+    };
+    EmailService.sendNotificationEmail.mockRejectedValueOnce(
+      new Error("SMTP Timeout"),
+    );
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+    expect(sendSlackNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("8. Slack failure does not prevent email delivery when both are configured", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email", "slack"],
+    };
+    sendSlackNotification.mockRejectedValueOnce(
+      new Error("Slack Integration Disconnected"),
+    );
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledTimes(1);
+    expect(sendSlackNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("9. Correct report content (summary, items, blockers) is formatted", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    const description = EmailService.sendNotificationEmail.mock.calls[0][2];
+    expect(description).toContain("Completed sprint tasks");
+    expect(description).toContain("- Fix auth bug");
+    expect(description).toContain("- Write tests");
+    expect(description).toContain("- Waiting for API specs");
+  });
+
+  it("10. Correct recipient, user, and organization parameters are passed", async () => {
+    const pref = {
+      user: "user123",
+      organization: "org123",
+      scheduleType: "daily",
+      deliveryChannels: ["email", "slack"],
+    };
+
+    await deliverStandupReport(pref, mockReport);
+
+    expect(EmailService.sendNotificationEmail).toHaveBeenCalledWith(
+      "jane@example.com",
+      expect.any(String),
+      expect.any(String),
+    );
+    expect(sendSlackNotification).toHaveBeenCalledWith(
+      "org123",
+      expect.any(String),
+    );
+  });
+});

--- a/server/jobs/standupReportJob.js
+++ b/server/jobs/standupReportJob.js
@@ -1,9 +1,138 @@
 import cron from "node-cron";
 import StandupPreference from "../models/standupPreferenceModel.js";
+import User from "../models/userModel.js";
 import { generateStandupReport } from "../services/standupReportService.js";
+import EmailService from "../services/EmailService.js";
+import { sendSlackNotification } from "../services/slackService.js";
 
 let isInitialized = false;
 let standupReportTask = null;
+
+/**
+ * Deliver a generated standup report via configured delivery channels (email, slack).
+ * @param {object} pref - StandupPreference document or object
+ * @param {object} report - Generated StandupReport document
+ */
+export const deliverStandupReport = async (pref, report) => {
+  if (!pref || !report) return;
+
+  const channels = pref.deliveryChannels || [];
+  if (!Array.isArray(channels) || channels.length === 0) return;
+
+  let user = null;
+  if (channels.includes("email") || channels.includes("slack")) {
+    try {
+      user = await User.findById(pref.user);
+    } catch (userErr) {
+      console.error(
+        `[StandupReportJob] Failed to fetch user ${pref.user} for delivery:`,
+        userErr.message,
+      );
+    }
+  }
+
+  // 1. Email Delivery
+  if (channels.includes("email")) {
+    try {
+      if (user?.email) {
+        const scheduleLabel =
+          pref.scheduleType === "weekly" ? "Weekly" : "Daily";
+        const title = `[Standup Report] ${scheduleLabel} Standup Report`;
+        let description =
+          report.aiSummary || "Your standup report has been generated.";
+
+        if (
+          Array.isArray(report.completedActionItems) &&
+          report.completedActionItems.length > 0
+        ) {
+          description +=
+            "\n\nCompleted Items:\n" +
+            report.completedActionItems.map((i) => `- ${i.text}`).join("\n");
+        }
+        if (
+          Array.isArray(report.upcomingActionItems) &&
+          report.upcomingActionItems.length > 0
+        ) {
+          description +=
+            "\n\nUpcoming Items:\n" +
+            report.upcomingActionItems.map((i) => `- ${i.text}`).join("\n");
+        }
+        if (Array.isArray(report.blockers) && report.blockers.length > 0) {
+          description +=
+            "\n\nBlockers:\n" +
+            report.blockers.map((i) => `- ${i.text}`).join("\n");
+        }
+
+        await EmailService.sendNotificationEmail(
+          user.email,
+          title,
+          description,
+        );
+        console.log(
+          `[StandupReportJob] Email report delivered to ${user.email} for report ${report._id}`,
+        );
+      } else {
+        console.warn(
+          `[StandupReportJob] User ${pref.user} missing email address for email delivery`,
+        );
+      }
+    } catch (emailErr) {
+      console.error(
+        `[StandupReportJob] Failed email delivery for user ${pref.user}:`,
+        emailErr.message,
+      );
+    }
+  }
+
+  // 2. Slack Delivery
+  if (channels.includes("slack")) {
+    try {
+      if (pref.organization) {
+        const scheduleLabel =
+          pref.scheduleType === "weekly" ? "Weekly" : "Daily";
+        const userName = user?.displayName || user?.name || "User";
+        const title = `${scheduleLabel} Standup Report for ${userName}`;
+        let message = `*${title}*\n\n${report.aiSummary || ""}`;
+
+        if (
+          Array.isArray(report.completedActionItems) &&
+          report.completedActionItems.length > 0
+        ) {
+          message +=
+            "\n\n*Completed Items:*\n" +
+            report.completedActionItems.map((i) => `• ${i.text}`).join("\n");
+        }
+        if (
+          Array.isArray(report.upcomingActionItems) &&
+          report.upcomingActionItems.length > 0
+        ) {
+          message +=
+            "\n\n*Upcoming Items:*\n" +
+            report.upcomingActionItems.map((i) => `• ${i.text}`).join("\n");
+        }
+        if (Array.isArray(report.blockers) && report.blockers.length > 0) {
+          message +=
+            "\n\n*Blockers:*\n" +
+            report.blockers.map((i) => `• ${i.text}`).join("\n");
+        }
+
+        await sendSlackNotification(pref.organization, message);
+        console.log(
+          `[StandupReportJob] Slack report delivered to org ${pref.organization} for report ${report._id}`,
+        );
+      } else {
+        console.warn(
+          `[StandupReportJob] Preference for user ${pref.user} missing organization for Slack delivery`,
+        );
+      }
+    } catch (slackErr) {
+      console.error(
+        `[StandupReportJob] Failed Slack delivery for org ${pref.organization}:`,
+        slackErr.message,
+      );
+    }
+  }
+};
 
 export const startStandupReportJob = () => {
   if (isInitialized) {
@@ -40,7 +169,7 @@ export const startStandupReportJob = () => {
             startDate.setDate(startDate.getDate() - 7);
           }
 
-          await generateStandupReport(
+          const report = await generateStandupReport(
             pref.user,
             pref.organization,
             pref.scheduleType,
@@ -52,7 +181,7 @@ export const startStandupReportJob = () => {
             `[StandupReportJob] Generated report for user ${pref.user} in org ${pref.organization}`,
           );
 
-          // TODO: If pref.deliveryChannels contains "slack" or "email", dispatch notifications here.
+          await deliverStandupReport(pref, report);
         } catch (prefErr) {
           console.error(
             `[StandupReportJob] Error generating report for user ${pref.user}:`,


### PR DESCRIPTION
## Description

Implemented standup report delivery through the existing email and Slack integrations based on saved delivery preferences.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2639

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

Added focused tests covering:
- Email delivery
- Slack delivery
- Both delivery channels
- No configured channels
- Email delivery failures
- Slack delivery failures
- Independent channel failure handling
- Correct report/recipient payloads

## Screenshots

Not applicable — backend job/notification functionality.

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Standup reports are now delivered through configured email, Slack, and in-app notification channels.
  - Notifications include the report summary and action items.
  - Delivery continues through available channels when one notification method fails.

- **Tests**
  - Added coverage for channel selection, failure handling, message content, and recipient details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->