### PR TITLE
fix: limit meeting search to title

### DIFF
--- a/client/src/components/meetings/MeetingRepository.jsx
+++ b/client/src/components/meetings/MeetingRepository.jsx
@@ -119,13 +119,10 @@ const MeetingRepository = () => {
 
     // Apply search
     if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (meeting) =>
-          meeting.title?.toLowerCase().includes(query) ||
-          meeting.summary?.toLowerCase().includes(query) ||
-          meeting.transcript?.toLowerCase().includes(query) ||
-          meeting.tags?.some((tag) => tag.toLowerCase().includes(query)),
+      const query = searchQuery.trim().toLowerCase();
+
+      filtered = filtered.filter((meeting) =>
+        meeting.title?.toLowerCase().includes(query),
       );
     }
 

--- a/client/src/components/meetings/MeetingSearch.jsx
+++ b/client/src/components/meetings/MeetingSearch.jsx
@@ -10,7 +10,7 @@ const MeetingSearch = ({ searchQuery, onSearchChange }) => {
       />
       <input
         type="text"
-        placeholder="Search meetings by title, summary, tags..."
+        placeholder="Search meetings by title..."
         value={searchQuery}
         onChange={(e) => onSearchChange(e.target.value)}
         className="w-full pl-10 pr-10 py-2.5 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 rounded-lg focus:ring-2 focus:ring-blue-400 focus:border-blue-400 outline-none transition-all"


### PR DESCRIPTION
# Pull Request

## Description

Updated the meeting search functionality to search meetings by title only.

The search now:
- Matches the meeting title case-insensitively.
- Trims extra spaces from the search query.
- Removes searching through summary, transcript, and tags.
- Updates the search input placeholder to clearly indicate title-only search.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2735

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

Tested the client locally using `npm run dev` and verified that the meeting search works correctly with title-based searching.

## Screenshots

Not applicable.

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review