### PR TITLE
fix(api): route remaining list endpoints through shared pagination

### DIFF
--- a/server/controllers/actionItemChangeLogController.js
+++ b/server/controllers/actionItemChangeLogController.js
@@ -1,4 +1,5 @@
 import ActionItemChangeLog from "../models/actionItemChangeLogModel.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 /**
  * @desc Get changelogs for a specific action item
@@ -8,30 +9,30 @@ import ActionItemChangeLog from "../models/actionItemChangeLogModel.js";
 export const getChangeLogs = async (req, res) => {
   try {
     const { id } = req.params;
-    const { type, userId, page = 1, limit = 50 } = req.query;
+    const { type, userId } = req.query;
 
     const query = { actionItemId: id };
     if (type) query.changeType = type;
     if (userId) query.changedBy = userId;
 
-    const skip = (page - 1) * limit;
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 50,
+    });
 
     const logs = await ActionItemChangeLog.find(query)
       .sort({ createdAt: -1 })
       .skip(skip)
-      .limit(Number(limit))
+      .limit(limit)
       .populate("changedBy", "name avatar email");
 
     const total = await ActionItemChangeLog.countDocuments(query);
 
+    const pagination = buildPaginationMeta({ total, page, limit });
+
     res.status(200).json({
       success: true,
       data: logs,
-      pagination: {
-        total,
-        page: Number(page),
-        pages: Math.ceil(total / limit),
-      },
+      pagination,
     });
   } catch (error) {
     console.error("Error fetching changelogs:", error);

--- a/server/controllers/aiMeetingNoteController.js
+++ b/server/controllers/aiMeetingNoteController.js
@@ -1,5 +1,6 @@
 import AiMeetingNote from "../models/aiMeetingNoteModel.js";
 import { escapeRegExp } from "../utils/regexUtils.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 /**
  * Built-in reusable note templates
@@ -297,9 +298,11 @@ export const getNotes = async (req, res) => {
       endDate,
       sortBy = "date",
       sortOrder = "desc",
-      page = 1,
-      limit = 20,
     } = req.query;
+
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+    });
 
     const query = { organization: organizationId };
 
@@ -326,14 +329,13 @@ export const getNotes = async (req, res) => {
       if (endDate) query.date.$lte = new Date(endDate);
     }
 
-    const skip = (Math.max(1, Number(page)) - 1) * Math.max(1, Number(limit));
     const sort = { [sortBy]: sortOrder === "asc" ? 1 : -1 };
 
     const [notes, total] = await Promise.all([
       AiMeetingNote.find(query)
         .sort(sort)
         .skip(skip)
-        .limit(Number(limit))
+        .limit(limit)
         .populate("meeting", "title date meetingType")
         .populate("createdBy", "name email")
         .populate("reviewedBy", "name email")
@@ -341,16 +343,13 @@ export const getNotes = async (req, res) => {
       AiMeetingNote.countDocuments(query),
     ]);
 
+    const pagination = buildPaginationMeta({ total, page, limit });
+
     return res.status(200).json({
       success: true,
       data: {
         notes,
-        pagination: {
-          total,
-          page: Number(page),
-          limit: Number(limit),
-          pages: Math.ceil(total / Number(limit)) || 1,
-        },
+        pagination,
       },
     });
   } catch (error) {

--- a/server/controllers/followUpController.js
+++ b/server/controllers/followUpController.js
@@ -4,6 +4,7 @@ import {
   updateTaskStatus,
 } from "../services/followUpWorkflowService.js";
 import mongoose from "mongoose";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 /**
  * Follow-Up Controller
@@ -17,7 +18,7 @@ import mongoose from "mongoose";
  */
 export const getTasks = async (req, res) => {
   try {
-    const { status, assignee, page = 1, limit = 20 } = req.query;
+    const { status, assignee } = req.query;
     const userId = req.user._id;
     const organizationId = req.user.organization;
 
@@ -25,6 +26,11 @@ export const getTasks = async (req, res) => {
 
     // Filter by assignee (default to current user)
     if (assignee) {
+      // Validate assignee is a well-formed ObjectId so a malformed value is
+      // rejected as a 400 client error instead of surfacing as a 500 CastError.
+      if (!mongoose.isValidObjectId(assignee)) {
+        return res.status(400).json({ message: "Invalid assignee ID" });
+      }
       query.assignee = assignee;
     } else {
       query.assignee = userId;
@@ -43,7 +49,9 @@ export const getTasks = async (req, res) => {
       query.$or = [{ snoozedUntil: null }, { snoozedUntil: { $lte: now } }];
     }
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+    });
 
     const tasks = await FollowUpTask.find(query)
       .populate("assignee", "name email profilePicture")
@@ -51,18 +59,15 @@ export const getTasks = async (req, res) => {
       .populate("completedBy", "name email")
       .sort({ deadline: 1 })
       .skip(skip)
-      .limit(parseInt(limit));
+      .limit(limit);
 
     const total = await FollowUpTask.countDocuments(query);
 
+    const pagination = buildPaginationMeta({ total, page, limit });
+
     res.status(200).json({
       tasks,
-      pagination: {
-        page: parseInt(page),
-        limit: parseInt(limit),
-        total,
-        totalPages: Math.ceil(total / parseInt(limit)),
-      },
+      pagination,
     });
   } catch (error) {
     console.error("Error fetching tasks:", error);

--- a/server/controllers/meetingROIController.js
+++ b/server/controllers/meetingROIController.js
@@ -1,4 +1,5 @@
 import MeetingROI from "../models/meetingROIModel.js";
+import { buildPaginationMeta, parsePagination } from "../utils/pagination.js";
 
 /**
  * Helper to calculate cost and ROI fields for payload/instance
@@ -80,9 +81,11 @@ export const getROIRecords = async (req, res) => {
       endDate,
       sortBy = "date",
       sortOrder = "desc",
-      page = 1,
-      limit = 20,
     } = req.query;
+
+    const { page, limit, skip } = parsePagination(req.query, {
+      defaultLimit: 20,
+    });
 
     const query = { organization: organizationId };
 
@@ -108,29 +111,25 @@ export const getROIRecords = async (req, res) => {
       if (endDate) query.date.$lte = new Date(endDate);
     }
 
-    const skip = (Math.max(1, Number(page)) - 1) * Math.max(1, Number(limit));
     const sort = { [sortBy]: sortOrder === "asc" ? 1 : -1 };
 
     const [records, total] = await Promise.all([
       MeetingROI.find(query)
         .sort(sort)
         .skip(skip)
-        .limit(Number(limit))
+        .limit(limit)
         .populate("meeting", "title date meetingType")
         .lean(),
       MeetingROI.countDocuments(query),
     ]);
 
+    const pagination = buildPaginationMeta({ total, page, limit });
+
     return res.status(200).json({
       success: true,
       data: {
         records,
-        pagination: {
-          total,
-          page: Number(page),
-          limit: Number(limit),
-          pages: Math.ceil(total / Number(limit)) || 1,
-        },
+        pagination,
       },
     });
   } catch (error) {

--- a/server/tests/paginationEndpoints.test.js
+++ b/server/tests/paginationEndpoints.test.js
@@ -1,0 +1,234 @@
+/**
+ * Endpoint pagination hardening (follow-up to #1071).
+ *
+ * These four list endpoints used to parse `?page=` / `?limit=` by hand, which
+ * reintroduced the exact failures the shared `parsePagination` /
+ * `buildPaginationMeta` helpers were written to prevent:
+ *
+ *   - no ceiling            -> `?limit=1000000` streams the whole collection
+ *   - no floor              -> `?page=0` produces a negative skip -> 500
+ *   - NaN skip              -> `?page=abc` -> 500
+ *   - `?limit=0`            -> means "no limit" in Mongoose -> whole collection
+ *   - missing `hasMore`     -> client cannot detect the last page
+ *   - unvalidated `assignee` -> malformed value reaches the query -> 500 CastError
+ *
+ * These suites pin the new behaviour for each of the four controllers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/FollowUpTask.js", () => {
+  const Mock = vi.fn();
+  Mock.find = vi.fn();
+  Mock.countDocuments = vi.fn();
+  return { default: Mock };
+});
+
+vi.mock("../services/followUpWorkflowService.js", () => ({
+  getCompletionAnalytics: vi.fn(),
+  updateTaskStatus: vi.fn(),
+}));
+
+vi.mock("../models/actionItemChangeLogModel.js", () => {
+  const Mock = vi.fn();
+  Mock.find = vi.fn();
+  Mock.countDocuments = vi.fn();
+  return { default: Mock };
+});
+
+vi.mock("../models/aiMeetingNoteModel.js", () => {
+  const Mock = vi.fn();
+  Mock.find = vi.fn();
+  Mock.countDocuments = vi.fn();
+  return { default: Mock };
+});
+
+vi.mock("../models/meetingROIModel.js", () => {
+  const Mock = vi.fn();
+  Mock.find = vi.fn();
+  Mock.countDocuments = vi.fn();
+  return { default: Mock };
+});
+
+import FollowUpTask from "../models/FollowUpTask.js";
+import ActionItemChangeLog from "../models/actionItemChangeLogModel.js";
+import AiMeetingNote from "../models/aiMeetingNoteModel.js";
+import MeetingROI from "../models/meetingROIModel.js";
+
+import { getTasks } from "../controllers/followUpController.js";
+import { getChangeLogs } from "../controllers/actionItemChangeLogController.js";
+import { getNotes } from "../controllers/aiMeetingNoteController.js";
+import { getROIRecords } from "../controllers/meetingROIController.js";
+
+import { DEFAULT_MAX_LIMIT } from "../utils/pagination.js";
+
+const makeChain = (docs) => ({
+  sort: vi.fn().mockReturnThis(),
+  populate: vi.fn().mockReturnThis(),
+  lean: vi.fn().mockResolvedValue(docs),
+  skip: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+});
+
+const makeRes = () => {
+  const res = {
+    statusCode: null,
+    body: null,
+    status: vi.fn(function (code) {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn(function (body) {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+};
+
+const VALID_OBJECT_ID = "507f1f77bcf86cd799439011";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("followUpController.getTasks (#1071 follow-up)", () => {
+  it("clamps an unbounded limit and reports hasMore", async () => {
+    FollowUpTask.find.mockReturnValue(makeChain([{ _id: "t1" }]));
+    FollowUpTask.countDocuments.mockResolvedValue(150);
+
+    const res = makeRes();
+    await getTasks(
+      {
+        user: { _id: VALID_OBJECT_ID, organization: "org-1" },
+        query: { limit: "1000000", page: "1" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.pagination.limit).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.pagination.total).toBe(150);
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+
+  it("answers 200 (not 500) for a zero page", async () => {
+    FollowUpTask.find.mockReturnValue(makeChain([]));
+    FollowUpTask.countDocuments.mockResolvedValue(0);
+
+    const res = makeRes();
+    await getTasks(
+      {
+        user: { _id: VALID_OBJECT_ID, organization: "org-1" },
+        query: { page: "0" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+    expect(res.body.pagination.skip).toBeUndefined();
+  });
+
+  it("answers 400 (not 500) for a malformed assignee", async () => {
+    const res = makeRes();
+    await getTasks(
+      {
+        user: { _id: VALID_OBJECT_ID, organization: "org-1" },
+        query: { assignee: "not-an-objectid" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(FollowUpTask.find).not.toHaveBeenCalled();
+  });
+});
+
+describe("actionItemChangeLogController.getChangeLogs (#1071 follow-up)", () => {
+  it("clamps an unbounded limit", async () => {
+    ActionItemChangeLog.find.mockReturnValue(makeChain([]));
+    ActionItemChangeLog.countDocuments.mockResolvedValue(5000);
+
+    const res = makeRes();
+    await getChangeLogs(
+      { params: { id: VALID_OBJECT_ID }, query: { limit: "999999" } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.pagination.limit).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.pagination.total).toBe(5000);
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+
+  it("answers 200 (not 500) for a zero page and zero limit", async () => {
+    ActionItemChangeLog.find.mockReturnValue(makeChain([]));
+    ActionItemChangeLog.countDocuments.mockResolvedValue(0);
+
+    const res = makeRes();
+    await getChangeLogs(
+      { params: { id: VALID_OBJECT_ID }, query: { page: "0", limit: "0" } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.pagination.page).toBe(1);
+  });
+});
+
+describe("aiMeetingNoteController.getNotes (#1071 follow-up)", () => {
+  it("clamps an unbounded limit and includes hasMore", async () => {
+    AiMeetingNote.find.mockReturnValue(makeChain([]));
+    AiMeetingNote.countDocuments.mockResolvedValue(120);
+
+    const res = makeRes();
+    await getNotes(
+      {
+        user: { organization: "org-1" },
+        query: { limit: "500000", page: "0" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.pagination.limit).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.data.pagination.page).toBe(1);
+    expect(res.body.data.pagination.total).toBe(120);
+    expect(res.body.data.pagination.hasMore).toBe(true);
+
+    // `?limit=0` must fall back to the endpoint default (20), never mean
+    // "no limit" (which would return the entire collection).
+    const resZero = makeRes();
+    AiMeetingNote.find.mockReturnValue(makeChain([]));
+    AiMeetingNote.countDocuments.mockResolvedValue(120);
+    await getNotes(
+      { user: { organization: "org-1" }, query: { limit: "0" } },
+      resZero,
+    );
+    expect(resZero.statusCode).toBe(200);
+    expect(resZero.body.data.pagination.limit).toBe(20);
+  });
+});
+
+describe("meetingROIController.getROIRecords (#1071 follow-up)", () => {
+  it("clamps an unbounded limit and includes hasMore", async () => {
+    MeetingROI.find.mockReturnValue(makeChain([]));
+    MeetingROI.countDocuments.mockResolvedValue(250);
+
+    const res = makeRes();
+    await getROIRecords(
+      {
+        user: { organization: "org-1" },
+        query: { limit: "500000", page: "abc" },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.pagination.limit).toBe(DEFAULT_MAX_LIMIT);
+    expect(res.body.data.pagination.page).toBe(1);
+    expect(res.body.data.pagination.total).toBe(250);
+    expect(res.body.data.pagination.hasMore).toBe(true);
+  });
+});


### PR DESCRIPTION


# Pull Request

## Description
Four list endpoints still parsed ?page= / ?limit= by hand, reintroducing the exact failures the shared parsePagination

- followUpController.getTasks - unbounded ?limit=, NaN/negative skip 500s, ?limit=0 returning the whole collection, and an unvalidated ?assignee= reaching MongoDB as a 500 CastError.
- actionItemChangeLogController.getChangeLogs - unbounded ?limit=.
- aiMeetingNoteController.getNotes - NaN limit, ?limit=0 = no limit.
- meetingROIController.getROIRecords - NaN limit, ?limit=0 = no limit.

All four now use parsePagination for page >= 1, clamped limits and skip >= 0, and buildPaginationMeta for a consistent envelope that includes hasMore. getTasks also validates ?assignee= as an ObjectId, returning 400 (not 500) for malformed values.

Adds server/tests/paginationEndpoints.test.js pinning the new behaviour.
Provide a brief description of the changes introduced in this pull request.

## Type of Change

- [ ] New Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2573 

## Testing

Describe the testing performed.

- [X] Tested locally
- [X] Existing functionality verified
- [X] No new warnings or errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [X] Code follows project conventions
- [X] Documentation updated where required
- [X] No unnecessary files included
- [X] Changes have been tested
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized pagination across action items, meeting notes, follow-ups, and ROI records.
  * Excessive page sizes are now capped, invalid page numbers are corrected, and zero limits use the default page size.
  * Follow-up requests with malformed assignee values now return a clear 400 error instead of a server error.
  * Pagination metadata now accurately reports available pages and whether more results exist.

* **Tests**
  * Added coverage for pagination limits, defaults, metadata, and invalid assignee handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->