### PR TITLE
fix(search): escape user input before building RegExp (#2572)

### DIFF
--- a/server/controllers/aiMeetingNoteController.js
+++ b/server/controllers/aiMeetingNoteController.js
@@ -1,4 +1,5 @@
 import AiMeetingNote from "../models/aiMeetingNoteModel.js";
+import { escapeRegExp } from "../utils/regexUtils.js";
 
 /**
  * Built-in reusable note templates
@@ -303,7 +304,7 @@ export const getNotes = async (req, res) => {
     const query = { organization: organizationId };
 
     if (search && search.trim()) {
-      const regex = new RegExp(search.trim(), "i");
+      const regex = new RegExp(escapeRegExp(search.trim()), "i");
       query.$or = [{ title: regex }, { summary: regex }, { tags: regex }];
     }
 

--- a/server/controllers/bookmarkController.js
+++ b/server/controllers/bookmarkController.js
@@ -1,6 +1,7 @@
 import Bookmark from "../models/bookmarkModel.js";
 import Meeting from "../models/meetingModel.js";
 import mongoose from "mongoose";
+import { escapeRegExp } from "../utils/regexUtils.js";
 import { isSameOrganization } from "../utils/authUtils.js";
 
 // @desc    Toggle bookmark (add if missing, remove if exists)
@@ -105,7 +106,7 @@ export const getBookmarks = async (req, res) => {
 
     let filteredBookmarks = bookmarks;
     if (search && typeof search === "string") {
-      const regex = new RegExp(search, "i");
+      const regex = new RegExp(escapeRegExp(search), "i");
       filteredBookmarks = bookmarks.filter(
         (b) =>
           regex.test(b.notes || "") ||

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -1,6 +1,7 @@
 import SessionCard from "../models/sessionCardModel.js";
 import { generateSessionCardAI } from "../services/GenerativeAIService.js";
 import { sendSuccess, sendError } from "../utils/responseHandler.js";
+import { literalRegExp } from "../utils/regexUtils.js";
 
 // @desc    Generate AI Session Card & Persist to Org Library
 // @route   POST /api/sessions/generate
@@ -119,14 +120,14 @@ export const getSessions = async (req, res) => {
     }
 
     if (event && event.trim()) {
-      filter.eventName = new RegExp(`^${event.trim()}$`, "i");
+      filter.eventName = literalRegExp(event.trim());
     }
 
     if (tag && tag.trim()) {
       filter.$or = filter.$or || [];
       filter.$or.push(
-        { keywords: new RegExp(`^${tag.trim()}$`, "i") },
-        { tags: new RegExp(`^${tag.trim()}$`, "i") },
+        { keywords: literalRegExp(tag.trim()) },
+        { tags: literalRegExp(tag.trim()) },
       );
     }
 

--- a/server/tests/regexEscaping.test.js
+++ b/server/tests/regexEscaping.test.js
@@ -102,6 +102,31 @@ beforeAll(async () => {
 
 // ───────────────────────────────────────────────────────────────────────────
 describe("regexUtils", () => {
+  describe("escapeRegExp neutralizes #2572 search inputs", () => {
+    it("does not throw on metacharacter input that broke the old RegExp", () => {
+      expect(() => new RegExp(escapeRegExp("C++"), "i")).not.toThrow();
+      expect(() => new RegExp(escapeRegExp("("), "i")).not.toThrow();
+    });
+
+    it("treats wildcards as literals (no filter bypass)", () => {
+      const re = new RegExp(escapeRegExp(".*"), "i");
+      expect(re.test(".*")).toBe(true);
+      expect(re.test("anything else")).toBe(false);
+    });
+
+    it("renders a ReDoS pattern inert", () => {
+      const re = new RegExp(escapeRegExp("(a+)+$"), "i");
+      const start = Date.now();
+      re.test("a".repeat(40) + "!");
+      expect(Date.now() - start).toBeLessThan(50);
+    });
+
+    it("literalRegExp anchors and escapes for exact match", () => {
+      expect(literalRegExp("C++").test("C++")).toBe(true);
+      expect(literalRegExp("C++").test("XC++Y")).toBe(false);
+    });
+  });
+
   describe("escapeRegExp", () => {
     it("neutralizes every metacharacter it claims to", () => {
       const specials = ".*+?^${}()|[]\\";


### PR DESCRIPTION
## What & why

Closes #2572.

Three controllers compiled **raw user input** into a `RegExp`, which allows:
- **ReDoS** — `bookmarkController.js` runs the regex in-process over already-loaded bookmarks (`regex.test(...)` in a `.filter`), so an input like `(a+)+$` pins the Node event loop for the whole process.
- **500s** — metacharacter input (e.g. `C++`, `(`) throws `SyntaxError` from the `RegExp` constructor.
- **Wildcard filter bypass** — `.*` matches everything instead of the literal.

The fix helper (`escapeRegExp` / `literalRegExp` in `server/utils/regexUtils.js`) already exists and is tested; these four sites simply bypassed it.

## Changes

- **`bookmarkController.js`** — `new RegExp(escapeRegExp(search), "i")`.
- **`aiMeetingNoteController.js`** — `new RegExp(escapeRegExp(search.trim()), "i")`.
- **`sessionController.js`** — the `event` and `tag` exact-match filters use `literalRegExp(...)` (identical anchored, case-insensitive shape via `^…$`, just escaped — no query-semantics change).
- `sessionController.js`'s free-text `search` was already escaped inline; left as-is.

## Testing

- Added a pure regression block to `server/tests/regexEscaping.test.js` (metacharacter no-throw, wildcard-as-literal, ReDoS-inert timing, `literalRegExp` exact-match). Green.
- Prettier + ESLint clean on all changed files. Escaping a plain string is a no-op, so existing search tests still match.

> Out of scope (noted follow-up): the `tag` filter's AND→OR widening in `sessionController.js` is a query-structure change best covered by a DB test — not part of this ReDoS fix.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
