### PR TITLE
fix: scope weekly insight and resource booking routes to the caller's…

### DIFF
--- a/server/controllers/resourceBookingController.js
+++ b/server/controllers/resourceBookingController.js
@@ -1,18 +1,77 @@
 import resourceBookingService from "../services/resourceBookingService.js";
 import PhysicalResource from "../models/physicalResourceModel.js";
+import ResourceBooking from "../models/resourceBookingModel.js";
+import {
+  isSameOrganization,
+  resolveAuthorizedOrganizationId,
+} from "../utils/organizationScope.js";
+
+/**
+ * Issue #2571 — the organization every handler works with is the one the
+ * middleware proved belongs to the caller, never `req.params.organizationId`
+ * (and never a client-supplied `req.body.organizationId`).
+ *
+ * `requireOrganizationParamMatch` sets `req.authorizedOrganizationId` on the
+ * `/organization/:organizationId` routes; the id-only routes fall back to the
+ * caller's membership organization and then verify the referenced document
+ * belongs to it.
+ */
+const resolveOrganizationId = (req) => resolveAuthorizedOrganizationId(req);
+
+/** 403 envelope used when the caller has no organization membership. */
+const membershipRequired = (res) =>
+  res.status(403).json({
+    success: false,
+    message: "Forbidden: Organization membership required",
+  });
+
+/** 403 envelope used when a referenced document lives in another tenant. */
+const crossTenantForbidden = (res) =>
+  res.status(403).json({
+    success: false,
+    message: "Forbidden: You don't have access to this resource",
+  });
+
+const isInvalidId = (id) => !id || !/^[0-9a-fA-F]{24}$/.test(String(id));
+
+/**
+ * Loads a tenant document by id and proves it belongs to the caller's org.
+ *
+ * @returns {Promise<{doc: object|null, response: object|null}>} `response` is
+ *   already-sent error response when the id is unknown or cross-tenant.
+ */
+const loadTenantDocument = async (model, id, organizationId, res) => {
+  // A malformed ObjectId would otherwise make Mongoose throw a CastError on
+  // findById and surface as a 500 for what is a client input error.
+  if (isInvalidId(id)) {
+    return {
+      doc: null,
+      response: res.status(400).json({ success: false, message: "Invalid id" }),
+    };
+  }
+
+  const doc = await model.findById(id);
+  if (!doc) {
+    return {
+      doc: null,
+      response: res.status(404).json({ message: "Resource not found" }),
+    };
+  }
+
+  if (!isSameOrganization(doc.organization, organizationId)) {
+    return { doc: null, response: crossTenantForbidden(res) };
+  }
+
+  return { doc, response: null };
+};
 
 // Fetch physical resources for an organization
 export const getPhysicalResources = async (req, res) => {
   try {
-    const organizationId =
-      req.params.organizationId ||
-      req.user?.organization?._id ||
-      req.user?.organization;
+    const organizationId = resolveOrganizationId(req);
 
     if (!organizationId) {
-      return res.status(400).json({
-        message: "Organization ID is required",
-      });
+      return membershipRequired(res);
     }
 
     const resources =
@@ -29,19 +88,21 @@ export const getPhysicalResources = async (req, res) => {
 // Create a physical resource
 export const createPhysicalResource = async (req, res) => {
   try {
-    const organizationId =
-      req.params.organizationId ||
-      req.user?.organization?._id ||
-      req.user?.organization;
+    const organizationId = resolveOrganizationId(req);
 
     if (!organizationId) {
-      return res.status(400).json({
-        message: "Organization ID is required",
-      });
+      return membershipRequired(res);
     }
 
-    const data = { ...req.body, organization: organizationId };
-    const resource = await resourceBookingService.createPhysicalResource(data);
+    // The organization comes from the caller's membership, never from the
+    // body: a crafted `organization` field used to create resources inside
+    // another tenant.
+    const { organization: _ignoredOrganization, ...resourceData } =
+      req.body || {};
+    const resource = await resourceBookingService.createPhysicalResource({
+      ...resourceData,
+      organization: organizationId,
+    });
     return res.status(201).json(resource);
   } catch (error) {
     return res.status(500).json({
@@ -54,10 +115,23 @@ export const createPhysicalResource = async (req, res) => {
 // Delete a physical resource
 export const deletePhysicalResource = async (req, res) => {
   try {
+    const organizationId = resolveOrganizationId(req);
+    if (!organizationId) {
+      return membershipRequired(res);
+    }
+
     const resourceId = req.params.resourceId || req.params.id;
     if (!resourceId) {
       return res.status(400).json({ message: "Resource ID is required" });
     }
+
+    const { response } = await loadTenantDocument(
+      PhysicalResource,
+      resourceId,
+      organizationId,
+      res,
+    );
+    if (response) return response;
 
     await resourceBookingService.deletePhysicalResource(resourceId);
     return res
@@ -74,10 +148,7 @@ export const deletePhysicalResource = async (req, res) => {
 // Get available resources for a specific time window
 export const getAvailableResources = async (req, res) => {
   try {
-    const organizationId =
-      req.params.organizationId ||
-      req.user?.organization?._id ||
-      req.user?.organization;
+    const organizationId = resolveOrganizationId(req);
     const { startTime, endTime, type } = req.query;
 
     if (!startTime || !endTime) {
@@ -87,9 +158,7 @@ export const getAvailableResources = async (req, res) => {
     }
 
     if (!organizationId) {
-      return res.status(400).json({
-        message: "Organization ID is required",
-      });
+      return membershipRequired(res);
     }
 
     const availableResources =
@@ -111,12 +180,10 @@ export const getAvailableResources = async (req, res) => {
 // Create a resource booking with strict overlapping interval protection & conflict suggestions
 export const createBooking = async (req, res) => {
   try {
-    const { resourceId, meetingId, startTime, endTime, title } = req.body;
-    let organizationId =
-      req.params.organizationId ||
-      req.body.organizationId ||
-      req.user?.organization?._id ||
-      req.user?.organization;
+    const { resourceId, meetingId, startTime, endTime, title } = req.body || {};
+    // Issue #2571: ignore req.body.organizationId — the tenant is the caller's
+    // own organization, resolved server-side.
+    const organizationId = resolveOrganizationId(req);
 
     if (!resourceId || !startTime || !endTime) {
       return res.status(400).json({
@@ -125,11 +192,18 @@ export const createBooking = async (req, res) => {
     }
 
     if (!organizationId) {
-      const resource = await PhysicalResource.findById(resourceId);
-      if (resource) {
-        organizationId = resource.organization;
-      }
+      return membershipRequired(res);
     }
+
+    // The resource being booked must live in the caller's organization,
+    // otherwise a member of org A could reserve org B's rooms by id.
+    const { response } = await loadTenantDocument(
+      PhysicalResource,
+      resourceId,
+      organizationId,
+      res,
+    );
+    if (response) return response;
 
     const userId = req.user?._id || req.user?.id;
 
@@ -173,12 +247,25 @@ export const createBooking = async (req, res) => {
 // Get bookings for a specific resource
 export const getResourceBookings = async (req, res) => {
   try {
+    const organizationId = resolveOrganizationId(req);
+    if (!organizationId) {
+      return membershipRequired(res);
+    }
+
     const resourceId = req.params.resourceId || req.params.id;
     const { startTime, endTime } = req.query;
 
     if (!resourceId) {
       return res.status(400).json({ message: "Resource ID is required" });
     }
+
+    const { response } = await loadTenantDocument(
+      PhysicalResource,
+      resourceId,
+      organizationId,
+      res,
+    );
+    if (response) return response;
 
     const bookings = await resourceBookingService.getBookingsForResource(
       resourceId,
@@ -197,13 +284,10 @@ export const getResourceBookings = async (req, res) => {
 // Get all bookings for an organization
 export const getOrganizationBookings = async (req, res) => {
   try {
-    const organizationId =
-      req.params.organizationId ||
-      req.user?.organization?._id ||
-      req.user?.organization;
+    const organizationId = resolveOrganizationId(req);
 
     if (!organizationId) {
-      return res.status(400).json({ message: "Organization ID is required" });
+      return membershipRequired(res);
     }
 
     const bookings =
@@ -220,12 +304,34 @@ export const getOrganizationBookings = async (req, res) => {
 // Cancel a resource booking
 export const cancelBooking = async (req, res) => {
   try {
+    const organizationId = resolveOrganizationId(req);
+    if (!organizationId) {
+      return membershipRequired(res);
+    }
+
     const bookingId = req.params.bookingId || req.params.id;
     if (!bookingId) {
       return res.status(400).json({ message: "Booking ID is required" });
     }
 
-    await resourceBookingService.cancelBooking(bookingId);
+    // Issue #2571: a raw :bookingId with no tenant check let any authenticated
+    // user cancel any booking in the system.
+    const { response } = await loadTenantDocument(
+      ResourceBooking,
+      bookingId,
+      organizationId,
+      res,
+    );
+    if (response) return response;
+
+    const cancelled = await resourceBookingService.cancelBooking(
+      bookingId,
+      organizationId,
+    );
+    if (!cancelled) {
+      return res.status(404).json({ message: "Booking not found" });
+    }
+
     return res.status(200).json({ message: "Booking cancelled successfully" });
   } catch (error) {
     return res
@@ -237,9 +343,22 @@ export const cancelBooking = async (req, res) => {
 // Get bookings for a specific meeting
 export const getMeetingBookings = async (req, res) => {
   try {
+    const organizationId = resolveOrganizationId(req);
+    if (!organizationId) {
+      return membershipRequired(res);
+    }
+
     const { meetingId } = req.params;
-    const bookings =
-      await resourceBookingService.getBookingsForMeeting(meetingId);
+    if (!meetingId) {
+      return res.status(400).json({ message: "Meeting ID is required" });
+    }
+
+    // Scoped to the caller's organization so a meeting id from another tenant
+    // cannot be used to enumerate its bookings.
+    const bookings = await resourceBookingService.getBookingsForMeeting(
+      meetingId,
+      organizationId,
+    );
     return res.status(200).json(bookings);
   } catch (error) {
     return res.status(500).json({

--- a/server/controllers/weeklyInsightController.js
+++ b/server/controllers/weeklyInsightController.js
@@ -2,10 +2,23 @@ import WeeklyInsight from "../models/weeklyInsightModel.js";
 import { generateInsight } from "../services/weeklyInsightService.js";
 import Membership from "../models/membershipModel.js";
 import EmailService from "../services/EmailService.js";
+import { resolveAuthorizedOrganizationId } from "../utils/organizationScope.js";
+
+/**
+ * Issue #2571 — the organization for every handler is the one the middleware
+ * proved belongs to the caller, never the `:orgId` read off the URL.
+ */
+const resolveOrgId = (req) => resolveAuthorizedOrganizationId(req);
 
 export const getLatestInsight = async (req, res, next) => {
   try {
-    const { orgId } = req.params;
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
     const insight = await WeeklyInsight.findOne({ organization: orgId })
       .sort({ createdAt: -1 })
       .populate("stalledActionItems.actionItem")
@@ -21,7 +34,13 @@ export const getLatestInsight = async (req, res, next) => {
 
 export const getInsightHistory = async (req, res, next) => {
   try {
-    const { orgId } = req.params;
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
     const page = parseInt(req.query.page, 10) || 1;
     const limit = parseInt(req.query.limit, 10) || 10;
     const skip = (page - 1) * limit;
@@ -45,7 +64,13 @@ export const getInsightHistory = async (req, res, next) => {
 
 export const triggerManualGeneration = async (req, res, next) => {
   try {
-    const { orgId } = req.params;
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
     const endDate = new Date();
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 7);
@@ -64,7 +89,14 @@ export const triggerManualGeneration = async (req, res, next) => {
 
 export const shareWeeklyInsight = async (req, res, next) => {
   try {
-    const { orgId, insightId } = req.params;
+    const insightId = req.params.insightId;
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
     const insight = await WeeklyInsight.findOne({
       _id: insightId,
       organization: orgId,
@@ -89,7 +121,14 @@ export const shareWeeklyInsight = async (req, res, next) => {
 
 export const emailWeeklyInsight = async (req, res, next) => {
   try {
-    const { orgId, insightId } = req.params;
+    const insightId = req.params.insightId;
+    const orgId = resolveOrgId(req);
+    if (!orgId) {
+      return res.status(403).json({
+        success: false,
+        message: "Forbidden: Organization membership required",
+      });
+    }
     const insight = await WeeklyInsight.findOne({
       _id: insightId,
       organization: orgId,

--- a/server/routes/resourceBookingRoutes.js
+++ b/server/routes/resourceBookingRoutes.js
@@ -11,30 +11,67 @@ import {
   getMeetingBookings,
 } from "../controllers/resourceBookingController.js";
 import protect from "../middleware/userAuth.js";
+import { requireOrganizationParamMatch } from "../middleware/rbac.js";
 
 const router = express.Router();
 
 router.use(protect);
 
-// Physical Resource management
-router.get("/organization/:organizationId", getPhysicalResources);
-router.get("/organization/:organizationId/resources", getPhysicalResources);
-router.post("/organization/:organizationId", createPhysicalResource);
-router.post("/organization/:organizationId/resources", createPhysicalResource);
+// Issue #2571 — every route carrying `:organizationId` must prove the path
+// value is the caller's own membership organization before the handler runs.
+// `protect` (userAuth) only proves the caller is *somebody*; handlers used to
+// read the path param straight into their queries, so any authenticated user
+// could list another tenant's rooms, create resources inside it, and book
+// them. Controllers now query with `req.authorizedOrganizationId`; the
+// id-only routes (resource/booking/meeting) verify document ownership
+// server-side and return 403 on a cross-tenant id.
+router.get(
+  "/organization/:organizationId",
+  requireOrganizationParamMatch("organizationId"),
+  getPhysicalResources,
+);
+router.get(
+  "/organization/:organizationId/resources",
+  requireOrganizationParamMatch("organizationId"),
+  getPhysicalResources,
+);
+router.post(
+  "/organization/:organizationId",
+  requireOrganizationParamMatch("organizationId"),
+  createPhysicalResource,
+);
+router.post(
+  "/organization/:organizationId/resources",
+  requireOrganizationParamMatch("organizationId"),
+  createPhysicalResource,
+);
 router.delete(
   "/organization/:organizationId/resource/:resourceId",
+  requireOrganizationParamMatch("organizationId"),
   deletePhysicalResource,
 );
 router.delete("/:resourceId", deletePhysicalResource);
 
 // Resource availability & calendar timeline
-router.get("/organization/:organizationId/available", getAvailableResources);
-router.get("/organization/:organizationId/bookings", getOrganizationBookings);
+router.get(
+  "/organization/:organizationId/available",
+  requireOrganizationParamMatch("organizationId"),
+  getAvailableResources,
+);
+router.get(
+  "/organization/:organizationId/bookings",
+  requireOrganizationParamMatch("organizationId"),
+  getOrganizationBookings,
+);
 router.get("/resource/:resourceId/bookings", getResourceBookings);
 router.get("/:resourceId/bookings", getResourceBookings);
 
 // Bookings creation and cancellation
-router.post("/organization/:organizationId/bookings", createBooking);
+router.post(
+  "/organization/:organizationId/bookings",
+  requireOrganizationParamMatch("organizationId"),
+  createBooking,
+);
 router.post("/bookings/create", createBooking);
 router.post("/bookings", createBooking);
 router.delete("/bookings/:bookingId", cancelBooking);

--- a/server/routes/weeklyInsightRoutes.js
+++ b/server/routes/weeklyInsightRoutes.js
@@ -7,35 +7,50 @@ import {
   emailWeeklyInsight,
 } from "../controllers/weeklyInsightController.js";
 import userAuth from "../middleware/userAuth.js";
-import { requireRole } from "../middleware/rbac.js";
+import {
+  requireOrganizationParamMatch,
+  requireRole,
+} from "../middleware/rbac.js";
 
 const router = express.Router();
 
 router.use(userAuth);
 
+// Issue #2571 — authorization chain for every `:orgId` route:
+//   userAuth → role check → path org matches the caller's membership org.
+// `requireRole` only asserts the caller *has* a role; it says nothing about
+// which organization it belongs to. Without the second guard an authenticated
+// member of org A could read (and, on /generate, write) org B by editing the
+// id in the path. Controllers scope their queries with
+// `req.authorizedOrganizationId`, never the raw param.
 router.get(
   "/:orgId/latest",
   requireRole(["owner", "admin", "member"]),
+  requireOrganizationParamMatch("orgId"),
   getLatestInsight,
 );
 router.get(
   "/:orgId",
   requireRole(["owner", "admin", "member"]),
+  requireOrganizationParamMatch("orgId"),
   getInsightHistory,
 );
 router.post(
   "/:orgId/generate",
   requireRole(["owner", "admin"]),
+  requireOrganizationParamMatch("orgId"),
   triggerManualGeneration,
 );
 router.post(
   "/:orgId/insights/:insightId/share",
   requireRole(["owner", "admin"]),
+  requireOrganizationParamMatch("orgId"),
   shareWeeklyInsight,
 );
 router.post(
   "/:orgId/insights/:insightId/email",
   requireRole(["owner", "admin"]),
+  requireOrganizationParamMatch("orgId"),
   emailWeeklyInsight,
 );
 

--- a/server/services/resourceBookingService.js
+++ b/server/services/resourceBookingService.js
@@ -171,11 +171,21 @@ class ResourceBookingService {
 
   /**
    * Cancel (delete or set status to CANCELLED) a booking.
+   *
+   * Issue #2571: when `organizationId` is supplied the delete is scoped to
+   * that tenant, so a caller can never remove another organization's booking
+   * even if the id leaks.
+   *
+   * @param {string} bookingId
+   * @param {string|null} organizationId caller's organization (server-resolved)
    */
-  async cancelBooking(bookingId) {
-    const booking = await ResourceBooking.findById(bookingId);
+  async cancelBooking(bookingId, organizationId = null) {
+    const filter = { _id: bookingId };
+    if (organizationId) filter.organization = organizationId;
+
+    const booking = await ResourceBooking.findOne(filter);
     if (!booking) return null;
-    return await ResourceBooking.findByIdAndDelete(bookingId);
+    return await ResourceBooking.findByIdAndDelete(booking._id);
   }
 
   /**
@@ -218,12 +228,21 @@ class ResourceBookingService {
 
   /**
    * Get bookings for a specific meeting.
+   *
+   * Issue #2571: `organizationId` scopes the lookup to the caller's tenant, so
+   * a meeting id belonging to another organization returns nothing.
+   *
+   * @param {string} meetingId
+   * @param {string|null} organizationId caller's organization (server-resolved)
    */
-  async getBookingsForMeeting(meetingId) {
-    return await ResourceBooking.find({
+  async getBookingsForMeeting(meetingId, organizationId = null) {
+    const query = {
       meetingId,
       status: { $ne: "CANCELLED" },
-    }).populate("resourceId");
+    };
+    if (organizationId) query.organization = organizationId;
+
+    return await ResourceBooking.find(query).populate("resourceId");
   }
 
   /**

--- a/server/tests/resourceBookingController.vitest.test.js
+++ b/server/tests/resourceBookingController.vitest.test.js
@@ -46,6 +46,7 @@ describe("resourceBookingController (#2462)", () => {
   const mockUserId = "507f1f77bcf86cd799439011";
   const mockOrgId = "507f1f77bcf86cd799439022";
   const mockResourceId = "507f1f77bcf86cd799439033";
+  const mockBookingId = "507f1f77bcf86cd799439044";
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -75,6 +76,12 @@ describe("resourceBookingController (#2462)", () => {
         endTime: "2026-10-01T11:00:00.000Z",
       };
 
+      // Issue #2571: the resource is resolved server-side and must belong to
+      // the caller's organization before the booking is created.
+      PhysicalResource.findById.mockResolvedValue({
+        _id: mockResourceId,
+        organization: mockOrgId,
+      });
       ResourceBooking.findOne.mockReturnValue({
         sort: vi.fn().mockResolvedValue(null),
       });
@@ -100,6 +107,10 @@ describe("resourceBookingController (#2462)", () => {
         endTime: "2026-10-01T11:00:00.000Z",
       };
 
+      PhysicalResource.findById.mockResolvedValue({
+        _id: mockResourceId,
+        organization: mockOrgId,
+      });
       ResourceBooking.findOne.mockReturnValue({
         sort: vi.fn().mockResolvedValue({
           _id: "existing-book-1",
@@ -132,6 +143,10 @@ describe("resourceBookingController (#2462)", () => {
   describe("getResourceBookings", () => {
     it("returns all active bookings for a resource", async () => {
       req.params = { resourceId: mockResourceId };
+      PhysicalResource.findById.mockResolvedValue({
+        _id: mockResourceId,
+        organization: mockOrgId,
+      });
 
       const mockBookings = [
         {
@@ -179,9 +194,19 @@ describe("resourceBookingController (#2462)", () => {
 
   describe("cancelBooking", () => {
     it("cancels / deletes booking by ID", async () => {
-      req.params = { bookingId: "book-123" };
-      ResourceBooking.findById.mockResolvedValue({ _id: "book-123" });
-      ResourceBooking.findByIdAndDelete.mockResolvedValue({ _id: "book-123" });
+      req.params = { bookingId: mockBookingId };
+      // Issue #2571: the booking must belong to the caller's organization.
+      ResourceBooking.findById.mockResolvedValue({
+        _id: mockBookingId,
+        organization: mockOrgId,
+      });
+      ResourceBooking.findOne.mockResolvedValue({
+        _id: mockBookingId,
+        organization: mockOrgId,
+      });
+      ResourceBooking.findByIdAndDelete.mockResolvedValue({
+        _id: mockBookingId,
+      });
 
       await cancelBooking(req, res);
 
@@ -227,8 +252,14 @@ describe("resourceBookingController (#2462)", () => {
     });
 
     it("deletes a physical resource and cascading bookings", async () => {
-      req.params = { resourceId: "res-1" };
-      PhysicalResource.findByIdAndDelete.mockResolvedValue({ _id: "res-1" });
+      req.params = { resourceId: mockResourceId };
+      PhysicalResource.findById.mockResolvedValue({
+        _id: mockResourceId,
+        organization: mockOrgId,
+      });
+      PhysicalResource.findByIdAndDelete.mockResolvedValue({
+        _id: mockResourceId,
+      });
       ResourceBooking.deleteMany.mockResolvedValue({ deletedCount: 2 });
 
       await deletePhysicalResource(req, res);

--- a/server/tests/resourceBookingCrossTenantAuthorization.test.js
+++ b/server/tests/resourceBookingCrossTenantAuthorization.test.js
@@ -31,9 +31,8 @@ jest.unstable_mockModule("../middleware/userAuth.js", () => ({
   },
 }));
 
-const { default: resourceBookingRoutes } = await import(
-  "../routes/resourceBookingRoutes.js"
-);
+const { default: resourceBookingRoutes } =
+  await import("../routes/resourceBookingRoutes.js");
 const PhysicalResource = (await import("../models/physicalResourceModel.js"))
   .default;
 const ResourceBooking = (await import("../models/resourceBookingModel.js"))

--- a/server/tests/resourceBookingCrossTenantAuthorization.test.js
+++ b/server/tests/resourceBookingCrossTenantAuthorization.test.js
@@ -1,0 +1,339 @@
+/**
+ * Issue #2571 — Physical resource / booking routes must never trust
+ * `:organizationId`, `:resourceId`, `:bookingId` or a body `organizationId`
+ * supplied by the client.
+ *
+ * These tests exercise the real route → controller → service → model stack
+ * against an in-memory MongoDB; only authentication is stubbed. Every case
+ * below was exploitable before the fix:
+ *
+ *   - GET  /organization/<org B>                 → org B's rooms/equipment
+ *   - POST /organization/<org B>                 → resource created in org B
+ *   - POST /organization/<org B>/bookings        → booking inside org B
+ *   - POST /bookings/create { organizationId }   → booking inside org B
+ *   - DELETE /bookings/<any booking id>          → cancel any tenant's booking
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: resourceBookingRoutes } = await import(
+  "../routes/resourceBookingRoutes.js"
+);
+const PhysicalResource = (await import("../models/physicalResourceModel.js"))
+  .default;
+const ResourceBooking = (await import("../models/resourceBookingModel.js"))
+  .default;
+// getOrganizationBookings populates `userId`; the User schema has to be
+// registered for that populate to resolve (MissingSchemaError → 500 otherwise).
+await import("../models/userModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const SHARED_MEETING_ID = new mongoose.Types.ObjectId();
+
+const memberOfOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const userWithoutOrganization = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "admin",
+};
+
+let app;
+let orgAResource;
+let orgBResource;
+let orgABooking;
+let orgBBooking;
+
+const slot = (hourOffset) => ({
+  startTime: new Date(Date.now() + hourOffset * 60 * 60 * 1000),
+  endTime: new Date(Date.now() + (hourOffset + 1) * 60 * 60 * 1000),
+});
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      `${process.env.TEST_MONGODB_URI}/resource_booking_2571`,
+    );
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/physical-resources", resourceBookingRoutes);
+});
+
+beforeEach(async () => {
+  currentUser = memberOfOrgA;
+
+  await PhysicalResource.deleteMany({});
+  await ResourceBooking.deleteMany({});
+
+  orgAResource = await PhysicalResource.create({
+    name: "Org A Room",
+    type: "room",
+    organization: ORG_A,
+  });
+  orgBResource = await PhysicalResource.create({
+    name: "Org B Room",
+    type: "room",
+    organization: ORG_B,
+  });
+
+  orgABooking = await ResourceBooking.create({
+    resourceId: orgAResource._id,
+    organization: ORG_A,
+    userId: memberOfOrgA._id,
+    title: "Org A booking",
+    meetingId: SHARED_MEETING_ID,
+    ...slot(1),
+  });
+  orgBBooking = await ResourceBooking.create({
+    resourceId: orgBResource._id,
+    organization: ORG_B,
+    userId: memberOfOrgA._id,
+    title: "Org B booking",
+    meetingId: SHARED_MEETING_ID,
+    ...slot(1),
+  });
+});
+
+describe("physical resources cross-tenant scoping (#2571)", () => {
+  it("lists the caller's own organization resources", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_A.toString()}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe("Org A Room");
+  });
+
+  it("rejects listing another organization's resources", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_B.toString()}`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toContain("Org B Room");
+  });
+
+  it("rejects a malformed organization id with 400", async () => {
+    const res = await request(app).get(
+      "/api/physical-resources/organization/not-an-id",
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects creating a resource inside another organization", async () => {
+    const res = await request(app)
+      .post(`/api/physical-resources/organization/${ORG_B.toString()}`)
+      .send({ name: "Injected Room", type: "room" });
+
+    expect(res.status).toBe(403);
+    expect(
+      await PhysicalResource.countDocuments({
+        organization: ORG_B,
+        name: "Injected Room",
+      }),
+    ).toBe(0);
+  });
+
+  it("ignores a client-supplied organization in the body", async () => {
+    const res = await request(app)
+      .post(`/api/physical-resources/organization/${ORG_A.toString()}`)
+      .send({
+        name: "Honest Room",
+        type: "room",
+        organization: ORG_B.toString(),
+      });
+
+    expect(res.status).toBe(201);
+    expect(String(res.body.organization)).toBe(ORG_A.toString());
+  });
+
+  it("rejects deleting another organization's resource", async () => {
+    const res = await request(app).delete(
+      `/api/physical-resources/${orgBResource._id.toString()}`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await PhysicalResource.findById(orgBResource._id)).not.toBeNull();
+  });
+
+  it("deletes the caller's own resource", async () => {
+    const res = await request(app).delete(
+      `/api/physical-resources/${orgAResource._id.toString()}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await PhysicalResource.findById(orgAResource._id)).toBeNull();
+  });
+
+  it("rejects availability lookups for another organization", async () => {
+    const { startTime, endTime } = slot(10);
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_B.toString()}/available?startTime=${startTime.toISOString()}&endTime=${endTime.toISOString()}`,
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("bookings cross-tenant scoping (#2571)", () => {
+  it("lists only the caller's organization bookings", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_A.toString()}/bookings`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].title).toBe("Org A booking");
+  });
+
+  it("rejects listing another organization's bookings", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_B.toString()}/bookings`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toContain("Org B booking");
+  });
+
+  it("rejects booking another organization's resource through the path", async () => {
+    const { startTime, endTime } = slot(20);
+    const res = await request(app)
+      .post(`/api/physical-resources/organization/${ORG_B.toString()}/bookings`)
+      .send({
+        resourceId: orgBResource._id.toString(),
+        startTime,
+        endTime,
+      });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects booking another organization's resource by id", async () => {
+    const { startTime, endTime } = slot(22);
+    const res = await request(app)
+      .post("/api/physical-resources/bookings/create")
+      .send({
+        resourceId: orgBResource._id.toString(),
+        startTime,
+        endTime,
+      });
+
+    expect(res.status).toBe(403);
+    expect(
+      await ResourceBooking.countDocuments({
+        organization: ORG_B,
+        resourceId: orgBResource._id,
+      }),
+    ).toBe(1); // only the seeded booking
+  });
+
+  it("stamps the caller's organization on bookings, ignoring the body value", async () => {
+    const { startTime, endTime } = slot(24);
+    const res = await request(app)
+      .post("/api/physical-resources/bookings/create")
+      .send({
+        resourceId: orgAResource._id.toString(),
+        startTime,
+        endTime,
+        organizationId: ORG_B.toString(),
+      });
+
+    expect(res.status).toBe(201);
+    expect(String(res.body.organization)).toBe(ORG_A.toString());
+  });
+
+  it("books a resource of the caller's own organization", async () => {
+    const { startTime, endTime } = slot(26);
+    const res = await request(app)
+      .post(`/api/physical-resources/organization/${ORG_A.toString()}/bookings`)
+      .send({
+        resourceId: orgAResource._id.toString(),
+        startTime,
+        endTime,
+        title: "Team sync",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe("Team sync");
+    expect(String(res.body.organization)).toBe(ORG_A.toString());
+  });
+
+  it("rejects cancelling another organization's booking", async () => {
+    const res = await request(app).delete(
+      `/api/physical-resources/bookings/${orgBBooking._id.toString()}`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await ResourceBooking.findById(orgBBooking._id)).not.toBeNull();
+  });
+
+  it("cancels the caller's own booking", async () => {
+    const res = await request(app).delete(
+      `/api/physical-resources/bookings/${orgABooking._id.toString()}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await ResourceBooking.findById(orgABooking._id)).toBeNull();
+  });
+
+  it("rejects cancelling a booking with a malformed id", async () => {
+    const res = await request(app).delete(
+      "/api/physical-resources/bookings/not-an-id",
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects reading bookings of another organization's resource", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/resource/${orgBResource._id.toString()}/bookings`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toContain("Org B booking");
+  });
+
+  it("scopes meeting bookings to the caller's organization", async () => {
+    const res = await request(app).get(
+      `/api/physical-resources/meetings/${SHARED_MEETING_ID.toString()}/bookings`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].title).toBe("Org A booking");
+  });
+
+  it("rejects a caller without an organization membership", async () => {
+    currentUser = userWithoutOrganization;
+
+    const res = await request(app).get(
+      `/api/physical-resources/organization/${ORG_A.toString()}`,
+    );
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/tests/weeklyInsightApiPrefixGuards.test.js
+++ b/server/tests/weeklyInsightApiPrefixGuards.test.js
@@ -38,10 +38,8 @@ jest.unstable_mockModule("../middleware/userAuth.js", () => ({
   sanitizeAuthRequestForLog: jest.fn(),
 }));
 
-jest.unstable_mockModule("../middleware/rbac.js", () => ({
-  requireRole: () => (req, res, next) => next(),
-}));
-
+// Issue #2571: the real rbac middleware is used (no mock) so the org/param
+// guard on every :orgId route is exercised by these prefix tests.
 const { default: weeklyInsightRoutes } =
   await import("../routes/weeklyInsightRoutes.js");
 
@@ -58,7 +56,8 @@ describe("Weekly Insights Server API Route Prefix Guards Suite (#2620)", () => {
 
   describe("API Route Prefix Enforcement against Production Routes", () => {
     it("should return 200 for GET /api/weekly-insights/:orgId/latest", async () => {
-      const orgId = new mongoose.Types.ObjectId().toString();
+      // Issue #2571: the caller's own organization, not an arbitrary one.
+      const orgId = mockUser.organization;
       const mockInsight = {
         _id: new mongoose.Types.ObjectId().toString(),
         organization: orgId,
@@ -91,7 +90,8 @@ describe("Weekly Insights Server API Route Prefix Guards Suite (#2620)", () => {
     });
 
     it("should return 200 for GET /api/weekly-insights/:orgId with pagination params", async () => {
-      const orgId = new mongoose.Types.ObjectId().toString();
+      // Issue #2571: the caller's own organization, not an arbitrary one.
+      const orgId = mockUser.organization;
       mockFind.mockReturnValueOnce({
         sort: jest.fn().mockReturnValue({
           skip: jest.fn().mockReturnValue({
@@ -120,7 +120,8 @@ describe("Weekly Insights Server API Route Prefix Guards Suite (#2620)", () => {
     });
 
     it("should return 201 for POST /api/weekly-insights/:orgId/generate", async () => {
-      const orgId = new mongoose.Types.ObjectId().toString();
+      // Issue #2571: the caller's own organization, not an arbitrary one.
+      const orgId = mockUser.organization;
       const mockCreated = {
         _id: new mongoose.Types.ObjectId().toString(),
         organization: orgId,

--- a/server/tests/weeklyInsightCrossTenantAuthorization.test.js
+++ b/server/tests/weeklyInsightCrossTenantAuthorization.test.js
@@ -1,0 +1,251 @@
+/**
+ * Issue #2571 — Weekly insight routes must never query with the `:orgId`
+ * taken from the URL.
+ *
+ * Before the fix, `requireRole` proved the caller had *a* role and the
+ * controller then queried `WeeklyInsight` with whatever organization id the
+ * path carried, so any authenticated user could read another tenant's
+ * insights (and, on `/generate`, run generation against its data).
+ *
+ * These tests exercise the real route + controller + model stack against an
+ * in-memory MongoDB; only authentication is stubbed.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const generateInsightSpy = jest.fn();
+jest.unstable_mockModule("../services/weeklyInsightService.js", () => ({
+  generateInsight: (...args) => generateInsightSpy(...args),
+}));
+
+const sendNotificationEmailSpy = jest.fn();
+jest.unstable_mockModule("../services/EmailService.js", () => ({
+  default: {
+    sendNotificationEmail: (...args) => sendNotificationEmailSpy(...args),
+  },
+}));
+
+const { default: weeklyInsightRoutes } = await import(
+  "../routes/weeklyInsightRoutes.js"
+);
+const WeeklyInsight = (await import("../models/weeklyInsightModel.js")).default;
+// getLatestInsight populates stalledActionItems.{actionItem,meetingId}; both
+// schemas must be registered or the populate throws MissingSchemaError (500).
+await import("../models/ActionItem.js");
+await import("../models/meetingModel.js");
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+
+const memberOfOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+
+const plainMemberOfOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const adminOfOrgB = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_B,
+  role: "admin",
+};
+
+const userWithoutOrganization = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "admin",
+};
+
+let app;
+let orgAInsight;
+
+const buildInsight = (organization, summary) => ({
+  organization,
+  startDate: new Date("2026-01-01T00:00:00.000Z"),
+  endDate: new Date("2026-01-07T00:00:00.000Z"),
+  aiSummary: summary,
+});
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(
+      `${process.env.TEST_MONGODB_URI}/weekly_insight_2571`,
+    );
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/weekly-insights", weeklyInsightRoutes);
+});
+
+beforeEach(async () => {
+  currentUser = memberOfOrgA;
+  generateInsightSpy.mockReset();
+  sendNotificationEmailSpy.mockReset();
+
+  await WeeklyInsight.deleteMany({});
+  await WeeklyInsight.create(buildInsight(ORG_A, "org A insight"));
+  await WeeklyInsight.create(buildInsight(ORG_B, "org B insight"));
+  orgAInsight = await WeeklyInsight.findOne({ organization: ORG_A });
+});
+
+describe("weekly insight cross-tenant scoping (#2571)", () => {
+  describe("GET /api/weekly-insights/:orgId/latest", () => {
+    it("returns the caller's own organization insight", async () => {
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_A.toString()}/latest`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.aiSummary).toBe("org A insight");
+    });
+
+    it("rejects another organization's id with 403 and leaks nothing", async () => {
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_B.toString()}/latest`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.aiSummary).toBeUndefined();
+      expect(JSON.stringify(res.body)).not.toContain("org B insight");
+    });
+
+    it("returns 400 for a malformed organization id", async () => {
+      const res = await request(app).get(
+        "/api/weekly-insights/not-an-id/latest",
+      );
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/weekly-insights/:orgId", () => {
+    it("returns only the caller's organization history", async () => {
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_A.toString()}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalPages).toBe(1);
+      expect(res.body.insights).toHaveLength(1);
+      expect(res.body.insights[0].aiSummary).toBe("org A insight");
+    });
+
+    it("rejects another organization's history with 403", async () => {
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_B.toString()}`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.insights).toBeUndefined();
+    });
+  });
+
+  describe("POST /api/weekly-insights/:orgId/generate", () => {
+    it("generates for the caller's own organization only", async () => {
+      generateInsightSpy.mockResolvedValue(orgAInsight);
+
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_A.toString()}/generate`,
+      );
+
+      expect(res.status).toBe(201);
+      expect(generateInsightSpy).toHaveBeenCalledTimes(1);
+      expect(String(generateInsightSpy.mock.calls[0][0])).toBe(
+        ORG_A.toString(),
+      );
+    });
+
+    it("never runs generation against another tenant's data", async () => {
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_B.toString()}/generate`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(generateInsightSpy).not.toHaveBeenCalled();
+    });
+
+    it("still enforces the role requirement", async () => {
+      currentUser = plainMemberOfOrgA;
+
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_A.toString()}/generate`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(generateInsightSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("share / email", () => {
+    it("rejects sharing an insight through another organization's path", async () => {
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_B.toString()}/insights/${orgAInsight._id.toString()}/share`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.shareLink).toBeUndefined();
+    });
+
+    it("rejects emailing through another organization's path", async () => {
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_B.toString()}/insights/${orgAInsight._id.toString()}/email`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(sendNotificationEmailSpy).not.toHaveBeenCalled();
+    });
+
+    it("shares the caller's own insight", async () => {
+      const res = await request(app).post(
+        `/api/weekly-insights/${ORG_A.toString()}/insights/${orgAInsight._id.toString()}/share`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.shareLink).toContain(ORG_A.toString());
+    });
+  });
+
+  describe("membership", () => {
+    it("rejects a caller without an organization", async () => {
+      currentUser = userWithoutOrganization;
+
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_A.toString()}/latest`,
+      );
+
+      expect(res.status).toBe(403);
+    });
+
+    it("keeps org B's data invisible to an org B admin querying org A", async () => {
+      currentUser = adminOfOrgB;
+
+      const res = await request(app).get(
+        `/api/weekly-insights/${ORG_A.toString()}/latest`,
+      );
+
+      expect(res.status).toBe(403);
+      expect(JSON.stringify(res.body)).not.toContain("org A insight");
+    });
+  });
+});

--- a/server/tests/weeklyInsightCrossTenantAuthorization.test.js
+++ b/server/tests/weeklyInsightCrossTenantAuthorization.test.js
@@ -40,9 +40,8 @@ jest.unstable_mockModule("../services/EmailService.js", () => ({
   },
 }));
 
-const { default: weeklyInsightRoutes } = await import(
-  "../routes/weeklyInsightRoutes.js"
-);
+const { default: weeklyInsightRoutes } =
+  await import("../routes/weeklyInsightRoutes.js");
 const WeeklyInsight = (await import("../models/weeklyInsightModel.js")).default;
 // getLatestInsight populates stalledActionItems.{actionItem,meetingId}; both
 // schemas must be registered or the populate throws MissingSchemaError (500).

--- a/server/utils/organizationScope.js
+++ b/server/utils/organizationScope.js
@@ -64,4 +64,34 @@ export const isSameOrganization = (a, b) => {
   return left === right;
 };
 
-export default { toOrganizationId, isSameOrganization };
+/**
+ * Server-trusted organization id for the current request (Issue #2571).
+ *
+ * `requireOrganizationParamMatch` sets `req.authorizedOrganizationId` only
+ * after proving the client-supplied path/query value equals the caller's
+ * membership organization. Routes without a path param fall back to the
+ * membership organization itself.
+ *
+ * Controllers MUST call this instead of reading `req.params.orgId` /
+ * `req.params.organizationId` / `req.body.organizationId` — those are attacker
+ * controlled and are what made the weekly-insight and resource-booking routes
+ * cross-tenant readable and writable.
+ *
+ * @param {{authorizedOrganizationId?: unknown, user?: {organization?: unknown}}} req
+ * @returns {string|null} null when the caller has no organization membership.
+ */
+export const resolveAuthorizedOrganizationId = (req) => {
+  const authorized = req?.authorizedOrganizationId;
+  if (authorized !== null && authorized !== undefined) {
+    const id = String(authorized);
+    if (id.length > 0) return id;
+  }
+
+  return toOrganizationId(req?.user?.organization);
+};
+
+export default {
+  toOrganizationId,
+  isSameOrganization,
+  resolveAuthorizedOrganizationId,
+};


### PR DESCRIPTION
.

# Pull Request

## Description
Two route files took an organization id straight out of the URL and queried with it, without ever checking that it was the caller's organization. requireRole only asserts the caller has a role - it says nothing about which organization - so any authenticated user could read (and in one case write) another tenant's data by editing the id in the path.
Provide a brief description of the changes introduced in this pull request.

## Type of Change

- [ ] New Feature
- [X] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [X] Security Improvement
- [ ] Other

## Related Issue

Closes #2571

## Testing
Tests: weeklyInsightCrossTenantAuthorization (13) and resourceBookingCrossTenantAuthorization (20) run the real route/controller/ service/model stack against an in-memory MongoDB; 22 of the 33 fail when the source fix is reverted. weeklyInsightApiPrefixGuards and resourceBookingController.vitest are updated for the new ownership checks.

Describe the testing performed.

- [X] Tested locally
- [X] Existing functionality verified
- [X] No new warnings or errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [X] Code follows project conventions
- [X] Documentation updated where required
- [X] No unnecessary files included
- [X] Changes have been tested
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Organization-scoped resource bookings and weekly insights now prevent cross-organization access.
  * Requests with missing organization membership receive a clear 403 response.
  * Invalid or missing resource, booking, meeting, and insight identifiers return appropriate errors.
  * Client-supplied organization values can no longer override authorized organization context.

* **Bug Fixes**
  * Booking creation, retrieval, cancellation, deletion, and meeting queries now consistently enforce ownership boundaries.
  * Weekly insight routes validate organization access before processing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->