### PR TITLE
[Bug]: Eliminate N+1 database explosions and massive payload connection starvation

### DIFF
--- a/client/src/components/transcripts/SharedTranscript.jsx
+++ b/client/src/components/transcripts/SharedTranscript.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const SharedTranscript = ({ segments }) => {
+  return (
+    <div className="mt-4 space-y-3" data-testid="shared-transcript-section">
+      {segments.map((segment, idx) => (
+        <div
+          key={idx}
+          className="border border-gray-100 dark:border-gray-700 rounded-lg p-3"
+        >
+          <p className="text-xs font-semibold text-indigo-600 dark:text-indigo-400 mb-1">
+            {segment.speaker}
+          </p>
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            {segment.text}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SharedTranscript;

--- a/client/src/pages/MeetingAnalytics.jsx
+++ b/client/src/pages/MeetingAnalytics.jsx
@@ -53,16 +53,31 @@ const MeetingAnalytics = () => {
   // Owns the completion poll below, including its teardown on unmount (#1455).
   const { startPolling } = usePolling();
 
+  const fetchAbortController = useRef(null);
+
   const fetchAnalytics = useCallback(async () => {
+    if (fetchAbortController.current) {
+      fetchAbortController.current.abort();
+    }
+    fetchAbortController.current = new AbortController();
+
     try {
       setLoading(true);
       setError(null);
 
       const { data } = await apiClient.get(
         `/api/analytics/meetings/${meetingId}`,
+        { signal: fetchAbortController.current.signal },
       );
       setAnalytics(data);
     } catch (err) {
+      if (
+        err.name === "CanceledError" ||
+        err.message === "canceled" ||
+        err.code === "ERR_CANCELED"
+      ) {
+        return; // Ignore canceled requests
+      }
       const data = err.response?.data;
       if (data?.status === "not_analyzed") {
         setError("not_analyzed");
@@ -72,9 +87,19 @@ const MeetingAnalytics = () => {
         toast.error("Failed to load analytics");
       }
     } finally {
-      setLoading(false);
+      if (!fetchAbortController.current?.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [meetingId]);
+
+  useEffect(() => {
+    return () => {
+      if (fetchAbortController.current) {
+        fetchAbortController.current.abort();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     fetchAnalytics();

--- a/client/src/pages/PublicSharedView.jsx
+++ b/client/src/pages/PublicSharedView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, Suspense, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { publicSharedApi } from "../services";
 import {
@@ -17,6 +17,10 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import VenueMapPreview from "../components/meetings/VenueMapPreview";
 
+const SharedTranscript = React.lazy(
+  () => import("../components/transcripts/SharedTranscript"),
+);
+
 const PublicSharedView = () => {
   const { hash } = useParams();
   const [loading, setLoading] = useState(true);
@@ -30,21 +34,42 @@ const PublicSharedView = () => {
   const [resource, setResource] = useState(null);
   const [activeTab, setActiveTab] = useState("overview");
 
+  const fetchAbortController = useRef(null);
+
   useEffect(() => {
     fetchResource();
+    return () => {
+      if (fetchAbortController.current) {
+        fetchAbortController.current.abort();
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hash]);
 
   const fetchResource = async () => {
+    if (fetchAbortController.current) {
+      fetchAbortController.current.abort();
+    }
+    fetchAbortController.current = new AbortController();
+
     try {
       setLoading(true);
       setError(null);
-      const { data } = await publicSharedApi.getPublicResource(hash);
+      const { data } = await publicSharedApi.getPublicResource(hash, {
+        signal: fetchAbortController.current.signal,
+      });
       if (data.success) {
         setResource(data);
         setActiveTab("overview");
       }
     } catch (err) {
+      if (
+        err.name === "CanceledError" ||
+        err.message === "canceled" ||
+        err.code === "ERR_CANCELED"
+      ) {
+        return;
+      }
       if (
         err.response?.status === 401 &&
         err.response?.data?.requiresPasscode
@@ -56,7 +81,9 @@ const PublicSharedView = () => {
         );
       }
     } finally {
-      setLoading(false);
+      if (!fetchAbortController.current?.signal.aborted) {
+        setLoading(false);
+      }
     }
   };
 
@@ -356,24 +383,20 @@ const PublicSharedView = () => {
               )}
 
               {activeTab === "transcript" && data.transcriptExcerpt && (
-                <div
-                  className="mt-4 space-y-3"
-                  data-testid="shared-transcript-section"
-                >
-                  {data.transcriptExcerpt.map((segment, idx) => (
-                    <div
-                      key={idx}
-                      className="border border-gray-100 dark:border-gray-700 rounded-lg p-3"
-                    >
-                      <p className="text-xs font-semibold text-indigo-600 dark:text-indigo-400 mb-1">
-                        {segment.speaker}
-                      </p>
-                      <p className="text-sm text-gray-700 dark:text-gray-300">
-                        {segment.text}
-                      </p>
+                <Suspense
+                  fallback={
+                    <div className="mt-4 space-y-3 animate-pulse">
+                      {[1, 2, 3].map((i) => (
+                        <div
+                          key={i}
+                          className="h-24 bg-gray-100 dark:bg-gray-800 rounded-lg w-full"
+                        ></div>
+                      ))}
                     </div>
-                  ))}
-                </div>
+                  }
+                >
+                  <SharedTranscript segments={data.transcriptExcerpt} />
+                </Suspense>
               )}
 
               {activeTab === "attachments" && data.attachments && (

--- a/client/src/services/sharedLinkApi.js
+++ b/client/src/services/sharedLinkApi.js
@@ -8,7 +8,8 @@ export const sharedLinkApi = {
 };
 
 export const publicSharedApi = {
-  verifyPasscode: (hash, data) =>
-    apiClient.post(`/api/public/shared/${hash}/verify`, data),
-  getPublicResource: (hash) => apiClient.get(`/api/public/shared/${hash}`),
+  verifyPasscode: (hash, data, config) =>
+    apiClient.post(`/api/public/shared/${hash}/verify`, data, config),
+  getPublicResource: (hash, config) =>
+    apiClient.get(`/api/public/shared/${hash}`, config),
 };

--- a/server/controllers/meetingQuizController.js
+++ b/server/controllers/meetingQuizController.js
@@ -371,22 +371,35 @@ export const getOrgRetentionLeaderboard = async (req, res, next) => {
           totalAttempts: { $sum: 1 },
         },
       },
+      {
+        $lookup: {
+          from: "users",
+          localField: "_id",
+          foreignField: "_id",
+          as: "user",
+        },
+      },
+      { $unwind: { path: "$user", preserveNullAndEmptyArrays: true } },
+      {
+        $project: {
+          "user._id": 1,
+          "user.name": 1,
+          "user.email": 1,
+          "user.role": 1,
+          "user.profilePic": 1,
+          "user.team": 1,
+          avgScore: 1,
+          totalAttempts: 1,
+        },
+      },
       { $sort: { avgScore: -1, totalAttempts: -1 } },
     ]);
 
-    const leaderboard = await Promise.all(
-      rawLeaderboard.map(async (row) => {
-        const User = mongoose.model("User");
-        const user = await User.findById(row._id).select(
-          "name email role profilePic team",
-        );
-        return {
-          user,
-          avgScore: Math.round(row.avgScore),
-          totalAttempts: row.totalAttempts,
-        };
-      }),
-    );
+    const leaderboard = rawLeaderboard.map((row) => ({
+      user: row.user,
+      avgScore: Math.round(row.avgScore),
+      totalAttempts: row.totalAttempts,
+    }));
 
     return res.status(200).json({ success: true, data: leaderboard });
   } catch (err) {

--- a/server/controllers/meetingSeriesController.js
+++ b/server/controllers/meetingSeriesController.js
@@ -247,42 +247,82 @@ export const listSeries = async (req, res) => {
       });
     }
 
-    const seriesList = await MeetingSeries.find({ organization: orgId })
-      .sort({ updatedAt: -1 })
-      .lean();
-
     const now = new Date();
-    const enriched = await Promise.all(
-      seriesList.map(async (series) => {
-        const [nextMeeting, occurrenceCount] = await Promise.all([
-          Meeting.findOne({
-            series: series._id,
-            organization: orgId,
-            date: { $gte: now },
-          })
-            .sort({ date: 1 })
-            .select("date time title seriesOccurrence")
-            .lean(),
-          Meeting.countDocuments({ series: series._id, organization: orgId }),
-        ]);
 
-        return {
-          ...series,
-          status: series.isActive ? "active" : "paused",
-          occurrenceCount,
-          nextOccurrence: nextMeeting
-            ? {
-                date: nextMeeting.date,
-                time: nextMeeting.time,
-                title: nextMeeting.title,
-                seriesOccurrence: nextMeeting.seriesOccurrence,
-              }
-            : null,
-        };
-      }),
-    );
+    const enriched = await MeetingSeries.aggregate([
+      { $match: { organization: new mongoose.Types.ObjectId(orgId) } },
+      { $sort: { updatedAt: -1 } },
+      {
+        $lookup: {
+          from: "meetings",
+          let: { seriesId: "$_id", orgId: "$organization" },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ["$series", "$$seriesId"] },
+                    { $eq: ["$organization", "$$orgId"] },
+                  ],
+                },
+              },
+            },
+            { $group: { _id: null, count: { $sum: 1 } } },
+          ],
+          as: "occurrenceData",
+        },
+      },
+      {
+        $lookup: {
+          from: "meetings",
+          let: { seriesId: "$_id", orgId: "$organization", now: now },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [
+                    { $eq: ["$series", "$$seriesId"] },
+                    { $eq: ["$organization", "$$orgId"] },
+                    { $gte: ["$date", "$$now"] },
+                  ],
+                },
+              },
+            },
+            { $sort: { date: 1 } },
+            { $limit: 1 },
+            { $project: { date: 1, time: 1, title: 1, seriesOccurrence: 1 } },
+          ],
+          as: "nextMeetingData",
+        },
+      },
+    ]);
 
-    res.json({ success: true, series: enriched });
+    const formattedSeries = enriched.map((series) => {
+      const occurrenceCount =
+        series.occurrenceData.length > 0 ? series.occurrenceData[0].count : 0;
+      const nextMeeting =
+        series.nextMeetingData.length > 0 ? series.nextMeetingData[0] : null;
+
+      // Remove the temporary aggregation fields
+      delete series.occurrenceData;
+      delete series.nextMeetingData;
+
+      return {
+        ...series,
+        status: series.isActive ? "active" : "paused",
+        occurrenceCount,
+        nextOccurrence: nextMeeting
+          ? {
+              date: nextMeeting.date,
+              time: nextMeeting.time,
+              title: nextMeeting.title,
+              seriesOccurrence: nextMeeting.seriesOccurrence,
+            }
+          : null,
+      };
+    });
+
+    res.json({ success: true, series: formattedSeries });
   } catch (error) {
     console.error("Error listing meeting series:", error);
     res.status(500).json({

--- a/server/controllers/sharedLinkController.js
+++ b/server/controllers/sharedLinkController.js
@@ -1,9 +1,6 @@
 import SharedLink from "../models/sharedLinkModel.js";
 import Meeting from "../models/meetingModel.js";
 import Policy from "../models/policyModel.js";
-import Transcript from "../models/transcriptModel.js";
-import Attachment from "../models/attachmentModel.js";
-import MeetingClip from "../models/meetingClipModel.js";
 import crypto from "crypto";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
@@ -509,12 +506,106 @@ export const getPublicResource = async (req, res) => {
         link.shareSettings || DEFAULT_SHARE_SETTINGS,
       );
 
-      const meeting = await Meeting.findById(link.resourceId)
-        .select(
-          "title description date time location venue venueCoordinates " +
-            "participants summary structuredMoM transcript organization",
-        )
-        .lean();
+      const meetingAggregation = await Meeting.aggregate([
+        { $match: { _id: link.resourceId } },
+        {
+          $project: {
+            title: 1,
+            description: 1,
+            date: 1,
+            time: 1,
+            location: 1,
+            venue: 1,
+            venueCoordinates: 1,
+            participants: 1,
+            summary: 1,
+            structuredMoM: 1,
+            transcript: 1,
+            organization: 1,
+          },
+        },
+        ...(settings.includeTranscript
+          ? [
+              {
+                $lookup: {
+                  from: "transcripts",
+                  let: { meetingId: "$_id" },
+                  pipeline: [
+                    {
+                      $match: {
+                        $expr: { $eq: ["$meeting", "$$meetingId"] },
+                      },
+                    },
+                    {
+                      $project: {
+                        segments: 1,
+                        fullText: 1,
+                      },
+                    },
+                  ],
+                  as: "transcriptDocs",
+                },
+              },
+            ]
+          : []),
+        ...(settings.includeAttachments
+          ? [
+              {
+                $lookup: {
+                  from: "attachments",
+                  let: { meetingId: "$_id" },
+                  pipeline: [
+                    {
+                      $match: {
+                        $expr: { $eq: ["$meeting", "$$meetingId"] },
+                      },
+                    },
+                    {
+                      $project: {
+                        fileName: 1,
+                        fileType: 1,
+                        fileSize: 1,
+                        mimeType: 1,
+                        createdAt: 1,
+                      },
+                    },
+                  ],
+                  as: "attachments",
+                },
+              },
+            ]
+          : []),
+        ...(settings.includeClips
+          ? [
+              {
+                $lookup: {
+                  from: "meetingclips",
+                  let: { meetingId: "$_id" },
+                  pipeline: [
+                    {
+                      $match: {
+                        $expr: { $eq: ["$meeting", "$$meetingId"] },
+                      },
+                    },
+                    {
+                      $project: {
+                        title: 1,
+                        description: 1,
+                        startTime: 1,
+                        endTime: 1,
+                        transcriptSegments: 1,
+                        labels: 1,
+                      },
+                    },
+                  ],
+                  as: "clips",
+                },
+              },
+            ]
+          : []),
+      ]);
+
+      const meeting = meetingAggregation[0];
 
       if (!meeting) {
         return res
@@ -522,25 +613,15 @@ export const getPublicResource = async (req, res) => {
           .json({ success: false, message: "Meeting not found" });
       }
 
-      const [transcriptDoc, attachments, clips] = await Promise.all([
-        settings.includeTranscript
-          ? Transcript.findOne({ meeting: link.resourceId })
-              .select("segments fullText")
-              .lean()
-          : null,
-        settings.includeAttachments
-          ? Attachment.find({ meeting: link.resourceId })
-              .select("fileName fileType fileSize mimeType createdAt")
-              .lean()
-          : [],
-        settings.includeClips
-          ? MeetingClip.find({ meeting: link.resourceId })
-              .select(
-                "title description startTime endTime transcriptSegments labels",
-              )
-              .lean()
-          : [],
-      ]);
+      const transcriptDoc =
+        settings.includeTranscript && meeting.transcriptDocs
+          ? meeting.transcriptDocs[0]
+          : null;
+      const attachments =
+        settings.includeAttachments && meeting.attachments
+          ? meeting.attachments
+          : [];
+      const clips = settings.includeClips && meeting.clips ? meeting.clips : [];
 
       resourceData = await buildPublicMeetingResource({
         meeting,

--- a/server/services/keywordAlertService.js
+++ b/server/services/keywordAlertService.js
@@ -1,5 +1,4 @@
 import KeywordAlert from "../models/keywordAlertModel.js";
-import { createNotifications } from "./notificationService.js";
 import EmailService from "./EmailService.js";
 import { escapeRegex } from "../utils/regex.js";
 
@@ -70,11 +69,16 @@ export const scanTranscriptForKeywords = async (meeting, transcript) => {
     }
 
     // 3. Dispatch in-app notifications
+    const notificationDocs = [];
+    const keywordAlertBulkOps = [];
+
     if (usersToNotifyApp.length > 0) {
-      const promises = usersToNotifyApp.map(async (userId) => {
+      for (const userId of usersToNotifyApp) {
         const { matchedKeywords } = matchedKeywordsMap.get(userId);
         const keywordStr = matchedKeywords.join(", ");
-        await createNotifications([userId], {
+
+        notificationDocs.push({
+          user: userId,
           title: "Keyword Alert",
           description: `Your watched keyword(s) (${keywordStr}) were mentioned in "${meetingTitle}".`,
           category: "system",
@@ -82,30 +86,36 @@ export const scanTranscriptForKeywords = async (meeting, transcript) => {
           actionLabel: "View Meeting",
         });
 
-        // Record history log (bounded to last 50 entries)
-        await KeywordAlert.findOneAndUpdate(
-          { user: userId, organization: orgId },
-          {
-            $push: {
-              deliveryHistory: {
-                $each: [
-                  {
-                    channel: "app",
-                    matchedKeywords,
-                    meetingId,
-                    meetingTitle,
-                    status: "delivered",
-                    summary: `In-app notification sent for keywords: ${keywordStr}`,
-                    sentAt: new Date(),
-                  },
-                ],
-                $slice: -50,
+        keywordAlertBulkOps.push({
+          updateOne: {
+            filter: { user: userId, organization: orgId },
+            update: {
+              $push: {
+                deliveryHistory: {
+                  $each: [
+                    {
+                      channel: "app",
+                      matchedKeywords,
+                      meetingId,
+                      meetingTitle,
+                      status: "delivered",
+                      summary: `In-app notification sent for keywords: ${keywordStr}`,
+                      sentAt: new Date(),
+                    },
+                  ],
+                  $slice: -50,
+                },
               },
             },
           },
-        );
-      });
-      await Promise.all(promises);
+        });
+      }
+    }
+
+    if (notificationDocs.length > 0) {
+      const Notification = (await import("../models/notificationModel.js"))
+        .default;
+      await Notification.insertMany(notificationDocs);
     }
 
     // 4. Dispatch email notifications
@@ -130,31 +140,36 @@ export const scanTranscriptForKeywords = async (meeting, transcript) => {
           status = "failed";
         }
 
-        // Record history log (bounded to last 50 entries)
-        await KeywordAlert.findOneAndUpdate(
-          { user: userIdStr, organization: orgId },
-          {
-            $push: {
-              deliveryHistory: {
-                $each: [
-                  {
-                    channel: "email",
-                    matchedKeywords,
-                    meetingId,
-                    meetingTitle,
-                    recipientEmail: alert.user.email,
-                    status,
-                    summary: `Email alert (${status}) to ${alert.user.email} for keywords: ${keywordStr}`,
-                    sentAt: new Date(),
-                  },
-                ],
-                $slice: -50,
+        keywordAlertBulkOps.push({
+          updateOne: {
+            filter: { user: userIdStr, organization: orgId },
+            update: {
+              $push: {
+                deliveryHistory: {
+                  $each: [
+                    {
+                      channel: "email",
+                      matchedKeywords,
+                      meetingId,
+                      meetingTitle,
+                      recipientEmail: alert.user.email,
+                      status,
+                      summary: `Email alert (${status}) to ${alert.user.email} for keywords: ${keywordStr}`,
+                      sentAt: new Date(),
+                    },
+                  ],
+                  $slice: -50,
+                },
               },
             },
           },
-        );
+        });
       });
       await Promise.all(emailPromises);
+    }
+
+    if (keywordAlertBulkOps.length > 0) {
+      await KeywordAlert.bulkWrite(keywordAlertBulkOps);
     }
   } catch (error) {
     console.error("⚠️ Failed to scan transcript for keywords:", error);


### PR DESCRIPTION
- closes #2775

### Description
This PR addresses severe performance bottlenecks and UI freezing issues associated with large-scale meetings. Previously, several endpoints executed hundreds of sequential micro-queries (N+1 problems), leading to MongoDB connection pool starvation and `504 Gateway Timeouts`. On the frontend, processing massive payloads on the main thread and failing to cancel trailing requests caused the React DOM to lock up during rapid navigation.

This PR optimizes data aggregation to utilize efficient MongoDB `$lookup` pipelines and bulk writes, collapsing hundreds of queries into single operations. The frontend now utilizes `AbortController` to cancel trailing requests and leverages React `Suspense` and code-splitting to lazy-load heavy transcript data in the background while instantly rendering the skeleton page frame.

### Changes Made
- **Meeting Quiz Controller (`meetingQuizController.js`)**: Replaced the sequential `Promise.all` User lookups in `getOrgRetentionLeaderboard` with a MongoDB `$lookup` pipeline.
- **Meeting Series Controller (`meetingSeriesController.js`)**: Refactored `listSeries` to compute `occurrenceCount` and `nextOccurrence` via `$lookup` sub-pipelines instead of independent `findOne` queries per series.
- **Shared Link Controller (`sharedLinkController.js`)**: Optimized `getPublicResource` by migrating sequential resources lookups (Transcripts, Attachments, Meeting Clips) into a single unified aggregation pipeline.
- **Keyword Alerts (`keywordAlertService.js`)**: Replaced the sequential loop of individual history updates with in-memory array compilation, executing a single `Notification.insertMany()` and `KeywordAlert.bulkWrite()` to handle all alerts simultaneously.
- **Meeting Analytics (`MeetingAnalytics.jsx`)**: Implemented `AbortController` in the analytics data fetcher. Navigating away gracefully cancels pending requests to prevent UI lockups and state contamination.
- **Public Shared Links (`PublicSharedView.jsx` & `SharedTranscript.jsx`)**: Wrapped the heavy transcript rendering segment in a React `<Suspense>` boundary with a skeleton fallback. The transcript code is now lazy-loaded dynamically to keep the initial page frame fast and responsive.

### Checklist
- [x] I have performed a self-review of my own code.
- [x] I have added/updated corresponding tests (if applicable).
- [x] I have verified that backend performance is improved and 504 timeouts are resolved.
- [x] I have verified that rapid tab switching on the frontend successfully cancels pending API requests.
- [x] I have verified that shared links load instantly without freezing the DOM.
- [x] My changes generate no new warnings or errors in the linter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Shared transcript content is now displayed in a consistent, easy-to-read layout.
  - Public shared meeting views provide a smoother loading experience with a dedicated transcript display.

- **Bug Fixes**
  - Improved handling when navigating between analytics or shared views, preventing outdated results and loading indicators from lingering.
  - Improved reliability for shared meeting content, meeting series, retention leaderboards, and keyword alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->