### PR TITLE
fix: mount Custom Roles API and resolve its tenant server-side

### DIFF
--- a/server/controllers/customRoleController.js
+++ b/server/controllers/customRoleController.js
@@ -1,19 +1,40 @@
 import CustomRole from "../models/customRoleModel.js";
 import rbacMatrixService from "../services/rbacMatrixService.js";
+import { toOrganizationId } from "../utils/organizationScope.js";
+
+/**
+ * Server-side tenant resolution (Issue #2570).
+ * Prefers the id a middleware verified, otherwise the caller's membership
+ * organization.
+ */
+const resolveAuthorizedOrganizationId = (req) =>
+  req.authorizedOrganizationId
+    ? String(req.authorizedOrganizationId)
+    : toOrganizationId(req.user?.organization);
 
 /**
  * Controller handling Custom Roles and Resource-Level ACL configurations
+ *
+ * Issue #2570 — the tenant is the authenticated user's membership
+ * organization, resolved server-side. `req.user.organizationId` does not exist
+ * (userAuth sets `req.user = user`, and the User field is `organization`), so
+ * the old `req.user?.organizationId || req.headers["x-organization-id"]` always
+ * fell through to the header: any authenticated user could send
+ * `x-organization-id: <someone else's org>` and act as that tenant.
  */
+const organizationContextRequired = (res) =>
+  res.status(403).json({
+    success: false,
+    error: "Organization context is required",
+  });
+
 export const createCustomRole = async (req, res) => {
   try {
-    const organizationId =
-      req.user?.organizationId || req.headers["x-organization-id"];
-    const { name, description, permissions, priority } = req.body;
+    const organizationId = resolveAuthorizedOrganizationId(req);
+    const { name, description, permissions, priority } = req.body || {};
 
     if (!organizationId) {
-      return res
-        .status(400)
-        .json({ error: "Organization context is required" });
+      return organizationContextRequired(res);
     }
     if (!name) {
       return res.status(400).json({ error: "Role name is required" });
@@ -43,13 +64,10 @@ export const createCustomRole = async (req, res) => {
 
 export const getCustomRoles = async (req, res) => {
   try {
-    const organizationId =
-      req.user?.organizationId || req.headers["x-organization-id"];
+    const organizationId = resolveAuthorizedOrganizationId(req);
 
     if (!organizationId) {
-      return res
-        .status(400)
-        .json({ error: "Organization context is required" });
+      return organizationContextRequired(res);
     }
 
     const roles = await CustomRole.find({ organizationId })
@@ -63,11 +81,14 @@ export const getCustomRoles = async (req, res) => {
 
 export const setResourceAclEntry = async (req, res) => {
   try {
-    const organizationId =
-      req.user?.organizationId || req.headers["x-organization-id"];
+    const organizationId = resolveAuthorizedOrganizationId(req);
     const userId = req.user?._id || req.user?.id;
     const { resourceType, resourceId, granteeType, granteeId, permissions } =
-      req.body;
+      req.body || {};
+
+    if (!organizationId) {
+      return organizationContextRequired(res);
+    }
 
     if (
       !resourceType ||
@@ -103,11 +124,21 @@ export const setResourceAclEntry = async (req, res) => {
 
 export const checkResourcePermission = async (req, res) => {
   try {
-    const organizationId =
-      req.user?.organizationId || req.headers["x-organization-id"];
+    const organizationId = resolveAuthorizedOrganizationId(req);
+
+    if (!organizationId) {
+      return organizationContextRequired(res);
+    }
+
     const userId = req.user?._id || req.user?.id;
     const userRoleId = req.user?.customRoleId || req.user?.roleId;
     const { resourceType, resourceId, requiredPermission } = req.query;
+
+    if (!resourceType || !resourceId) {
+      return res
+        .status(400)
+        .json({ error: "resourceType and resourceId are required" });
+    }
 
     const hasAccess = await rbacMatrixService.evaluateResourceAccess({
       organizationId,

--- a/server/models/resourceAclModel.js
+++ b/server/models/resourceAclModel.js
@@ -45,8 +45,16 @@ const ResourceAclSchema = new mongoose.Schema(
   },
 );
 
+// Issue #2570 — granteeType is part of a grant's identity: a USER grant and a
+// ROLE grant for the same granteeId must be able to coexist.
 ResourceAclSchema.index(
-  { organizationId: 1, resourceType: 1, resourceId: 1, granteeId: 1 },
+  {
+    organizationId: 1,
+    resourceType: 1,
+    resourceId: 1,
+    granteeType: 1,
+    granteeId: 1,
+  },
   { unique: true },
 );
 

--- a/server/routes/customRoleRoutes.js
+++ b/server/routes/customRoleRoutes.js
@@ -1,5 +1,6 @@
 import express from "express";
 import userAuth from "../middleware/userAuth.js";
+import { requirePermission } from "../middleware/rbac.js";
 import {
   createCustomRole,
   getCustomRoles,
@@ -11,9 +12,22 @@ const router = express.Router();
 
 router.use(userAuth);
 
-router.post("/roles", createCustomRole);
+// Issue #2570 — reads are open to any authenticated member of the
+// organization; writes (defining roles and granting resource ACLs) are an
+// administrative action, not something a bare session may perform.
+// The tenant itself is resolved server-side from req.user.organization in the
+// controller — never from the x-organization-id request header.
+router.post(
+  "/roles",
+  requirePermission("team_members", "change_role"),
+  createCustomRole,
+);
 router.get("/roles", getCustomRoles);
-router.post("/acl", setResourceAclEntry);
+router.post(
+  "/acl",
+  requirePermission("team_members", "change_role"),
+  setResourceAclEntry,
+);
 router.get("/check-permission", checkResourcePermission);
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -343,4 +343,10 @@ router.use("/api/meeting-retrospectives", meetingRetrospectiveRoutes);
 import meetingQuestionRoutes from "./meetingQuestionRoutes.js";
 router.use("/api", meetingQuestionRoutes);
 
+// Issue #2570 — the Custom Roles / Resource-ACL router existed but was never
+// imported here, so every endpoint in the feature returned 404 in the running
+// app. Mounted once under /api/custom-roles.
+import customRoleRoutes from "./customRoleRoutes.js";
+router.use("/api/custom-roles", customRoleRoutes);
+
 export default router;

--- a/server/services/rbacMatrixService.js
+++ b/server/services/rbacMatrixService.js
@@ -30,6 +30,15 @@ class RbacMatrixService {
     resourceId,
     requiredPermission,
   }) {
+    // Issue #2570 — Mongoose strips `undefined` from a filter, so an
+    // unscoped query here silently matched an ACL row belonging to *any*
+    // organization. Fail loudly instead of evaluating without a tenant.
+    if (!organizationId) {
+      throw new Error(
+        "Organization context is required to evaluate resource access",
+      );
+    }
+
     // 1. Check direct user ACL
     const userAcl = await ResourceAcl.findOne({
       organizationId,
@@ -104,11 +113,20 @@ class RbacMatrixService {
     permissions,
     grantedBy,
   }) {
+    // Issue #2570 — an unscoped upsert would write an ACL row into no
+    // organization at all.
+    if (!organizationId) {
+      throw new Error("Organization context is required to set a resource ACL");
+    }
+
+    // `granteeType` is part of the identity of a grant: without it a USER
+    // grant and a ROLE grant sharing an id overwrite each other.
     return await ResourceAcl.findOneAndUpdate(
       {
         organizationId,
         resourceType,
         resourceId,
+        granteeType,
         granteeId,
       },
       {

--- a/server/tests/customRoleTenantIsolation.test.js
+++ b/server/tests/customRoleTenantIsolation.test.js
@@ -1,0 +1,261 @@
+/**
+ * Issue #2570 — Custom Roles / Resource-ACL.
+ *
+ * The router is mounted under /api/custom-roles in routes/index.js (asserted in
+ * routeRegistration.test.js). These tests cover the tenant handling of the
+ * handlers themselves: the organization must come from the authenticated
+ * session, never from the `x-organization-id` request header, and a request
+ * without a resolvable organization must never become an unscoped query.
+ *
+ * Real route → controller → service → model stack against an in-memory
+ * MongoDB; only `userAuth` is stubbed.
+ */
+
+import { jest } from "@jest/globals";
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+
+let currentUser = null;
+
+jest.unstable_mockModule("../middleware/userAuth.js", () => ({
+  default: (req, res, next) => {
+    if (!currentUser) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+    req.user = currentUser;
+    next();
+  },
+}));
+
+const { default: customRoleRoutes } =
+  await import("../routes/customRoleRoutes.js");
+const CustomRole = (await import("../models/customRoleModel.js")).default;
+const ResourceAcl = (await import("../models/resourceAclModel.js")).default;
+
+const ORG_A = new mongoose.Types.ObjectId();
+const ORG_B = new mongoose.Types.ObjectId();
+const RESOURCE_ID = new mongoose.Types.ObjectId();
+
+const adminOfOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "admin",
+};
+
+const memberOfOrgA = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: ORG_A,
+  role: "member",
+};
+
+const userWithoutOrganization = {
+  _id: new mongoose.Types.ObjectId(),
+  organization: null,
+  role: "admin",
+};
+
+let app;
+
+beforeAll(async () => {
+  if (mongoose.connection.readyState !== 1) {
+    await mongoose.connect(`${process.env.TEST_MONGODB_URI}/custom_roles_2570`);
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use("/api/custom-roles", customRoleRoutes);
+});
+
+beforeEach(async () => {
+  currentUser = adminOfOrgA;
+  await CustomRole.deleteMany({});
+  await ResourceAcl.deleteMany({});
+});
+
+describe("custom roles tenant resolution (#2570)", () => {
+  it("returns only the caller's organization roles", async () => {
+    await CustomRole.create({ organizationId: ORG_A, name: "Org A role" });
+    await CustomRole.create({ organizationId: ORG_B, name: "Org B role" });
+
+    const res = await request(app).get("/api/custom-roles/roles");
+
+    expect(res.status).toBe(200);
+    expect(res.body.roles).toHaveLength(1);
+    expect(res.body.roles[0].name).toBe("Org A role");
+  });
+
+  it("ignores the x-organization-id header", async () => {
+    await CustomRole.create({ organizationId: ORG_A, name: "Org A role" });
+    await CustomRole.create({ organizationId: ORG_B, name: "Org B role" });
+
+    const res = await request(app)
+      .get("/api/custom-roles/roles")
+      .set("x-organization-id", ORG_B.toString());
+
+    expect(res.status).toBe(200);
+    expect(res.body.roles).toHaveLength(1);
+    expect(res.body.roles[0].name).toBe("Org A role");
+    expect(JSON.stringify(res.body)).not.toContain("Org B role");
+  });
+
+  it("rejects a caller without an organization instead of querying unscoped", async () => {
+    await CustomRole.create({ organizationId: ORG_A, name: "Org A role" });
+    currentUser = userWithoutOrganization;
+
+    const res = await request(app)
+      .get("/api/custom-roles/roles")
+      .set("x-organization-id", ORG_A.toString());
+
+    expect(res.status).toBe(403);
+    expect(res.body.roles).toBeUndefined();
+  });
+
+  it("requires an administrative permission to create a role", async () => {
+    currentUser = memberOfOrgA;
+
+    const res = await request(app)
+      .post("/api/custom-roles/roles")
+      .send({ name: "Member role" });
+
+    expect(res.status).toBe(403);
+    expect(await CustomRole.countDocuments({ name: "Member role" })).toBe(0);
+  });
+
+  it("stamps the caller's organization on the role, ignoring body and header", async () => {
+    const res = await request(app)
+      .post("/api/custom-roles/roles")
+      .set("x-organization-id", ORG_B.toString())
+      .send({ name: "Admin role", organizationId: ORG_B.toString() });
+
+    expect(res.status).toBe(201);
+    expect(String(res.body.role.organizationId)).toBe(ORG_A.toString());
+  });
+});
+
+describe("resource ACL tenant resolution (#2570)", () => {
+  it("requires an administrative permission to write an ACL", async () => {
+    currentUser = memberOfOrgA;
+
+    const res = await request(app)
+      .post("/api/custom-roles/acl")
+      .send({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        granteeType: "USER",
+        granteeId: adminOfOrgA._id.toString(),
+        permissions: ["READ"],
+      });
+
+    expect(res.status).toBe(403);
+    expect(await ResourceAcl.countDocuments({})).toBe(0);
+  });
+
+  it("writes the ACL into the caller's organization", async () => {
+    const res = await request(app)
+      .post("/api/custom-roles/acl")
+      .set("x-organization-id", ORG_B.toString())
+      .send({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        granteeType: "USER",
+        granteeId: adminOfOrgA._id.toString(),
+        permissions: ["READ"],
+        organizationId: ORG_B.toString(),
+      });
+
+    expect(res.status).toBe(200);
+    expect(String(res.body.acl.organizationId)).toBe(ORG_A.toString());
+  });
+
+  it("keeps USER and ROLE grants for the same granteeId separate", async () => {
+    await request(app)
+      .post("/api/custom-roles/acl")
+      .send({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        granteeType: "USER",
+        granteeId: adminOfOrgA._id.toString(),
+        permissions: ["READ"],
+      });
+
+    await request(app)
+      .post("/api/custom-roles/acl")
+      .send({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        granteeType: "ROLE",
+        granteeId: adminOfOrgA._id.toString(),
+        permissions: ["WRITE"],
+      });
+
+    const grants = await ResourceAcl.find({
+      organizationId: ORG_A,
+      resourceId: RESOURCE_ID,
+    }).lean();
+
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => g.granteeType).sort()).toEqual(["ROLE", "USER"]);
+  });
+
+  it("evaluates permissions against the caller's organization only", async () => {
+    // A grant in org B for this same user must not grant access in org A.
+    await ResourceAcl.create({
+      organizationId: ORG_B,
+      resourceType: "MEETING",
+      resourceId: RESOURCE_ID,
+      granteeType: "USER",
+      granteeId: adminOfOrgA._id,
+      permissions: ["READ"],
+    });
+
+    const res = await request(app)
+      .get("/api/custom-roles/check-permission")
+      .query({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        requiredPermission: "READ",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.hasAccess).toBe(false);
+  });
+
+  it("honours a grant inside the caller's own organization", async () => {
+    await ResourceAcl.create({
+      organizationId: ORG_A,
+      resourceType: "MEETING",
+      resourceId: RESOURCE_ID,
+      granteeType: "USER",
+      granteeId: adminOfOrgA._id,
+      permissions: ["READ"],
+    });
+
+    const res = await request(app)
+      .get("/api/custom-roles/check-permission")
+      .query({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        requiredPermission: "READ",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.hasAccess).toBe(true);
+  });
+
+  it("rejects a permission check with no resolvable organization", async () => {
+    currentUser = userWithoutOrganization;
+
+    const res = await request(app)
+      .get("/api/custom-roles/check-permission")
+      .set("x-organization-id", ORG_A.toString())
+      .query({
+        resourceType: "MEETING",
+        resourceId: RESOURCE_ID.toString(),
+        requiredPermission: "READ",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.hasAccess).toBeUndefined();
+  });
+});

--- a/server/tests/routeRegistration.test.js
+++ b/server/tests/routeRegistration.test.js
@@ -80,6 +80,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/admin/jobs",
       "/api/admin/embeddings",
       "/api/admin/rbac",
+      "/api/custom-roles",
     ];
 
     for (const prefix of standaloneRoutePrefixes) {
@@ -160,6 +161,7 @@ describe("Route Consolidation and Registration", () => {
       "/api/admin/jobs",
       "/api/admin/embeddings",
       "/api/admin/rbac",
+      "/api/custom-roles",
     ];
 
     for (const routePath of expectedRoutes) {


### PR DESCRIPTION


# Pull Request

## Description

Fixes:
- routes/index.js: mount the router under /api/custom-roles.
- customRoleRoutes.js: requirePermission("team_members", "change_role") on the two write endpoints (creating roles and granting ACLs is administrative).
- customRoleController.js: resolve the tenant with resolveAuthorizedOrganizationId(req) (req.user.organization); 403 when the caller has no organization, instead of running an unscoped query; validate resourceType/resourceId on the permission check.
- rbacMatrixService.js: throw when organizationId is missing (never evaluate or upsert unscoped) and include granteeType in the ACL upsert filter so a USER grant and a ROLE grant for the same id cannot clobber one another.
- resourceAclModel.js: add granteeType to the unique index.
Provide a brief description of the changes introduced in this pull request.

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [X] Security Improvement
- [ ] Other

## Related Issue

Closes #2570 

## Testing
customRoleTenantIsolation (11) covers header being ignored, body organizationId being ignored, admin-only writes, tenant-scoped evaluation and USER/ROLE grants coexisting. routeRegistration now asserts /api/custom-roles is mounted - the check that would have caught the dead router.
Describe the testing performed.

- [X] Tested locally
- [X] Existing functionality verified
- [X] No new warnings or errors

## Screenshots

If applicable, add screenshots of the changes.

## Checklist

- [X] Code follows project conventions
- [X] Documentation updated where required
- [X] No unnecessary files included
- [X] Changes have been tested
- [X] Ready for review
