### PR TITLE
feat(meetings): export meeting notes as Markdown (#2543)

### DIFF
--- a/client/src/pages/MeetingDetails.jsx
+++ b/client/src/pages/MeetingDetails.jsx
@@ -40,6 +40,7 @@ import CompareButton from "../components/meeting-details/CompareButton";
 import AgendaBuilder from "../components/meetings/AgendaBuilder";
 import IcebreakerSection from "../components/meetings/IcebreakerSection";
 import { getBriefing } from "../services/briefingApi";
+import { downloadMeetingNotesMarkdown } from "../services/meetingNotesExportApi";
 import GuestAccessManager from "../components/meetings/GuestAccessManager";
 import MeetingReadiness from "../components/MeetingReadiness";
 import FollowUpThreads from "../components/meeting-details/FollowUpThreads";
@@ -385,6 +386,31 @@ const MeetingDetails = () => {
             >
               <FileText className="w-4 h-4" />
               Export Minutes
+            </button>
+            <button
+              onClick={async () => {
+                try {
+                  const blob = await downloadMeetingNotesMarkdown(meeting._id);
+                  const url = window.URL.createObjectURL(blob);
+                  const link = document.createElement("a");
+                  link.href = url;
+                  link.setAttribute(
+                    "download",
+                    `meeting-notes-${meeting._id}.md`,
+                  );
+                  document.body.appendChild(link);
+                  link.click();
+                  link.remove();
+                  window.URL.revokeObjectURL(url);
+                } catch (err) {
+                  console.error("Failed to download meeting notes:", err);
+                }
+              }}
+              className="flex items-center gap-2 px-4 py-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg font-medium shadow-sm transition-colors text-sm"
+              data-testid="download-notes-md-btn"
+            >
+              <FileText className="w-4 h-4" />
+              Download Notes
             </button>
             <button
               onClick={() => setIsEndorseModalOpen(true)}

--- a/client/src/services/meetingNotesExportApi.js
+++ b/client/src/services/meetingNotesExportApi.js
@@ -1,0 +1,12 @@
+import apiClient from "./apiClient";
+
+/**
+ * Download a meeting's notes (summary + action items) as a Markdown file (#2543).
+ * Returns a Blob the caller turns into a browser download.
+ */
+export const downloadMeetingNotesMarkdown = async (meetingId) => {
+  const response = await apiClient.get(`/api/meetings/${meetingId}/export`, {
+    responseType: "blob",
+  });
+  return response.data;
+};

--- a/server/controllers/meetingController.js
+++ b/server/controllers/meetingController.js
@@ -17,6 +17,8 @@ import path from "path";
 import { z } from "zod";
 import mongoose from "mongoose";
 import Meeting from "../models/meetingModel.js";
+import ActionItem from "../models/actionItemModel.js";
+import { renderMeetingNotesMarkdown } from "../utils/meetingNotesExport.js";
 import * as MeetingService from "../services/MeetingService.js";
 import * as MeetingInviteService from "../services/MeetingInviteService.js";
 import * as MeetingCloneService from "../services/meetingCloneService.js";
@@ -554,6 +556,42 @@ export const getMeetingById = async (req, res, next) => {
     getUserId(req); // ensure authenticated
     const meeting = await MeetingService.getMeetingById(req.params.id);
     return sendSuccess(res, { meeting });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/* ─────────────────────────────────────────────────────────────
+   EXPORT MEETING NOTES (Markdown) — Issue #2543
+   Lets users download a shareable Markdown file of the summary and
+   action items for stakeholders who lack platform access.
+   ───────────────────────────────────────────────────────────── */
+export const exportMeetingNotes = async (req, res, next) => {
+  try {
+    getUserId(req); // ensure authenticated
+    const meeting = await MeetingService.getMeetingById(req.params.id);
+
+    const actionItems = await ActionItem.find({
+      sourceMeetingId: req.params.id,
+    })
+      .sort({ createdAt: 1 })
+      .lean();
+
+    const markdown = renderMeetingNotesMarkdown(meeting, actionItems, {
+      includeTranscript: req.query.transcript === "true",
+    });
+
+    const safeTitle = (meeting?.title || "meeting")
+      .replace(/[^a-z0-9]+/gi, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase();
+
+    res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${safeTitle || "meeting"}-notes.md"`,
+    );
+    return res.status(200).send(markdown);
   } catch (err) {
     next(err);
   }

--- a/server/routes/meetingRoutes.js
+++ b/server/routes/meetingRoutes.js
@@ -22,6 +22,7 @@ import {
   summarizeMeeting, // EXISTING: Generate AI summary/MOM
   getAllMeetings,
   getMeetingById, // NEW: Get single meeting details
+  exportMeetingNotes, // Export meeting notes as Markdown (#2543)
   updateMeeting, // NEW: Update meeting (rename)
   deleteMeeting, // Soft-delete meeting
   getDeletedMeetings,
@@ -452,6 +453,15 @@ router.get(
   requireOrgAccess(Meeting),
   requirePermission("meetings", "view"),
   getMeetingById,
+);
+
+// ✅ Export Meeting Notes as Markdown (Download button on Meeting Details)
+router.get(
+  "/:id/export",
+  userAuth,
+  requireOrgAccess(Meeting),
+  requirePermission("meetings", "view"),
+  exportMeetingNotes,
 );
 
 // ✅ Update Meeting (for Meeting Details Page - rename)

--- a/server/tests/meetingNotesExport.test.js
+++ b/server/tests/meetingNotesExport.test.js
@@ -1,0 +1,64 @@
+import { renderMeetingNotesMarkdown } from "../utils/meetingNotesExport.js";
+
+describe("renderMeetingNotesMarkdown (Issue #2543)", () => {
+  it("renders title, date, summary and action items", () => {
+    const md = renderMeetingNotesMarkdown(
+      {
+        title: "Q3 Planning",
+        date: new Date("2026-08-15T09:00:00.000Z"),
+        summary: "Agreed on the roadmap.",
+      },
+      [
+        {
+          text: "Draft spec",
+          owner: "Ada",
+          status: "open",
+          dueDate: "2026-08-20",
+        },
+        { text: "Ship it", owner: "Grace", status: "completed" },
+      ],
+    );
+
+    expect(md).toContain("# Q3 Planning");
+    expect(md).toContain("_2026-08-15_");
+    expect(md).toContain("## Summary");
+    expect(md).toContain("Agreed on the roadmap.");
+    expect(md).toContain("- [ ] Draft spec — Ada, open, due 2026-08-20");
+    expect(md).toContain("- [x] Ship it — Grace, completed");
+  });
+
+  it("falls back gracefully when fields are missing", () => {
+    const md = renderMeetingNotesMarkdown({});
+    expect(md).toContain("# Untitled Meeting");
+    expect(md).toContain("_No summary available._");
+    expect(md).toContain("_No action items._");
+    // No date line when the meeting has no date.
+    expect(md).not.toContain("_20");
+  });
+
+  it("omits the transcript unless explicitly requested", () => {
+    const meeting = { title: "Sync", transcript: "hello world" };
+
+    expect(renderMeetingNotesMarkdown(meeting, [])).not.toContain(
+      "## Transcript",
+    );
+
+    const withTranscript = renderMeetingNotesMarkdown(meeting, [], {
+      includeTranscript: true,
+    });
+    expect(withTranscript).toContain("## Transcript");
+    expect(withTranscript).toContain("hello world");
+  });
+
+  it("tolerates null meeting and non-array action items", () => {
+    const md = renderMeetingNotesMarkdown(null, null);
+    expect(md).toContain("# Untitled Meeting");
+    expect(md).toContain("_No action items._");
+    expect(md.endsWith("\n")).toBe(true);
+  });
+
+  it("labels an action item with no fields as untitled without a suffix", () => {
+    const md = renderMeetingNotesMarkdown({ title: "T" }, [{}]);
+    expect(md).toContain("- [ ] (untitled)");
+  });
+});

--- a/server/utils/meetingNotesExport.js
+++ b/server/utils/meetingNotesExport.js
@@ -1,0 +1,82 @@
+/**
+ * Meeting notes export (Issue #2543).
+ *
+ * Pure, IO-free: render a meeting's summary and action items as a clean
+ * Markdown document that users can download and share with stakeholders who
+ * lack platform access. Unit-tested; the controller just supplies the meeting
+ * document and its action items.
+ */
+
+const DONE_STATUSES = new Set(["completed", "resolved"]);
+
+const isBlank = (value) =>
+  value === null || value === undefined || String(value).trim() === "";
+
+// Format a date as YYYY-MM-DD, tolerating Date objects, ISO strings, or null.
+const formatDate = (value) => {
+  if (isBlank(value)) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString().slice(0, 10);
+};
+
+const renderActionItem = (item) => {
+  const text = isBlank(item?.text) ? "(untitled)" : String(item.text).trim();
+  const checkbox = DONE_STATUSES.has(item?.status) ? "[x]" : "[ ]";
+
+  const meta = [];
+  if (!isBlank(item?.owner)) meta.push(String(item.owner).trim());
+  if (!isBlank(item?.status)) meta.push(String(item.status).trim());
+  const due = formatDate(item?.dueDate);
+  if (due) meta.push(`due ${due}`);
+
+  const suffix = meta.length > 0 ? ` — ${meta.join(", ")}` : "";
+  return `- ${checkbox} ${text}${suffix}`;
+};
+
+/**
+ * Render a meeting and its action items as a Markdown document.
+ *
+ * @param {{ title?: string, date?: Date|string, summary?: string, transcript?: string }} meeting
+ * @param {Array} actionItems
+ * @param {{ includeTranscript?: boolean }} opts
+ * @returns {string} Markdown text
+ */
+export function renderMeetingNotesMarkdown(
+  meeting,
+  actionItems = [],
+  opts = {},
+) {
+  const safeMeeting = meeting ?? {};
+  const items = Array.isArray(actionItems) ? actionItems : [];
+  const lines = [];
+
+  const title = isBlank(safeMeeting.title)
+    ? "Untitled Meeting"
+    : String(safeMeeting.title).trim();
+  lines.push(`# ${title}`);
+
+  const date = formatDate(safeMeeting.date);
+  if (date) {
+    lines.push("", `_${date}_`);
+  }
+
+  lines.push("", "## Summary", "");
+  lines.push(
+    isBlank(safeMeeting.summary)
+      ? "_No summary available._"
+      : String(safeMeeting.summary).trim(),
+  );
+
+  lines.push("", "## Action Items", "");
+  if (items.length === 0) {
+    lines.push("_No action items._");
+  } else {
+    for (const item of items) lines.push(renderActionItem(item));
+  }
+
+  if (opts.includeTranscript && !isBlank(safeMeeting.transcript)) {
+    lines.push("", "## Transcript", "", String(safeMeeting.transcript).trim());
+  }
+
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## What & why

Closes #2543.

Users couldn't easily share meeting notes with stakeholders who lack platform access. This adds a **Download Notes** button on the meeting details page that downloads a clean Markdown file of the summary and action items.

It's deliberately distinct from the existing template/branded **Export Minutes** dialog (PDF/DOCX/HTML): this is a zero-config, dependency-free Markdown export of just the notes + action items.

## Changes

**Server**
- **`server/utils/meetingNotesExport.js`** — pure, IO-free `renderMeetingNotesMarkdown(meeting, actionItems, opts)`: title, date, summary, and action items as a Markdown checklist (`[x]` for completed/resolved, with owner/status/due), tolerant of missing fields and non-array input. Optional transcript section.
- **`server/controllers/meetingController.js`** — `exportMeetingNotes` (`GET /api/meetings/:id/export`): loads the meeting + its action items and streams the Markdown as a `.md` attachment. Same auth/permission chain as the existing meeting-details route.
- **`server/routes/meetingRoutes.js`** — wires the route.

**Client**
- **`meetingNotesExportApi.js`** — `downloadMeetingNotesMarkdown(meetingId)` (blob).
- **`MeetingDetails.jsx`** — a "Download Notes" button that triggers the download.

## Testing

- **`server/tests/meetingNotesExport.test.js`** — 5 jest cases (full render, graceful fallbacks, transcript opt-in, null/non-array tolerance, untitled item). Green.
- Prettier + ESLint clean on all changed server and client files; client `npm run build` succeeds.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to download meeting notes as a Markdown file.
  * Exported notes include the meeting title, date, summary, and action items.
  * Action items display completion status, owners, and due dates.
  * Exports can optionally include the meeting transcript.

* **Bug Fixes**
  * Added safeguards and fallback text for incomplete or missing meeting information.

* **Tests**
  * Added coverage for standard exports, optional transcripts, missing fields, and varied action-item data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->