### PR TITLE
test(client): centralize /api prefix regression suite

### DIFF
--- a/client/src/api/actionItemChangeLogApi.js
+++ b/client/src/api/actionItemChangeLogApi.js
@@ -6,9 +6,12 @@ import api from "../services/apiClient.js";
  * @param {object} params - Query parameters (page, limit, type, userId)
  */
 export const fetchChangeLogs = async (actionItemId, params = {}) => {
-  const { data } = await api.get(`/action-items/${actionItemId}/changelog`, {
-    params,
-  });
+  const { data } = await api.get(
+    `/api/action-items/${actionItemId}/changelog`,
+    {
+      params,
+    },
+  );
   return data;
 };
 
@@ -18,7 +21,7 @@ export const fetchChangeLogs = async (actionItemId, params = {}) => {
  */
 export const fetchChangeLogStats = async (actionItemId) => {
   const { data } = await api.get(
-    `/action-items/${actionItemId}/changelog/stats`,
+    `/api/action-items/${actionItemId}/changelog/stats`,
   );
   return data;
 };

--- a/client/src/api/debriefQAApi.js
+++ b/client/src/api/debriefQAApi.js
@@ -2,7 +2,7 @@ import apiClient from "../services/apiClient";
 
 export const debriefQAApi = {
   askQuestion: async (meetingId, question) => {
-    const response = await apiClient.post("/debrief/session", {
+    const response = await apiClient.post("/api/debrief/session", {
       meetingId,
       question,
     });
@@ -10,7 +10,7 @@ export const debriefQAApi = {
   },
 
   getSession: async (meetingId) => {
-    const response = await apiClient.get(`/debrief/session/${meetingId}`);
+    const response = await apiClient.get(`/api/debrief/session/${meetingId}`);
     return response.data;
   },
 };

--- a/client/src/services/__tests__/apiPrefixRegression.test.js
+++ b/client/src/services/__tests__/apiPrefixRegression.test.js
@@ -1,0 +1,392 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import apiClient from "../apiClient";
+import { assertAllCallsUseApiPrefix } from "./helpers/apiPrefixAssertionHelper.js";
+import * as asyncMeetingApi from "../asyncMeetingApi";
+import * as attendanceApi from "../attendanceApi";
+import * as icebreakerApi from "../icebreakerApi";
+import * as meetingAttendanceApi from "../meetingAttendanceApi";
+import * as minutesApprovalApi from "../minutesApprovalApi";
+import * as weeklyInsightApi from "../weeklyInsightApi.js";
+import transferApi from "../transferApi";
+import { debriefQAApi } from "../../api/debriefQAApi.js";
+import * as actionItemChangeLogApi from "../../api/actionItemChangeLogApi.js";
+
+/**
+ * Centralized `/api` prefix regression suite (Issue #2657).
+ *
+ * Every client request path is relative: `apiClient`'s `baseURL` is the bare
+ * backend origin, and the server mounts every router under `/api/...`. A path
+ * that omits the prefix therefore 404s at runtime while looking perfectly
+ * correct in review — the most common silent failure mode in this codebase.
+ *
+ * Two layers of protection live here:
+ *
+ *  1. An enumerated table of the critical modules whose prefixes were repaired
+ *     across the prefix-fix issue series (weekly insights, ownership transfer,
+ *     minutes approval, attendance, debrief Q&A, icebreakers, async meetings).
+ *     Each entry pins the exact path a function must call, so a regression is
+ *     reported as a path diff rather than a mystery 404.
+ *  2. A static scan of every module under `client/src/services` and
+ *     `client/src/api` that fails when *any* service — including one added
+ *     tomorrow — issues a relative request that does not start with `/api/`.
+ */
+
+vi.mock("../apiClient", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const MEETING_ID = "m-100";
+const ORG_ID = "org-100";
+
+/**
+ * Critical client service paths, grouped by module.
+ *
+ * `invoke` calls the real exported function against the mocked `apiClient`;
+ * `method`/`path` describe the request that call must produce.
+ */
+const CRITICAL_MODULE_PATHS = [
+  {
+    module: "weeklyInsightApi",
+    calls: [
+      {
+        name: "getLatestInsight",
+        invoke: () => weeklyInsightApi.getLatestInsight(ORG_ID),
+        method: "get",
+        path: `/api/weekly-insights/${ORG_ID}/latest`,
+      },
+      {
+        name: "getInsightHistory",
+        invoke: () => weeklyInsightApi.getInsightHistory(ORG_ID, 2, 10),
+        method: "get",
+        path: `/api/weekly-insights/${ORG_ID}`,
+      },
+      {
+        name: "triggerManualGeneration",
+        invoke: () => weeklyInsightApi.triggerManualGeneration(ORG_ID),
+        method: "post",
+        path: `/api/weekly-insights/${ORG_ID}/generate`,
+      },
+    ],
+  },
+  {
+    module: "transferApi",
+    calls: [
+      {
+        name: "initiateTransfer",
+        invoke: () => transferApi.initiateTransfer(MEETING_ID, "u-200"),
+        method: "post",
+        path: `/api/meetings/${MEETING_ID}/transfers`,
+      },
+      {
+        name: "getTransferInbox",
+        invoke: () => transferApi.getTransferInbox(),
+        method: "get",
+        path: "/api/ownership-transfers/inbox",
+      },
+      {
+        name: "acceptTransfer",
+        invoke: () => transferApi.acceptTransfer("t-100"),
+        method: "post",
+        path: "/api/ownership-transfers/t-100/accept",
+      },
+      {
+        name: "rejectTransfer",
+        invoke: () => transferApi.rejectTransfer("t-100"),
+        method: "post",
+        path: "/api/ownership-transfers/t-100/reject",
+      },
+    ],
+  },
+  {
+    module: "minutesApprovalApi",
+    calls: [
+      {
+        name: "getApprovalStatus",
+        invoke: () => minutesApprovalApi.getApprovalStatus(MEETING_ID),
+        method: "get",
+        path: `/api/meetings/${MEETING_ID}/minutes-approval`,
+      },
+      {
+        name: "submitApproval",
+        invoke: () =>
+          minutesApprovalApi.submitApproval(MEETING_ID, "Summary", ["u-200"]),
+        method: "post",
+        path: `/api/meetings/${MEETING_ID}/minutes-approval/submit`,
+      },
+      {
+        name: "respondApproval",
+        invoke: () =>
+          minutesApprovalApi.respondApproval(
+            MEETING_ID,
+            "approved",
+            "Looks ok",
+          ),
+        method: "put",
+        path: `/api/meetings/${MEETING_ID}/minutes-approval/respond`,
+      },
+    ],
+  },
+  {
+    module: "attendanceApi",
+    calls: [
+      {
+        name: "getAttendanceStats",
+        invoke: () => attendanceApi.getAttendanceStats({ range: "30d" }),
+        method: "get",
+        path: "/api/attendance-analytics/stats",
+      },
+      {
+        name: "getAttendanceHeatmap",
+        invoke: () => attendanceApi.getAttendanceHeatmap({ range: "30d" }),
+        method: "get",
+        path: "/api/attendance-analytics/heatmap",
+      },
+      {
+        name: "getAttendanceTrends",
+        invoke: () => attendanceApi.getAttendanceTrends({ range: "30d" }),
+        method: "get",
+        path: "/api/attendance-analytics/trends",
+      },
+      {
+        name: "getMeetingTypeBreakdown",
+        invoke: () => attendanceApi.getMeetingTypeBreakdown({ range: "30d" }),
+        method: "get",
+        path: "/api/attendance-analytics/types",
+      },
+      {
+        name: "exportAttendanceCSV",
+        invoke: () => attendanceApi.exportAttendanceCSV({ range: "30d" }),
+        method: "get",
+        path: "/api/attendance-analytics/export",
+      },
+    ],
+  },
+  {
+    module: "meetingAttendanceApi",
+    calls: [
+      {
+        name: "getMeetingAttendance",
+        invoke: () => meetingAttendanceApi.getMeetingAttendance(MEETING_ID),
+        method: "get",
+        path: `/api/meetings/${MEETING_ID}/attendance`,
+      },
+      {
+        name: "checkIn",
+        invoke: () =>
+          meetingAttendanceApi.checkIn(
+            MEETING_ID,
+            "user@example.com",
+            "2026-08-31T10:00:00.000Z",
+          ),
+        method: "post",
+        path: `/api/meetings/${MEETING_ID}/attendance/checkin`,
+      },
+      {
+        name: "checkOut",
+        invoke: () =>
+          meetingAttendanceApi.checkOut(
+            MEETING_ID,
+            "user@example.com",
+            "2026-08-31T11:00:00.000Z",
+          ),
+        method: "post",
+        path: `/api/meetings/${MEETING_ID}/attendance/checkout`,
+      },
+      {
+        name: "markExcused",
+        invoke: () =>
+          meetingAttendanceApi.markExcused(MEETING_ID, "user@example.com"),
+        method: "put",
+        path: `/api/meetings/${MEETING_ID}/attendance/excuse`,
+      },
+      {
+        name: "finalizeAttendance",
+        invoke: () => meetingAttendanceApi.finalizeAttendance(MEETING_ID),
+        method: "post",
+        path: `/api/meetings/${MEETING_ID}/attendance/finalize`,
+      },
+    ],
+  },
+  {
+    module: "debriefQAApi",
+    calls: [
+      {
+        name: "askQuestion",
+        invoke: () => debriefQAApi.askQuestion(MEETING_ID, "What was decided?"),
+        method: "post",
+        path: "/api/debrief/session",
+      },
+      {
+        name: "getSession",
+        invoke: () => debriefQAApi.getSession(MEETING_ID),
+        method: "get",
+        path: `/api/debrief/session/${MEETING_ID}`,
+      },
+    ],
+  },
+  {
+    module: "icebreakerApi",
+    calls: [
+      {
+        name: "generateIcebreakers",
+        invoke: () => icebreakerApi.generateIcebreakers(MEETING_ID, ["u-200"]),
+        method: "post",
+        path: "/api/icebreakers/generate",
+      },
+      {
+        name: "selectIcebreaker",
+        invoke: () =>
+          icebreakerApi.selectIcebreaker(MEETING_ID, "fun", "Prompt text"),
+        method: "post",
+        path: "/api/icebreakers/select",
+      },
+    ],
+  },
+  {
+    module: "asyncMeetingApi",
+    calls: [
+      {
+        name: "getAsyncMeetings",
+        invoke: () => asyncMeetingApi.getAsyncMeetings({ status: "pending" }),
+        method: "get",
+        path: "/api/async-meetings",
+      },
+      {
+        name: "getAsyncMeetingById",
+        invoke: () => asyncMeetingApi.getAsyncMeetingById("async-100"),
+        method: "get",
+        path: "/api/async-meetings/async-100",
+      },
+      {
+        name: "createAsyncMeeting",
+        invoke: () => asyncMeetingApi.createAsyncMeeting({ title: "Sync" }),
+        method: "post",
+        path: "/api/async-meetings",
+      },
+      {
+        name: "submitAsyncUpdate",
+        invoke: () => asyncMeetingApi.submitAsyncUpdate("async-100", []),
+        method: "post",
+        path: "/api/async-meetings/async-100/submit",
+      },
+    ],
+  },
+  {
+    module: "actionItemChangeLogApi",
+    calls: [
+      {
+        name: "fetchChangeLogs",
+        invoke: () => actionItemChangeLogApi.fetchChangeLogs("a-100", {}),
+        method: "get",
+        path: "/api/action-items/a-100/changelog",
+      },
+      {
+        name: "fetchChangeLogStats",
+        invoke: () => actionItemChangeLogApi.fetchChangeLogStats("a-100"),
+        method: "get",
+        path: "/api/action-items/a-100/changelog/stats",
+      },
+    ],
+  },
+];
+
+describe("Centralized /api prefix regression suite (#2657)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Services unwrap `response.data`, so every method must resolve a response.
+    apiClient.get.mockResolvedValue({ data: {} });
+    apiClient.post.mockResolvedValue({ data: {} });
+    apiClient.put.mockResolvedValue({ data: {} });
+    apiClient.patch.mockResolvedValue({ data: {} });
+    apiClient.delete.mockResolvedValue({ data: {} });
+  });
+
+  describe.each(CRITICAL_MODULE_PATHS)("$module", ({ calls }) => {
+    it.each(calls)(
+      "$name requests $method $path",
+      async ({ invoke, method, path }) => {
+        await invoke();
+
+        expect(apiClient[method]).toHaveBeenCalledTimes(1);
+        expect(apiClient[method].mock.calls[0][0]).toBe(path);
+        assertAllCallsUseApiPrefix(apiClient);
+      },
+    );
+  });
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLIENT_SRC = resolve(__dirname, "../..");
+const SCANNED_DIRS = ["services", "api"];
+const HTTP_CALL_PATTERN =
+  /\.(get|post|put|patch|delete)\(\s*(["'`])([^"'`]*)\2/g;
+
+/** Every non-test module under the scanned service directories. */
+const collectServiceModules = (dir) => {
+  const modules = [];
+  for (const entry of readdirSync(dir)) {
+    const entryPath = join(dir, entry);
+    if (statSync(entryPath).isDirectory()) {
+      // `__tests__` / `__mocks__` hold expectations, not real request paths.
+      if (entry.startsWith("__")) continue;
+      modules.push(...collectServiceModules(entryPath));
+      continue;
+    }
+    if (!/\.jsx?$/.test(entry)) continue;
+    if (/\.(test|spec)\.jsx?$/.test(entry)) continue;
+    modules.push(entryPath);
+  }
+  return modules;
+};
+
+/**
+ * Relative request paths in `file` that are missing the `/api` prefix.
+ *
+ * Only root-relative string literals are inspected: absolute URLs (external
+ * services) and non-path arguments such as `headers.get("Authorization")`
+ * carry no prefix obligation.
+ */
+const findUnprefixedPaths = (file) => {
+  const source = readFileSync(file, "utf8");
+  const violations = [];
+  for (const [, method, , url] of source.matchAll(HTTP_CALL_PATTERN)) {
+    if (!url.startsWith("/")) continue;
+    if (url === "/api" || url.startsWith("/api/")) continue;
+    violations.push(`${method.toUpperCase()} ${url}`);
+  }
+  return violations;
+};
+
+describe("Service path prefix guard (#2657)", () => {
+  const modules = SCANNED_DIRS.flatMap((dir) =>
+    collectServiceModules(join(CLIENT_SRC, dir)),
+  );
+
+  it("scans every service module", () => {
+    expect(modules.length).toBeGreaterThan(0);
+  });
+
+  it("rejects relative request paths that omit /api", () => {
+    const violations = modules.flatMap((file) =>
+      findUnprefixedPaths(file).map(
+        (call) => `client/src/${relative(CLIENT_SRC, file)}: ${call}`,
+      ),
+    );
+
+    expect(
+      violations,
+      `Relative request paths must start with /api — the server mounts every router under /api.\n${violations.join(
+        "\n",
+      )}`,
+    ).toEqual([]);
+  });
+});

--- a/client/src/services/__tests__/attendance.integration.test.js
+++ b/client/src/services/__tests__/attendance.integration.test.js
@@ -16,7 +16,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
   });
 
   describe("Contract Assertions", () => {
-    it("should call GET /meetings/:meetingId/attendance when fetching attendance", async () => {
+    it("should call GET /api/meetings/:meetingId/attendance when fetching attendance", async () => {
       const mockResponse = {
         data: [{ email: "user@example.com", status: "invited" }],
       };
@@ -24,11 +24,13 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
 
       const res = await meetingAttendanceApi.getMeetingAttendance("m-100");
 
-      expect(apiClient.get).toHaveBeenCalledWith("/meetings/m-100/attendance");
+      expect(apiClient.get).toHaveBeenCalledWith(
+        "/api/meetings/m-100/attendance",
+      );
       expect(res).toEqual(mockResponse);
     });
 
-    it("should call POST /meetings/:meetingId/attendance/checkin with email & joinTime", async () => {
+    it("should call POST /api/meetings/:meetingId/attendance/checkin with email & joinTime", async () => {
       const mockResponse = {
         data: { email: "user@example.com", status: "checked_in" },
       };
@@ -42,7 +44,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       );
 
       expect(apiClient.post).toHaveBeenCalledWith(
-        "/meetings/m-100/attendance/checkin",
+        "/api/meetings/m-100/attendance/checkin",
         {
           email: "user@example.com",
           joinTime,
@@ -51,7 +53,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       expect(res).toEqual(mockResponse);
     });
 
-    it("should call POST /meetings/:meetingId/attendance/checkout with email & leaveTime", async () => {
+    it("should call POST /api/meetings/:meetingId/attendance/checkout with email & leaveTime", async () => {
       const mockResponse = {
         data: { email: "user@example.com", status: "checked_out" },
       };
@@ -65,7 +67,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       );
 
       expect(apiClient.post).toHaveBeenCalledWith(
-        "/meetings/m-100/attendance/checkout",
+        "/api/meetings/m-100/attendance/checkout",
         {
           email: "user@example.com",
           leaveTime,
@@ -74,7 +76,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       expect(res).toEqual(mockResponse);
     });
 
-    it("should call PUT /meetings/:meetingId/attendance/excuse when marking excused", async () => {
+    it("should call PUT /api/meetings/:meetingId/attendance/excuse when marking excused", async () => {
       const mockResponse = {
         data: { email: "user@example.com", status: "excused" },
       };
@@ -86,13 +88,13 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       );
 
       expect(apiClient.put).toHaveBeenCalledWith(
-        "/meetings/m-100/attendance/excuse",
+        "/api/meetings/m-100/attendance/excuse",
         { email: "user@example.com" },
       );
       expect(res).toEqual(mockResponse);
     });
 
-    it("should call POST /meetings/:meetingId/attendance/finalize when finalizing", async () => {
+    it("should call POST /api/meetings/:meetingId/attendance/finalize when finalizing", async () => {
       const mockResponse = {
         data: { message: "Attendance finalized successfully" },
       };
@@ -101,7 +103,7 @@ describe("Meeting Attendance Client Service Integration Tests (#2666)", () => {
       const res = await meetingAttendanceApi.finalizeAttendance("m-100");
 
       expect(apiClient.post).toHaveBeenCalledWith(
-        "/meetings/m-100/attendance/finalize",
+        "/api/meetings/m-100/attendance/finalize",
       );
       expect(res).toEqual(mockResponse);
     });

--- a/client/src/services/icebreakerApi.js
+++ b/client/src/services/icebreakerApi.js
@@ -1,7 +1,7 @@
 import api from "./apiClient"; // Ensure we use the pre-configured axios instance
 
 export const generateIcebreakers = async (meetingId, participantIds = []) => {
-  const response = await api.post("/icebreakers/generate", {
+  const response = await api.post("/api/icebreakers/generate", {
     meetingId,
     participantIds,
   });
@@ -9,7 +9,7 @@ export const generateIcebreakers = async (meetingId, participantIds = []) => {
 };
 
 export const selectIcebreaker = async (meetingId, category, promptText) => {
-  const response = await api.post("/icebreakers/select", {
+  const response = await api.post("/api/icebreakers/select", {
     meetingId,
     category,
     promptText,

--- a/client/src/services/meetingAttendanceApi.js
+++ b/client/src/services/meetingAttendanceApi.js
@@ -1,27 +1,29 @@
 import apiClient from "./apiClient";
 
 export const getMeetingAttendance = (meetingId) => {
-  return apiClient.get(`/meetings/${meetingId}/attendance`);
+  return apiClient.get(`/api/meetings/${meetingId}/attendance`);
 };
 
 export const checkIn = (meetingId, email, joinTime) => {
-  return apiClient.post(`/meetings/${meetingId}/attendance/checkin`, {
+  return apiClient.post(`/api/meetings/${meetingId}/attendance/checkin`, {
     email,
     joinTime,
   });
 };
 
 export const checkOut = (meetingId, email, leaveTime) => {
-  return apiClient.post(`/meetings/${meetingId}/attendance/checkout`, {
+  return apiClient.post(`/api/meetings/${meetingId}/attendance/checkout`, {
     email,
     leaveTime,
   });
 };
 
 export const markExcused = (meetingId, email) => {
-  return apiClient.put(`/meetings/${meetingId}/attendance/excuse`, { email });
+  return apiClient.put(`/api/meetings/${meetingId}/attendance/excuse`, {
+    email,
+  });
 };
 
 export const finalizeAttendance = (meetingId) => {
-  return apiClient.post(`/meetings/${meetingId}/attendance/finalize`);
+  return apiClient.post(`/api/meetings/${meetingId}/attendance/finalize`);
 };


### PR DESCRIPTION
Closes #2657

## Summary

`apiClient`'s `baseURL` is the bare backend origin and every server router is mounted under `/api`, so a client path that omits the prefix 404s at runtime while looking correct in review. Prefix guards existed for a few domains only. This adds one centralized suite covering the modules from the prefix-fix series plus a guard that catches services added later.

`client/src/services/__tests__/apiPrefixRegression.test.js` (32 tests):

- **Enumerated critical paths** — a single table pins the exact request path for every exported function in `weeklyInsightApi`, `transferApi`, `minutesApprovalApi`, `attendanceApi`, `meetingAttendanceApi`, `debriefQAApi`, `icebreakerApi`, `asyncMeetingApi` and `actionItemChangeLogApi`. Each case invokes the real function against a mocked `apiClient`, so a regression surfaces as a path diff instead of a mystery 404. Re-uses the existing `helpers/apiPrefixAssertionHelper.js`.
- **Static prefix guard** — scans every non-test module under `client/src/services` and `client/src/api`, extracts string-literal request paths, and fails with a file-and-path list if any root-relative path does not start with `/api/`. Absolute URLs (external services) and non-path arguments such as `headers.get("Authorization")` are ignored. New services are covered automatically; no registry to update.

## Prefix fixes required to land the guard green

The guard flagged four modules whose paths do not match their server mounts. Only the path strings changed:

| Module | Before | Server mount |
| --- | --- | --- |
| `services/icebreakerApi.js` | `/icebreakers/generate`, `/icebreakers/select` | `/api/icebreakers` |
| `api/debriefQAApi.js` | `/debrief/session`, `/debrief/session/:meetingId` | `/api/debrief` |
| `services/meetingAttendanceApi.js` | `/meetings/:id/attendance*` (5 calls) | `/api/meetings/:meetingId/attendance` |
| `api/actionItemChangeLogApi.js` | `/action-items/:id/changelog`, `/changelog/stats` | `/api/action-items` |

Three of the four (attendance, debrief, icebreakers) are named in the issue's problem statement; `actionItemChangeLogApi` was surfaced by the new guard. `attendance.integration.test.js` expectations were updated to the corrected paths.

## Testing

- `npx vitest run src/services/__tests__/apiPrefixRegression.test.js` — 32 passed.
- Negative check: reverting one path to `/icebreakers/select` fails both the enumerated assertion and the guard (which reports `client/src/services/icebreakerApi.js: POST /icebreakers/select`), exit code 1.
- All prefix suites together (`apiPrefix`, `agendaAndCarryForwardApiPrefix`, `sharedLinkApiPrefix`, `transferApiPrefix`, `asyncMeetingsApiPrefix`, `attendance.integration`, new suite) — 68 passed.
- `eslint`, `prettier --check` and `npm run build` all clean on the changed files.
- `vitest related` on the changed sources reports 18 failing page test files; the identical file list fails the same way on unmodified `main`, so those are pre-existing and unrelated.

## Not in this PR

`client/src/services/__tests__/asyncMeetings.integration.test.js` still asserts pre-fix `/async-meetings` paths and fails on `main` independently of this change. Left untouched to keep the diff scoped; happy to correct it here if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated action item, debrief, icebreaker, and meeting attendance requests to use the correct API routes.
  - Improved reliability for loading change logs and statistics, debrief sessions, icebreaker content, and attendance actions.
- **Tests**
  - Added coverage to verify API routes consistently use the required path format.
  - Updated attendance integration checks to reflect the corrected routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->