### PR TITLE
fix: route client api modules through the shared apiClient (closes #2…

### DIFF
--- a/client/src/__tests__/noDirectAxiosImportApi.test.js
+++ b/client/src/__tests__/noDirectAxiosImportApi.test.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("API modules must not import axios directly", () => {
+  const apiDir = path.resolve(__dirname, "../api");
+  const files = fs
+    .readdirSync(apiDir)
+    .filter((f) => f.endsWith(".js") && !f.includes(".test."));
+
+  files.forEach((file) => {
+    it(`${file} should not import axios directly`, () => {
+      const content = fs.readFileSync(path.join(apiDir, file), "utf8");
+      const hasDirectAxiosImport = /import\s+axios\s+from\s+["']axios["']/.test(
+        content
+      );
+      expect(hasDirectAxiosImport).toBe(false);
+    });
+  });
+});

--- a/client/src/api/participantContributionApi.js
+++ b/client/src/api/participantContributionApi.js
@@ -1,17 +1,12 @@
-import axios from "axios";
-
-const API_BASE_URL = "/api";
+import apiClient from "../services/apiClient";
 
 /**
  * Fetch participant contributions for a given meeting
  * @param {string} meetingId
  */
 export const getMeetingContributions = async (meetingId) => {
-  const response = await axios.get(
-    `${API_BASE_URL}/meetings/${meetingId}/contributions`,
-    {
-      withCredentials: true,
-    },
+  const response = await apiClient.get(
+    `/api/meetings/${meetingId}/contributions`,
   );
   return response.data;
 };
@@ -21,12 +16,10 @@ export const getMeetingContributions = async (meetingId) => {
  * @param {string} meetingId
  */
 export const calculateMeetingContributions = async (meetingId) => {
-  const response = await axios.post(
-    `${API_BASE_URL}/meetings/${meetingId}/contributions/calculate`,
+  const response = await apiClient.post(
+    `/api/meetings/${meetingId}/contributions/calculate`,
     {},
-    {
-      withCredentials: true,
-    },
+    
   );
   return response.data;
 };

--- a/client/src/api/recurringActionItemApi.js
+++ b/client/src/api/recurringActionItemApi.js
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from "../services/apiClient";
 
 export const getRecurringActionItems = async () => {
   const response = await apiClient.get("/api/recurring-action-items");


### PR DESCRIPTION
…574)

# Pull Request

## Description
Fixes two client/src/api/ modules that bypass the shared apiClient — recurringActionItemApi.js imported a non-existent ./apiClient path, and participantContributionApi.js used raw axios instead of the shared client.
Provide a brief description of the changes introduced in this pull request.

## Type of Change

- [ ] New Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2574

## Testing

Describe the testing performed.
Tested locally, and under it note Ran npm run build --prefix client — 79 modules transformed, built successfully with no import errors.
- [X] Tested locally
- [X] Existing functionality verified
- [X] No new warnings or errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [X] Code follows project conventions
- [X] Documentation updated where required
- [X] No unnecessary files included
- [X] Changes have been tested
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the consistency and reliability of contribution and recurring action item data requests.
  * Centralized API communication through the shared service, reducing differences in how requests are handled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->